### PR TITLE
fix(qwen): hide cmd window on Windows during OAuth login

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -80,6 +80,7 @@ function openBrowser(url: string): void {
 			spawn("cmd", ["/c", "start", "", url], {
 				detached: true,
 				shell: false,
+				windowsHide: true,
 			}).unref();
 		} else if (process.platform === "darwin") {
 			spawn("open", [url], { detached: true }).unref();


### PR DESCRIPTION
Adds windowsHide: true to spawn options to prevent visible cmd window flash.