### PR TITLE
fix: correct malformed package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,5 @@
 			"./providers/qwen.ts",
 			"./providers/modal.ts"
 		]
-	},
-}
+	}
 }


### PR DESCRIPTION
Extra closing brace left after removing self-referencing dependency in #54.