### PR TITLE
feat: auto-switch failover for rate limits

### DIFF
--- a/.github/workflows/update-benchmarks.yml
+++ b/.github/workflows/update-benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '20'
           
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         
       - name: Update benchmark data
         env:

--- a/lib/model-detection.ts
+++ b/lib/model-detection.ts
@@ -1,0 +1,268 @@
+/**
+ * Model detection utilities for pi-free-providers.
+ * Extracts and adapts model family detection from pi-models.
+ * Used for failover when providers hit rate limits.
+ */
+
+import type { Model } from "@mariozechner/pi-ai";
+import type { ProviderModelConfig } from "./types.ts";
+
+export interface ModelInfo {
+	id: string;
+	name?: string;
+	provider: string;
+	isFree: boolean;
+	inputCost: number;
+	outputCost: number;
+}
+
+export interface ModelFamily {
+	id: string; // Normalized family ID (e.g., "claude-sonnet")
+	displayName: string; // Human readable (e.g., "Claude Sonnet")
+	models: ModelInfo[]; // All models in this family
+}
+
+/**
+ * Check if a model is free (zero input and output cost)
+ */
+export function isModelFree(model: {
+	cost?: { input: number; output: number };
+}): boolean {
+	if (!model.cost) return true;
+	return model.cost.input === 0 && model.cost.output === 0;
+}
+
+/**
+ * Convert Pi's Model type to ModelInfo for internal use
+ */
+export function toModelInfo(model: Model<any>): ModelInfo {
+	return {
+		id: model.id,
+		name: model.name,
+		provider: model.provider,
+		isFree: isModelFree(model),
+		inputCost: model.cost?.input ?? 0,
+		outputCost: model.cost?.output ?? 0,
+	};
+}
+
+/**
+ * Convert ProviderModelConfig to ModelInfo for internal use
+ */
+export function toProviderModelInfo(model: ProviderModelConfig): ModelInfo {
+	return {
+		id: model.id,
+		name: model.name,
+		provider: "", // Will be set by caller
+		isFree: isModelFree(model),
+		inputCost: model.cost?.input ?? 0,
+		outputCost: model.cost?.output ?? 0,
+	};
+}
+
+/**
+ * Detect the model family from a model's ID or name.
+ * Returns the family ID and display name.
+ */
+export function detectModelFamily(
+	model: ModelInfo,
+): { familyId: string; familyName: string } | null {
+	const id = model.id.toLowerCase();
+	const name = (model.name || "").toLowerCase();
+	const fullText = `${id} ${name}`;
+
+	// Router models (gateways to free models) - group into "other"
+	if (/\brouter\b/.test(fullText) || /\bauto\b/.test(fullText) || id === "kilo-auto/free") {
+		return { familyId: "other", familyName: "Other" };
+	}
+
+	// Known brand keywords - order matters: more specific/longer matches first
+	const brandMappings: {
+		keywords: string[];
+		familyId: string;
+		familyName: string;
+	}[] = [
+		{ keywords: ["claude"], familyId: "claude", familyName: "Claude" },
+		{ keywords: ["deepseek"], familyId: "deepseek", familyName: "DeepSeek" },
+		{ keywords: ["gemini"], familyId: "gemini", familyName: "Gemini" },
+		{ keywords: ["gpt"], familyId: "gpt", familyName: "GPT" },
+		{ keywords: ["llama"], familyId: "llama", familyName: "Llama" },
+		{ keywords: ["minimax"], familyId: "minimax", familyName: "MiniMax" },
+		{ keywords: ["qwen"], familyId: "qwen", familyName: "Qwen" },
+		{ keywords: ["nemotron"], familyId: "nemotron", familyName: "Nemotron" },
+		{ keywords: ["kimi", "moonshot"], familyId: "kimi", familyName: "Kimi" },
+		{ keywords: ["glm", "chatglm"], familyId: "glm", familyName: "GLM" },
+		{ keywords: ["mistral"], familyId: "mistral", familyName: "Mistral" },
+		{ keywords: ["arcee", "trinity"], familyId: "arcee", familyName: "Arcee" },
+		{ keywords: ["o1", "o3"], familyId: "openai-o", familyName: "OpenAI o" },
+	];
+
+	// Check for known brands in ID or name
+	for (const mapping of brandMappings) {
+		for (const keyword of mapping.keywords) {
+			if (fullText.includes(keyword)) {
+				return { familyId: mapping.familyId, familyName: mapping.familyName };
+			}
+		}
+	}
+
+	// Provider-specific fallbacks for models without brand in ID/name
+	const providerMappings: Record<string, { familyId: string; familyName: string }> = {
+		minimax: { familyId: "minimax", familyName: "MiniMax" },
+		minimaxai: { familyId: "minimax", familyName: "MiniMax" },
+		deepseek: { familyId: "deepseek", familyName: "DeepSeek" },
+		nvidia: { familyId: "nemotron", familyName: "Nemotron" },
+		moonshot: { familyId: "kimi", familyName: "Kimi" },
+		zhipu: { familyId: "glm", familyName: "GLM" },
+	};
+
+	if (providerMappings[model.provider]) {
+		return providerMappings[model.provider];
+	}
+
+	// Helper to find brand in ID parts
+	function findBrandInParts(parts: string[]): { familyId: string; familyName: string } | null {
+		for (const part of parts) {
+			for (const mapping of brandMappings) {
+				for (const keyword of mapping.keywords) {
+					if (part.includes(keyword)) {
+						return { familyId: mapping.familyId, familyName: mapping.familyName };
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	// Smart fallback: try to identify brand from model ID structure
+	const parts = id.split(/[-_:.@]/);
+	const firstPart = parts[0];
+
+	// If ID starts with a version number, check remaining parts for brand
+	if (firstPart && /^v?\d+(\.\d+)?$/.test(firstPart)) {
+		const brandFromParts = findBrandInParts(parts.slice(1));
+		if (brandFromParts) {
+			return brandFromParts;
+		}
+	}
+
+	// If ID has multiple parts, check ALL parts for brand keywords
+	if (parts.length > 1) {
+		const brandFromParts = findBrandInParts(parts);
+		if (brandFromParts) {
+			return brandFromParts;
+		}
+
+		// Use first part as brand if it looks brand-like
+		if (firstPart && !/^v?\d+(\.\d+)?$/.test(firstPart)) {
+			return {
+				familyId: firstPart,
+				familyName: firstPart.charAt(0).toUpperCase() + firstPart.slice(1),
+			};
+		}
+	}
+
+	// Last resort: use first non-version part
+	if (firstPart && /^v?\d+(\.\d+)?$/.test(firstPart) && parts.length > 1) {
+		for (let i = 1; i < parts.length; i++) {
+			const part = parts[i];
+			if (
+				part &&
+				!/^v?\d+(\.\d+)?$/.test(part) &&
+				!["latest", "preview", "rc", "beta", "alpha", "dev", "free"].includes(part)
+			) {
+				return {
+					familyId: part,
+					familyName: part.charAt(0).toUpperCase() + part.slice(1),
+				};
+			}
+		}
+	}
+
+	return {
+		familyId: firstPart || id,
+		familyName: (firstPart || id).charAt(0).toUpperCase() + (firstPart || id).slice(1),
+	};
+}
+
+/**
+ * Normalize a model name for comparison by removing provider-specific suffixes
+ * and common qualifiers. This helps detect when the same model is offered by
+ * multiple providers with slightly different naming.
+ */
+export function normalizeModelName(name: string): string {
+	return (
+		name
+			.toLowerCase()
+			// Remove common suffixes added by providers
+			.replace(/\s*\(free\)\s*$/i, "")
+			.replace(/\s*\(cline\)\s*$/i, "")
+			.replace(/\s*\(ci:\s*[\d.]+\)\s*$/i, "")
+			.replace(/\s*\[ci:\s*[\d.]+\]\s*$/i, "")
+			.replace(/\s*\([^)]*\)\s*$/g, "") // Remove any trailing parenthetical
+			.replace(/\s*-\s*free\s*$/i, "") // e.g., "minimax-m2.5-free"
+			.replace(/\s*free\s*$/i, "") // trailing "free"
+			.trim()
+	);
+}
+
+/**
+ * Get all model families from a list of models.
+ * Groups models by family and merges same-name models across providers.
+ */
+export function getModelFamilies(models: ModelInfo[]): ModelFamily[] {
+	const byFamily = new Map<string, ModelInfo[]>();
+	const nameToFamilyId = new Map<string, string>();
+
+	for (const model of models) {
+		const family = detectModelFamily(model);
+		if (!family) continue;
+
+		const existing = byFamily.get(family.familyId) ?? [];
+		existing.push(model);
+		byFamily.set(family.familyId, existing);
+	}
+
+	// Second pass: merge families with models that have the same normalized name
+	const familyIds = [...byFamily.keys()];
+	for (const familyId of familyIds) {
+		const familyModels = byFamily.get(familyId);
+		if (!familyModels) continue;
+
+		for (const model of familyModels) {
+			const normalizedName = normalizeModelName(model.name || model.id);
+			if (!normalizedName) continue;
+
+			const existingFamilyForName = nameToFamilyId.get(normalizedName);
+			if (existingFamilyForName && existingFamilyForName !== familyId) {
+				// Same model name found in different family - merge them
+				const targetFamily = byFamily.get(existingFamilyForName);
+				const sourceFamily = byFamily.get(familyId);
+				if (targetFamily && sourceFamily) {
+					targetFamily.push(...sourceFamily);
+					byFamily.delete(familyId);
+					break;
+				}
+			} else {
+				nameToFamilyId.set(normalizedName, familyId);
+			}
+		}
+	}
+
+	const families: ModelFamily[] = [];
+	for (const [id, familyModels] of byFamily) {
+		const firstModel = familyModels[0]!;
+		const familyInfo = detectModelFamily(firstModel)!;
+
+		families.push({
+			id,
+			displayName: familyInfo.familyName,
+			models: familyModels.sort(
+				(a, b) =>
+					a.provider.localeCompare(b.provider) || b.id.localeCompare(a.id),
+			),
+		});
+	}
+
+	return families.sort((a, b) => a.displayName.localeCompare(b.displayName));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,821 @@
 {
-	"name": "pi-free-providers",
+	"name": "pi-free",
 	"version": "1.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "pi-free-providers",
+			"name": "pi-free",
 			"version": "1.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^1.0.0",
 				"tsx": "^4.0.0",
 				"vitest": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@mariozechner/pi-ai": "*",
+				"@mariozechner/pi-coding-agent": "*",
+				"@mariozechner/pi-tui": "*",
+				"@sinclair/typebox": "*"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1024.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1024.0.tgz",
+			"integrity": "sha512-nIhsn0/eYrL2fTh4kMO7Hpfmhv+AkkXl0KGNpD6+fdmotGvRBWcDv9/PmP/+sT6gvrKTYyzH3vu4efpTPzzP0Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-node": "^3.972.29",
+				"@aws-sdk/eventstream-handler-node": "^3.972.12",
+				"@aws-sdk/middleware-eventstream": "^3.972.8",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/middleware-websocket": "^3.972.14",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/token-providers": "3.1024.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.12",
+				"@smithy/eventstream-serde-node": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-stream": "^4.5.21",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.973.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+			"integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/xml-builder": "^3.972.16",
+				"@smithy/core": "^3.23.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+			"integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+			"integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.21",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+			"integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-env": "^3.972.24",
+				"@aws-sdk/credential-provider-http": "^3.972.26",
+				"@aws-sdk/credential-provider-login": "^3.972.28",
+				"@aws-sdk/credential-provider-process": "^3.972.24",
+				"@aws-sdk/credential-provider-sso": "^3.972.28",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.28",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+			"integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+			"integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.24",
+				"@aws-sdk/credential-provider-http": "^3.972.26",
+				"@aws-sdk/credential-provider-ini": "^3.972.28",
+				"@aws-sdk/credential-provider-process": "^3.972.24",
+				"@aws-sdk/credential-provider-sso": "^3.972.28",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.28",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+			"integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+			"integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/token-providers": "3.1021.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1021.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+			"integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+			"integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+			"integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+			"integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+			"integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+			"integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+			"integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+			"integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@smithy/core": "^3.23.13",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-retry": "^4.2.13",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+			"integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-format-url": "^3.972.8",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.996.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+			"integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+			"integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1024.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1024.0.tgz",
+			"integrity": "sha512-eoyTMgd6OzoE1dq50um5Y53NrosEkWsjH0W6pswi7vrv1W9hY/7hR43jDcPevqqj+OQksf/5lc++FTqRlb8Y1Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+			"integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-endpoints": "^3.3.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+			"integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+			"integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+			"integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"fast-xml-parser": "5.5.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -456,6 +1260,30 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@google/genai": {
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.48.0.tgz",
+			"integrity": "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -475,6 +1303,327 @@
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+			"integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+				"@mariozechner/clipboard-darwin-universal": "0.3.2",
+				"@mariozechner/clipboard-darwin-x64": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+			"integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+			"integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+			"integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+			"integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+			"integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+			"integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+			"integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/jiti": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"std-env": "^3.10.0",
+				"yoctocolors": "^2.1.2"
+			},
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.65.2.tgz",
+			"integrity": "sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.65.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.65.2.tgz",
+			"integrity": "sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.73.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "1.14.1",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai/node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.65.2.tgz",
+			"integrity": "sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.65.2",
+				"@mariozechner/pi-ai": "^0.65.2",
+				"@mariozechner/pi-tui": "^0.65.2",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"ajv": "^8.17.1",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.65.2.tgz",
+			"integrity": "sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+			"integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+			"peer": true,
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.24.1"
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -520,6 +1669,80 @@
 			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.60.0",
@@ -871,12 +2094,731 @@
 				"win32"
 			]
 		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.10",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
 			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "4.4.13",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+			"integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.23.13",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+			"integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-stream": "^4.5.21",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+			"integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+			"integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+			"integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+			"integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+			"integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+			"integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.15",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+			"integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+			"integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+			"integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+			"integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.28",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+			"integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.13",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.4.46",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
+			"integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.16",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+			"integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.13",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+			"integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+			"integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+			"integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+			"integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+			"integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+			"integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+			"integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+			"integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+			"integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+			"integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.12.8",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+			"integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.13",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.21",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+			"integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/querystring-parser": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.44",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
+			"integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.48",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
+			"integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+			"integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+			"integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
+			"integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "4.5.21",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+			"integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -884,6 +2826,41 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/node": {
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+			"integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@vitest/expect": {
 			"version": "1.6.1",
@@ -1007,6 +2984,64 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
 		"node_modules/ansi-styles": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1020,6 +3055,13 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1028,6 +3070,90 @@
 			"license": "MIT",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -1042,6 +3168,23 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/cac": {
 			"version": "6.7.14",
@@ -1072,6 +3215,19 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/check-error": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -1084,6 +3240,116 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/confbox": {
 			"version": "0.1.8",
@@ -1107,11 +3373,20 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -1138,6 +3413,31 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -1146,6 +3446,33 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/esbuild": {
@@ -1190,6 +3517,62 @@
 				"@esbuild/win32-x64": "0.27.4"
 			}
 		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1198,6 +3581,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/execa": {
@@ -1224,6 +3617,57 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/extract-zip/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1241,6 +3685,60 @@
 				"node": ">=8.6.0"
 			}
 		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1251,12 +3749,65 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/fflate": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
 			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
@@ -1278,6 +3829,19 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1291,6 +3855,59 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-func-name": {
@@ -1329,6 +3946,49 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1342,6 +4002,102 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/human-signals": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -1352,6 +4108,47 @@
 				"node": ">=16.17.0"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1360,6 +4157,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
@@ -1412,6 +4219,72 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/koffi": {
+			"version": "2.15.5",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.5.tgz",
+			"integrity": "sha512-4/35/oOpnH9tzrpWAC3ObjAERBSe0Q0Dh2NP1eBBPRGpohEj4vFw2+7tej9W9MTExvk0vtF0PjMqIGG4rf6feQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"url": "https://liberapay.com/Koromix"
+			}
+		},
 		"node_modules/local-pkg": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -1429,6 +4302,13 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
 		"node_modules/loupe": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -1439,6 +4319,16 @@
 				"get-func-name": "^2.0.1"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
+			"integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1447,6 +4337,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -1480,6 +4383,33 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/mimic-fn": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -1491,6 +4421,32 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/mlly": {
@@ -1527,8 +4483,19 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -1547,6 +4514,56 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -1578,6 +4595,26 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
 		"node_modules/onetime": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -1592,6 +4629,28 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/p-limit": {
@@ -1610,6 +4669,101 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
+			"integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1618,6 +4772,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/pathe": {
@@ -1636,6 +4807,13 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -1720,6 +4898,108 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1748,6 +5028,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/resolve-pkg-maps": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1756,6 +5056,16 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/reusify": {
@@ -1838,6 +5148,27 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1896,6 +5227,58 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1917,8 +5300,61 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
 		},
 		"node_modules/strip-final-newline": {
 			"version": "3.0.0",
@@ -1944,6 +5380,72 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+			"integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/tinybench": {
@@ -1986,6 +5488,25 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -1995,6 +5516,20 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tsx": {
 			"version": "4.21.0",
@@ -2032,6 +5567,36 @@
 			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+			"integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/vite": {
 			"version": "5.4.21",
@@ -2612,6 +6177,16 @@
 				}
 			}
 		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2645,6 +6220,158 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
@@ -2656,6 +6383,39 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/provider-failover/auto-switch.ts
+++ b/provider-failover/auto-switch.ts
@@ -1,0 +1,346 @@
+/**
+ * Auto-switch failover for pi-free-providers.
+ * 
+ * When a provider hits a 429 or capacity error, this module finds
+ * an equivalent or similar model from another provider and switches to it.
+ * 
+ * Strategy:
+ * 1. Extract the base model name/family from the failed model
+ * 2. Search all available models for the same model (different provider)
+ * 3. If not found, find a similar model in the same family
+ * 4. If not found, find any free model with similar capability
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { Model } from "@mariozechner/pi-ai";
+import { createLogger } from "../lib/logger.ts";
+import {
+	detectModelFamily,
+	normalizeModelName,
+	toModelInfo,
+	isModelFree,
+	type ModelInfo,
+} from "../lib/model-detection.ts";
+import { getHardcodedScore } from "./hardcoded-benchmarks.ts";
+
+const _logger = createLogger("auto-switch");
+
+export interface AutoSwitchConfig {
+	/** Whether to enable auto-switching (can be disabled by user) */
+	enabled: boolean;
+	/** Maximum CI score degradation allowed (e.g., 10 = can drop up to 10 points) */
+	maxCIScoreDrop: number;
+	/** Provider priority for fallback (preferred first) */
+	providerPriority: string[];
+}
+
+const DEFAULT_CONFIG: AutoSwitchConfig = {
+	enabled: true,
+	maxCIScoreDrop: 15,
+	providerPriority: ["zen", "kilo", "openrouter", "nvidia", "fireworks", "mistral", "ollama", "cline"],
+};
+
+export interface AutoSwitchResult {
+	success: boolean;
+	switched: boolean;
+	message: string;
+	fallbackModel?: ModelInfo;
+}
+
+interface CandidateModel {
+	model: Model<any>;
+	modelInfo: ModelInfo;
+	ciScore: number;
+	normalizedName: string;
+	family: string;
+}
+
+/**
+ * Find a fallback model when the current provider fails.
+ * 
+ * Priority order:
+ * 1. Same model name from different provider (best match)
+ * 2. Same model family, prefer free models
+ * 3. Any free model with similar CI score
+ */
+export async function findFallbackModel(
+	failedModel: Model<any>,
+	availableModels: Model<any>[],
+	config: Partial<AutoSwitchConfig> = {},
+): Promise<CandidateModel | null> {
+	const fullConfig = { ...DEFAULT_CONFIG, ...config };
+
+	// Convert to ModelInfo for internal processing
+	const failedModelInfo = toModelInfo(failedModel);
+	const failedFamily = detectModelFamily(failedModelInfo);
+	const failedNormalizedName = normalizeModelName(failedModelInfo.name || failedModelInfo.id);
+	const failedCIScore = getHardcodedScore(failedModel.name || "", failedModel.id) ?? 30;
+
+	_logger.info("Finding fallback model", {
+		failedModel: failedModel.id,
+		failedProvider: failedModel.provider,
+		failedFamily: failedFamily?.familyId,
+		failedNormalizedName: failedNormalizedName,
+		failedCIScore,
+	});
+
+	// Build candidate list
+	const candidates: CandidateModel[] = [];
+
+	for (const candidate of availableModels) {
+		// Skip the same provider
+		if (candidate.provider === failedModel.provider) continue;
+
+		// Skip if no auth configured for this provider
+		// (We'll assume available models have auth, but check anyway)
+		if (!candidate.baseUrl) continue;
+
+		const modelInfo = toModelInfo(candidate);
+		const family = detectModelFamily(modelInfo);
+		const normalizedName = normalizeModelName(modelInfo.name || modelInfo.id);
+		const ciScore = getHardcodedScore(candidate.name || "", candidate.id) ?? 30;
+
+		candidates.push({
+			model: candidate,
+			modelInfo,
+			ciScore,
+			normalizedName,
+			family: family?.familyId ?? "other",
+		});
+	}
+
+	if (candidates.length === 0) {
+		_logger.info("No candidate models found");
+		return null;
+	}
+
+	// Priority 1: Same model name (different provider)
+	// e.g., "minimax-m2.5" on zen → "minimax-m2.5" on openrouter
+	const sameName = candidates.find(
+		(c) => c.normalizedName === failedNormalizedName && c.model.provider !== failedModel.provider,
+	);
+	if (sameName) {
+		_logger.info("Found exact model match", {
+			provider: sameName.model.provider,
+			model: sameName.model.id,
+		});
+		return sameName;
+	}
+
+	// Priority 2: Same model family, prefer free models
+	const sameFamily = candidates
+		.filter((c) => c.family === failedFamily?.familyId && c.model.provider !== failedModel.provider)
+		.sort((a, b) => {
+			// Prefer free models
+			if (a.modelInfo.isFree !== b.modelInfo.isFree) {
+				return a.modelInfo.isFree ? -1 : 1;
+			}
+			// Then by CI score
+			return b.ciScore - a.ciScore;
+		});
+
+	if (sameFamily.length > 0) {
+		const best = sameFamily[0]!;
+		_logger.info("Found same family model", {
+			provider: best.model.provider,
+			model: best.model.id,
+			family: best.family,
+			isFree: best.modelInfo.isFree,
+			ciScore: best.ciScore,
+		});
+		return best;
+	}
+
+	// Priority 3: Any free model with similar CI score
+	// Check CI score degradation limit
+	const freeCandidates = candidates
+		.filter((c) => {
+			// Must be free
+			if (!c.modelInfo.isFree) return false;
+			// Must not drop CI score too much
+			const ciDrop = failedCIScore - c.ciScore;
+			return ciDrop <= fullConfig.maxCIScoreDrop;
+		})
+		.sort((a, b) => {
+			// Sort by CI score (closest to failed model first)
+			return b.ciScore - a.ciScore;
+		});
+
+	if (freeCandidates.length > 0) {
+		const best = freeCandidates[0]!;
+		_logger.info("Found free fallback model", {
+			provider: best.model.provider,
+			model: best.model.id,
+			ciScore: best.ciScore,
+			ciDrop: failedCIScore - best.ciScore,
+		});
+		return best;
+	}
+
+	// Priority 4: Any free model (no CI limit)
+	const anyFree = candidates
+		.filter((c) => c.modelInfo.isFree)
+		.sort((a, b) => b.ciScore - a.ciScore);
+
+	if (anyFree.length > 0) {
+		const best = anyFree[0]!;
+		_logger.info("Found any free fallback", {
+			provider: best.model.provider,
+			model: best.model.id,
+			ciScore: best.ciScore,
+		});
+		return best;
+	}
+
+	// Priority 5: Any model with similar CI score
+	const similarCI = candidates
+		.filter((c) => {
+			const ciDrop = failedCIScore - c.ciScore;
+			return ciDrop <= fullConfig.maxCIScoreDrop;
+		})
+		.sort((a, b) => {
+			// Prefer providers in priority order
+			const aPriority = fullConfig.providerPriority.indexOf(a.model.provider);
+			const bPriority = fullConfig.providerPriority.indexOf(b.model.provider);
+			if (aPriority !== bPriority && aPriority >= 0 && bPriority >= 0) {
+				return aPriority - bPriority;
+			}
+			// Then by CI score
+			return b.ciScore - a.ciScore;
+		});
+
+	if (similarCI.length > 0) {
+		const best = similarCI[0]!;
+		_logger.info("Found similar CI fallback", {
+			provider: best.model.provider,
+			model: best.model.id,
+			ciScore: best.ciScore,
+		});
+		return best;
+	}
+
+	// Last resort: any model, prefer by provider priority
+	const anyModel = candidates.sort((a, b) => {
+		const aPriority = fullConfig.providerPriority.indexOf(a.model.provider);
+		const bPriority = fullConfig.providerPriority.indexOf(b.model.provider);
+		if (aPriority !== bPriority && aPriority >= 0 && bPriority >= 0) {
+			return aPriority - bPriority;
+		}
+		return b.ciScore - a.ciScore;
+	});
+
+	if (anyModel.length > 0) {
+		const best = anyModel[0]!;
+		_logger.info("Found any fallback", {
+			provider: best.model.provider,
+			model: best.model.id,
+			ciScore: best.ciScore,
+		});
+		return best;
+	}
+
+	return null;
+}
+
+/**
+ * Perform automatic failover when a provider hits an error.
+ * Returns the result of the switch attempt.
+ */
+export async function autoFailover(
+	errorMessage: string,
+	failedModel: Model<any>,
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	config: Partial<AutoSwitchConfig> = {},
+): Promise<AutoSwitchResult> {
+	if (!config.enabled) {
+		return {
+			success: false,
+			switched: false,
+			message: "Auto-switch disabled",
+		};
+	}
+
+	// Get all available models
+	const availableModels = ctx.modelRegistry.getAvailable();
+
+	if (availableModels.length === 0) {
+		return {
+			success: false,
+			switched: false,
+			message: "No alternative models available",
+		};
+	}
+
+	// Find fallback model
+	const fallback = await findFallbackModel(failedModel, availableModels, config);
+
+	if (!fallback) {
+		return {
+			success: false,
+			switched: false,
+			message: `No fallback model found for ${failedModel.provider}/${failedModel.id}`,
+		};
+	}
+
+	// Attempt to switch
+	const success = await pi.setModel(fallback.model);
+
+	if (success) {
+		const freeStatus = fallback.modelInfo.isFree ? " (free)" : "";
+		return {
+			success: true,
+			switched: true,
+			message: `Switched from ${failedModel.provider} to ${fallback.model.provider}/${fallback.model.id}${freeStatus}`,
+			fallbackModel: fallback.modelInfo,
+		};
+	} else {
+		return {
+			success: false,
+			switched: false,
+			message: `Failed to switch to ${fallback.model.provider}/${fallback.model.id} (no API key?)`,
+			fallbackModel: fallback.modelInfo,
+		};
+	}
+}
+
+/**
+ * Check if a model is available from multiple providers
+ */
+export function getModelAvailability(
+	modelId: string,
+	availableModels: Model<any>[],
+): string[] {
+	const normalizedName = normalizeModelName(modelId);
+
+	return availableModels
+		.filter((m) => {
+			const mNormalized = normalizeModelName(m.name || m.id);
+			return mNormalized === normalizedName;
+		})
+		.map((m) => m.provider);
+}
+
+/**
+ * Get a summary of available models grouped by family
+ */
+export function getModelAvailabilitySummary(
+	availableModels: Model<any>[],
+): Map<string, string[]> {
+	const families = new Map<string, string[]>();
+
+	for (const model of availableModels) {
+		const modelInfo = toModelInfo(model);
+		const family = detectModelFamily(modelInfo);
+
+		if (!family) continue;
+
+		const existing = families.get(family.familyId) ?? [];
+		if (!existing.includes(model.provider)) {
+			existing.push(model.provider);
+		}
+		families.set(family.familyId, existing);
+	}
+
+	return families;
+}

--- a/provider-failover/hardcoded-benchmarks.ts
+++ b/provider-failover/hardcoded-benchmarks.ts
@@ -9842,11 +9842,29 @@ export const HARDCODED_BENCHMARKS: Record<string, HardcodedBenchmark> = {
 /**
  * Find benchmark data by model name
  */
+/**
+ * Normalize a model ID/name for benchmark lookup.
+ * Only strips trailing "free" suffix - preserves the core model name.
+ */
+function normalizeForBenchmark(input: string): string {
+	return (
+		input
+			.toLowerCase()
+			// Only remove "free" at the end (with optional separator)
+			.replace(/[-_]?free$/i, "")
+			// Remove trailing separators that might remain
+			.replace(/[-_]+$/, "")
+	);
+}
+
 export function findHardcodedBenchmark(
 	modelName: string,
 	modelId: string,
 ): HardcodedBenchmark | null {
-	const search = `${modelName} ${modelId}`.toLowerCase();
+	// Normalize both inputs for matching
+	const normalizedName = normalizeForBenchmark(modelName);
+	const normalizedId = normalizeForBenchmark(modelId);
+	const search = `${normalizedName} ${normalizedId}`.toLowerCase();
 
 	// Direct lookup
 	for (const [key, data] of Object.entries(HARDCODED_BENCHMARKS)) {
@@ -9855,7 +9873,7 @@ export function findHardcodedBenchmark(
 		}
 	}
 
-	// Variant matching
+	// Variant matching - normalize variants too
 	const variants: Record<string, string[]> = {
 		"gpt-4o": ["gpt-4o", "gpt-4-o"],
 		"gpt-4": ["gpt-4", "gpt4"],
@@ -9871,12 +9889,16 @@ export function findHardcodedBenchmark(
 		"qwen2.5-72b": ["qwen2.5-72b", "qwen-2.5-72b"],
 		"deepseek-v3": ["deepseek-v3", "deepseekv3", "deepseek-chat"],
 		"mimo-v2-pro": ["mimo-v2-pro", "mimo-v2-pro-free", "mimo-pro"],
+		"mimo-v2-omni": ["mimo-v2-omni", "mimo-v2-omni-free", "mimo-omni"],
+		"mimo-v2-flash": ["mimo-v2-flash", "mimo-v2-flash-free", "mimo-flash"],
 		"big-pickle": ["big-pickle", "bigpickle"],
 		"minimax-m2.5": ["minimax-m2.5", "minimax-m2.5-free", "minimax-m25"],
+		"trinity-large-preview": ["trinity-large-preview", "trinity-large", "trinity-preview", "arcee-trinity"],
+		"nemotron-3-super": ["nemotron-3-super", "nemotron-super", "nemotron-3"],
 	};
 
 	for (const [canonical, names] of Object.entries(variants)) {
-		if (names.some((n) => search.includes(n.toLowerCase()))) {
+		if (names.some((n) => normalizeForBenchmark(n).length > 0 && search.includes(normalizeForBenchmark(n)))) {
 			return HARDCODED_BENCHMARKS[canonical] || null;
 		}
 	}

--- a/provider-failover/index.ts
+++ b/provider-failover/index.ts
@@ -3,13 +3,16 @@
  * Coordinates error detection and provider switching
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { createLogger } from "../lib/logger.ts";
 import {
 	type ClassifiedError,
 	classifyError,
 	logErrorClassification,
-} from "./errors.js";
+} from "./errors.ts";
+import { autoFailover, findFallbackModel, type AutoSwitchConfig } from "./auto-switch.ts";
+
+export type { AutoSwitchConfig } from "./auto-switch.ts";
 
 const _logger = createLogger("failover");
 
@@ -19,13 +22,18 @@ export interface FailoverConfig {
 
 	// Whether this provider is in paid mode
 	isPaidMode: boolean;
+
+	// Auto-switch configuration
+	autoSwitch?: Partial<AutoSwitchConfig>;
 }
 
 export interface FailoverResult {
-	action: "retry" | "fail";
+	action: "retry" | "fail" | "switch";
 	message: string;
 	shouldRetry: boolean;
 	retryDelayMs?: number;
+	/** The model to switch to */
+	switchToModel?: string;
 }
 
 // Track consecutive failures per provider
@@ -38,15 +46,16 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 export async function handleProviderError(
 	error: unknown,
 	config: FailoverConfig,
-	_pi: ExtensionAPI,
+	pi: ExtensionAPI,
 	ctx: {
 		ui: {
 			notify: (message: string, type: "info" | "warning" | "error") => void;
 		};
+		model?: { provider?: string; id?: string };
 		session?: { id?: string };
 	},
 ): Promise<FailoverResult> {
-	const { provider, isPaidMode } = config;
+	const { provider, isPaidMode, autoSwitch } = config;
 
 	// Classify the error
 	const classified = classifyError(error);
@@ -64,10 +73,10 @@ export async function handleProviderError(
 
 	switch (classified.type) {
 		case "rate_limit":
-			return handleRateLimit(classified, provider, isPaidMode, ctx);
+			return handleRateLimit(classified, provider, isPaidMode, ctx, pi, autoSwitch);
 
 		case "capacity":
-			return handleCapacityError(classified, provider);
+			return handleCapacityError(classified, provider, ctx, pi, autoSwitch);
 
 		case "auth":
 			return handleAuthError(classified, provider);
@@ -91,11 +100,27 @@ function handleRateLimit(
 		ui: {
 			notify: (message: string, type: "info" | "warning" | "error") => void;
 		};
+		model?: { provider?: string; id?: string };
 	},
+	_pi: ExtensionAPI,
+	autoSwitchConfig?: Partial<AutoSwitchConfig>,
 ): FailoverResult {
-	_logger.info(`Rate limit on ${provider}`, { isPaidMode });
+	_logger.info(`Rate limit on ${provider}`, { isPaidMode, model: _ctx.model });
 
 	const waitTime = Math.round((classified.retryAfterMs ?? 60000) / 1000);
+
+	// If auto-switch is enabled and we have model info, try to find a fallback
+	if (autoSwitchConfig?.enabled && _ctx.model?.id) {
+		_logger.info("Attempting auto-switch for rate limit");
+		// Note: Actual switching happens in provider-helper.ts turn_end handler
+		// This just signals that a switch is possible
+		return {
+			action: "switch",
+			message: `Rate limit on ${provider}. Auto-switching to another provider...`,
+			shouldRetry: false,
+			retryDelayMs: classified.retryAfterMs,
+		};
+	}
 
 	return {
 		action: "fail",
@@ -111,8 +136,27 @@ function handleRateLimit(
 function handleCapacityError(
 	classified: ClassifiedError,
 	provider: string,
+	_ctx: {
+		ui: {
+			notify: (message: string, type: "info" | "warning" | "error") => void;
+		};
+		model?: { provider?: string; id?: string };
+	},
+	_pi: ExtensionAPI,
+	autoSwitchConfig?: Partial<AutoSwitchConfig>,
 ): FailoverResult {
-	_logger.info(`Capacity error on ${provider}`);
+	_logger.info(`Capacity error on ${provider}`, { model: _ctx.model });
+
+	// If auto-switch is enabled and we have model info, try to find a fallback
+	if (autoSwitchConfig?.enabled && _ctx.model?.id) {
+		_logger.info("Attempting auto-switch for capacity error");
+		return {
+			action: "switch",
+			message: `${provider} is at capacity. Auto-switching to another provider...`,
+			shouldRetry: false,
+			retryDelayMs: classified.retryAfterMs ?? 30000,
+		};
+	}
 
 	return {
 		action: "retry",

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -11,6 +11,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { saveConfig } from "./config.ts";
 import { createLogger } from "./lib/logger.ts";
 import { enhanceModelNameWithCodingIndex } from "./provider-failover/hardcoded-benchmarks.ts";
@@ -18,7 +19,8 @@ import {
 	handleProviderError,
 	isProviderExhausted,
 	resetFailureCount,
-} from "./provider-failover/index.js";
+} from "./provider-failover/index.ts";
+import { autoFailover, type AutoSwitchConfig } from "./provider-failover/auto-switch.ts";
 import { incrementRequestCount } from "./usage/metrics.ts";
 import { incrementModelRequestCount } from "./usage/tracking.ts";
 
@@ -49,6 +51,8 @@ export interface ProviderSetupConfig {
 			ui: { notify: (m: string, t: "info" | "warning" | "error") => void };
 		},
 	) => Promise<boolean>;
+	/** Auto-switch configuration for failover. If enabled, will automatically switch providers on rate limits. */
+	autoSwitch?: Partial<AutoSwitchConfig>;
 }
 
 export interface StoredModels {
@@ -252,12 +256,14 @@ export function setupProvider(
 				{
 					provider: providerId,
 					isPaidMode: currentShowPaid,
+					autoSwitch: config.autoSwitch,
 				},
 				pi,
 				ctx as {
 					ui: {
 						notify: (m: string, t: "info" | "warning" | "error") => void;
 					};
+					model?: { provider?: string; id?: string };
 					session?: { id?: string };
 				},
 			);
@@ -273,6 +279,27 @@ export function setupProvider(
 				}
 			} else if (result.action === "fail") {
 				ctx.ui.notify(result.message, "error");
+			} else if (result.action === "switch") {
+				// Auto-switch to another provider on rate limit
+				if (ctx.model) {
+					const switchResult = await autoFailover(
+						errorMsg,
+						ctx.model as any,
+						pi,
+						ctx as ExtensionContext,
+						config.autoSwitch ?? {},
+					);
+					if (switchResult.switched) {
+						ctx.ui.notify(switchResult.message, "info");
+					} else {
+						ctx.ui.notify(
+							`${result.message} (${switchResult.message})`,
+							"warning",
+						);
+					}
+				} else {
+					ctx.ui.notify(result.message, "warning");
+				}
 			}
 
 			// Don't reset failure count on error


### PR DESCRIPTION
## Summary

Adds automatic provider failover when hitting rate limits (429). When a provider is rate-limited, the system will automatically find and switch to an equivalent model from another provider.

### Changes

- **model-detection.ts**: Model family detection and normalization (from pi-models)
- **auto-switch.ts**: Core failover logic with CI score matching
- **failover/index.ts**: Updated to return 'switch' action on rate limits
- **provider-helper.ts**: Integrated auto-switch into turn_end handler
- **hardcoded-benchmarks.ts**: Fixed CI lookup to strip 'free' suffix

### How it works

1. When 429/capacity error detected on provider X with model Y
2. Search all available models for same model on different provider
3. If not found, find similar model in same family (prefer free)
4. If not found, find any free model with similar CI score
5. Auto-switch to the best available alternative

### Testing

Run the workflow to update benchmarks:
```bash
gh workflow run update-benchmarks.yml
```