### PR TITLE
chore: replace silent catch blocks with structured logging

### DIFF
--- a/lib/json-persistence.ts
+++ b/lib/json-persistence.ts
@@ -5,6 +5,9 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { createLogger } from "./logger.ts";
+
+const _logger = createLogger("json-persistence");
 
 export interface JSONStore<T> {
 	load(): T;
@@ -28,8 +31,7 @@ export function createJSONStore<T extends object>(
 				return cached;
 			}
 		} catch (err) {
-			// Silently fail and return default
-			void err;
+			_logger.warn("Failed to load JSON store, using default", { filepath, error: err });
 		}
 		cached = defaultValue;
 		return cached;
@@ -44,8 +46,7 @@ export function createJSONStore<T extends object>(
 			}
 			writeFileSync(filepath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
 		} catch (err) {
-			// Silently fail - persistence is best-effort
-			void err;
+			_logger.warn("Failed to save JSON store", { filepath, error: err });
 		}
 	}
 
@@ -71,8 +72,8 @@ export function createJSONLStore<T extends object>(
 					.filter((line) => line.trim())
 					.map((line) => JSON.parse(line) as T);
 			}
-		} catch {
-			// Return empty on error
+		} catch (err) {
+			_logger.warn("Failed to load JSONL store, using empty array", { filepath, error: err });
 		}
 		return [];
 	}
@@ -85,16 +86,16 @@ export function createJSONLStore<T extends object>(
 			}
 			const line = JSON.stringify(entry);
 			writeFileSync(filepath, `${line}\n`, { flag: "a", encoding: "utf-8" });
-		} catch {
-			// Silently fail
+		} catch (err) {
+			_logger.warn("Failed to append to JSONL store", { filepath, error: err });
 		}
 	}
 
 	function clear(): void {
 		try {
 			writeFileSync(filepath, "", "utf-8");
-		} catch {
-			// Silently fail
+		} catch (err) {
+			_logger.warn("Failed to clear JSONL store", { filepath, error: err });
 		}
 	}
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -63,8 +63,8 @@ function appendToFile(line: string): void {
 			mkdirSync(dir, { recursive: true });
 		}
 		appendFileSync(LOG_PATH, `${line}\n`, "utf8");
-	} catch {
-		// Never throw from logger
+	} catch (err) {
+		console.error("Failed to write to log file:", err);
 	}
 }
 

--- a/provider-failover/hardcoded-benchmarks.ts
+++ b/provider-failover/hardcoded-benchmarks.ts
@@ -9971,13 +9971,4 @@ export const HARDCODED_BENCHMARKS: Record<string, HardcodedBenchmark> = {
 	},
 };
 
-// =============================================================================
-// Re-export lookup functions from benchmark-lookup.ts
-// Consumers that imported from this file will still work.
-// =============================================================================
 
-export {
-	findHardcodedBenchmark,
-	getHardcodedScore,
-	enhanceModelNameWithCodingIndex,
-} from "./benchmark-lookup.js";

--- a/usage/sessions.ts
+++ b/usage/sessions.ts
@@ -51,12 +51,12 @@ async function getAllSessionFiles(signal?: AbortSignal): Promise<string[]> {
 						files.push(join(cwdPath, file));
 					}
 				}
-			} catch {
-				// Skip directories we can't read
+			} catch (err) {
+				_logger.debug("Skipping unreadable directory", { path: cwdPath, error: err });
 			}
 		}
-	} catch {
-		// Return empty if we can't read sessions dir
+	} catch (err) {
+		_logger.debug("Cannot read sessions directory", { sessionsDir, error: err });
 	}
 
 	return files;
@@ -124,13 +124,14 @@ async function parseSessionFile(
 						});
 					}
 				}
-			} catch {
-				// Skip malformed lines
+			} catch (err) {
+				_logger.debug("Skipping malformed session line", { filePath, line: i, error: err });
 			}
 		}
 
 		return sessionId ? { sessionId, messages } : null;
-	} catch {
+	} catch (err) {
+		_logger.warn("Failed to parse session file", { filePath, error: err });
 		return null;
 	}
 }


### PR DESCRIPTION
## What changed

Replaces bare `catch {}` and `catch { // comment }` blocks with structured logging so failures are observable instead of invisible.

### Changes by file

**lib/json-persistence.ts**
- Added logger import
- `load()` failures → `_logger.warn` (was silently returning default)
- `save()` failures → `_logger.warn` (was silently discarding)
- `load()` (JSONL) → `_logger.warn` (was returning empty array)
- `append()` failures → `_logger.warn` (was silently failing)
- `clear()` failures → `_logger.warn` (was silently failing)

**lib/logger.ts**
- `appendToFile()` file write failure → `console.error` (was silently discarding — can't use logger to log logger failures)

**usage/sessions.ts**
- Unreadable directories → `_logger.debug` (was silently skipping)
- Malformed session lines → `_logger.debug` (was silently skipping)
- Session file parse failures → `_logger.warn` (was returning null silently)

**provider-failover/hardcoded-benchmarks.ts**
- Removed stale re-exports of `findHardcodedBenchmark`, `getHardcodedScore`, `enhanceModelNameWithCodingIndex` from benchmark-lookup.ts — no consumers import from this file anymore