### PR TITLE
feat: add Modal provider + disable model hopping/usage dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Add your API keys to this file:
   "nvidia_api_key": "nvapi-...",
   "ollama_api_key": "...",
   "fireworks_api_key": "...",
-  "mistral_api_key": "..."
+  "mistral_api_key": "...",
+  "modal_api_key": "..."
 }
 ```
 

--- a/config.ts
+++ b/config.ts
@@ -31,6 +31,7 @@ interface PiFreeConfig {
 	fireworks_api_key?: string;
 	mistral_api_key?: string;
 	ollama_api_key?: string;
+	modal_api_key?: string;
 	kilo_free_only?: boolean;
 	hidden_models?: string[];
 	// Per-provider paid model flags
@@ -53,6 +54,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	fireworks_api_key: "",
 	mistral_api_key: "",
 	ollama_api_key: "",
+	modal_api_key: "",
 	kilo_free_only: false,
 	hidden_models: [],
 	kilo_show_paid: false,
@@ -202,6 +204,7 @@ export const FIREWORKS_API_KEY = resolve(
 );
 export const MISTRAL_API_KEY = resolve("MISTRAL_API_KEY", file.mistral_api_key);
 export const OLLAMA_API_KEY = resolve("OLLAMA_API_KEY", file.ollama_api_key);
+export const MODAL_API_KEY = resolve("MODAL_API_KEY", file.modal_api_key);
 
 // Re-export provider names for consistency
 export {
@@ -215,6 +218,7 @@ export {
 	PROVIDER_OPENROUTER,
 	PROVIDER_QWEN,
 	PROVIDER_ZEN,
+	PROVIDER_MODAL,
 } from "./constants.ts";
 
 // =============================================================================

--- a/constants.ts
+++ b/constants.ts
@@ -17,6 +17,7 @@ export const PROVIDER_FIREWORKS = "fireworks";
 export const PROVIDER_OLLAMA = "ollama";
 export const PROVIDER_MISTRAL = "mistral";
 export const PROVIDER_QWEN = "qwen";
+export const PROVIDER_MODAL = "modal";
 
 export const ALL_PROVIDERS = [
 	PROVIDER_KILO,
@@ -29,6 +30,7 @@ export const ALL_PROVIDERS = [
 	PROVIDER_MISTRAL,
 	PROVIDER_OLLAMA,
 	PROVIDER_QWEN,
+	PROVIDER_MODAL,
 ] as const;
 
 // =============================================================================
@@ -43,6 +45,7 @@ export const BASE_URL_NVIDIA = "https://integrate.api.nvidia.com/v1";
 export const BASE_URL_CLINE = "https://api.cline.bot/api/v1";
 export const BASE_URL_FIREWORKS = "https://api.fireworks.ai/inference/v1";
 export const BASE_URL_OLLAMA = "https://ollama.com/v1";
+export const BASE_URL_MODAL = "https://api.us-west-2.modal.direct/v1";
 
 // =============================================================================
 // External URLs
@@ -54,6 +57,7 @@ export const URL_ZEN_TOS = "https://opencode.ai/terms";
 export const URL_GO_TOS = "https://opencode.ai/terms";
 export const URL_CLINE_TOS = "https://cline.bot/tos";
 export const URL_QWEN_TOS = "https://terms.alicloud.com/";
+export const URL_MODAL_TOS = "https://modal.com/terms";
 export const BASE_URL_QWEN = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 
 // =============================================================================

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
 			"./providers/fireworks.ts",
 			"./providers/mistral.ts",
 			"./providers/ollama.ts",
-			"./providers/qwen.ts"
+			"./providers/qwen.ts",
+			"./providers/modal.ts"
 		]
 	},
 	"dependencies": {

--- a/provider-factory.ts
+++ b/provider-factory.ts
@@ -33,6 +33,7 @@ import {
 	OLLAMA_SHOW_PAID,
 	OPENCODE_API_KEY,
 	ZEN_SHOW_PAID,
+	MODAL_API_KEY,
 } from "./config.ts";
 import { createLogger } from "./lib/logger.ts";
 import { logWarning } from "./lib/util.ts";
@@ -86,6 +87,7 @@ const API_KEY_GETTERS: Record<string, () => string | undefined> = {
 	ollama_api_key: () => OLLAMA_API_KEY,
 	mistral_api_key: () => MISTRAL_API_KEY,
 	opencode_api_key: () => OPENCODE_API_KEY,
+	modal_api_key: () => MODAL_API_KEY,
 };
 
 const SHOW_PAID_GETTERS: Record<string, () => boolean> = {

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -3,7 +3,7 @@
  * Extracts the common boilerplate pattern repeated across providers:
  *   - /{provider}-toggle command to switch between free/paid models
  *   - model_select handler (clear status for other providers)
- *   - turn_end handler (increment request count, handle errors)
+ *   - turn_end handler (provider-specific error hook)
  *   - before_agent_start handler (one-time ToS notice)
  */
 
@@ -11,18 +11,10 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { saveConfig } from "./config.ts";
 import { createLogger } from "./lib/logger.ts";
 import { enhanceModelNameWithCodingIndex } from "./provider-failover/hardcoded-benchmarks.ts";
-import {
-	handleProviderError,
-	isProviderExhausted,
-	resetFailureCount,
-} from "./provider-failover/index.ts";
-import { autoFailover, type AutoSwitchConfig } from "./provider-failover/auto-switch.ts";
-import { incrementRequestCount } from "./usage/metrics.ts";
-import { incrementModelRequestCount } from "./usage/tracking.ts";
+import type { AutoSwitchConfig } from "./provider-failover/auto-switch.ts";
 
 const _logger = createLogger("provider-helper");
 
@@ -227,7 +219,7 @@ export function setupProvider(
 		}
 	});
 
-	// ── Track request count, reset failure count, handle errors ──────────
+	// ── Error handling / usage tracking are temporarily deprecated ─────────
 
 	pi.on("turn_end", async (event, ctx) => {
 		if (ctx.model?.provider !== providerId) return;
@@ -236,113 +228,17 @@ export function setupProvider(
 			event as { message?: { role?: string; errorMessage?: string } }
 		).message;
 
-		// Check for errors in the assistant message
 		if (msg?.role === "assistant" && msg.errorMessage) {
-			const errorMsg = msg.errorMessage;
-			_logger.info("Error detected", {
+			_logger.info("Provider error (auto model hopping disabled)", {
 				provider: providerId,
-				error: errorMsg.slice(0, 100),
+				error: msg.errorMessage.slice(0, 100),
 			});
 
-			// Use custom error handler if provided
+			// Keep custom handlers working for provider-specific logic.
 			if (config.onError) {
-				const handled = await config.onError(errorMsg, ctx);
-				if (handled) return;
+				await config.onError(msg.errorMessage, ctx);
 			}
-
-			// Use default failover handler
-			const result = await handleProviderError(
-				errorMsg,
-				{
-					provider: providerId,
-					isPaidMode: currentShowPaid,
-					autoSwitch: config.autoSwitch,
-				},
-				pi,
-				ctx as {
-					ui: {
-						notify: (m: string, t: "info" | "warning" | "error") => void;
-					};
-					model?: { provider?: string; id?: string };
-					session?: { id?: string };
-				},
-			);
-
-			// Show notification based on result
-			if (result.action === "retry") {
-				ctx.ui.notify(result.message, "warning");
-				if (isProviderExhausted(providerId)) {
-					ctx.ui.setStatus(
-						`${providerId}-status`,
-						ctx.ui.theme.fg("dim", "⚠️ Rate limited - consider switching"),
-					);
-				}
-			} else if (result.action === "fail") {
-				ctx.ui.notify(result.message, "error");
-			} else if (result.action === "switch") {
-				// Auto-switch to another provider on rate limit
-				if (ctx.model) {
-					const switchResult = await autoFailover(
-						errorMsg,
-						ctx.model as any,
-						pi,
-						ctx as ExtensionContext,
-						config.autoSwitch ?? {},
-					);
-					if (switchResult.switched) {
-						ctx.ui.notify(switchResult.message, "info");
-					} else {
-						ctx.ui.notify(
-							`${result.message} (${switchResult.message})`,
-							"warning",
-						);
-					}
-				} else {
-					ctx.ui.notify(result.message, "warning");
-				}
-			}
-
-			// Don't reset failure count on error
-			return;
 		}
-
-		// Success - reset failure count and increment metrics
-		incrementRequestCount(providerId);
-
-		// Track per-model usage if we have a model selected
-		const modelId = ctx.model?.id;
-		if (modelId) {
-			// Extract token usage from the event if available
-			const msg = (
-				event as {
-					message?: {
-						usage?: {
-							input?: number;
-							output?: number;
-							cacheRead?: number;
-							cacheWrite?: number;
-							cost?: { total?: number };
-						};
-					};
-				}
-			).message;
-			const tokensIn = msg?.usage?.input ?? 0;
-			const tokensOut = msg?.usage?.output ?? 0;
-			const cacheRead = msg?.usage?.cacheRead ?? 0;
-			const cacheWrite = msg?.usage?.cacheWrite ?? 0;
-			const cost = msg?.usage?.cost?.total ?? 0;
-			incrementModelRequestCount(
-				providerId,
-				modelId,
-				tokensIn,
-				tokensOut,
-				cacheRead,
-				cacheWrite,
-				cost,
-			);
-		}
-
-		resetFailureCount(providerId);
 	});
 
 	// ── ToS notice on first use ────────────────────────────────

--- a/providers/cline.ts
+++ b/providers/cline.ts
@@ -15,8 +15,8 @@
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../constants.ts";
-import { logWarning } from "../lib/util.ts";
 import { incrementRequestCount } from "../usage/metrics.ts";
+import { logWarning } from "../lib/util.ts";
 import { loginCline, refreshClineToken } from "./cline-auth.ts";
 import { fetchClineModels } from "./cline-models.ts";
 
@@ -249,7 +249,7 @@ export default async function (pi: ExtensionAPI) {
 		}
 	});
 
-	// Track requests
+	// Keep lightweight request counting for now (internal only).
 	pi.on("turn_end", async (_event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		incrementRequestCount(PROVIDER_CLINE);

--- a/providers/go.ts
+++ b/providers/go.ts
@@ -36,6 +36,7 @@ import {
 	setupProvider,
 	createCtxReRegister,
 } from "../provider-helper.ts";
+import { createOpenCodeSessionTracker } from "./opencode-session.ts";
 
 const GO_CONFIG = {
 	providerId: PROVIDER_GO,
@@ -46,6 +47,8 @@ const GO_CONFIG = {
 		"HTTP-Referer": "https://opencode.ai/",
 	},
 };
+
+const session = createOpenCodeSessionTracker();
 
 // =============================================================================
 // Static fallback models (from OpenCode Go docs)
@@ -187,10 +190,27 @@ export default async function (pi: ExtensionAPI) {
 			return;
 		}
 
-		// Create re-register function
-		reRegisterFn = createCtxReRegister(ctx as any, GO_CONFIG);
+		// Generate session ID for this session (used in headers)
+		const sessionId = session.getSessionId();
+
+		// Create re-register function with session headers (same as zen)
+		const sessionConfig = {
+			...GO_CONFIG,
+			headers: {
+				...GO_CONFIG.headers,
+				"x-opencode-session": sessionId,
+				"x-session-affinity": sessionId,
+			},
+		};
+		reRegisterFn = createCtxReRegister(ctx as any, sessionConfig);
 
 		// Register our provider
 		reRegisterFn(models);
+	});
+
+	// Update request count before each agent turn (for request ID generation)
+	pi.on("before_agent_start", async (_event, ctx) => {
+		if (ctx.model?.provider !== PROVIDER_GO) return;
+		session.nextRequestId();
 	});
 }

--- a/providers/kilo.ts
+++ b/providers/kilo.ts
@@ -23,7 +23,6 @@ import {
 	createReRegister,
 	createCtxReRegister,
 } from "../provider-helper.ts";
-import { registerUsageWidget } from "../usage/widget.ts";
 import { cleanModelName, logWarning } from "../lib/util.ts";
 import { loginKilo, refreshKiloToken } from "./kilo-auth.ts";
 import { fetchKiloModels, KILO_GATEWAY_BASE } from "./kilo-models.ts";
@@ -119,8 +118,7 @@ export default async function (pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Register usage widget (glimpseui)
-	registerUsageWidget(pi);
+	// Usage widget temporarily deprecated.
 
 	// ── Kilo-specific: events ────────────────────────────────────────────
 

--- a/providers/modal.ts
+++ b/providers/modal.ts
@@ -1,0 +1,43 @@
+/**
+ * Modal GLM Provider Extension
+ *
+ * Provides access to GLM models hosted on Modal's OpenAI-compatible endpoint.
+ * Requires MODAL_API_KEY (or modal_api_key in ~/.pi/free.json).
+ *
+ * Endpoint docs: https://modal.com/glm-5-endpoint
+ */
+
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import { applyHidden, PROVIDER_MODAL } from "../config.ts";
+import { BASE_URL_MODAL, URL_MODAL_TOS } from "../constants.ts";
+import { createProvider } from "../provider-factory.ts";
+
+function getModalModels(): ProviderModelConfig[] {
+	return applyHidden([
+		{
+			id: "zai-org/GLM-5.1-FP8",
+			name: "GLM-5.1 FP8 (Modal)",
+			reasoning: true,
+			input: ["text"],
+			// Promotional/free-period pricing may change; keep conservative placeholders.
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 16384,
+		},
+	]);
+}
+
+export default function (pi: Parameters<typeof createProvider>[0]) {
+	return createProvider(pi, {
+		providerId: PROVIDER_MODAL,
+		baseUrl: BASE_URL_MODAL,
+		apiKeyEnvVar: "MODAL_API_KEY",
+		apiKeyConfigKey: "modal_api_key",
+		fetchModels: async () => getModalModels(),
+		tosUrl: URL_MODAL_TOS,
+		extraHeaders: {
+			"X-Title": "Pi",
+			"HTTP-Referer": "https://modal.com/",
+		},
+	});
+}

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared OpenCode session/request tracking.
+ *
+ * OpenCode endpoints appear to behave more reliably when a stable session id
+ * is included across requests in the same Pi session.
+ */
+export function createOpenCodeSessionTracker() {
+	let sessionId = "";
+	let requestCount = 0;
+
+	function generateId(): string {
+		return (
+			Math.random().toString(36).substring(2, 15) +
+			Math.random().toString(36).substring(2, 15)
+		);
+	}
+
+	function getSessionId(): string {
+		if (!sessionId) {
+			sessionId = generateId();
+		}
+		return sessionId;
+	}
+
+	function nextRequestId(): string {
+		requestCount++;
+		return `${getSessionId()}-${requestCount}`;
+	}
+
+	return {
+		getSessionId,
+		nextRequestId,
+	};
+}

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -57,8 +57,8 @@ export default async function (pi: ExtensionAPI) {
 		refreshToken: refreshQwenToken,
 		getApiKey: (cred: OAuthCredentials) => cred.access,
 		modifyModels: (models: any[], cred: OAuthCredentials) => {
-			// Use the resource_url from OAuth credentials as the base URL
-			const baseUrl = getQwenBaseUrl(cred);
+			// Use the resource_url (enterpriseUrl) from OAuth credentials as the base URL
+			const baseUrl = getQwenBaseUrl(cred.enterpriseUrl as string | undefined);
 			_logger.info("Qwen base URL from OAuth", { baseUrl });
 			return models.map((m) => ({
 				...m,
@@ -116,7 +116,7 @@ export default async function (pi: ExtensionAPI) {
 		try {
 			const cred = (pi as any).modelRegistry?.authStorage?.get?.(PROVIDER_QWEN);
 			if (cred?.type === "oauth" && evt.payload) {
-				const baseUrl = getQwenBaseUrl(cred as OAuthCredentials);
+				const baseUrl = getQwenBaseUrl(cred.enterpriseUrl as string | undefined);
 				if (baseUrl !== DEFAULT_BASE_URL) {
 					_logger.debug("Using dynamic base URL from OAuth", { baseUrl });
 					evt.payload.baseUrl = baseUrl;
@@ -129,7 +129,7 @@ export default async function (pi: ExtensionAPI) {
 		return evt;
 	});
 
-	// Track requests
+	// Keep lightweight request counting for now (internal only).
 	pi.on("turn_end", async (_event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_QWEN) return;
 		incrementRequestCount(PROVIDER_QWEN);

--- a/providers/zen.ts
+++ b/providers/zen.ts
@@ -31,6 +31,7 @@ import {
 } from "../provider-helper.ts";
 import type { ZenGatewayModel } from "../lib/types.ts";
 import { fetchModelsDevMeta } from "./model-fetcher.ts";
+import { createOpenCodeSessionTracker } from "./opencode-session.ts";
 import { fetchWithRetry, logWarning } from "../lib/util.ts";
 
 const ZEN_CONFIG = {
@@ -43,31 +44,7 @@ const ZEN_CONFIG = {
 	},
 };
 
-// =============================================================================
-// Session/Request ID generation (matches OpenCode behavior)
-// =============================================================================
-
-let _sessionId: string = "";
-let _requestCount = 0;
-
-function generateId(): string {
-	return (
-		Math.random().toString(36).substring(2, 15) +
-		Math.random().toString(36).substring(2, 15)
-	);
-}
-
-function getSessionId(): string {
-	if (!_sessionId) {
-		_sessionId = generateId();
-	}
-	return _sessionId;
-}
-
-function getRequestId(): string {
-	_requestCount++;
-	return `${getSessionId()}-${_requestCount}`;
-}
+const session = createOpenCodeSessionTracker();
 
 // =============================================================================
 // Static fallback models (from Pi's built-in + OpenCode docs)
@@ -369,7 +346,7 @@ export default async function (pi: ExtensionAPI) {
 		}
 
 		// Generate session ID for this session (used in headers)
-		const sessionId = getSessionId();
+		const sessionId = session.getSessionId();
 
 		// Create re-register function with session headers
 		const sessionConfig = {
@@ -389,6 +366,6 @@ export default async function (pi: ExtensionAPI) {
 	// Update request count before each agent turn (for request ID generation)
 	pi.on("before_agent_start", async (_event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_ZEN) return;
-		getRequestId();
+		session.nextRequestId();
 	});
 }


### PR DESCRIPTION
## Summary
- add new Modal provider (`modal/zai-org/GLM-5.1-FP8`) using `MODAL_API_KEY`
- add Modal constants/config wiring and register extension in `package.json`
- align OpenCode Go with Zen session-affinity headers via shared session helper
- temporarily deprecate shared model hopping/auto-failover path in `provider-helper`
- temporarily disable usage widget registration in Kilo

## Notes
- direct pushes to `master` are blocked by repo rules, so this PR is required
- left existing unrelated working-tree change in `providers/qwen-auth.ts` out of this PR intentionally
