### PR TITLE
Fix Qwen OAuth token refresh after 401s

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Pi-Free Providers Index
+ *
+ * Loads all free model providers into a single extension entry point.
+ * This keeps the extension list clean in pi (one entry instead of many).
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+// Import all provider extensions (from providers/ directory)
+import cline from "./providers/cline/cline.ts";
+import fireworks from "./providers/fireworks/fireworks.ts";
+import go from "./providers/go/go.ts";
+import kilo from "./providers/kilo/kilo.ts";
+import mistral from "./providers/mistral/mistral.ts";
+import modal from "./providers/modal/modal.ts";
+import nvidia from "./providers/nvidia/nvidia.ts";
+import ollama from "./providers/ollama/ollama.ts";
+import openrouter from "./providers/openrouter/openrouter.ts";
+import qwen from "./providers/qwen/qwen.ts";
+import zen from "./providers/zen/zen.ts";
+
+/**
+ * Main extension entry point that loads all providers.
+ * Called once by pi - each provider initializes independently.
+ */
+export default async function (pi: ExtensionAPI) {
+	// Load all providers concurrently
+	await Promise.allSettled([
+		fireworks(pi),
+		mistral(pi),
+		ollama(pi),
+		modal(pi),
+		zen(pi),
+		openrouter(pi),
+		nvidia(pi),
+		go(pi),
+		kilo(pi),
+		qwen(pi),
+		cline(pi),
+	]);
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"node": ">=20.0.0"
 	},
 	"files": [
+		"index.ts",
 		"providers/**/*.ts",
 		"lib/**/*.ts",
 		"usage/**/*.ts",
@@ -69,17 +70,7 @@
 	},
 	"pi": {
 		"extensions": [
-			"./providers/kilo.ts",
-			"./providers/zen.ts",
-			"./providers/go.ts",
-			"./providers/openrouter.ts",
-			"./providers/nvidia.ts",
-			"./providers/cline.ts",
-			"./providers/fireworks.ts",
-			"./providers/mistral.ts",
-			"./providers/ollama.ts",
-			"./providers/qwen.ts",
-			"./providers/modal.ts"
+			"./index.ts"
 		]
 	}
 }

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -15,8 +15,8 @@ import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
 } from "@mariozechner/pi-ai";
-import { BASE_URL_CLINE, CLINE_AUTH_TIMEOUT_MS } from "../constants.ts";
-import { createLogger } from "../lib/logger.ts";
+import { BASE_URL_CLINE, CLINE_AUTH_TIMEOUT_MS } from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
 
 const logger = createLogger("cline-auth");
 

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -4,14 +4,14 @@
  * Fetches zero-cost models from OpenRouter (Cline's gateway).
  */
 
-import { applyHidden } from "../config.ts";
+import { applyHidden } from "../../config.ts";
 import {
 	BASE_URL_OPENROUTER,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	DEFAULT_MIN_SIZE_B,
-} from "../constants.ts";
-import type { ProviderModelConfig } from "../lib/types.ts";
-import { cleanModelName, fetchWithRetry, isUsableModel } from "../lib/util.ts";
+} from "../../constants.ts";
+import type { ProviderModelConfig } from "../../lib/types.ts";
+import { cleanModelName, fetchWithRetry, isUsableModel } from "../../lib/util.ts";
 
 interface OpenRouterRaw {
 	id: string;

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -14,9 +14,9 @@
 
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { BASE_URL_CLINE, PROVIDER_CLINE } from "../constants.ts";
-import { incrementRequestCount } from "../usage/metrics.ts";
-import { logWarning } from "../lib/util.ts";
+import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
+import { incrementRequestCount } from "../../usage/metrics.ts";
+import { logWarning } from "../../lib/util.ts";
 import { loginCline, refreshClineToken } from "./cline-auth.ts";
 import { fetchClineModels } from "./cline-models.ts";
 

--- a/providers/fireworks/fireworks.ts
+++ b/providers/fireworks/fireworks.ts
@@ -10,9 +10,9 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { PROVIDER_FIREWORKS } from "../config.ts";
-import { BASE_URL_FIREWORKS } from "../constants.ts";
-import { createProvider } from "../provider-factory.ts";
+import { PROVIDER_FIREWORKS } from "../../config.ts";
+import { BASE_URL_FIREWORKS } from "../../constants.ts";
+import { createProvider } from "../../provider-factory.ts";
 
 // =============================================================================
 // Static model list (Fireworks doesn't have a models API)

--- a/providers/go/go.ts
+++ b/providers/go/go.ts
@@ -26,17 +26,17 @@ import {
 	OPENCODE_API_KEY,
 	OPENCODE_GO_API_KEY as CONFIG_API_KEY,
 	PROVIDER_GO,
-} from "../config.ts";
+} from "../../config.ts";
 import {
 	BASE_URL_GO,
 	URL_GO_TOS,
-} from "../constants.ts";
+} from "../../constants.ts";
 import {
 	type StoredModels,
 	setupProvider,
 	createCtxReRegister,
-} from "../provider-helper.ts";
-import { createOpenCodeSessionTracker } from "./opencode-session.ts";
+} from "../../provider-helper.ts";
+import { createOpenCodeSessionTracker } from "../opencode-session.ts";
 
 const GO_CONFIG = {
 	providerId: PROVIDER_GO,

--- a/providers/kilo/kilo-auth.ts
+++ b/providers/kilo/kilo-auth.ts
@@ -9,9 +9,9 @@ import type {
 import {
 	KILO_POLL_INTERVAL_MS,
 	KILO_TOKEN_EXPIRATION_MS,
-} from "../constants.ts";
-import { createLogger } from "../lib/logger.ts";
-import { openBrowser } from "../lib/open-browser.ts";
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { openBrowser } from "../../lib/open-browser.ts";
 
 const _logger = createLogger("kilo-auth");
 

--- a/providers/kilo/kilo-models.ts
+++ b/providers/kilo/kilo-models.ts
@@ -2,8 +2,8 @@
  * Kilo model fetching and mapping (OpenRouter-compatible format).
  */
 
-import { applyHidden } from "../config.ts";
-import { fetchOpenRouterCompatibleModels } from "./model-fetcher.ts";
+import { applyHidden } from "../../config.ts";
+import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 
 const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
 export const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -14,16 +14,16 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import { KILO_FREE_ONLY, KILO_SHOW_PAID, PROVIDER_KILO } from "../config.ts";
-import { URL_KILO_TOS } from "../constants.ts";
+import { KILO_FREE_ONLY, KILO_SHOW_PAID, PROVIDER_KILO } from "../../config.ts";
+import { URL_KILO_TOS } from "../../constants.ts";
 import {
 	enhanceWithCI,
 	type StoredModels,
 	setupProvider,
 	createReRegister,
 	createCtxReRegister,
-} from "../provider-helper.ts";
-import { cleanModelName, logWarning } from "../lib/util.ts";
+} from "../../provider-helper.ts";
+import { cleanModelName, logWarning } from "../../lib/util.ts";
 import { loginKilo, refreshKiloToken } from "./kilo-auth.ts";
 import { fetchKiloModels, KILO_GATEWAY_BASE } from "./kilo-models.ts";
 

--- a/providers/mistral/mistral.ts
+++ b/providers/mistral/mistral.ts
@@ -13,9 +13,9 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { applyHidden, MISTRAL_SHOW_PAID, PROVIDER_MISTRAL } from "../config.ts";
-import { BASE_URL_MISTRAL } from "../constants.ts";
-import { createProvider } from "../provider-factory.ts";
+import { applyHidden, MISTRAL_SHOW_PAID, PROVIDER_MISTRAL } from "../../config.ts";
+import { BASE_URL_MISTRAL } from "../../constants.ts";
+import { createProvider } from "../../provider-factory.ts";
 
 // =============================================================================
 // Static model list

--- a/providers/modal/modal.ts
+++ b/providers/modal/modal.ts
@@ -8,9 +8,9 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { applyHidden, PROVIDER_MODAL } from "../config.ts";
-import { BASE_URL_MODAL, URL_MODAL_TOS } from "../constants.ts";
-import { createProvider } from "../provider-factory.ts";
+import { applyHidden, PROVIDER_MODAL } from "../../config.ts";
+import { BASE_URL_MODAL, URL_MODAL_TOS } from "../../constants.ts";
+import { createProvider } from "../../provider-factory.ts";
 
 function getModalModels(): ProviderModelConfig[] {
 	return applyHidden([

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -14,16 +14,16 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { applyHidden, NVIDIA_SHOW_PAID, PROVIDER_NVIDIA } from "../config.ts";
+import { applyHidden, NVIDIA_SHOW_PAID, PROVIDER_NVIDIA } from "../../config.ts";
 import {
 	BASE_URL_NVIDIA,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	NVIDIA_MIN_SIZE_B,
 	URL_MODELS_DEV,
-} from "../constants.ts";
-import type { ModelsDevProvider } from "../lib/types.ts";
-import { fetchWithRetry, isUsableModel } from "../lib/util.ts";
-import { createProvider } from "../provider-factory.ts";
+} from "../../constants.ts";
+import type { ModelsDevProvider } from "../../lib/types.ts";
+import { fetchWithRetry, isUsableModel } from "../../lib/util.ts";
+import { createProvider } from "../../provider-factory.ts";
 
 // =============================================================================
 // Fetch + map

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -9,10 +9,10 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { OLLAMA_API_KEY, PROVIDER_OLLAMA } from "../config.ts";
-import { BASE_URL_OLLAMA, DEFAULT_FETCH_TIMEOUT_MS } from "../constants.ts";
-import { fetchWithRetry } from "../lib/util.ts";
-import { createProvider } from "../provider-factory.ts";
+import { OLLAMA_API_KEY, PROVIDER_OLLAMA } from "../../config.ts";
+import { BASE_URL_OLLAMA, DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { createProvider } from "../../provider-factory.ts";
 
 // =============================================================================
 // Fetch + map

--- a/providers/openrouter/openrouter.ts
+++ b/providers/openrouter/openrouter.ts
@@ -17,21 +17,21 @@ import {
 	OPENROUTER_API_KEY as CONFIG_API_KEY,
 	OPENROUTER_SHOW_PAID,
 	PROVIDER_OPENROUTER,
-} from "../config.ts";
+} from "../../config.ts";
 import {
 	BASE_URL_OPENROUTER,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	DEFAULT_MIN_SIZE_B,
-} from "../constants.ts";
-import { fetchOpenRouterMetrics } from "../usage/metrics.ts";
+} from "../../constants.ts";
+import { fetchOpenRouterMetrics } from "../../usage/metrics.ts";
 import {
 	type StoredModels,
 	setupProvider,
 	createCtxReRegister,
-} from "../provider-helper.ts";
-import { createLogger } from "../lib/logger.ts";
-import { cleanModelName, isUsableModel, logWarning } from "../lib/util.ts";
-import { fetchOpenRouterModelsWithFree } from "./model-fetcher.ts";
+} from "../../provider-helper.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { cleanModelName, isUsableModel, logWarning } from "../../lib/util.ts";
+import { fetchOpenRouterModelsWithFree } from "../model-fetcher.ts";
 
 const _logger = createLogger("openrouter");
 

--- a/providers/qwen/qwen-auth.ts
+++ b/providers/qwen/qwen-auth.ts
@@ -17,8 +17,8 @@ import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
 } from "@mariozechner/pi-ai";
-import { createLogger } from "../lib/logger.ts";
-import { openBrowser } from "../lib/open-browser.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { openBrowser } from "../../lib/open-browser.ts";
 
 const _logger = createLogger("qwen-auth");
 

--- a/providers/qwen/qwen-auth.ts
+++ b/providers/qwen/qwen-auth.ts
@@ -37,6 +37,12 @@ const QWEN_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 const INITIAL_POLL_INTERVAL_MS = 2000;
 const MAX_POLL_INTERVAL_MS = 10000;
 
+// Token refresh buffer: proactively refresh this many ms before actual expiry.
+// Matches qwen-code's SharedTokenManager which uses a 30s buffer.
+// We use 5 minutes (same as pi-core's reference qwen-cli example) to be safe
+// against clock skew, network latency, and server-side early revocation.
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
 // =============================================================================
 // PKCE Utilities
 // =============================================================================
@@ -46,10 +52,7 @@ function generateCodeVerifier(): string {
 }
 
 function generateCodeChallenge(codeVerifier: string): string {
-	return crypto
-		.createHash("sha256")
-		.update(codeVerifier)
-		.digest("base64url");
+	return crypto.createHash("sha256").update(codeVerifier).digest("base64url");
 }
 
 function generatePKCEPair(): {
@@ -67,10 +70,7 @@ function generatePKCEPair(): {
 
 function objectToUrlEncoded(data: Record<string, string>): string {
 	return Object.keys(data)
-		.map(
-			(key) =>
-				`${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`,
-		)
+		.map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`)
 		.join("&");
 }
 
@@ -149,9 +149,7 @@ async function requestDeviceAuthorization(
 		);
 	}
 
-	const result = (await response.json()) as
-		| DeviceAuthorizationData
-		| ErrorData;
+	const result = (await response.json()) as DeviceAuthorizationData | ErrorData;
 
 	if ("error" in result) {
 		throw new Error(
@@ -305,8 +303,8 @@ export async function loginQwen(
 				access: data.access_token!,
 				refresh: data.refresh_token ?? "",
 				expires: data.expires_in
-					? Date.now() + data.expires_in * 1000
-					: Date.now() + 3600 * 1000, // 1 hour default
+					? Date.now() + data.expires_in * 1000 - EXPIRY_BUFFER_MS
+					: Date.now() + 3600 * 1000 - EXPIRY_BUFFER_MS, // 1 hour default minus buffer
 				resource_url: resourceUrl,
 			};
 		}
@@ -334,7 +332,11 @@ export async function loginQwen(
 export async function refreshQwenToken(
 	credentials: OAuthCredentials,
 ): Promise<OAuthCredentials> {
-	if (credentials.expires > Date.now()) return credentials;
+	// Note: we intentionally DO NOT early-return when the token appears valid.
+	// pi-core calls refreshToken() only when it has already determined the token
+	// needs refreshing (Date.now() >= cred.expires). The early return was
+	// redundant and blocked forced-refreshes after server-side token revocation
+	// (where the stored expiry hasn't been reached yet but the token is invalid).
 
 	if (!credentials.refresh) {
 		throw new Error(
@@ -378,21 +380,23 @@ export async function refreshQwenToken(
 	}
 
 	// Preserve resource_url as a proper field (not encoded in refresh token)
-	const resourceUrl = data.resource_url || (credentials.resource_url as string) || "";
+	const resourceUrl =
+		data.resource_url || (credentials.resource_url as string) || "";
 
 	return {
 		access: data.access_token,
 		refresh: data.refresh_token ?? credentials.refresh,
 		expires: data.expires_in
-			? Date.now() + data.expires_in * 1000
-			: Date.now() + 3600 * 1000,
+			? Date.now() + data.expires_in * 1000 - EXPIRY_BUFFER_MS
+			: Date.now() + 3600 * 1000 - EXPIRY_BUFFER_MS,
 		resource_url: resourceUrl,
 	};
 }
 
 // Fallback endpoint used when resource_url is absent from the OAuth token.
 // Mirrors qwen-code's DEFAULT_QWEN_BASE_URL.
-const QWEN_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+const QWEN_DEFAULT_BASE_URL =
+	"https://dashscope.aliyuncs.com/compatible-mode/v1";
 
 /**
  * Resolve the API base URL from OAuth credentials.

--- a/providers/qwen/qwen-models.ts
+++ b/providers/qwen/qwen-models.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { createLogger } from "../lib/logger.ts";
+import { createLogger } from "../../lib/logger.ts";
 
 const _logger = createLogger("qwen-models");
 

--- a/providers/qwen/qwen.ts
+++ b/providers/qwen/qwen.ts
@@ -24,6 +24,19 @@ import { createLogger } from "../../lib/logger.ts";
 import { loginQwen, refreshQwenToken, getQwenBaseUrl } from "./qwen-auth.ts";
 import { fetchQwenModels } from "./qwen-models.ts";
 
+// =============================================================================
+// 401 detection patterns
+// =============================================================================
+
+/** Patterns that indicate an auth failure requiring token refresh. */
+const AUTH_ERROR_PATTERNS = [
+	"invalid access token",
+	"token expired",
+	"401",
+	"unauthorized",
+	"authentication",
+] as const;
+
 const _logger = createLogger("qwen");
 
 // =============================================================================
@@ -124,9 +137,63 @@ export default async function (pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Keep lightweight request counting for now (internal only).
-	pi.on("turn_end", async (_event, ctx) => {
+	// Request counting + 401 auth-error detection with forced token refresh.
+	//
+	// When Qwen returns a 401 / "invalid access token" error, the stored token
+	// may have been revoked server-side even though its expiry hasn't been reached.
+	// We force-expire the credential in auth storage so that pi-core's next
+	// getApiKey() call will trigger a token refresh via refreshToken().
+	// This mirrors qwen-code's executeWithCredentialManagement() retry logic.
+	//
+	pi.on("turn_end", async (event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_QWEN) return;
 		incrementRequestCount(PROVIDER_QWEN);
+
+		const msg = (
+			event as { message?: { role?: string; errorMessage?: string } }
+		).message;
+
+		if (msg?.role === "assistant" && msg.errorMessage) {
+			const errLower = msg.errorMessage.toLowerCase();
+			const isAuthError = AUTH_ERROR_PATTERNS.some((p) =>
+				errLower.includes(p),
+			);
+
+			if (isAuthError) {
+				_logger.warn(
+					"Qwen auth error detected, force-expiring token for refresh",
+					{ error: msg.errorMessage.slice(0, 100) },
+				);
+
+				// Force-expire the stored credential so the next getApiKey() call
+				// triggers refreshQwenToken(). The credential object in auth.json
+				// is updated with expires = 0 (already past).
+				try {
+					const authStorage =
+						(ctx as any).modelRegistry?.authStorage;
+					if (authStorage) {
+						const cred = authStorage.get(PROVIDER_QWEN);
+						if (cred?.type === "oauth" && cred.expires > Date.now()) {
+							// Set expiry to 0 to force refresh on next request
+							authStorage.set(PROVIDER_QWEN, {
+								...cred,
+								expires: 0,
+							});
+							_logger.info(
+								"Qwen token force-expired; will refresh on next request",
+							);
+						}
+					}
+					ctx.ui.notify(
+						"Qwen: auth error detected, refreshing token…",
+						"warning",
+					);
+				} catch (e) {
+					_logger.warn("Failed to force-expire Qwen token", {
+						error: e instanceof Error ? e.message : String(e),
+					});
+				}
+			}
+		}
 	});
 }

--- a/providers/qwen/qwen.ts
+++ b/providers/qwen/qwen.ts
@@ -11,16 +11,16 @@
 
 import type { OAuthCredentials, Model, Api } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { PROVIDER_QWEN, URL_QWEN_TOS } from "../constants.ts";
+import { PROVIDER_QWEN, URL_QWEN_TOS } from "../../constants.ts";
 import {
 	enhanceWithCI,
 	type StoredModels,
 	setupProvider,
 	createReRegister,
-} from "../provider-helper.ts";
-import { incrementRequestCount } from "../usage/metrics.ts";
-import { logWarning } from "../lib/util.ts";
-import { createLogger } from "../lib/logger.ts";
+} from "../../provider-helper.ts";
+import { incrementRequestCount } from "../../usage/metrics.ts";
+import { logWarning } from "../../lib/util.ts";
+import { createLogger } from "../../lib/logger.ts";
 import { loginQwen, refreshQwenToken, getQwenBaseUrl } from "./qwen-auth.ts";
 import { fetchQwenModels } from "./qwen-models.ts";
 

--- a/providers/zen/zen.ts
+++ b/providers/zen/zen.ts
@@ -18,21 +18,21 @@ import {
 	OPENCODE_API_KEY as CONFIG_API_KEY,
 	PROVIDER_ZEN,
 	ZEN_SHOW_PAID,
-} from "../config.ts";
+} from "../../config.ts";
 import {
 	BASE_URL_ZEN,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	URL_ZEN_TOS,
-} from "../constants.ts";
+} from "../../constants.ts";
 import {
 	type StoredModels,
 	setupProvider,
 	createCtxReRegister,
-} from "../provider-helper.ts";
-import type { ZenGatewayModel } from "../lib/types.ts";
-import { fetchModelsDevMeta } from "./model-fetcher.ts";
-import { createOpenCodeSessionTracker } from "./opencode-session.ts";
-import { fetchWithRetry, logWarning } from "../lib/util.ts";
+} from "../../provider-helper.ts";
+import type { ZenGatewayModel } from "../../lib/types.ts";
+import { fetchModelsDevMeta } from "../model-fetcher.ts";
+import { createOpenCodeSessionTracker } from "../opencode-session.ts";
+import { fetchWithRetry, logWarning } from "../../lib/util.ts";
 
 const ZEN_CONFIG = {
 	providerId: PROVIDER_ZEN,

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -19,18 +19,18 @@ vi.mock("../util.ts", () => ({
 	logWarning: vi.fn(),
 }));
 
-vi.mock("../providers/cline-auth.ts", () => ({
+vi.mock("../providers/cline/cline-auth.ts", () => ({
 	loginCline: vi.fn(),
 	refreshClineToken: vi.fn(),
 }));
 
-vi.mock("../providers/cline-models.ts", () => ({
+vi.mock("../providers/cline/cline-models.ts", () => ({
 	fetchClineModels: vi.fn(),
 }));
 
-import clineProvider from "../providers/cline.ts";
-import { loginCline } from "../providers/cline-auth.ts";
-import { fetchClineModels } from "../providers/cline-models.ts";
+import clineProvider from "../providers/cline/cline.ts";
+import { loginCline } from "../providers/cline/cline-auth.ts";
+import { fetchClineModels } from "../providers/cline/cline-models.ts";
 
 describe("Cline Provider", () => {
 	let mockPi: ExtensionAPI;

--- a/tests/fireworks.test.ts
+++ b/tests/fireworks.test.ts
@@ -50,7 +50,7 @@ describe("Fireworks Provider", () => {
 	describe("initialization", () => {
 		it("should register provider with hardcoded models", async () => {
 			const { default: fireworksProvider } = await import(
-				"../providers/fireworks.ts"
+				"../providers/fireworks/fireworks.ts"
 			);
 			await fireworksProvider(mockPi);
 
@@ -69,7 +69,7 @@ describe("Fireworks Provider", () => {
 			delete process.env.FIREWORKS_API_KEY;
 
 			const { default: fireworksProvider } = await import(
-				"../providers/fireworks.ts"
+				"../providers/fireworks/fireworks.ts"
 			);
 			await fireworksProvider(mockPi);
 
@@ -83,7 +83,7 @@ describe("Fireworks Provider", () => {
 				.mockReturnValue(undefined as any);
 
 			const { default: fireworksProvider } = await import(
-				"../providers/fireworks.ts"
+				"../providers/fireworks/fireworks.ts"
 			);
 			await fireworksProvider(mockPi);
 
@@ -98,7 +98,7 @@ describe("Fireworks Provider", () => {
 	describe("model configuration", () => {
 		it("should have hardcoded models with correct structure", async () => {
 			const { default: fireworksProvider } = await import(
-				"../providers/fireworks.ts"
+				"../providers/fireworks/fireworks.ts"
 			);
 			await fireworksProvider(mockPi);
 
@@ -129,7 +129,7 @@ describe("Fireworks Provider", () => {
 	describe("setupProvider integration", () => {
 		it("should call setupProvider with stored models", async () => {
 			const { default: fireworksProvider } = await import(
-				"../providers/fireworks.ts"
+				"../providers/fireworks/fireworks.ts"
 			);
 			await fireworksProvider(mockPi);
 

--- a/tests/go.test.ts
+++ b/tests/go.test.ts
@@ -64,7 +64,7 @@ describe("Go Provider", () => {
 			logWarning: vi.fn(),
 		}));
 
-		const { default: goProvider } = await import("../providers/go.ts");
+		const { default: goProvider } = await import("../providers/go/go.ts");
 
 		const mockOn = vi.fn();
 		const mockPi = {
@@ -128,7 +128,7 @@ describe("Go Provider", () => {
 			logWarning: vi.fn(),
 		}));
 
-		const { default: goProvider } = await import("../providers/go.ts");
+		const { default: goProvider } = await import("../providers/go/go.ts");
 
 		const mockOn = vi.fn();
 		const mockPi = {

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -40,7 +40,7 @@ vi.mock("../lib/util.ts", () => ({
 	logWarning: vi.fn(),
 }));
 
-import kiloProvider from "../providers/kilo.ts";
+import kiloProvider from "../providers/kilo/kilo.ts";
 
 describe("Kilo toggle behavior", () => {
 	let mockPi: ExtensionAPI;

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -14,12 +14,12 @@ vi.mock("../config.ts", () => ({
 	PROVIDER_KILO: "kilo",
 }));
 
-vi.mock("../providers/kilo-models.ts", () => ({
+vi.mock("../providers/kilo/kilo-models.ts", () => ({
 	fetchKiloModels: (...args: unknown[]) => mockFetchKiloModels(...args),
 	KILO_GATEWAY_BASE: "https://api.kilo.ai/api/gateway",
 }));
 
-vi.mock("../providers/kilo-auth.ts", () => ({
+vi.mock("../providers/kilo/kilo-auth.ts", () => ({
 	loginKilo: vi.fn().mockResolvedValue({ access: "oauth-token" }),
 	refreshKiloToken: vi.fn(),
 }));

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -16,7 +16,7 @@ vi.mock("../providers/kilo-auth.ts", () => ({
 	refreshKiloToken: vi.fn(),
 }));
 
-vi.mock("../providers/kilo-models.ts", () => ({
+vi.mock("../providers/kilo/kilo-models.ts", () => ({
 	fetchKiloModels: (...args: unknown[]) => mockFetchKiloModels(...args),
 	KILO_GATEWAY_BASE: "https://api.kilo.ai/api/gateway",
 }));
@@ -36,8 +36,8 @@ vi.mock("../lib/util.ts", () => ({
 }));
 
 import { setupProvider } from "../provider-helper.ts";
-import kiloProvider from "../providers/kilo.ts";
-import { fetchKiloModels } from "../providers/kilo-models.ts";
+import kiloProvider from "../providers/kilo/kilo.ts";
+import { fetchKiloModels } from "../providers/kilo/kilo-models.ts";
 
 describe("Kilo Provider", () => {
 	let mockPi: ExtensionAPI;

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -11,7 +11,7 @@ const mockSetupProvider = vi.fn();
 const mockLoginKilo = vi.fn();
 
 // Mock dependencies before importing the provider
-vi.mock("../providers/kilo-auth.ts", () => ({
+vi.mock("../providers/kilo/kilo-auth.ts", () => ({
 	loginKilo: (...args: unknown[]) => mockLoginKilo(...args),
 	refreshKiloToken: vi.fn(),
 }));

--- a/tests/mistral.test.ts
+++ b/tests/mistral.test.ts
@@ -47,7 +47,7 @@ vi.mock("../lib/logger.ts", () => ({
 	}),
 }));
 
-import mistralProvider from "../providers/mistral.ts";
+import mistralProvider from "../providers/mistral/mistral.ts";
 
 describe("Mistral Provider", () => {
 	beforeEach(() => {

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -31,7 +31,7 @@ vi.mock("../constants.ts", () => ({
 	URL_MODELS_DEV: "https://models.dev/api.json",
 }));
 
-import nvidiaProvider from "../providers/nvidia.ts";
+import nvidiaProvider from "../providers/nvidia/nvidia.ts";
 
 describe("NVIDIA Provider", () => {
 	beforeEach(() => {

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -72,7 +72,7 @@ describe("Ollama Provider", () => {
 			} as Response);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -91,7 +91,7 @@ describe("Ollama Provider", () => {
 			delete process.env.OLLAMA_API_KEY;
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -104,7 +104,7 @@ describe("Ollama Provider", () => {
 				.mockReturnValue(undefined as any);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -118,7 +118,7 @@ describe("Ollama Provider", () => {
 				.mockReturnValue(false);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -157,7 +157,7 @@ describe("Ollama Provider", () => {
 			} as Response);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -186,7 +186,7 @@ describe("Ollama Provider", () => {
 			} as Response);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -213,7 +213,7 @@ describe("Ollama Provider", () => {
 			} as Response);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 
@@ -242,7 +242,7 @@ describe("Ollama Provider", () => {
 			} as Response);
 
 			const { default: ollamaProvider } = await import(
-				"../providers/ollama.ts"
+				"../providers/ollama/ollama.ts"
 			);
 			await ollamaProvider(mockPi);
 

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -49,7 +49,7 @@ vi.mock("../providers/model-fetcher.ts", () => ({
 
 import { setupProvider } from "../provider-helper.ts";
 import { fetchOpenRouterModelsWithFree } from "../providers/model-fetcher.ts";
-import openrouterProvider from "../providers/openrouter.ts";
+import openrouterProvider from "../providers/openrouter/openrouter.ts";
 
 describe("OpenRouter Provider", () => {
 	let mockPi: ExtensionAPI;

--- a/tests/qwen.test.ts
+++ b/tests/qwen.test.ts
@@ -36,7 +36,7 @@ vi.mock("../lib/util.ts", () => ({
 	logWarning: vi.fn(),
 }));
 
-vi.mock("../providers/qwen-auth.ts", () => ({
+vi.mock("../providers/qwen/qwen-auth.ts", () => ({
 	loginQwen: vi.fn(),
 	refreshQwenToken: vi.fn(),
 	// Default: no resource_url → fallback DashScope (mirrors qwen-code behaviour)
@@ -52,7 +52,7 @@ const PORTAL_COMPAT = {
 	maxTokensField: "max_tokens" as const,
 };
 
-vi.mock("../providers/qwen-models.ts", () => ({
+vi.mock("../providers/qwen/qwen-models.ts", () => ({
 	fetchQwenModels: vi.fn(),
 	PORTAL_COMPAT: {
 		supportsStore: false,
@@ -84,8 +84,8 @@ vi.mock("../providers/qwen-models.ts", () => ({
 }));
 
 import { setupProvider } from "../provider-helper.ts";
-import { loginQwen } from "../providers/qwen-auth.ts";
-import { fetchQwenModels } from "../providers/qwen-models.ts";
+import { loginQwen } from "../providers/qwen/qwen-auth.ts";
+import { fetchQwenModels } from "../providers/qwen/qwen-models.ts";
 import { incrementRequestCount } from "../usage/metrics.ts";
 
 const MOCK_MODEL = {
@@ -121,7 +121,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -146,7 +146,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -159,7 +159,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -186,7 +186,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -213,7 +213,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(loginQwen).mockResolvedValue(mockCreds);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -228,7 +228,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -249,7 +249,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -269,7 +269,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -290,7 +290,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -314,7 +314,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -335,7 +335,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 
@@ -360,7 +360,7 @@ describe("Qwen OAuth Provider", () => {
 			vi.mocked(fetchQwenModels).mockResolvedValue([MOCK_MODEL]);
 
 			const { default: qwenProvider } = await import(
-				"../providers/qwen.ts"
+				"../providers/qwen/qwen.ts"
 			);
 			await qwenProvider(mockPi);
 

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -245,7 +245,10 @@ describe("Utility Functions", () => {
 				json: async () => ({ data: [{ id: "model-1" }, { id: "model-2" }] }),
 			} as Response;
 
-			const result = await parseModelResponse(mockResponse, "test-provider");
+			const result = await parseModelResponse<{ id: string }>(
+				mockResponse,
+				"test-provider",
+			);
 
 			expect(result.data).toHaveLength(2);
 			expect(result.data[0].id).toBe("model-1");

--- a/tests/zen.test.ts
+++ b/tests/zen.test.ts
@@ -43,7 +43,7 @@ vi.mock("../lib/util.ts", () => ({
 
 import { fetchWithRetry } from "../lib/util.ts";
 import { setupProvider } from "../provider-helper.ts";
-import zenProvider from "../providers/zen.ts";
+import zenProvider from "../providers/zen/zen.ts";
 
 describe("Zen Provider", () => {
 	let mockPi: ExtensionAPI;


### PR DESCRIPTION
## Summary\n- detect Qwen auth-related 401s and force-expire stored OAuth credentials\n- remove the refresh short-circuit so forced refreshes can proceed after server-side revocation\n- apply a proactive token expiry buffer to reduce late refresh failures\n\n## Validation\n- npm run check\n- npm run test:run