### PR TITLE
fix: scope Qwen modifyModels baseUrl patch to Qwen models only

### DIFF
--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -77,7 +77,12 @@ export default async function (pi: ExtensionAPI) {
 				modelCount: models.length,
 			});
 			if (baseUrl === DEFAULT_BASE_URL) return models;
-			return (models as Model<Api>[]).map((m) => ({ ...m, baseUrl }));
+			// modifyModels receives ALL models across providers — only patch Qwen ones.
+			const nonQwen = models.filter((m) => m.provider !== PROVIDER_QWEN);
+			const qwen = models
+				.filter((m) => m.provider === PROVIDER_QWEN)
+				.map((m) => ({ ...m, baseUrl }));
+			return [...nonQwen, ...qwen];
 		},
 	};
 


### PR DESCRIPTION
## Summary
- `modifyModels` receives **all** models across every registered provider, not just the caller's own
- The previous `map()` was stamping the Qwen dashscope `baseUrl` onto every model, so after a `/login qwen` flow, all other OAuth providers (Kilo, OpenRouter, etc.) pointed at the wrong endpoint and returned 404
- Fix: filter to `provider === PROVIDER_QWEN` before patching `baseUrl`; non-Qwen models pass through unchanged — mirrors the pattern already used in `kilo.ts:72-74`

Fixes #56

## Test plan
- [ ] `/login qwen` then switch to a non-Qwen OAuth model (e.g. Kilo) — requests should succeed as before
- [ ] International Qwen account (`resource_url` set) — `baseUrl` override should still apply to Qwen models
- [ ] Chinese Qwen account (no `resource_url`) — no change, default dashscope URL used

🤖 Generated with [Claude Code](https://claude.com/claude-code)