### PR TITLE
fix(qwen): use PowerShell to open browser on Windows, fixing URL truncation at &

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -77,11 +77,13 @@ function objectToUrlEncoded(data: Record<string, string>): string {
 function openBrowser(url: string): void {
 	try {
 		if (process.platform === "win32") {
-			spawn("cmd", ["/c", "start", "", url], {
-				detached: true,
-				shell: false,
-				windowsHide: true,
-			}).unref();
+			// cmd.exe interprets & as a command separator, breaking URLs with query params.
+			// PowerShell's Start-Process treats the URL as a literal string.
+			spawn(
+				"powershell.exe",
+				["-NoProfile", "-NonInteractive", "-Command", `Start-Process "${url.replace(/"/g, '\\"')}"`],
+				{ detached: true, shell: false, windowsHide: true },
+			).unref();
 		} else if (process.platform === "darwin") {
 			spawn("open", [url], { detached: true }).unref();
 		} else {


### PR DESCRIPTION
## Summary
- Fixes OAuth login browser opening on Windows where `cmd /c start "" URL` truncates URLs at `&` (cmd.exe treats `&` as a command separator)
- Switches to `powershell.exe -Command Start-Process "URL"` which passes the URL as a literal string

## Root cause
The auth URL `https://chat.qwen.ai/authorize?user_code=CDVWQMT9&client=qwen-code` was being opened as `https://chat.qwen.ai/authorize?user_code=CDVWQMT9` — the browser never received `&client=qwen-code`, so auth failed unless the user manually copied and pasted the full URL.

## Test plan
- [ ] `/login qwen` opens the browser with the complete URL including `&client=qwen-code`
- [ ] OAuth flow completes without manual copy-paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)