### PR TITLE
fix: remove self-referencing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,5 @@
 			"./providers/modal.ts"
 		]
 	},
-	"dependencies": {
-		"pi-free": "github:apmantza/pi-free"
-	}
+}
 }


### PR DESCRIPTION
## Summary
- Removed `"dependencies": { "pi-free": "github:apmantza/pi-free" }` — the package was depending on itself, causing a circular dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)