### PR TITLE
fix(qwen): route to DashScope, fix 400 errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3121,9 +3121,9 @@
 			"peer": true
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+			"integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4821,8 +4821,11 @@
 		},
 		"node_modules/pi-free": {
 			"version": "1.0.7",
-			"resolved": "git+ssh://git@github.com/apmantza/pi-free.git#ab6f99e4356c163060fb12153cb09bdd67f1b023",
+			"resolved": "git+ssh://git@github.com/apmantza/pi-free.git#a22de196b5b77e766eb6c8a4e83baaac88befe65",
 			"license": "MIT",
+			"dependencies": {
+				"pi-free": "github:apmantza/pi-free"
+			},
 			"engines": {
 				"node": ">=20.0.0"
 			},

--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -410,22 +410,14 @@ export async function refreshQwenToken(
 
 /**
  * Extract the API base URL from credentials.
- * The resource_url is stored as a proper field on OAuthCredentials
- * (the type has [key: string]: unknown for extensibility).
- * Falls back to the default DashScope endpoint if not present.
+ *
+ * resource_url returned by Qwen OAuth is "portal.qwen.ai" (the web UI).
+ * That endpoint returns 400 on chat completions — DashScope is the correct
+ * API endpoint for OAuth tokens. We always use DashScope and ignore resource_url.
+ *
+ * qwen-code uses the same approach: DEFAULT_DASHSCOPE_BASE_URL regardless of
+ * what resource_url the token carries.
  */
-export function getQwenBaseUrl(credentials: OAuthCredentials): string {
-	const resourceUrl = (credentials.resource_url as string) || "";
-
-	if (resourceUrl) {
-		const normalized = resourceUrl.startsWith("http")
-			? resourceUrl
-			: `https://${resourceUrl}`;
-		return normalized.endsWith("/v1")
-			? normalized
-			: `${normalized}/v1`;
-	}
-
-	// Default endpoint (portal.qwen.ai)
-	return "https://portal.qwen.ai/v1";
+export function getQwenBaseUrl(_credentials?: OAuthCredentials): string {
+	return "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 }

--- a/providers/qwen-models.ts
+++ b/providers/qwen-models.ts
@@ -1,7 +1,7 @@
 /**
  * Qwen OAuth model definitions.
  *
- * Free tier provides Qwen 3.6 Plus (coder-model) with 1,000 requests/day.
+ * Free tier provides Qwen Coder Plus with 1,000 requests/day.
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
@@ -15,7 +15,7 @@ const _logger = createLogger("qwen-models");
  * portal.qwen.ai's OpenAI-compatible API does not support several parameters
  * that the pi framework sends by default.
  */
-const PORTAL_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
+export const PORTAL_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
 	supportsStore: false,
 	supportsDeveloperRole: false,
 	supportsReasoningEffort: false,
@@ -24,6 +24,10 @@ const PORTAL_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
 	maxTokensField: "max_tokens",
 };
 
+/**
+ * Fallback model used before OAuth completes or if model discovery fails.
+ * The real model ID is resolved dynamically via fetchQwenLiveModels() after auth.
+ */
 export const QWEN_FREE_MODELS: ProviderModelConfig[] = [
 	{
 		id: "coder-model",
@@ -43,4 +47,49 @@ export const QWEN_FREE_MODELS: ProviderModelConfig[] = [
 export async function fetchQwenModels(): Promise<ProviderModelConfig[]> {
 	_logger.info("Qwen OAuth: using static free tier models");
 	return QWEN_FREE_MODELS;
+}
+
+/**
+ * Fetch live model list from the Qwen API using the OAuth access token.
+ * Returns updated models with real IDs from the server, or the original
+ * models unchanged if the request fails.
+ */
+export async function fetchQwenLiveModels(
+	baseUrl: string,
+	accessToken: string,
+	templateModels: ProviderModelConfig[],
+): Promise<ProviderModelConfig[]> {
+	try {
+		const response = await fetch(`${baseUrl}/models`, {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				Accept: "application/json",
+			},
+		});
+
+		if (!response.ok) {
+			_logger.info("Qwen /v1/models fetch failed, keeping current model IDs", {
+				status: response.status,
+			});
+			return templateModels;
+		}
+
+		interface ModelEntry { id: string }
+		const data = (await response.json()) as { data?: ModelEntry[] };
+		const ids: string[] = (data.data ?? []).map((m: ModelEntry) => m.id).filter(Boolean);
+
+		_logger.info("Qwen live models discovered", { ids });
+
+		if (ids.length === 0) return templateModels;
+
+		// Prefer a coder model if available, otherwise use the first model
+		const preferred = ids.find((id) => /coder/i.test(id)) ?? ids[0];
+
+		return templateModels.map((m) => ({ ...m, id: preferred }));
+	} catch (err) {
+		_logger.info("Qwen live model fetch error, keeping current model IDs", {
+			error: String(err),
+		});
+		return templateModels;
+	}
 }

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -22,7 +22,7 @@ import { incrementRequestCount } from "../usage/metrics.ts";
 import { logWarning } from "../lib/util.ts";
 import { createLogger } from "../lib/logger.ts";
 import { loginQwen, refreshQwenToken, getQwenBaseUrl } from "./qwen-auth.ts";
-import { fetchQwenModels } from "./qwen-models.ts";
+import { fetchQwenModels, fetchQwenLiveModels } from "./qwen-models.ts";
 
 const _logger = createLogger("qwen");
 
@@ -30,7 +30,7 @@ const _logger = createLogger("qwen");
 // Constants
 // =============================================================================
 
-const DEFAULT_BASE_URL = "https://portal.qwen.ai/v1";
+const DEFAULT_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 
 // =============================================================================
 // Extension entry point
@@ -56,21 +56,21 @@ export default async function (pi: ExtensionAPI) {
 		login: loginQwen,
 		refreshToken: refreshQwenToken,
 		getApiKey: (cred: OAuthCredentials) => cred.access,
-		modifyModels: (models: Model<Api>[], cred: OAuthCredentials) => {
-			// Use resource_url from OAuth credentials to set the correct API base URL
+		modifyModels: async (models: Model<Api>[], cred: OAuthCredentials) => {
 			const baseUrl = getQwenBaseUrl(cred);
-			_logger.info("Qwen OAuth modifyModels called", { 
-				baseUrl, 
+			_logger.info("Qwen OAuth modifyModels called", {
+				baseUrl,
 				defaultBaseUrl: DEFAULT_BASE_URL,
 				modelCount: models.length,
 				hasAccessToken: !!cred.access,
-				hasResourceUrl: !!cred.resource_url 
+				hasResourceUrl: !!cred.resource_url,
 			});
-			if (baseUrl === DEFAULT_BASE_URL) return models;
-			return models.map((m) => ({
-				...m,
-				baseUrl,
-			}));
+
+			// Resolve the real model ID from the live API
+			const resolved = await fetchQwenLiveModels(baseUrl, cred.access, models as any);
+
+			if (baseUrl === DEFAULT_BASE_URL) return resolved;
+			return (resolved as Model<Api>[]).map((m) => ({ ...m, baseUrl }));
 		},
 	};
 
@@ -82,6 +82,7 @@ export default async function (pi: ExtensionAPI) {
 			api: "openai-completions" as const,
 			headers: {
 				"User-Agent": "pi-free",
+				"X-DashScope-AuthType": "qwen-oauth",
 			},
 			models: enhanceWithCI(m),
 			oauth: oauthConfig,

--- a/tests/qwen.test.ts
+++ b/tests/qwen.test.ts
@@ -39,16 +39,7 @@ vi.mock("../lib/util.ts", () => ({
 vi.mock("../providers/qwen-auth.ts", () => ({
 	loginQwen: vi.fn(),
 	refreshQwenToken: vi.fn(),
-	getQwenBaseUrl: vi.fn((cred: { resource_url?: string }) => {
-		const resourceUrl = cred?.resource_url || "";
-		if (resourceUrl) {
-			const normalized = resourceUrl.startsWith("http")
-				? resourceUrl
-				: `https://${resourceUrl}`;
-			return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
-		}
-		return "https://portal.qwen.ai/v1";
-	}),
+	getQwenBaseUrl: vi.fn(() => "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
 }));
 
 const PORTAL_COMPAT = {
@@ -62,9 +53,18 @@ const PORTAL_COMPAT = {
 
 vi.mock("../providers/qwen-models.ts", () => ({
 	fetchQwenModels: vi.fn(),
+	fetchQwenLiveModels: vi.fn(async (_baseUrl: string, _token: string, models: unknown[]) => models),
+	PORTAL_COMPAT: {
+		supportsStore: false,
+		supportsDeveloperRole: false,
+		supportsReasoningEffort: false,
+		supportsUsageInStreaming: false,
+		supportsStrictMode: false,
+		maxTokensField: "max_tokens",
+	},
 	QWEN_FREE_MODELS: [
 		{
-			id: "coder-model",
+			id: "coder-model", // confirmed from qwen-code v0.14.3 bundle
 			name: "Qwen Coder — Free 1k/day",
 			reasoning: false,
 			input: ["text"],
@@ -128,7 +128,7 @@ describe("Qwen OAuth Provider", () => {
 			expect(mockRegisterProvider).toHaveBeenCalledWith(
 				"qwen",
 				expect.objectContaining({
-					baseUrl: "https://portal.qwen.ai/v1",
+					baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 					apiKey: "QWEN_API_KEY",
 					api: "openai-completions",
 					models: [MOCK_MODEL],
@@ -331,7 +331,7 @@ describe("Qwen OAuth Provider", () => {
 			});
 		});
 
-		it("should preserve compat when modifyModels updates baseUrl", async () => {
+		it("should preserve compat after modifyModels resolves", async () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
@@ -341,23 +341,24 @@ describe("Qwen OAuth Provider", () => {
 
 			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
 			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384, compat: PORTAL_COMPAT },
+				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384, compat: PORTAL_COMPAT },
 			];
 
-			const result = oauth.modifyModels(mockModels, {
+			const result = await oauth.modifyModels(mockModels, {
 				access: "token",
 				refresh: "refresh",
 				expires: Date.now() + 3600000,
 				resource_url: "custom.api.example.com",
 			});
 
-			expect(result[0].baseUrl).toBe("https://custom.api.example.com/v1");
+			// Always routes to DashScope regardless of resource_url
+			expect(result[0].baseUrl).toBe("https://dashscope-intl.aliyuncs.com/compatible-mode/v1");
 			expect(result[0].compat).toEqual(PORTAL_COMPAT);
 		});
 	});
 
 	describe("modifyModels callback", () => {
-		it("should return models unchanged when resource_url is empty (default portal)", async () => {
+		it("should always route to DashScope regardless of resource_url", async () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
@@ -367,40 +368,25 @@ describe("Qwen OAuth Provider", () => {
 
 			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
 			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
+				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
 			];
 
-			const result = oauth.modifyModels(mockModels, {
+			// resource_url is ignored — always DashScope
+			const resultEmpty = await oauth.modifyModels(mockModels, {
 				access: "token",
 				refresh: "refresh",
 				expires: Date.now() + 3600000,
 				resource_url: "",
 			});
+			expect(resultEmpty[0].baseUrl).toBe("https://dashscope-intl.aliyuncs.com/compatible-mode/v1");
 
-			expect(result).toEqual(mockModels);
-		});
-
-		it("should update baseUrl when resource_url is present", async () => {
-			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
-
-			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
-			);
-			await qwenProvider(mockPi);
-
-			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
-			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
-			];
-
-			const result = oauth.modifyModels(mockModels, {
+			const resultCustom = await oauth.modifyModels(mockModels, {
 				access: "token",
 				refresh: "refresh",
 				expires: Date.now() + 3600000,
-				resource_url: "custom.api.example.com",
+				resource_url: "portal.qwen.ai",
 			});
-
-			expect(result[0].baseUrl).toBe("https://custom.api.example.com/v1");
+			expect(resultCustom[0].baseUrl).toBe("https://dashscope-intl.aliyuncs.com/compatible-mode/v1");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Route Qwen OAuth requests to DashScope (`dashscope-intl.aliyuncs.com/compatible-mode/v1`) instead of `portal.qwen.ai` which returns 400 on chat completions
- Add `X-DashScope-AuthType: qwen-oauth` header so DashScope accepts OAuth tokens
- Revert model ID to `coder-model` (confirmed correct from qwen-code v0.14.3 bundle)
- Add `fetchQwenLiveModels` for dynamic model ID discovery after OAuth

## Test plan
- [ ] All 12 qwen tests pass
- [ ] Fresh `/login qwen` then send a message using the Qwen model — should get a valid response instead of 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)