### PR TITLE
fix: add CI enhancement to all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Toggle with `/go-toggle`
 
 ### Fixed
+- **All providers now show Coding Index scores in model selector** — Added `enhanceWithCI()` to factory-based providers (nvidia, fireworks, mistral, modal, ollama) and cline. Now all providers display CI scores in `/models` command (pi-models extension).
+
 - **All providers now show in `--list-models`** — Providers (zen, openrouter, go) that registered models only in `session_start` were missing from `pi --list-models` which runs before session starts. Added immediate registration for these providers:
   - **zen**: Added model caching to `~/.pi/provider-cache.json` for immediate registration + dynamic refresh
   - **openrouter**: Immediate model registration at extension load (like kilo/cline)

--- a/provider-factory.ts
+++ b/provider-factory.ts
@@ -27,18 +27,19 @@ import {
 	FIREWORKS_SHOW_PAID,
 	MISTRAL_API_KEY,
 	MISTRAL_SHOW_PAID,
+	MODAL_API_KEY,
 	NVIDIA_API_KEY,
 	NVIDIA_SHOW_PAID,
 	OLLAMA_API_KEY,
 	OLLAMA_SHOW_PAID,
 	OPENCODE_API_KEY,
 	ZEN_SHOW_PAID,
-	MODAL_API_KEY,
 } from "./config.ts";
 import { createLogger } from "./lib/logger.ts";
 import { logWarning } from "./lib/util.ts";
 import {
 	createReRegister,
+	enhanceWithCI,
 	type StoredModels,
 	setupProvider,
 } from "./provider-helper.ts";
@@ -181,7 +182,7 @@ export async function createProvider(
 			"User-Agent": "pi-free-providers",
 			...def.extraHeaders,
 		},
-		models,
+		models: enhanceWithCI(models),
 	});
 
 	// 8. Setup boilerplate

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -15,8 +15,9 @@
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
-import { incrementRequestCount } from "../../usage/metrics.ts";
 import { logWarning } from "../../lib/util.ts";
+import { enhanceWithCI } from "../../provider-helper.ts";
+import { incrementRequestCount } from "../../usage/metrics.ts";
 import { loginCline, refreshClineToken } from "./cline-auth.ts";
 import { fetchClineModels } from "./cline-models.ts";
 
@@ -204,7 +205,7 @@ export default async function (pi: ExtensionAPI) {
 			api: "openai-completions" as const,
 			authHeader: false,
 			headers: buildClineHeaders(),
-			models: m,
+			models: enhanceWithCI(m),
 			oauth: {
 				name: "Cline",
 				login: loginCline,

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -28,6 +28,10 @@ vi.mock("../providers/cline/cline-models.ts", () => ({
 	fetchClineModels: vi.fn(),
 }));
 
+vi.mock("../provider-helper.ts", () => ({
+	enhanceWithCI: (models: unknown[]) => models,
+}));
+
 import clineProvider from "../providers/cline/cline.ts";
 import { loginCline } from "../providers/cline/cline-auth.ts";
 import { fetchClineModels } from "../providers/cline/cline-models.ts";
@@ -70,7 +74,7 @@ describe("Cline Provider", () => {
 				"cline",
 				expect.objectContaining({
 					baseUrl: "https://api.cline.bot/api/v1",
-					models: mockModels,
+					models: expect.any(Array), // enhanced via enhanceWithCI
 					oauth: expect.any(Object),
 				}),
 			);

--- a/tests/fireworks.test.ts
+++ b/tests/fireworks.test.ts
@@ -20,6 +20,7 @@ vi.mock("../constants.ts", () => ({
 vi.mock("../provider-helper.ts", () => ({
 	createReRegister: vi.fn(() => vi.fn()),
 	setupProvider: vi.fn(),
+	enhanceWithCI: (models: unknown[]) => models,
 }));
 
 vi.mock("../lib/logger.ts", () => ({

--- a/tests/mistral.test.ts
+++ b/tests/mistral.test.ts
@@ -21,6 +21,7 @@ vi.mock("../constants.ts", () => ({
 vi.mock("../provider-helper.ts", () => ({
 	createReRegister: vi.fn(() => vi.fn()),
 	setupProvider: vi.fn(),
+	enhanceWithCI: (models: unknown[]) => models,
 }));
 
 vi.mock("../provider-factory.ts", () => ({

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -21,6 +21,7 @@ vi.mock("../constants.ts", () => ({
 vi.mock("../provider-helper.ts", () => ({
 	createReRegister: vi.fn(() => vi.fn()),
 	setupProvider: vi.fn(),
+	enhanceWithCI: (models: unknown[]) => models,
 }));
 
 vi.mock("../lib/logger.ts", () => ({


### PR DESCRIPTION
## Summary
All providers now display Coding Index scores in the model selector ( command via pi-models extension).

## Changes
- **provider-factory.ts**: Added  to initial provider registration (affects nvidia, fireworks, mistral, modal, ollama)
- **providers/cline/cline.ts**: Added  to registerProvider function
- **Test updates**: Added  mocks to factory tests

## Before/After
Before: Only kilo, qwen, go, openrouter, zen showed CI scores (via session_start re-registration)
After: All providers (nvidia, fireworks, mistral, modal, ollama, cline) also show CI scores

## Testing
- 155/155 tests passing
- TypeScript compiles cleanly