### PR TITLE
fix: Add missing API key exports for Ollama and Cloudflare

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -176,6 +176,14 @@ export const MODAL_SHOW_PAID = resolveBool(
 	"MODAL_SHOW_PAID",
 	file.modal_show_paid,
 );
+export const OLLAMA_SHOW_PAID = resolveBool(
+	"OLLAMA_SHOW_PAID",
+	file.ollama_show_paid,
+);
+export const CLOUDFLARE_SHOW_PAID = resolveBool(
+	"CLOUDFLARE_SHOW_PAID",
+	file.cloudflare_show_paid,
+);
 
 // Built-in pi providers - per-provider free model filtering
 export const OPENROUTER_SHOW_PAID = resolveBool(
@@ -206,6 +214,11 @@ export const FIREWORKS_API_KEY = resolve(
 	file.fireworks_api_key,
 );
 export const MODAL_API_KEY = resolve("MODAL_API_KEY", file.modal_api_key);
+export const OLLAMA_API_KEY = resolve("OLLAMA_API_KEY", file.ollama_api_key);
+export const CLOUDFLARE_API_TOKEN = resolve(
+	"CLOUDFLARE_API_TOKEN",
+	file.cloudflare_api_token,
+);
 export const OPENCODE_API_KEY = resolve(
 	"OPENCODE_API_KEY",
 	file.opencode_api_key,

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -32,24 +32,24 @@
  *   # Use /cloudflare-toggle to show all vs limited set
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
 import {
 	applyHidden,
+	CLOUDFLARE_API_TOKEN,
 	CLOUDFLARE_SHOW_PAID,
-	PROVIDER_CLOUDFLARE,
 } from "../../config.ts";
 import {
 	BASE_URL_CLOUDFLARE,
 	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_CLOUDFLARE,
 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../index.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
-import {
-	createReRegister,
-	enhanceWithCI,
-} from "../../provider-helper.ts";
+import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 
 const _logger = createLogger("cloudflare");
 
@@ -105,7 +105,7 @@ async function verifyCloudflareToken(
 		`${BASE_URL_CLOUDFLARE}/user/tokens/verify`,
 		{
 			headers: {
-				"Authorization": `Bearer ${apiToken}`,
+				Authorization: `Bearer ${apiToken}`,
 				"Content-Type": "application/json",
 			},
 		},
@@ -123,7 +123,8 @@ async function verifyCloudflareToken(
 	const json = (await response.json()) as CloudflareVerifyResponse;
 
 	if (!json.success) {
-		const errorMsg = json.errors?.map(e => e.message).join(", ") || "Invalid token";
+		const errorMsg =
+			json.errors?.map((e) => e.message).join(", ") || "Invalid token";
 		throw new Error(`Cloudflare token verification failed: ${errorMsg}`);
 	}
 
@@ -155,7 +156,7 @@ async function fetchCloudflareModels(
 		url,
 		{
 			headers: {
-				"Authorization": `Bearer ${apiToken}`,
+				Authorization: `Bearer ${apiToken}`,
 				"Content-Type": "application/json",
 			},
 		},
@@ -173,7 +174,8 @@ async function fetchCloudflareModels(
 	const json = (await response.json()) as CloudflareModelsResponse;
 
 	if (!json.success || !json.result) {
-		const errorMsg = json.errors?.map(e => e.message).join(", ") || "Unknown error";
+		const errorMsg =
+			json.errors?.map((e) => e.message).join(", ") || "Unknown error";
 		throw new Error(`Cloudflare API error: ${errorMsg}`);
 	}
 
@@ -182,7 +184,9 @@ async function fetchCloudflareModels(
 		(m) => m.capabilities?.text_generation === true,
 	);
 
-	_logger.info(`[cloudflare] Fetched ${chatModels.length} text generation models`);
+	_logger.info(
+		`[cloudflare] Fetched ${chatModels.length} text generation models`,
+	);
 
 	const result = applyHidden(
 		chatModels.map(
@@ -217,12 +221,17 @@ async function fetchCloudflareModels(
 // =============================================================================
 
 export default async function (pi: ExtensionAPI) {
-	const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+	const apiToken = CLOUDFLARE_API_TOKEN;
 
 	if (!apiToken) {
-		_logger.info("[cloudflare] Skipping - CLOUDFLARE_API_TOKEN not set");
+		_logger.info(
+			"[cloudflare] Skipping - CLOUDFLARE_API_TOKEN not set (env var or ~/.pi/free.json)",
+		);
 		return;
 	}
+
+	// Inject into process.env so Pi's apiKey lookup finds it
+	process.env.CLOUDFLARE_API_TOKEN = apiToken;
 
 	// Verify token and get account info
 	let accountId: string;
@@ -230,10 +239,9 @@ export default async function (pi: ExtensionAPI) {
 		const tokenInfo = await verifyCloudflareToken(apiToken);
 		accountId = tokenInfo.accountId;
 	} catch (error) {
-		_logger.error(
-			"[cloudflare] Token verification failed",
-			error instanceof Error ? error.message : String(error),
-		);
+		_logger.error("[cloudflare] Token verification failed", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return;
 	}
 
@@ -243,10 +251,9 @@ export default async function (pi: ExtensionAPI) {
 	try {
 		allModels = await fetchCloudflareModels(accountId, apiToken);
 	} catch (error) {
-		_logger.error(
-			"[cloudflare] Failed to fetch models at startup",
-			error instanceof Error ? error.message : String(error),
-		);
+		_logger.error("[cloudflare] Failed to fetch models at startup", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return;
 	}
 

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -20,24 +20,20 @@
  *   # Use /ollama-toggle to show all vs limited set
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import {
-	applyHidden,
-	OLLAMA_SHOW_PAID,
-	PROVIDER_OLLAMA,
-} from "../../config.ts";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { applyHidden, OLLAMA_API_KEY, OLLAMA_SHOW_PAID } from "../../config.ts";
 import {
 	BASE_URL_OLLAMA,
 	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_OLLAMA,
 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../index.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
-import {
-	createReRegister,
-	enhanceWithCI,
-} from "../../provider-helper.ts";
+import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 
 const _logger = createLogger("ollama");
 
@@ -76,7 +72,7 @@ async function fetchOllamaModels(
 		`${BASE_URL_OLLAMA}/api/tags`,
 		{
 			headers: {
-				"Authorization": `Bearer ${apiKey}`,
+				Authorization: `Bearer ${apiKey}`,
 				"Content-Type": "application/json",
 			},
 		},
@@ -112,9 +108,12 @@ async function fetchOllamaModels(
 				id: m.name,
 				name: m.name,
 				// Try to infer reasoning from model name/family
-				reasoning: m.name.toLowerCase().includes("reasoning") ||
+				reasoning:
+					m.name.toLowerCase().includes("reasoning") ||
 					m.name.toLowerCase().includes("r1") ||
-					m.details?.families?.some(f => f.toLowerCase().includes("reasoning")),
+					!!m.details?.families?.some((f) =>
+						f.toLowerCase().includes("reasoning"),
+					),
 				input: ["text"],
 				// Ollama Cloud uses usage-based pricing (GPU time), not per-token
 				// Free tier has limits but no direct cost per token
@@ -139,19 +138,19 @@ async function fetchOllamaModels(
  */
 function parseContextWindow(paramSize?: string): number {
 	if (!paramSize) return 8192;
-	
+
 	const match = paramSize.match(/(\d+(?:\.\d+)?)\s*([KMGT]?)/i);
 	if (!match) return 8192;
-	
+
 	const size = parseFloat(match[1]);
 	const unit = match[2].toUpperCase();
-	
+
 	// Rough heuristic: larger models tend to have larger context windows
 	// This is a simplification - actual context varies by model architecture
 	if (unit === "T" || size >= 100) return 128000; // 100B+ models
 	if (size >= 70) return 128000; // 70B models
-	if (size >= 30) return 32768;  // 30B+ models
-	if (size >= 7) return 32768;   // 7B+ models
+	if (size >= 30) return 32768; // 30B+ models
+	if (size >= 7) return 32768; // 7B+ models
 	return 8192; // Smaller models
 }
 
@@ -160,12 +159,17 @@ function parseContextWindow(paramSize?: string): number {
 // =============================================================================
 
 export default async function (pi: ExtensionAPI) {
-	const apiKey = process.env.OLLAMA_API_KEY;
+	const apiKey = OLLAMA_API_KEY;
 
 	if (!apiKey) {
-		_logger.info("[ollama] Skipping - OLLAMA_API_KEY not set");
+		_logger.info(
+			"[ollama] Skipping - OLLAMA_API_KEY not set (env var or ~/.pi/free.json)",
+		);
 		return;
 	}
+
+	// Inject into process.env so Pi's apiKey lookup finds it
+	process.env.OLLAMA_API_KEY = apiKey;
 
 	// Fetch models
 	let allModels: ProviderModelConfig[] = [];
@@ -173,10 +177,9 @@ export default async function (pi: ExtensionAPI) {
 	try {
 		allModels = await fetchOllamaModels(apiKey);
 	} catch (error) {
-		_logger.error(
-			"[ollama] Failed to fetch models at startup",
-			error instanceof Error ? error.message : String(error),
-		);
+		_logger.error("[ollama] Failed to fetch models at startup", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Fixes Ollama and Cloudflare providers not appearing in /model selector despite having API keys configured.

## Changes

- Added missing exports for OLLAMA_API_KEY, OLLAMA_SHOW_PAID
- Added missing exports for CLOUDFLARE_API_TOKEN, CLOUDFLARE_SHOW_PAID
- Updated providers to use config exports instead of process.env directly
- Added process.env injection to match Fireworks provider pattern
- Fixed logger error argument types
- Fixed PROVIDER_* imports to use constants.ts

## Testing

- [x] TypeScript compiles without errors
- [x] Matches Fireworks provider pattern (which works)

## Affected Providers

- Ollama Cloud (OLLAMA_API_KEY)
- Cloudflare Workers AI (CLOUDFLARE_API_TOKEN)