### PR TITLE
fix(qwen): revert to portal.qwen.ai, remove DashScope header

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -413,13 +413,22 @@ export async function refreshQwenToken(
 /**
  * Extract the API base URL from credentials.
  *
- * resource_url returned by Qwen OAuth is "portal.qwen.ai" (the web UI).
- * That endpoint returns 400 on chat completions — DashScope is the correct
- * API endpoint for OAuth tokens. We always use DashScope and ignore resource_url.
+ * The OAuth flow authenticates via chat.qwen.ai (Qwen Studio). The resulting
+ * token is valid for portal.qwen.ai, which is the correct API endpoint.
+ * DashScope is a separate Alibaba Cloud service that requires its own API key.
  *
- * qwen-code uses the same approach: DEFAULT_DASHSCOPE_BASE_URL regardless of
- * what resource_url the token carries.
+ * If resource_url is present in credentials, use it (allows custom endpoints).
+ * Otherwise default to portal.qwen.ai.
  */
-export function getQwenBaseUrl(_credentials?: OAuthCredentials): string {
-	return "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+export function getQwenBaseUrl(credentials?: OAuthCredentials): string {
+	const resourceUrl = (credentials?.resource_url as string) || "";
+
+	if (resourceUrl) {
+		const normalized = resourceUrl.startsWith("http")
+			? resourceUrl
+			: `https://${resourceUrl}`;
+		return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+	}
+
+	return "https://portal.qwen.ai/v1";
 }

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -30,7 +30,7 @@ const _logger = createLogger("qwen");
 // Constants
 // =============================================================================
 
-const DEFAULT_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+const DEFAULT_BASE_URL = "https://portal.qwen.ai/v1";
 
 // =============================================================================
 // Extension entry point
@@ -75,7 +75,6 @@ export default async function (pi: ExtensionAPI) {
 			api: "openai-completions" as const,
 			headers: {
 				"User-Agent": "pi-free",
-				"X-DashScope-AuthType": "qwen-oauth",
 			},
 			models: enhanceWithCI(m),
 			oauth: oauthConfig,

--- a/tests/qwen.test.ts
+++ b/tests/qwen.test.ts
@@ -39,7 +39,7 @@ vi.mock("../lib/util.ts", () => ({
 vi.mock("../providers/qwen-auth.ts", () => ({
 	loginQwen: vi.fn(),
 	refreshQwenToken: vi.fn(),
-	getQwenBaseUrl: vi.fn(() => "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+	getQwenBaseUrl: vi.fn(() => "https://portal.qwen.ai/v1"),
 }));
 
 const PORTAL_COMPAT = {
@@ -127,7 +127,7 @@ describe("Qwen OAuth Provider", () => {
 			expect(mockRegisterProvider).toHaveBeenCalledWith(
 				"qwen",
 				expect.objectContaining({
-					baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+					baseUrl: "https://portal.qwen.ai/v1",
 					apiKey: "QWEN_API_KEY",
 					api: "openai-completions",
 					models: [MOCK_MODEL],
@@ -340,7 +340,7 @@ describe("Qwen OAuth Provider", () => {
 
 			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
 			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384, compat: PORTAL_COMPAT },
+				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384, compat: PORTAL_COMPAT },
 			];
 
 			const result = oauth.modifyModels(mockModels, {
@@ -365,7 +365,7 @@ describe("Qwen OAuth Provider", () => {
 
 			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
 			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
+				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
 			];
 
 			const result = oauth.modifyModels(mockModels, {


### PR DESCRIPTION
## Summary
- Reverts API endpoint back to `portal.qwen.ai/v1` (from `dashscope-intl.aliyuncs.com`)
- Removes `X-DashScope-AuthType: qwen-oauth` header

## Root cause
OAuth tokens issued by `chat.qwen.ai` (Qwen Studio) are only valid for `portal.qwen.ai`. DashScope is a completely separate Alibaba Cloud service that requires its own API key — forwarding a Qwen Studio OAuth token there always returns `401 Incorrect API key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)