### PR TITLE
fix(qwen): fix 401 by correcting fallback endpoint and skip redundant refresh

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -352,6 +352,8 @@ export async function loginQwen(
 export async function refreshQwenToken(
 	credentials: OAuthCredentials,
 ): Promise<OAuthCredentials> {
+	if (credentials.expires > Date.now()) return credentials;
+
 	if (!credentials.refresh) {
 		throw new Error(
 			"No refresh token available. Run /login qwen to re-authenticate.",
@@ -424,6 +426,6 @@ export function getQwenBaseUrl(credentials: OAuthCredentials): string {
 			: `${normalized}/v1`;
 	}
 
-	// Default DashScope endpoint
-	return "https://dashscope.aliyuncs.com/compatible-mode/v1";
+	// Default endpoint (portal.qwen.ai)
+	return "https://portal.qwen.ai/v1";
 }


### PR DESCRIPTION
## Summary
- `getQwenBaseUrl` fallback was returning `dashscope.aliyuncs.com` but the provider uses `portal.qwen.ai` — tokens issued for portal.qwen.ai were rejected by dashscope with 401
- `refreshQwenToken` now skips the network call when credentials are still valid (matches cline/kilo pattern)

## Test plan
- [ ] Re-login with `/login qwen` to get fresh credentials
- [ ] Confirm requests succeed without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)