### PR TITLE
fix(qwen): replicate qwen-code endpoint logic, add DashScope headers

### DIFF
--- a/providers/qwen-auth.ts
+++ b/providers/qwen-auth.ts
@@ -410,25 +410,23 @@ export async function refreshQwenToken(
 	};
 }
 
+// Fallback endpoint used when resource_url is absent from the OAuth token.
+// Mirrors qwen-code's DEFAULT_QWEN_BASE_URL.
+const QWEN_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
 /**
- * Extract the API base URL from credentials.
+ * Resolve the API base URL from OAuth credentials.
  *
- * The OAuth flow authenticates via chat.qwen.ai (Qwen Studio). The resulting
- * token is valid for portal.qwen.ai, which is the correct API endpoint.
- * DashScope is a separate Alibaba Cloud service that requires its own API key.
- *
- * If resource_url is present in credentials, use it (allows custom endpoints).
- * Otherwise default to portal.qwen.ai.
+ * Replicates qwen-code's getCurrentEndpoint() logic exactly:
+ *   - Chinese accounts receive resource_url "dashscope.aliyuncs.com"
+ *     → normalised to "https://dashscope.aliyuncs.com/v1"
+ *   - International accounts receive resource_url "portal.qwen.ai"
+ *     → normalised to "https://portal.qwen.ai/v1"
+ *   - No resource_url → fallback "https://dashscope.aliyuncs.com/compatible-mode/v1"
  */
 export function getQwenBaseUrl(credentials?: OAuthCredentials): string {
 	const resourceUrl = (credentials?.resource_url as string) || "";
-
-	if (resourceUrl) {
-		const normalized = resourceUrl.startsWith("http")
-			? resourceUrl
-			: `https://${resourceUrl}`;
-		return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
-	}
-
-	return "https://portal.qwen.ai/v1";
+	const base = resourceUrl || QWEN_DEFAULT_BASE_URL;
+	const normalized = base.startsWith("http") ? base : `https://${base}`;
+	return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
 }

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -38,6 +38,7 @@ const DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 const DASHSCOPE_HEADERS = {
 	"X-DashScope-AuthType": "qwen-oauth",
 	"X-DashScope-CacheControl": "enable",
+	"X-DashScope-UserAgent": "QwenCode/0.0.5 (pi-free)",
 	"Client-Code": "QwenCode",
 };
 

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -30,7 +30,16 @@ const _logger = createLogger("qwen");
 // Constants
 // =============================================================================
 
-const DEFAULT_BASE_URL = "https://portal.qwen.ai/v1";
+// Mirrors qwen-code's DEFAULT_QWEN_BASE_URL (used when resource_url is absent).
+const DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
+// Headers required by DashScope's OpenAI-compatible API for OAuth tokens.
+// Replicates DashScopeOpenAICompatibleProvider.buildHeaders() from qwen-code.
+const DASHSCOPE_HEADERS = {
+	"X-DashScope-AuthType": "qwen-oauth",
+	"X-DashScope-CacheControl": "enable",
+	"Client-Code": "QwenCode",
+};
 
 // =============================================================================
 // Extension entry point
@@ -57,13 +66,17 @@ export default async function (pi: ExtensionAPI) {
 		refreshToken: refreshQwenToken,
 		getApiKey: (cred: OAuthCredentials) => cred.access,
 		modifyModels: (models: Model<Api>[], cred: OAuthCredentials) => {
+			// Mirror qwen-code: resolve baseUrl from resource_url per-credential.
+			// Chinese accounts → dashscope.aliyuncs.com/v1
+			// International accounts → portal.qwen.ai/v1 (or custom endpoint)
 			const baseUrl = getQwenBaseUrl(cred);
 			_logger.info("Qwen OAuth modifyModels called", {
 				baseUrl,
+				resource_url: cred.resource_url,
 				modelCount: models.length,
-				hasAccessToken: !!cred.access,
 			});
-			return models;
+			if (baseUrl === DEFAULT_BASE_URL) return models;
+			return (models as Model<Api>[]).map((m) => ({ ...m, baseUrl }));
 		},
 	};
 
@@ -75,6 +88,7 @@ export default async function (pi: ExtensionAPI) {
 			api: "openai-completions" as const,
 			headers: {
 				"User-Agent": "pi-free",
+				...DASHSCOPE_HEADERS,
 			},
 			models: enhanceWithCI(m),
 			oauth: oauthConfig,

--- a/tests/qwen.test.ts
+++ b/tests/qwen.test.ts
@@ -39,7 +39,8 @@ vi.mock("../lib/util.ts", () => ({
 vi.mock("../providers/qwen-auth.ts", () => ({
 	loginQwen: vi.fn(),
 	refreshQwenToken: vi.fn(),
-	getQwenBaseUrl: vi.fn(() => "https://portal.qwen.ai/v1"),
+	// Default: no resource_url → fallback DashScope (mirrors qwen-code behaviour)
+	getQwenBaseUrl: vi.fn(() => "https://dashscope.aliyuncs.com/compatible-mode/v1"),
 }));
 
 const PORTAL_COMPAT = {
@@ -127,7 +128,7 @@ describe("Qwen OAuth Provider", () => {
 			expect(mockRegisterProvider).toHaveBeenCalledWith(
 				"qwen",
 				expect.objectContaining({
-					baseUrl: "https://portal.qwen.ai/v1",
+					baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
 					apiKey: "QWEN_API_KEY",
 					api: "openai-completions",
 					models: [MOCK_MODEL],
@@ -340,7 +341,7 @@ describe("Qwen OAuth Provider", () => {
 
 			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
 			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384, compat: PORTAL_COMPAT },
+				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384, compat: PORTAL_COMPAT },
 			];
 
 			const result = oauth.modifyModels(mockModels, {
@@ -365,7 +366,7 @@ describe("Qwen OAuth Provider", () => {
 
 			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
 			const mockModels = [
-				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://portal.qwen.ai/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
+				{ id: "coder-model", name: "Qwen Coder", provider: "qwen", api: "openai-completions", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", reasoning: false, input: ["text" as const], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131_072, maxTokens: 16_384 },
 			];
 
 			const result = oauth.modifyModels(mockModels, {


### PR DESCRIPTION
## Summary
- `getQwenBaseUrl` now exactly mirrors qwen-code's `getCurrentEndpoint()`: `resource_url` → `https://{url}/v1`, fallback `dashscope.aliyuncs.com/compatible-mode/v1`
- Added all 4 required DashScope headers: `X-DashScope-AuthType: qwen-oauth`, `X-DashScope-CacheControl: enable`, `X-DashScope-UserAgent`, `Client-Code: QwenCode`
- `modifyModels` applies per-credential `baseUrl` dynamically (non-async, sync with framework)

## Root cause
Chinese accounts receive `resource_url: "dashscope.aliyuncs.com"` → DashScope works with OAuth token + DashScope headers. International accounts receive `resource_url: "portal.qwen.ai"` — needs live testing with fresh login.

## Test plan
- [ ] All 12 qwen tests pass
- [ ] Fresh `/login qwen` → send a message → no 401/400

🤖 Generated with [Claude Code](https://claude.com/claude-code)