### PR TITLE
fix: check-extensions uses npm pack --dry-run for accurate file list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
         shell: bash
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
-          node --experimental-strip-types scripts/check-extensions.mjs "$INSTALL_DIR"
+          node scripts/check-extensions.mjs "$INSTALL_DIR"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,14 @@ jobs:
       - name: Pack tarball
         run: npm pack
 
-      - name: Verify required files in tarball
-        shell: bash
-        run: |
-          TARBALL=$(ls *.tgz)
-          echo "Checking tarball: $TARBALL"
-          tar -tzf "$TARBALL" | grep "package.json" || \
-            (echo "ERROR: package.json missing from tarball" && exit 1)
-
       - name: Install from tarball (simulates pi install npm:...)
         shell: bash
         run: |
           TARBALL=$(ls *.tgz)
           npm install -g "$TARBALL"
+
+      - name: Load each extension entry point (catches missing files)
+        shell: bash
+        run: |
+          INSTALL_DIR=$(npm root -g)/pi-free
+          node --experimental-strip-types scripts/check-extensions.mjs "$INSTALL_DIR"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free-providers",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free-providers",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"scripts/check-extensions.mjs"
 	],
 	"scripts": {
-		"check": "node --experimental-strip-types scripts/check-extensions.mjs .",
+		"check": "node scripts/check-extensions.mjs",
 		"test": "vitest",
 		"test:ui": "vitest --ui",
 		"test:run": "vitest run"

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
 		"provider-helper.ts",
 		"README.md",
 		"LICENSE",
-		"CHANGELOG.md"
+		"CHANGELOG.md",
+		"scripts/check-extensions.mjs"
 	],
 	"scripts": {
+		"check": "node --experimental-strip-types scripts/check-extensions.mjs .",
 		"test": "vitest",
 		"test:ui": "vitest --ui",
 		"test:run": "vitest run"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"lib/**/*.ts",
 		"usage/**/*.ts",
 		"provider-failover/**/*.ts",
+		"widget/**/*.ts",
 		"config.ts",
 		"constants.ts",
 		"provider-factory.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"type": "module",
 	"description": "AIO Free AI models for Pi - Access free models from Kilo, Zen, OpenRouter, NVIDIA, Cline, Mistral, and Ollama",
 	"keywords": [

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -1,49 +1,87 @@
 /**
- * Verifies all pi extension entry points can be loaded after install.
- * Catches "Cannot find module" errors caused by missing files in the npm package.
+ * Verifies all relative imports in the published package resolve to real files.
+ * Catches "Cannot find module" errors from missing files in the npm tarball.
  *
- * Usage: node scripts/check-extensions.mjs <install-dir>
- * Example: node scripts/check-extensions.mjs $(npm root -g)/pi-free
+ * Usage:
+ *   node scripts/check-extensions.mjs           # from source (uses npm pack --dry-run)
+ *   node scripts/check-extensions.mjs <dir>     # from installed location
  */
 
-import { readFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
-import { join, resolve } from "node:path";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { execSync } from "node:child_process";
 
 const installDir = resolve(process.argv[2] ?? ".");
-const pkg = JSON.parse(readFileSync(join(installDir, "package.json"), "utf8"));
-const extensions = pkg.pi?.extensions ?? [];
+const fromSource = process.argv[2] == null;
 
-if (extensions.length === 0) {
-  console.error("No pi.extensions found in package.json");
-  process.exit(1);
+function getFiles() {
+  if (fromSource) {
+    // Use npm pack --dry-run to get exactly the files that would be published
+    const out = execSync("npm pack --dry-run 2>&1", { encoding: "utf8" });
+    return out
+      .split("\n")
+      .map(l => l.match(/npm notice [\d.]+\w+\s+(.+)/)?.[1]?.trim())
+      .filter(f => f && (f.endsWith(".ts") || f.endsWith(".mjs")))
+      .map(f => join(installDir, f));
+  }
+  // Installed location: walk all .ts/.mjs files
+  const files = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (entry === "node_modules") continue;
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith(".ts") || entry.endsWith(".mjs")) files.push(full);
+    }
+  }
+  walk(installDir);
+  return files;
 }
 
-console.log(`Checking ${extensions.length} extension(s) in: ${installDir}\n`);
+function resolveImport(fromFile, importPath) {
+  const base = join(dirname(fromFile), importPath);
+  for (const candidate of [
+    base,
+    base.replace(/\.js$/, ".ts"),   // .js → .ts (TypeScript ESM convention)
+    base + ".ts",
+    join(base, "index.ts"),
+  ]) {
+    try { if (statSync(candidate).isFile()) return candidate; } catch {}
+  }
+  return null;
+}
 
+const files = getFiles();
+console.log(`Checking ${files.length} file(s) in: ${installDir}\n`);
+
+let totalImports = 0;
 let failed = 0;
+const seen = new Set();
 
-for (const ext of extensions) {
-  const file = ext.replace(/^\.\//, "");
-  const fullPath = join(installDir, file);
-  const url = pathToFileURL(fullPath).href;
-
-  process.stdout.write(`  ${file} ... `);
-  try {
-    await import(url);
-    console.log("✓");
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (msg.includes("Cannot find module") || msg.includes("Cannot find package") || msg.includes("ERR_MODULE_NOT_FOUND")) {
-      console.log("✗ FAILED");
-      console.error(`    → ${msg.split("\n")[0]}`);
+for (const file of files) {
+  const src = readFileSync(file, "utf8");
+  const relFile = file.slice(installDir.length + 1).replace(/\\/g, "/");
+  // Strip comments before matching imports
+  const stripped = src.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+  const importRe = /from\s+['"](\.[^'"]+)['"]/g;
+  let match;
+  while ((match = importRe.exec(stripped)) !== null) {
+    const importPath = match[1];
+    const key = `${relFile}:${importPath}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    totalImports++;
+    if (!resolveImport(file, importPath)) {
+      console.error(`  ✗ ${relFile}`);
+      console.error(`      imports '${importPath}' → NOT FOUND`);
       failed++;
-    } else {
-      // Non-module errors (missing pi API, config issues) are expected in a stub env
-      console.log(`✓ (runtime error ignored: ${msg.slice(0, 80)})`);
     }
   }
 }
 
-console.log(`\n${failed === 0 ? "All extensions loaded OK" : `${failed} extension(s) failed`}`);
+console.log(`Checked ${totalImports} relative import(s) across ${files.length} file(s).`);
+console.log(failed === 0
+  ? `\nAll imports resolve OK ✓`
+  : `\n${failed} import(s) could not be resolved ✗`);
+
 process.exit(failed > 0 ? 1 : 0);

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -1,0 +1,49 @@
+/**
+ * Verifies all pi extension entry points can be loaded after install.
+ * Catches "Cannot find module" errors caused by missing files in the npm package.
+ *
+ * Usage: node scripts/check-extensions.mjs <install-dir>
+ * Example: node scripts/check-extensions.mjs $(npm root -g)/pi-free
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { join, resolve } from "node:path";
+
+const installDir = resolve(process.argv[2] ?? ".");
+const pkg = JSON.parse(readFileSync(join(installDir, "package.json"), "utf8"));
+const extensions = pkg.pi?.extensions ?? [];
+
+if (extensions.length === 0) {
+  console.error("No pi.extensions found in package.json");
+  process.exit(1);
+}
+
+console.log(`Checking ${extensions.length} extension(s) in: ${installDir}\n`);
+
+let failed = 0;
+
+for (const ext of extensions) {
+  const file = ext.replace(/^\.\//, "");
+  const fullPath = join(installDir, file);
+  const url = pathToFileURL(fullPath).href;
+
+  process.stdout.write(`  ${file} ... `);
+  try {
+    await import(url);
+    console.log("✓");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("Cannot find module") || msg.includes("Cannot find package") || msg.includes("ERR_MODULE_NOT_FOUND")) {
+      console.log("✗ FAILED");
+      console.error(`    → ${msg.split("\n")[0]}`);
+      failed++;
+    } else {
+      // Non-module errors (missing pi API, config issues) are expected in a stub env
+      console.log(`✓ (runtime error ignored: ${msg.slice(0, 80)})`);
+    }
+  }
+}
+
+console.log(`\n${failed === 0 ? "All extensions loaded OK" : `${failed} extension(s) failed`}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Avoids false positives from test files not in the tarball. Also drops --experimental-strip-types (script is plain .mjs).