### PR TITLE
fix(qwen): add client_id to verification URL

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -263,18 +263,25 @@ export async function loginQwen(
 		verificationUri: deviceAuth.verification_uri,
 	});
 
-	// 3. Show auth URL to user
+	// 3. Build complete auth URL with client_id (Qwen website requires it)
+	const authUrl = new URL(deviceAuth.verification_uri_complete);
+	authUrl.searchParams.set("client_id", QWEN_OAUTH_CLIENT_ID);
+	const fullAuthUrl = authUrl.toString();
+
+	_logger.info("Opening auth URL", { url: fullAuthUrl });
+
+	// 4. Show auth URL to user
 	callbacks.onAuth({
-		url: deviceAuth.verification_uri_complete,
+		url: fullAuthUrl,
 		instructions: `Open this URL and enter code: ${deviceAuth.user_code}`,
 	});
 
-	// 4. Open browser
-	openBrowser(deviceAuth.verification_uri_complete);
+	// 5. Open browser
+	openBrowser(fullAuthUrl);
 
 	callbacks.onProgress?.("Waiting for browser authorization...");
 
-	// 5. Poll for token
+	// 6. Poll for token
 	const deadline = Date.now() + deviceAuth.expires_in * 1000;
 	let pollInterval = INITIAL_POLL_INTERVAL_MS;
 


### PR DESCRIPTION
Fixes 'user_code or client is null' error during Qwen OAuth login.

The Qwen authorization page requires client_id in the URL parameters. Previously, verification_uri_complete only contained user_code, causing auth failures. Now appends client_id before opening browser.