### PR TITLE
fix: add required baseUrl/apiKey/api when registering openrouter provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
     branches: [master]
 
 jobs:
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Type check
+        run: npx tsc --noEmit
+
   install-test:
     name: Install test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/index.ts
+++ b/index.ts
@@ -161,6 +161,9 @@ function setupBuiltInProviderToggles(pi: ExtensionAPI, _state: FilterState) {
 			// Filter to only free models by re-registering with filtered list
 			const freeModels = openrouterModels.filter(isFreeModel);
 			pi.registerProvider("openrouter", {
+				baseUrl: "https://openrouter.ai/api/v1",
+				apiKey: "OPENROUTER_API_KEY",
+				api: "openai-completions",
 				models: freeModels,
 			});
 			_logger.info(
@@ -200,6 +203,9 @@ function setupBuiltInProviderToggles(pi: ExtensionAPI, _state: FilterState) {
 				// Filter to only free models
 				const freeModels = openrouterModels.filter(isFreeModel);
 				pi.registerProvider("openrouter", {
+					baseUrl: "https://openrouter.ai/api/v1",
+					apiKey: "OPENROUTER_API_KEY",
+					api: "openai-completions",
 					models: freeModels,
 				});
 				ctx.ui.notify(


### PR DESCRIPTION
Fixes runtime error: Provider openrouter: baseUrl is required when defining models.

- Added baseUrl, apiKey, and api fields to registerProvider calls with filtered models
- Added typecheck job to CI for earlier error detection