### PR TITLE
fix: toggle commands now actually filter models from UI

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@
  * - Fireworks: Fireworks AI (paid, but useful for failover)
  */
 
+import type { Api, Model } from "@mariozechner/pi-ai";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
@@ -147,38 +148,63 @@ function setupBuiltInProviderToggles(pi: ExtensionAPI, _state: FilterState) {
 	// OpenRouter toggle - controls free vs all models for built-in OpenRouter provider
 	let openrouterShowPaid = OPENROUTER_SHOW_PAID;
 
+	// Apply initial OpenRouter filtering on session start (when registry is ready)
+	pi.on("session_start", async (_event, ctx) => {
+		const available = await ctx.modelRegistry.getAvailable();
+		const openrouterModels = available.filter(
+			(m: Model<Api>) => m.provider === "openrouter",
+		);
+		const freeCount = openrouterModels.filter(isFreeModel).length;
+		const paidCount = openrouterModels.length - freeCount;
+
+		if (!openrouterShowPaid && paidCount > 0) {
+			// Filter to only free models by re-registering with filtered list
+			const freeModels = openrouterModels.filter(isFreeModel);
+			pi.registerProvider("openrouter", {
+				models: freeModels,
+			});
+			_logger.info(
+				`[pi-free] OpenRouter: filtered to ${freeCount} free models (${paidCount} paid hidden)`,
+			);
+		} else if (openrouterShowPaid) {
+			// Unregister to restore all built-in models
+			pi.unregisterProvider("openrouter");
+			_logger.info(
+				`[pi-free] OpenRouter: showing all ${openrouterModels.length} models`,
+			);
+		}
+	});
+
 	pi.registerCommand("openrouter-toggle", {
 		description: "Toggle between free and all OpenRouter models",
 		handler: async (_args, ctx) => {
 			openrouterShowPaid = !openrouterShowPaid;
 			saveConfig({ openrouter_show_paid: openrouterShowPaid });
 
-			// Get current models and filter if needed
+			// Get current models and apply filtering
 			const available = await ctx.modelRegistry.getAvailable();
 			const openrouterModels = available.filter(
-				(m) => m.provider === "openrouter",
+				(m: Model<Api>) => m.provider === "openrouter",
 			);
 			const freeCount = openrouterModels.filter(isFreeModel).length;
 			const paidCount = openrouterModels.length - freeCount;
 
 			if (openrouterShowPaid) {
+				// Unregister to restore all built-in models
+				pi.unregisterProvider("openrouter");
 				ctx.ui.notify(
 					`openrouter: showing all ${openrouterModels.length} models (including paid)`,
 					"info",
 				);
 			} else {
+				// Filter to only free models
+				const freeModels = openrouterModels.filter(isFreeModel);
+				pi.registerProvider("openrouter", {
+					models: freeModels,
+				});
 				ctx.ui.notify(
 					`openrouter: showing only ${freeCount} free models (${paidCount} paid hidden)`,
 					"info",
-				);
-			}
-
-			// Note: We can't directly re-register built-in providers.
-			// The filtering happens at model selection time via the model_select event.
-			// For immediate effect, we log a note to the user.
-			if (!openrouterShowPaid && paidCount > 0) {
-				_logger.info(
-					`[pi-free] OpenRouter: ${paidCount} paid models will be filtered from selection`,
 				);
 			}
 		},

--- a/providers/fireworks/fireworks.ts
+++ b/providers/fireworks/fireworks.ts
@@ -6,13 +6,15 @@
  * Get a key at: https://app.fireworks.ai/settings/users/api-keys
  *
  * All models are credit-based (no free tier).
- * Set FIREWORKS_SHOW_PAID=true to enable.
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { PROVIDER_FIREWORKS } from "../../config.ts";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { FIREWORKS_API_KEY, PROVIDER_FIREWORKS } from "../../config.ts";
 import { BASE_URL_FIREWORKS } from "../../constants.ts";
-import { createProvider } from "../../provider-factory.ts";
+import { enhanceWithCI } from "../../provider-helper.ts";
 
 // =============================================================================
 // Static model list (Fireworks doesn't have a models API)
@@ -37,13 +39,29 @@ function getFireworksModels(): ProviderModelConfig[] {
 // Extension Entry Point
 // =============================================================================
 
-export default function (pi: Parameters<typeof createProvider>[0]) {
-	return createProvider(pi, {
-		providerId: PROVIDER_FIREWORKS,
+export default function (pi: ExtensionAPI): void {
+	// Skip if no API key configured
+	if (!FIREWORKS_API_KEY) {
+		console.log(
+			"[fireworks] No API key found — set FIREWORKS_API_KEY to enable",
+		);
+		return;
+	}
+
+	// Inject key into env for Pi's lookup
+	process.env.FIREWORKS_API_KEY = FIREWORKS_API_KEY;
+
+	// Register provider directly (no toggle since all models are paid)
+	const models = getFireworksModels();
+	pi.registerProvider(PROVIDER_FIREWORKS, {
 		baseUrl: BASE_URL_FIREWORKS,
-		apiKeyEnvVar: "FIREWORKS_API_KEY",
-		apiKeyConfigKey: "fireworks_api_key",
-		showPaidFlag: "FIREWORKS_SHOW_PAID",
-		fetchModels: async () => getFireworksModels(),
+		apiKey: "FIREWORKS_API_KEY",
+		api: "openai-completions" as const,
+		headers: {
+			"User-Agent": "pi-free-providers",
+		},
+		models: enhanceWithCI(models),
 	});
+
+	console.log(`[fireworks] Registered ${models.length} paid models`);
 }

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -14,7 +14,11 @@
  */
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { applyHidden, NVIDIA_SHOW_PAID, PROVIDER_NVIDIA } from "../../config.ts";
+import {
+	applyHidden,
+	NVIDIA_SHOW_PAID,
+	PROVIDER_NVIDIA,
+} from "../../config.ts";
 import {
 	BASE_URL_NVIDIA,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -29,7 +33,9 @@ import { createProvider } from "../../provider-factory.ts";
 // Fetch + map
 // =============================================================================
 
-async function fetchNvidiaModels(): Promise<ProviderModelConfig[]> {
+async function fetchNvidiaModels(
+	showPaid = false,
+): Promise<ProviderModelConfig[]> {
 	const response = await fetchWithRetry(
 		URL_MODELS_DEV,
 		{
@@ -70,8 +76,8 @@ async function fetchNvidiaModels(): Promise<ProviderModelConfig[]> {
 			})
 			.filter((m) => {
 				// All NVIDIA models are credit-based (no hard cost.input = 0 distinction).
-				// Respect NVIDIA_SHOW_PAID: without the flag, only expose models marked free.
-				if (!NVIDIA_SHOW_PAID && (m.cost?.input ?? 0) > 0) return false;
+				// Respect showPaid flag: without it, only expose models marked free.
+				if (!showPaid && (m.cost?.input ?? 0) > 0) return false;
 				return true;
 			})
 			.map(
@@ -97,17 +103,65 @@ async function fetchNvidiaModels(): Promise<ProviderModelConfig[]> {
 	return result;
 }
 
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+	createReRegister,
+	type StoredModels,
+	setupProvider,
+} from "../../provider-helper.ts";
+
 // =============================================================================
 // Extension Entry Point
 // =============================================================================
 
-export default function (pi: Parameters<typeof createProvider>[0]) {
-	return createProvider(pi, {
+export default async function (pi: ExtensionAPI) {
+	// Track current mode (synced with config)
+	let currentShowPaid = NVIDIA_SHOW_PAID;
+
+	// Fetch initial models based on config
+	let freeModels: ProviderModelConfig[] = [];
+	let allModels: ProviderModelConfig[] = [];
+
+	try {
+		// Fetch free models initially
+		freeModels = await fetchNvidiaModels(false);
+		// Fetch all models for toggle (if paid mode enabled later)
+		allModels = await fetchNvidiaModels(true);
+	} catch (error) {
+		console.error("[nvidia] Failed to fetch models at startup", error);
+		return;
+	}
+
+	// Store both sets for toggle
+	const stored: StoredModels = { free: freeModels, all: allModels };
+	const initialModels = currentShowPaid ? allModels : freeModels;
+
+	// Register provider with initial models
+	pi.registerProvider(PROVIDER_NVIDIA, {
+		baseUrl: BASE_URL_NVIDIA,
+		apiKey: "NVIDIA_API_KEY",
+		api: "openai-completions" as const,
+		headers: {
+			"User-Agent": "pi-free-providers",
+		},
+		models: initialModels,
+	});
+
+	// Create re-register function for toggle
+	const reRegister = createReRegister(pi, {
 		providerId: PROVIDER_NVIDIA,
 		baseUrl: BASE_URL_NVIDIA,
-		apiKeyEnvVar: "NVIDIA_API_KEY",
-		apiKeyConfigKey: "nvidia_api_key",
-		// Note: NVIDIA_SHOW_PAID filtering is handled inside fetchNvidiaModels
-		fetchModels: fetchNvidiaModels,
+		apiKey: "NVIDIA_API_KEY",
 	});
+
+	// Wire up toggle command and events
+	setupProvider(pi, {
+		providerId: PROVIDER_NVIDIA,
+		initialShowPaid: NVIDIA_SHOW_PAID,
+		reRegister: (models) => {
+			// Update showPaid state based on which model set is being registered
+			currentShowPaid = models === stored.all;
+			reRegister(models);
+		},
+	}, stored);
 }

--- a/tests/fireworks.test.ts
+++ b/tests/fireworks.test.ts
@@ -18,8 +18,6 @@ vi.mock("../constants.ts", () => ({
 }));
 
 vi.mock("../provider-helper.ts", () => ({
-	createReRegister: vi.fn(() => vi.fn()),
-	setupProvider: vi.fn(),
 	enhanceWithCI: (models: unknown[]) => models,
 }));
 
@@ -32,7 +30,7 @@ vi.mock("../lib/logger.ts", () => ({
 	}),
 }));
 
-import { setupProvider } from "../provider-helper.ts";
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
 
 describe("Fireworks Provider", () => {
 	let mockPi: ExtensionAPI;
@@ -106,7 +104,7 @@ describe("Fireworks Provider", () => {
 			expect(mockRegisterProvider).toHaveBeenCalled();
 			const registerCall = mockRegisterProvider.mock.calls[0];
 			expect(registerCall).toBeDefined();
-			const models = registerCall?.[1]?.models;
+			const models: ProviderModelConfig[] = registerCall?.[1]?.models;
 
 			expect(models).toBeInstanceOf(Array);
 			expect(models.length).toBeGreaterThan(0);
@@ -124,26 +122,6 @@ describe("Fireworks Provider", () => {
 			// Verify non-zero costs (paid model, not free)
 			expect(firstModel.cost.input).toBeGreaterThan(0);
 			expect(firstModel.cost.output).toBeGreaterThan(0);
-		});
-	});
-
-	describe("setupProvider integration", () => {
-		it("should call setupProvider with stored models", async () => {
-			const { default: fireworksProvider } = await import(
-				"../providers/fireworks/fireworks.ts"
-			);
-			await fireworksProvider(mockPi);
-
-			expect(setupProvider).toHaveBeenCalledWith(
-				mockPi,
-				expect.objectContaining({
-					providerId: "fireworks",
-				}),
-				expect.objectContaining({
-					free: expect.any(Array),
-					all: expect.any(Array),
-				}),
-			);
 		});
 	});
 });

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -4,15 +4,18 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ModelsDevModel, ModelsDevProvider } from "../lib/types.ts";
+import type { ModelsDevModel } from "../lib/types.ts";
 
-let capturedConfig: any = null;
+let capturedSetupConfig: any = null;
+let capturedStored: any = null;
 
-vi.mock("../provider-factory.ts", () => ({
-	createProvider: vi.fn(async (_pi: any, def: any) => {
-		capturedConfig = def;
-		// Don't call fetchModels - just capture config
-		return;
+// Mock provider-helper for toggle behavior testing
+vi.mock("../provider-helper.ts", () => ({
+	enhanceWithCI: (m: any[]) => m,
+	createReRegister: vi.fn(() => vi.fn()),
+	setupProvider: vi.fn((_pi: any, config: any, stored: any) => {
+		capturedSetupConfig = config;
+		capturedStored = stored;
 	}),
 }));
 
@@ -36,7 +39,8 @@ import nvidiaProvider from "../providers/nvidia/nvidia.ts";
 describe("NVIDIA Provider", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		capturedConfig = null;
+		capturedSetupConfig = null;
+		capturedStored = null;
 	});
 
 	describe("model filtering logic", () => {
@@ -226,18 +230,35 @@ describe("NVIDIA Provider", () => {
 		});
 	});
 
-	it("should configure factory correctly", async () => {
-		const mockPi = {} as ExtensionAPI;
+	it("should configure provider correctly with toggle support", async () => {
+		const mockPi = {
+			registerProvider: vi.fn(),
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+		} as unknown as ExtensionAPI;
+
 		await nvidiaProvider(mockPi);
 
-		expect(capturedConfig).toMatchObject({
+		// Should call registerProvider with nvidia provider
+		expect(mockPi.registerProvider).toHaveBeenCalledWith(
+			"nvidia",
+			expect.objectContaining({
+				baseUrl: "https://integrate.api.nvidia.com/v1",
+				apiKey: "NVIDIA_API_KEY",
+				api: "openai-completions",
+			}),
+		);
+
+		// Should setup toggle with both free and all model sets
+		expect(capturedSetupConfig).toMatchObject({
 			providerId: "nvidia",
-			baseUrl: "https://integrate.api.nvidia.com/v1",
-			apiKeyEnvVar: "NVIDIA_API_KEY",
-			apiKeyConfigKey: "nvidia_api_key",
+			initialShowPaid: true, // From mock config
 		});
-		// Should NOT have showPaidFlag (NVIDIA filters internally)
-		expect(capturedConfig.showPaidFlag).toBeUndefined();
-		expect(typeof capturedConfig.fetchModels).toBe("function");
+		expect(capturedStored.free).toBeDefined();
+		expect(capturedStored.all).toBeDefined();
+		expect(capturedStored.free.length).toBeGreaterThanOrEqual(0);
+		expect(capturedStored.all.length).toBeGreaterThanOrEqual(
+			capturedStored.free.length,
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the toggle commands to actually filter models from the model picker UI, not just show notifications.

## Changes

### OpenRouter ()
- **Before**: Only toggled a flag and showed notifications - paid models still appeared in UI
- **After**: Uses / to actually filter models from the picker

### NVIDIA ()  
- **Before**:  used static config - toggle just re-registered same cached models
- **After**: Accepts dynamic  parameter, fetches both sets at startup, toggle switches between them

### Fireworks
- **Before**: Broken toggle with  that prevented registration entirely if false
- **After**: Removed toggle (all models are paid, no free tier to toggle between)

## Test Results
- ✅ Type check: Passed
- ✅ Tests: 97 passed across 11 test files

## Files Changed
-  - OpenRouter toggle fix
-  - Dynamic fetch + proper toggle
-  - Remove broken toggle
-  - Updated for new implementation
-  - Updated for simplified implementation