### PR TITLE
chore: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,24 @@
+# Tests - not needed for users
+ tests/
+
+ # Documentation (except README which npm shows)
+ docs/
+
+ # GitHub workflows
+ .github/
+
+ # Development scripts
+ scripts/
+
+ # Development files
+ todo.md
+ .pi/
+
+ # Cache
+ .ruff_cache/
+ .pi-lens/
+
+ # Config that shouldn't be published
+ .gitignore
+ tsconfig.json
+ vitest.config.ts


### PR DESCRIPTION
Add .npmignore to control what files are published to npm.

**Excluded from npm package:**
- tests/ - not needed by users
- docs/ - README.md still included (shown on npm page)
- .github/ - CI workflows
- scripts/ - development scripts
- Development files: todo.md, .pi/, cache dirs
- Config files: tsconfig.json, vitest.config.ts

**Result:** Smaller package size, only essential code published.