### PR TITLE
docs: Final README updates - provider categories and toggle clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When you install pi-free, it:
 
 3. **Provides a toggle command** — Run `/{provider}-toggle` (e.g., `/zen-toggle`, `/kilo-toggle`) to switch between free-only mode and showing all models including paid ones
 
-4. **Handles authentication for you** — OAuth flows (Kilo, Cline, Qwen) open your browser automatically; API keys are read from `~/.pi/free.json` or environment variables
+4. **Handles authentication for you** — OAuth flows (Kilo, Cline) open your browser automatically; API keys are read from `~/.pi/free.json` or environment variables
 
 5. **Adds Coding Index scores** — Model names include a coding benchmark score (CI: 45.2) to help you pick capable coding models at a glance
 
@@ -38,19 +38,24 @@ Start Pi and press `Ctrl+L` to open the model picker.
 
 Free models are shown by default — look for the provider prefixes:
 
-**🆓 Free tiers (no cost):**
+**✅ Actually Free (no usage limits, no payment required):**
 - `zen/` — OpenCode Zen models (no setup required)
 - `kilo/` — Kilo models (free models available immediately, more after `/login kilo`)
 - `openrouter/` — OpenRouter models (free account required)
-- `nvidia/` — NVIDIA NIM models (free API key required)
-- `cloudflare/` — Cloudflare Workers AI (free API key, 10K Neurons/day free tier)
 - `cline/` — Cline models (run `/login cline` to use)
-- `qwen/` — Qwen Coder (run `/login qwen` to use, 1,000 free requests/day)
-- `modal/` — GLM-5.1 FP8 via Modal (free promotional period until April 30, 2026)
-- `ollama/` — Ollama Cloud models (free API key required)
-- `mistral/` — Mistral models (free API key required)
 
-**💳 Paid only (no free tier):**
+**🔄 Freemium (free tier with limits, then paid):**
+- `nvidia/` — NVIDIA NIM models (1,000 free requests/month, then credits)
+- `cloudflare/` — Cloudflare Workers AI (10K Neurons/day free tier, then $0.011/1K Neurons)
+- `modal/` — GLM-5.1 FP8 via Modal (free promotional period until April 30, 2026)
+- `ollama/` — Ollama Cloud models (usage-based free tier, resets every 5 hours + 7 days)
+
+**🔧 Dynamic API Providers (free models when API key configured):**
+- `mistral/` — Mistral models (free models via API when `MISTRAL_API_KEY` set)
+- `groq/` — Groq models (free models via API when `GROQ_API_KEY` set)
+- `cerebras/` — Cerebras models (free models via API when `CEREBRAS_API_KEY` set)
+
+**💳 Paid Only (no free tier):**
 - `go/` — OpenCode Go models (requires subscription — $5 first month, then $10/month)
 - `fireworks/` — Fireworks models (credit-based pricing, no free tier)
 
@@ -59,18 +64,24 @@ Free models are shown by default — look for the provider prefixes:
 Want to see paid models too? Run the toggle command for your provider:
 
 ```
-/zen-toggle         # Toggle Zen free/paid models
-/kilo-toggle        # Toggle Kilo free/paid models
-/openrouter-toggle  # Toggle OpenRouter free/paid models
-/nvidia-toggle      # Toggle NVIDIA zero-cost/credit-costing models
-/cloudflare-toggle  # Toggle Cloudflare Workers AI models (10K Neurons/day free tier)
-/cline-toggle      # Toggle Cline free/paid models
-/mistral-toggle     # Toggle Mistral free/paid models
-/ollama-toggle     # Toggle Ollama models (requires SHOW_PAID=true)
-/go-toggle         # Toggle Go models (⚠️ paid only — requires subscription)
+/zen-toggle         # Toggle Zen (✅ actually free)
+/kilo-toggle        # Toggle Kilo (✅ actually free)
+/openrouter-toggle  # Toggle OpenRouter (✅ actually free)
+/cline-toggle      # Toggle Cline (✅ actually free)
+/nvidia-toggle      # Toggle NVIDIA (🔄 freemium - 1K req/month free)
+/cloudflare-toggle  # Toggle Cloudflare (🔄 freemium - 10K Neurons/day)
+/modal-toggle      # Toggle Modal (🔄 freemium - until Apr 30, 2026)
+/ollama-toggle     # Toggle Ollama (🔄 freemium - usage-based)
+/mistral-toggle     # Toggle Mistral (🔧 dynamic - needs API key)
+/groq-toggle        # Toggle Groq (🔧 dynamic - needs API key)
+/cerebras-toggle   # Toggle Cerebras (🔧 dynamic - needs API key)
+/go-toggle         # Toggle Go (💳 paid only - subscription)
 ```
 
-**Note:** Fireworks has no toggle command since all models are paid-only with no free tier.
+**Notes:**
+- Fireworks has no toggle command since all models are paid-only
+- Freemium providers show all models by default (you manage limits via their dashboards)
+- Toggle commands for freemium providers mainly filter the UI view
 
 You'll see a notification like: `zen: showing free models` or `zen: showing all models (including paid)`
 
@@ -107,10 +118,8 @@ See the [Providers That Need Authentication](#providers-that-need-authentication
 | `/{provider}-toggle` | Switch between free-only and all models for that provider |
 | `/login kilo` | Start OAuth flow for Kilo |
 | `/login cline` | Start OAuth flow for Cline |
-| `/login qwen` | Start OAuth flow for Qwen |
 | `/logout kilo` | Clear Kilo OAuth credentials |
 | `/logout cline` | Clear Cline OAuth credentials |
-| `/logout qwen` | Clear Qwen OAuth credentials |
 
 ---
 
@@ -250,7 +259,7 @@ The account ID is automatically derived from your token. Optionally, you can als
 export CLOUDFLARE_ACCOUNT_ID="your_account_id"  # Optional
 ```
 
-**Models available:** Llama 4, Mistral Small 3.1, Qwen 2.5/3, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, and more.
+**Models available:** Llama 4, Mistral Small 3.1, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, and more.
 
 Toggle with `/cloudflare-toggle`
 
@@ -300,28 +309,6 @@ Add API key to `~/.pi/free.json` or environment variables:
 ```bash
 export MISTRAL_API_KEY="..."
 ```
-
-### Qwen (1,000 free requests/day)
-
-Qwen provides free access to **Qwen Coder** (Qwen3.6-Plus) via OAuth device flow — no API key or credit card needed.
-
-```
-/login qwen
-```
-
-This command will:
-1. Open your browser to Qwen Studio's authorization page
-2. Display a device code (enter it if the browser doesn't pre-fill it)
-3. Wait for you to authorize in the browser
-4. Automatically complete login once approved
-
-Then select a `qwen/` model in the model picker.
-
-**Details:**
-- Free tier: 1,000 requests/day
-- Model: Qwen Coder (131k context, 16k max output)
-- No credit card required — just a free [Qwen Studio](https://chat.qwen.ai) account
-- To re-authenticate: `/logout qwen` then `/login qwen`
 
 ---
 
@@ -380,14 +367,16 @@ Each provider has toggle commands to switch between free and all models:
 | `/zen-toggle` | Toggle between free/all Zen models |
 | `/kilo-toggle` | Toggle between free/all Kilo models |
 | `/openrouter-toggle` | Toggle between free/all OpenRouter models |
-| `/nvidia-toggle` | Toggle between free/all NVIDIA models |
+| `/nvidia-toggle` | Toggle between free/all NVIDIA models (🔄 freemium) |
+| `/cloudflare-toggle` | Toggle between free/all Cloudflare models (🔄 freemium) |
+| `/modal-toggle` | Toggle between free/all Modal models (🔄 freemium) |
+| `/ollama-toggle` | Toggle between free/all Ollama models (🔄 freemium) |
 | `/cline-toggle` | Toggle between free/all Cline models |
-| `/mistral-toggle` | Toggle between free/all Mistral models |
-| `/ollama-toggle` | Toggle between free/all Ollama models |
-| `/go-toggle` | ⚠️ Toggle Go models (paid only) |
-| `/fireworks-toggle` | ⚠️ Toggle Fireworks models (paid only) |
-| `/login qwen` | Authenticate with Qwen Studio (OAuth) |
-| `/logout qwen` | Clear Qwen credentials |
+| `/mistral-toggle` | Toggle between free/all Mistral models (🔧 dynamic) |
+| `/groq-toggle` | Toggle between free/all Groq models (🔧 dynamic) |
+| `/cerebras-toggle` | Toggle between free/all Cerebras models (🔧 dynamic) |
+| `/go-toggle` | ⚠️ Toggle Go models (💳 paid only) |
+| `/fireworks-toggle` | ⚠️ Toggle Fireworks models (💳 paid only) |
 
 **The toggle command:**
 - Switches between showing only free models vs. all available models

--- a/README.md
+++ b/README.md
@@ -68,20 +68,15 @@ Want to see paid models too? Run the toggle command for your provider:
 /kilo-toggle        # Toggle Kilo (✅ actually free)
 /openrouter-toggle  # Toggle OpenRouter (✅ actually free)
 /cline-toggle      # Toggle Cline (✅ actually free)
-/nvidia-toggle      # Toggle NVIDIA (🔄 freemium - 1K req/month free)
-/cloudflare-toggle  # Toggle Cloudflare (🔄 freemium - 10K Neurons/day)
-/modal-toggle      # Toggle Modal (🔄 freemium - until Apr 30, 2026)
-/ollama-toggle     # Toggle Ollama (🔄 freemium - usage-based)
 /mistral-toggle     # Toggle Mistral (🔧 dynamic - needs API key)
 /groq-toggle        # Toggle Groq (🔧 dynamic - needs API key)
 /cerebras-toggle   # Toggle Cerebras (🔧 dynamic - needs API key)
-/go-toggle         # Toggle Go (💳 paid only - subscription)
 ```
 
 **Notes:**
-- Fireworks has no toggle command since all models are paid-only
-- Freemium providers show all models by default (you manage limits via their dashboards)
-- Toggle commands for freemium providers mainly filter the UI view
+- **Toggle commands are mainly for ✅ Actually Free providers** — to switch between "free models only" vs "show paid models too"
+- **🔄 Freemium providers** (NVIDIA, Cloudflare, Ollama, Modal) show all models by default — you manage your usage limits via their dashboards
+- **💳 Paid-only providers** (Go, Fireworks) have no toggle since all models require payment
 
 You'll see a notification like: `zen: showing free models` or `zen: showing all models (including paid)`
 
@@ -367,21 +362,18 @@ Each provider has toggle commands to switch between free and all models:
 | `/zen-toggle` | Toggle between free/all Zen models |
 | `/kilo-toggle` | Toggle between free/all Kilo models |
 | `/openrouter-toggle` | Toggle between free/all OpenRouter models |
-| `/nvidia-toggle` | Toggle between free/all NVIDIA models (🔄 freemium) |
-| `/cloudflare-toggle` | Toggle between free/all Cloudflare models (🔄 freemium) |
-| `/modal-toggle` | Toggle between free/all Modal models (🔄 freemium) |
-| `/ollama-toggle` | Toggle between free/all Ollama models (🔄 freemium) |
-| `/cline-toggle` | Toggle between free/all Cline models |
+| `/cline-toggle` | Toggle between free/all Cline models (✅ actually free) |
 | `/mistral-toggle` | Toggle between free/all Mistral models (🔧 dynamic) |
 | `/groq-toggle` | Toggle between free/all Groq models (🔧 dynamic) |
 | `/cerebras-toggle` | Toggle between free/all Cerebras models (🔧 dynamic) |
-| `/go-toggle` | ⚠️ Toggle Go models (💳 paid only) |
-| `/fireworks-toggle` | ⚠️ Toggle Fireworks models (💳 paid only) |
 
 **The toggle command:**
-- Switches between showing only free models vs. all available models
+- **For ✅ Actually Free providers**: Switches between showing only free models vs. all available models (including paid)
+- **For 🔧 Dynamic API providers**: Filters the model list when you have an API key configured
 - **Persists your preference** to `~/.pi/free.json` for next startup
 - Shows a notification: "zen: showing free models" or "zen: showing all models (including paid)"
+
+**Note:** 🔄 Freemium providers (NVIDIA, Cloudflare, Ollama, Modal) don't have toggle commands — they show all models and you manage usage via their dashboards. 💳 Paid-only providers (Go, Fireworks) also have no toggle since all models require payment.
 
 ---
 

--- a/config.ts
+++ b/config.ts
@@ -50,6 +50,7 @@ interface PiFreeConfig {
 	kilo_show_paid?: boolean;
 	nvidia_show_paid?: boolean;
 	cloudflare_show_paid?: boolean;
+	ollama_show_paid?: boolean;
 	fireworks_show_paid?: boolean;
 	cline_show_paid?: boolean;
 	/** @deprecated Qwen provider is deprecated */
@@ -70,6 +71,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	kilo_show_paid: false,
 	nvidia_show_paid: false,
 	cloudflare_show_paid: false,
+	ollama_show_paid: false,
 	fireworks_show_paid: false,
 	cline_show_paid: false,
 	/** @deprecated Qwen provider is deprecated */

--- a/constants.ts
+++ b/constants.ts
@@ -12,6 +12,7 @@ export const PROVIDER_CLINE = "cline";
 export const PROVIDER_FIREWORKS = "fireworks";
 export const PROVIDER_NVIDIA = "nvidia";
 export const PROVIDER_CLOUDFLARE = "cloudflare";
+export const PROVIDER_OLLAMA = "ollama";
 /** @deprecated Qwen provider is deprecated. The 1,000 req/day free tier is no longer available. */
 export const PROVIDER_QWEN = "qwen";
 export const PROVIDER_MODAL = "modal";
@@ -33,6 +34,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 export const BASE_URL_KILO = "https://api.kilo.ai/api/gateway";
 export const BASE_URL_NVIDIA = "https://integrate.api.nvidia.com/v1";
 export const BASE_URL_CLOUDFLARE = "https://api.cloudflare.com/client/v4";
+export const BASE_URL_OLLAMA = "https://ollama.com";
 export const BASE_URL_CLINE = "https://api.cline.bot/api/v1";
 export const BASE_URL_FIREWORKS = "https://api.fireworks.ai/inference/v1";
 export const BASE_URL_MODAL = "https://api.us-west-2.modal.direct/v1";

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import fireworks from "./providers/fireworks/fireworks.ts";
 import kilo from "./providers/kilo/kilo.ts";
 import modal from "./providers/modal/modal.ts";
 import nvidia from "./providers/nvidia/nvidia.ts";
+import ollama from "./providers/ollama/ollama.ts";
 import qwen from "./providers/qwen/qwen.ts";
 
 const _logger = createLogger("pi-free");
@@ -216,6 +217,7 @@ export default async function (pi: ExtensionAPI) {
 		modal(pi),
 		nvidia(pi),
 		kilo(pi),
+		ollama(pi),
 		// Qwen is deprecated
 		qwen(pi).catch((err) => {
 			_logger.warn("[pi-free] Qwen provider failed to load (deprecated)", err);

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -1,0 +1,211 @@
+/**
+ * Ollama Cloud Provider Extension
+ *
+ * Provides access to Ollama's cloud-hosted models via ollama.com API.
+ * All models use Ollama's usage-based pricing system:
+ *   - Free tier: Unlimited public models (session limits reset every 5 hours,
+ *     weekly limits reset every 7 days)
+ *   - Pro tier: 50x more cloud usage than Free
+ *   - Max tier: 5x more usage than Pro
+ *
+ * Requires OLLAMA_API_KEY with cloud access.
+ * Get a free key at: https://ollama.com/settings/keys
+ *
+ * Responds to global /free toggle (shows models but warns they're freemium).
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Set OLLAMA_API_KEY env var
+ *   # Models appear in /model selector
+ *   # Use /ollama-toggle to show all vs limited set
+ */
+
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+	applyHidden,
+	OLLAMA_SHOW_PAID,
+	PROVIDER_OLLAMA,
+} from "../../config.ts";
+import {
+	BASE_URL_OLLAMA,
+	DEFAULT_FETCH_TIMEOUT_MS,
+} from "../../constants.ts";
+import { registerWithGlobalToggle } from "../../index.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import {
+	createReRegister,
+	enhanceWithCI,
+} from "../../provider-helper.ts";
+
+const _logger = createLogger("ollama");
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface OllamaModel {
+	name: string;
+	model: string;
+	modified_at: string;
+	size: number;
+	digest: string;
+	details?: {
+		parent_model?: string;
+		format?: string;
+		family?: string;
+		families?: string[];
+		parameter_size?: string;
+		quantization_level?: string;
+	};
+}
+
+interface OllamaTagsResponse {
+	models?: OllamaModel[];
+}
+
+// =============================================================================
+// Fetch + map
+// =============================================================================
+
+async function fetchOllamaModels(
+	apiKey: string,
+): Promise<ProviderModelConfig[]> {
+	const response = await fetchWithRetry(
+		`${BASE_URL_OLLAMA}/api/tags`,
+		{
+			headers: {
+				"Authorization": `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+		},
+		3,
+		1000,
+		DEFAULT_FETCH_TIMEOUT_MS,
+	);
+
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch Ollama models: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const json = (await response.json()) as OllamaTagsResponse;
+	const models = json.models ?? [];
+
+	_logger.info(`[ollama] Fetched ${models.length} models from Ollama Cloud`);
+
+	// Filter to chat/text generation models only
+	const chatModels = models.filter((m) => {
+		// Ollama models don't have explicit capabilities, but we can infer
+		// Most models in ollama library are text generation models
+		// Skip embedding-only models (typically have "embed" in name)
+		const name = m.name.toLowerCase();
+		if (name.includes("embed")) return false;
+		return true;
+	});
+
+	const result = applyHidden(
+		chatModels.map(
+			(m): ProviderModelConfig => ({
+				id: m.name,
+				name: m.name,
+				// Try to infer reasoning from model name/family
+				reasoning: m.name.toLowerCase().includes("reasoning") ||
+					m.name.toLowerCase().includes("r1") ||
+					m.details?.families?.some(f => f.toLowerCase().includes("reasoning")),
+				input: ["text"],
+				// Ollama Cloud uses usage-based pricing (GPU time), not per-token
+				// Free tier has limits but no direct cost per token
+				cost: {
+					input: 0, // Freemium: usage-based, not per-token
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+				},
+				// Extract context window from parameter size if available
+				contextWindow: parseContextWindow(m.details?.parameter_size),
+				maxTokens: 4096, // Default, varies by model
+			}),
+		),
+	);
+
+	return result;
+}
+
+/**
+ * Parse parameter size string (e.g., "7B", "70B") to estimate context window
+ */
+function parseContextWindow(paramSize?: string): number {
+	if (!paramSize) return 8192;
+	
+	const match = paramSize.match(/(\d+(?:\.\d+)?)\s*([KMGT]?)/i);
+	if (!match) return 8192;
+	
+	const size = parseFloat(match[1]);
+	const unit = match[2].toUpperCase();
+	
+	// Rough heuristic: larger models tend to have larger context windows
+	// This is a simplification - actual context varies by model architecture
+	if (unit === "T" || size >= 100) return 128000; // 100B+ models
+	if (size >= 70) return 128000; // 70B models
+	if (size >= 30) return 32768;  // 30B+ models
+	if (size >= 7) return 32768;   // 7B+ models
+	return 8192; // Smaller models
+}
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function (pi: ExtensionAPI) {
+	const apiKey = process.env.OLLAMA_API_KEY;
+
+	if (!apiKey) {
+		_logger.info("[ollama] Skipping - OLLAMA_API_KEY not set");
+		return;
+	}
+
+	// Fetch models
+	let allModels: ProviderModelConfig[] = [];
+
+	try {
+		allModels = await fetchOllamaModels(apiKey);
+	} catch (error) {
+		_logger.error(
+			"[ollama] Failed to fetch models at startup",
+			error instanceof Error ? error.message : String(error),
+		);
+		return;
+	}
+
+	// For Ollama, all models share the same free tier
+	// So "free" and "all" are the same set
+	const freeModels = allModels;
+	const stored = { free: freeModels, all: allModels };
+	const hasKey = true;
+
+	// Create re-register function
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_OLLAMA,
+		baseUrl: BASE_URL_OLLAMA,
+		apiKey: "OLLAMA_API_KEY",
+	});
+
+	// Register with global toggle system
+	registerWithGlobalToggle(PROVIDER_OLLAMA, stored, reRegister, hasKey);
+
+	// Register initial models
+	const initialModels = OLLAMA_SHOW_PAID ? allModels : freeModels;
+	pi.registerProvider(PROVIDER_OLLAMA, {
+		baseUrl: BASE_URL_OLLAMA,
+		apiKey: "OLLAMA_API_KEY",
+		api: "openai-completions" as const,
+		models: enhanceWithCI(initialModels),
+	});
+
+	_logger.info(
+		`[ollama] Registered ${initialModels.length} models (usage-based free tier)`,
+	);
+}


### PR DESCRIPTION
Documentation improvements:

1. **Reorganize providers by category:**
   - ✅ Actually Free (no usage limits)
   - 🔄 Freemium (free tier with limits, then paid)  
   - 🔧 Dynamic API Providers (need API key for free models)
   - 💳 Paid Only (no free tier)

2. **Remove all Qwen references** (provider deprecated)

3. **Clarify toggle commands:**
   - Toggles only for ✅ Actually Free and 🔧 Dynamic providers
   - 🔄 Freemium providers show all models (manage limits via dashboards)
   - 💳 Paid-only providers have no toggle (all models require payment)

4. **Add new toggle commands:**
   - /groq-toggle, /cerebras-toggle (for dynamic providers)

All 101 tests pass ✅