### PR TITLE
fix: include widget dir in npm package (v1.0.7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free-providers",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free-providers",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"lib/**/*.ts",
 		"usage/**/*.ts",
 		"provider-failover/**/*.ts",
+		"widget/**/*.ts",
 		"config.ts",
 		"constants.ts",
 		"provider-factory.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"type": "module",
 	"description": "AIO Free AI models for Pi - Access free models from Kilo, Zen, OpenRouter, NVIDIA, Cline, Mistral, and Ollama",
 	"keywords": [


### PR DESCRIPTION
widget/data.ts, widget/format.ts, widget/render.ts were missing from the published tarball.