### PR TITLE
chore: bump version to 1.0.9 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9] - 2026-04-14
+
+### Fixed
+- **Qwen OAuth breaks other OAuth providers** — `modifyModels` receives all models across every registered provider, not just Qwen's. The previous `map()` stamped the Qwen dashscope `baseUrl` onto every model, causing other OAuth providers (Kilo, OpenRouter, etc.) to return 404 after a `/login qwen` flow. Now only models with `provider === PROVIDER_QWEN` are patched; others pass through unchanged.
+
 ## [1.0.8] - 2026-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"type": "module",
 	"description": "AIO Free AI models for Pi - Access free models from Kilo, Zen, OpenRouter, NVIDIA, Cline, Mistral, Ollama, and Qwen",
 	"keywords": [

--- a/providers/qwen.ts
+++ b/providers/qwen.ts
@@ -77,7 +77,12 @@ export default async function (pi: ExtensionAPI) {
 				modelCount: models.length,
 			});
 			if (baseUrl === DEFAULT_BASE_URL) return models;
-			return (models as Model<Api>[]).map((m) => ({ ...m, baseUrl }));
+			// modifyModels receives ALL models across providers — only patch Qwen ones.
+			const nonQwen = models.filter((m) => m.provider !== PROVIDER_QWEN);
+			const qwen = models
+				.filter((m) => m.provider === PROVIDER_QWEN)
+				.map((m) => ({ ...m, baseUrl }));
+			return [...nonQwen, ...qwen];
 		},
 	};
 


### PR DESCRIPTION
## Summary
- Bumps `package.json` version `1.0.8` → `1.0.9`
- Adds changelog entry for the Qwen `modifyModels` baseUrl scope fix (#57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)