### PR TITLE
fix: include provider-failover in npm package + bump to v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free-providers",
-	"version": "1.0.1",
+	"version": "1.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free-providers",
-			"version": "1.0.1",
+			"version": "1.0.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"providers/**/*.ts",
 		"lib/**/*.ts",
 		"usage/**/*.ts",
+		"provider-failover/**/*.ts",
 		"config.ts",
 		"constants.ts",
 		"provider-factory.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"type": "module",
 	"description": "AIO Free AI models for Pi - Access free models from Kilo, Zen, OpenRouter, NVIDIA, Cline, Mistral, and Ollama",
 	"keywords": [


### PR DESCRIPTION
## Summary
- Add `provider-failover/**/*.ts` to `files` in package.json — this directory was missing from the published tarball, causing `Cannot find module './provider-failover/hardcoded-benchmarks.ts'` errors at runtime for all providers (kilo, zen, openrouter, nvidia, fireworks, mistral, ollama)
- Bump version to 1.0.6

## Test plan
- [ ] `npm pack --dry-run` shows `provider-failover/hardcoded-benchmarks.ts` in tarball ✓
- [ ] Install from npm and verify providers load without module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)