### PR TITLE
chore: bump to v1.0.8, add Qwen and Modal to changelog and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.8] - 2026-04-13
 
 ### Added
+- **Modal provider** — Free access to GLM-5.1 FP8 (128k context, 16k max output) during promotional period (free until April 30, 2026)
+  - Requires a free Modal API key (`MODAL_API_KEY` or `modal_api_key` in `~/.pi/free.json`)
+  - Model: `zai-org/GLM-5.1-FP8` — 128k context window, 16k max output tokens
 - **Qwen provider** — Free access to Qwen Coder (1,000 requests/day) via OAuth device flow
   - Run `/login qwen` to authenticate through Qwen Studio (chat.qwen.ai)
   - Uses `coder-model` alias (maps to Qwen3.6-Plus on the backend)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-04-13
+
+### Added
+- **Qwen provider** — Free access to Qwen Coder (1,000 requests/day) via OAuth device flow
+  - Run `/login qwen` to authenticate through Qwen Studio (chat.qwen.ai)
+  - Uses `coder-model` alias (maps to Qwen3.6-Plus on the backend)
+  - 131k context window, 16k max output tokens, zero cost
+
+### Fixed
+- **Qwen OAuth browser launch on Windows** — URLs with `&` query params were truncated by `cmd.exe`'s `&` command separator; switched to `powershell.exe Start-Process` which passes the URL as a literal string
+- **Qwen API endpoint** — Replicates qwen-code's `getCurrentEndpoint()` logic: uses `resource_url` from OAuth token response (`dashscope.aliyuncs.com` for Chinese accounts, `portal.qwen.ai` for international), with fallback to `dashscope.aliyuncs.com/compatible-mode/v1`
+- **Qwen DashScope headers** — Added all headers required by DashScope's OpenAI-compatible API: `X-DashScope-AuthType: qwen-oauth`, `X-DashScope-CacheControl: enable`, `X-DashScope-UserAgent`, `Client-Code: QwenCode`
+- **Qwen modifyModels crash** — `modifyModels` must be synchronous; making it async caused the pi framework to receive a `Promise` instead of a `Model[]`, breaking `ModelRegistry.find()`
+
 ## [1.0.5] - 2025-04-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Free AI model providers for [Pi](https://pi.dev). Access **free models** from mu
 
 ## What does pi-free do
 
-**pi-free is a Pi extension that unlocks free AI models from 8 different providers.**
+**pi-free is a Pi extension that unlocks free AI models from 9 different providers.**
 
 When you install pi-free, it:
 
-1. **Registers 7 AI providers** with Pi's model picker — OpenCode Zen, Kilo, OpenRouter, NVIDIA NIM, Cline, Mistral, and Ollama Cloud
+1. **Registers 8 AI providers** with Pi's model picker — OpenCode Zen, Kilo, OpenRouter, NVIDIA NIM, Cline, Mistral, Ollama Cloud, and Qwen
 
 2. **Filters to show only free models by default** — You see only the models that cost $0 to use, no API key required for some providers
 
@@ -44,6 +44,7 @@ Free models are shown by default — look for the provider prefixes:
 - `cline/` — Cline models (run `/login cline` to use)
 - `mistral/` — Mistral models (API key required)
 - `ollama/` — Ollama Cloud models (API key required)
+- `qwen/` — Qwen Coder (run `/login qwen` to use, 1,000 free requests/day)
 
 ### 3. Toggle between free and paid models
 
@@ -93,8 +94,10 @@ See the [Providers That Need Authentication](#providers-that-need-authentication
 | `/{provider}-toggle` | Switch between free-only and all models for that provider |
 | `/login kilo` | Start OAuth flow for Kilo |
 | `/login cline` | Start OAuth flow for Cline |
+| `/login qwen` | Start OAuth flow for Qwen |
 | `/logout kilo` | Clear Kilo OAuth credentials |
 | `/logout cline` | Clear Cline OAuth credentials |
+| `/logout qwen` | Clear Qwen OAuth credentials |
 
 ---
 
@@ -234,6 +237,28 @@ Add API key to `~/.pi/free.json` or environment variables:
 export MISTRAL_API_KEY="..."
 ```
 
+### Qwen (1,000 free requests/day)
+
+Qwen provides free access to **Qwen Coder** (Qwen3.6-Plus) via OAuth device flow — no API key or credit card needed.
+
+```
+/login qwen
+```
+
+This command will:
+1. Open your browser to Qwen Studio's authorization page
+2. Display a device code (enter it if the browser doesn't pre-fill it)
+3. Wait for you to authorize in the browser
+4. Automatically complete login once approved
+
+Then select a `qwen/` model in the model picker.
+
+**Details:**
+- Free tier: 1,000 requests/day
+- Model: Qwen Coder (131k context, 16k max output)
+- No credit card required — just a free [Qwen Studio](https://chat.qwen.ai) account
+- To re-authenticate: `/logout qwen` then `/login qwen`
+
 ---
 
 ## Slash Commands
@@ -249,6 +274,8 @@ Each provider has toggle commands to switch between free and all models:
 | `/cline-toggle` | Toggle between free/all Cline models |
 | `/mistral-toggle` | Toggle between free/all Mistral models |
 | `/ollama-toggle` | Toggle between free/all Ollama models |
+| `/login qwen` | Authenticate with Qwen Studio (OAuth) |
+| `/logout qwen` | Clear Qwen credentials |
 
 **The toggle command:**
 - Switches between showing only free models vs. all available models

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Free AI model providers for [Pi](https://pi.dev). Access **free models** from mu
 
 ## What does pi-free do
 
-**pi-free is a Pi extension that unlocks free AI models from 9 different providers.**
+**pi-free is a Pi extension that unlocks free AI models from 10 different providers.**
 
 When you install pi-free, it:
 
-1. **Registers 8 AI providers** with Pi's model picker — OpenCode Zen, Kilo, OpenRouter, NVIDIA NIM, Cline, Mistral, Ollama Cloud, and Qwen
+1. **Registers 9 AI providers** with Pi's model picker — OpenCode Zen, Kilo, OpenRouter, NVIDIA NIM, Cline, Mistral, Ollama Cloud, Qwen, and Modal
 
 2. **Filters to show only free models by default** — You see only the models that cost $0 to use, no API key required for some providers
 
@@ -45,6 +45,7 @@ Free models are shown by default — look for the provider prefixes:
 - `mistral/` — Mistral models (API key required)
 - `ollama/` — Ollama Cloud models (API key required)
 - `qwen/` — Qwen Coder (run `/login qwen` to use, 1,000 free requests/day)
+- `modal/` — GLM-5.1 FP8 via Modal (API key required, free promotional period until April 30, 2026)
 
 ### 3. Toggle between free and paid models
 
@@ -79,7 +80,7 @@ Add your API keys to this file:
   "ollama_api_key": "...",
   "fireworks_api_key": "...",
   "mistral_api_key": "...",
-  "modal_api_key": "..."
+  "modal_api_key": "sk-modal-..."
 }
 ```
 
@@ -229,6 +230,29 @@ This command will:
 - Free account required (no credit card)
 - Uses local ports 48801-48811 for OAuth callback
 
+### Modal (GLM-5.1 FP8 — free until April 30, 2026)
+
+Modal hosts GLM-5.1 FP8 with a free promotional period. Get an API key at [modal.com](https://modal.com), then:
+
+**Option A: Environment variable**
+```bash
+export MODAL_API_KEY="sk-modal-..."
+```
+
+**Option B: Config file** (`~/.pi/free.json`)
+```json
+{
+  "modal_api_key": "sk-modal-..."
+}
+```
+
+Then select a `modal/` model in the model picker.
+
+**Details:**
+- Free promotional period until April 30, 2026
+- Model: GLM-5.1 FP8 (128k context, 16k max output)
+- No credit card required during the promotional period
+
 ### Mistral
 
 Add API key to `~/.pi/free.json` or environment variables:
@@ -297,6 +321,7 @@ Create `~/.pi/free.json` in your home directory:
   "opencode_api_key": "YOUR_ZEN_KEY",
   "ollama_api_key": "YOUR_OLLAMA_KEY",
   "ollama_show_paid": true,
+  "modal_api_key": "YOUR_MODAL_KEY",
   "hidden_models": ["model-id-to-hide"]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"type": "module",
 	"description": "AIO Free AI models for Pi - Access free models from Kilo, Zen, OpenRouter, NVIDIA, Cline, Mistral, Ollama, and Qwen",
 	"keywords": [


### PR DESCRIPTION
## Summary
- Bumped version to 1.0.8
- Added Qwen OAuth provider docs (login flow, 1k/day free tier, slash commands)
- Added Modal provider docs (GLM-5.1 FP8, free until April 30 2026)
- Updated CHANGELOG.md with all fixes from the Qwen OAuth work

## Test plan
- [ ] Verify `/login qwen` flow works end-to-end
- [ ] Verify `modal/` models appear with a valid `MODAL_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)