### PR TITLE
fix(qwen): add DashScope compat settings to prevent 400 errors

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -264,12 +264,20 @@ export async function loginQwen(
 		verificationUri: deviceAuth.verification_uri,
 	});
 
-	// 3. Use verification_uri_complete directly (server already embedded the code)
-	// If not available, fall back to verification_uri + user_code
-	const authUrl = deviceAuth.verification_uri_complete || deviceAuth.verification_uri;
-	const instructions = deviceAuth.verification_uri_complete
-		? undefined // Code is already embedded in the URL
-		: `Enter code: ${deviceAuth.user_code}`;
+	// 3. Use verification_uri_complete directly (server embeds client=qwen-code)
+	// Fallback: construct URL with user_code and explicitly add client parameter
+	let authUrl: string;
+	if (deviceAuth.verification_uri_complete) {
+		authUrl = deviceAuth.verification_uri_complete;
+	} else {
+		// verification_uri doesn't have user_code or client, so we must add both
+		authUrl = `${deviceAuth.verification_uri}?user_code=${deviceAuth.user_code}&client=qwen-code`;
+	}
+	// Instructions: show user_code only when verification_uri_complete is missing
+	// (otherwise the URL already has everything embedded)
+	const instructions = !deviceAuth.verification_uri_complete
+		? `Enter code: ${deviceAuth.user_code}`
+		: undefined;
 
 	_logger.info("Opening auth URL", { url: authUrl });
 

--- a/providers/qwen-models.ts
+++ b/providers/qwen-models.ts
@@ -10,9 +10,26 @@ import { createLogger } from "../lib/logger.ts";
 const _logger = createLogger("qwen-models");
 
 /**
- * Hardcoded models available for Qwen OAuth free tier.
- * These match the official qwen-code QWEN_OAUTH_MODELS constant.
+ * DashScope compatibility settings for Qwen models.
+ *
+ * DashScope's OpenAI-compatible API does NOT support several parameters
+ * that the pi framework sends by default. Without these overrides, the
+ * API returns 400 "Unrecognized request argument" errors.
+ *
+ * - store: false              → not supported (omit entirely)
+ * - max_completion_tokens      → use max_tokens instead
+ * - stream_options.usage      → not supported
+ * - developer role            → not supported (use system)
+ * - reasoning_effort          → not supported
  */
+const DASHSCOPE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: false,
+	supportsUsageInStreaming: false,
+	maxTokensField: "max_tokens",
+};
+
 export const QWEN_FREE_MODELS: ProviderModelConfig[] = [
 	{
 		id: "coder-model",
@@ -22,6 +39,7 @@ export const QWEN_FREE_MODELS: ProviderModelConfig[] = [
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 131_072,
 		maxTokens: 16_384,
+		compat: DASHSCOPE_COMPAT,
 	},
 ];
 

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -58,9 +58,14 @@ export default async function (pi: ExtensionAPI) {
 		getApiKey: (cred: OAuthCredentials) => cred.access,
 		modifyModels: (models: Model<Api>[], cred: OAuthCredentials) => {
 			// Use resource_url from OAuth credentials to set the correct API base URL
-			// The resource_url field is stored on OAuthCredentials via [key: string]: unknown
 			const baseUrl = getQwenBaseUrl(cred);
-			_logger.info("Qwen base URL from OAuth", { baseUrl });
+			_logger.info("Qwen OAuth modifyModels called", { 
+				baseUrl, 
+				defaultBaseUrl: DEFAULT_BASE_URL,
+				modelCount: models.length,
+				hasAccessToken: !!cred.access,
+				hasResourceUrl: !!cred.resource_url 
+			});
 			if (baseUrl === DEFAULT_BASE_URL) return models;
 			return models.map((m) => ({
 				...m,
@@ -76,7 +81,10 @@ export default async function (pi: ExtensionAPI) {
 			apiKey: "QWEN_API_KEY",
 			api: "openai-completions" as const,
 			headers: {
-				"User-Agent": "pi-free-providers",
+				"User-Agent": "pi-free",
+				"X-DashScope-CacheControl": "enable",
+				"X-DashScope-UserAgent": "pi-free",
+				"X-DashScope-AuthType": "oauth2",
 			},
 			models: enhanceWithCI(m),
 			oauth: oauthConfig,

--- a/tests/qwen.test.ts
+++ b/tests/qwen.test.ts
@@ -63,9 +63,24 @@ vi.mock("../providers/qwen-models.ts", () => ({
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 131_072,
 			maxTokens: 16_384,
+			compat: {
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				supportsUsageInStreaming: false,
+				maxTokensField: "max_tokens",
+			},
 		},
 	],
 }));
+
+const DASHSCOPE_COMPAT = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: false,
+	supportsUsageInStreaming: false,
+	maxTokensField: "max_tokens" as const,
+};
 
 import { setupProvider } from "../provider-helper.ts";
 import { loginQwen } from "../providers/qwen-auth.ts";
@@ -76,10 +91,11 @@ const MOCK_MODEL = {
 	id: "coder-model",
 	name: "Qwen 3.6 Plus (Coder) — Free 1k/day",
 	reasoning: false,
-	input: ["text"],
+	input: ["text" as const],
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 	contextWindow: 131_072,
 	maxTokens: 16_384,
+	compat: DASHSCOPE_COMPAT,
 };
 
 describe("Qwen OAuth Provider", () => {
@@ -294,6 +310,59 @@ describe("Qwen OAuth Provider", () => {
 					all: expect.any(Array),
 				}),
 			);
+		});
+	});
+
+	describe("DashScope compat settings", () => {
+		it("should set compat to disable unsupported DashScope parameters", async () => {
+			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
+
+			const { default: qwenProvider } = await import(
+				"../providers/qwen.ts"
+			);
+			await qwenProvider(mockPi);
+
+			const registerCall = mockRegisterProvider.mock.calls[0];
+			const models = registerCall?.[1]?.models;
+
+			expect(models[0].compat).toEqual({
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				supportsUsageInStreaming: false,
+				maxTokensField: "max_tokens",
+			});
+		});
+
+		it("should preserve compat when modifyModels updates baseUrl", async () => {
+			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
+
+			const { default: qwenProvider } = await import(
+				"../providers/qwen.ts"
+			);
+			await qwenProvider(mockPi);
+
+			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
+			const mockModels = [
+				{ id: "coder-model", name: "Qwen", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384, compat: { supportsStore: false, supportsDeveloperRole: false, supportsReasoningEffort: false, supportsUsageInStreaming: false, maxTokensField: "max_tokens" as const } },
+			];
+
+			const result = oauth.modifyModels(mockModels, {
+				access: "token",
+				refresh: "refresh",
+				expires: Date.now() + 3600000,
+				resource_url: "custom.api.example.com",
+			});
+
+			// compat should be preserved when baseUrl is updated
+			expect(result[0].baseUrl).toBe("https://custom.api.example.com/v1");
+			expect(result[0].compat).toEqual({
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				supportsUsageInStreaming: false,
+				maxTokensField: "max_tokens",
+			});
 		});
 	});
 


### PR DESCRIPTION
## Problem

After fixing the OAuth flow for Qwen, selecting a Qwen model results in a **400 Bad Request** error from the DashScope API.

## Root Cause

DashScope's OpenAI-compatible API does NOT support several parameters that the pi framework sends by default. The framework's `detectCompat()` has no special case for DashScope, so it was sending:

| Parameter | Default | DashScope | Fix |
|---|---|---|---|
| `store: false` | Always sent | ❌ Not supported | `supportsStore: false` |
| `max_completion_tokens` | Default field | ❌ Use `max_tokens` | `maxTokensField: "max_tokens"` |
| `stream_options: { include_usage: true }` | Always sent | ❌ Not supported | `supportsUsageInStreaming: false` |
| `developer` role | Supported | ❌ Use `system` | `supportsDeveloperRole: false` |
| `reasoning_effort` | Supported | ❌ Not supported | `supportsReasoningEffort: false` |

Confirmed against the [official DashScope compatibility docs](https://www.alibabacloud.com/help/en/model-studio/compatibility-of-openai-with-dashscope) and the [qwen-code source](https://github.com/QwenLM/qwen-code/blob/main/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts).

## Fix

- Add `DASHSCOPE_COMPAT` compat object on the Qwen model definition to tell the pi framework to omit/adjust unsupported parameters
- Update provider headers to match official qwen-code (`X-DashScope-*` headers)
- Add tests verifying compat is set and preserved through `modifyModels`/`enhanceWithCI`

## Testing

```
✓ 13 tests pass in tests/qwen.test.ts
✓ 155 tests pass across full suite
```