### PR TITLE
ci: load extension entry points to catch missing files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,14 @@ jobs:
       - name: Pack tarball
         run: npm pack
 
-      - name: Verify required files in tarball
-        shell: bash
-        run: |
-          TARBALL=$(ls *.tgz)
-          echo "Checking tarball: $TARBALL"
-          tar -tzf "$TARBALL" | grep "package.json" || \
-            (echo "ERROR: package.json missing from tarball" && exit 1)
-
       - name: Install from tarball (simulates pi install npm:...)
         shell: bash
         run: |
           TARBALL=$(ls *.tgz)
           npm install -g "$TARBALL"
+
+      - name: Load each extension entry point (catches missing files)
+        shell: bash
+        run: |
+          INSTALL_DIR=$(npm root -g)/pi-free
+          node --experimental-strip-types scripts/check-extensions.mjs "$INSTALL_DIR"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free-providers",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free-providers",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
 		"provider-helper.ts",
 		"README.md",
 		"LICENSE",
-		"CHANGELOG.md"
+		"CHANGELOG.md",
+		"scripts/check-extensions.mjs"
 	],
 	"scripts": {
+		"check": "node --experimental-strip-types scripts/check-extensions.mjs .",
 		"test": "vitest",
 		"test:ui": "vitest --ui",
 		"test:run": "vitest run"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"lib/**/*.ts",
 		"usage/**/*.ts",
 		"provider-failover/**/*.ts",
+		"widget/**/*.ts",
 		"config.ts",
 		"constants.ts",
 		"provider-factory.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"type": "module",
 	"description": "AIO Free AI models for Pi - Access free models from Kilo, Zen, OpenRouter, NVIDIA, Cline, Mistral, and Ollama",
 	"keywords": [

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -1,0 +1,49 @@
+/**
+ * Verifies all pi extension entry points can be loaded after install.
+ * Catches "Cannot find module" errors caused by missing files in the npm package.
+ *
+ * Usage: node scripts/check-extensions.mjs <install-dir>
+ * Example: node scripts/check-extensions.mjs $(npm root -g)/pi-free
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { join, resolve } from "node:path";
+
+const installDir = resolve(process.argv[2] ?? ".");
+const pkg = JSON.parse(readFileSync(join(installDir, "package.json"), "utf8"));
+const extensions = pkg.pi?.extensions ?? [];
+
+if (extensions.length === 0) {
+  console.error("No pi.extensions found in package.json");
+  process.exit(1);
+}
+
+console.log(`Checking ${extensions.length} extension(s) in: ${installDir}\n`);
+
+let failed = 0;
+
+for (const ext of extensions) {
+  const file = ext.replace(/^\.\//, "");
+  const fullPath = join(installDir, file);
+  const url = pathToFileURL(fullPath).href;
+
+  process.stdout.write(`  ${file} ... `);
+  try {
+    await import(url);
+    console.log("✓");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("Cannot find module") || msg.includes("Cannot find package") || msg.includes("ERR_MODULE_NOT_FOUND")) {
+      console.log("✗ FAILED");
+      console.error(`    → ${msg.split("\n")[0]}`);
+      failed++;
+    } else {
+      // Non-module errors (missing pi API, config issues) are expected in a stub env
+      console.log(`✓ (runtime error ignored: ${msg.slice(0, 80)})`);
+    }
+  }
+}
+
+console.log(`\n${failed === 0 ? "All extensions loaded OK" : `${failed} extension(s) failed`}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Adds a CI step that imports each extension the same way pi does. Would have caught the provider-failover and widget missing-files bugs before publish.