### PR TITLE
ci: add install test workflow for all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  install-test:
+    name: Install test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Pack tarball
+        run: npm pack
+
+      - name: Verify required files in tarball
+        shell: bash
+        run: |
+          TARBALL=$(ls *.tgz)
+          echo "Checking tarball: $TARBALL"
+          tar -tzf "$TARBALL" | grep "package.json" || \
+            (echo "ERROR: package.json missing from tarball" && exit 1)
+
+      - name: Install from tarball (simulates pi install npm:...)
+        shell: bash
+        run: |
+          TARBALL=$(ls *.tgz)
+          npm install -g "$TARBALL"


### PR DESCRIPTION
Adds GitHub Actions CI that tests npm install from tarball on Ubuntu, Windows, and macOS.