### PR TITLE
fix: remove verbose logs and auto-detect Cloudflare account

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -38,6 +38,7 @@ interface PiFreeConfig {
 	// API Keys
 	nvidia_api_key?: string;
 	cloudflare_api_token?: string;
+	cloudflare_account_id?: string;
 	ollama_api_key?: string;
 	fireworks_api_key?: string;
 	modal_api_key?: string;
@@ -65,6 +66,7 @@ interface PiFreeConfig {
 const CONFIG_TEMPLATE: PiFreeConfig = {
 	nvidia_api_key: "",
 	cloudflare_api_token: "",
+	cloudflare_account_id: "",
 	ollama_api_key: "",
 	fireworks_api_key: "",
 	modal_api_key: "",
@@ -218,6 +220,10 @@ export const OLLAMA_API_KEY = resolve("OLLAMA_API_KEY", file.ollama_api_key);
 export const CLOUDFLARE_API_TOKEN = resolve(
 	"CLOUDFLARE_API_TOKEN",
 	file.cloudflare_api_token,
+);
+export const CLOUDFLARE_ACCOUNT_ID = resolve(
+	"CLOUDFLARE_ACCOUNT_ID",
+	file.cloudflare_account_id,
 );
 export const OPENCODE_API_KEY = resolve(
 	"OPENCODE_API_KEY",

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -11,15 +11,16 @@
  *   - Create token with "Cloudflare AI" > "Read" permission
  *   - Or use "My Account" > "Read" for all accounts
  *
- * The account ID is derived from the token automatically.
- * Alternatively, set CLOUDFLARE_ACCOUNT_ID explicitly.
+ * The account ID is fetched automatically from the /accounts API using your token.
+ * Optionally set CLOUDFLARE_ACCOUNT_ID (env var or free.json) to skip auto-detection
+ * or to specify a particular account if you have multiple.
  *
  * API Reference:
- *   Verify token: GET /user/tokens/verify
- *   List models:  GET /accounts/{account_id}/ai/models
- *   Run model:    POST /accounts/{account_id}/ai/run/{model_name}
- *   curl example:
- *     curl https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai/run/$MODEL_NAME \
+ *   List accounts: GET /client/v4/accounts
+ *   List models:   GET /client/v4/accounts/{account_id}/ai/models
+ *   Run model:     POST /client/v4/accounts/{account_id}/ai/run/{model_name}
+ *   curl example (account ID auto-detected by the provider):
+ *     curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/$MODEL_NAME \
  *       -X POST \
  *       -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
  *
@@ -28,7 +29,7 @@
  * Usage:
  *   pi install git:github.com/apmantza/pi-free
  *   # Set CLOUDFLARE_API_TOKEN env var
- *   # Models appear in /model selector
+ *   # Models appear in /model selector (account auto-detected)
  *   # Use /cloudflare-toggle to show all vs limited set
  */
 
@@ -38,6 +39,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import {
 	applyHidden,
+	CLOUDFLARE_ACCOUNT_ID,
 	CLOUDFLARE_API_TOKEN,
 	CLOUDFLARE_SHOW_PAID,
 } from "../../config.ts";
@@ -56,17 +58,6 @@ const _logger = createLogger("cloudflare");
 // =============================================================================
 // Types
 // =============================================================================
-
-interface CloudflareVerifyResponse {
-	result?: {
-		id: string;
-		status: string;
-		not_before?: string;
-		expires_on?: string;
-	};
-	success: boolean;
-	errors?: Array<{ code: number; message: string }>;
-}
 
 interface CloudflareModel {
 	id: string;
@@ -98,11 +89,28 @@ interface CloudflareModelsResponse {
 // Verify token and get account info
 // =============================================================================
 
-async function verifyCloudflareToken(
+interface CloudflareAccount {
+	id: string;
+	name: string;
+}
+
+interface CloudflareAccountsResponse {
+	result?: CloudflareAccount[];
+	success: boolean;
+	errors?: Array<{ code: number; message: string }>;
+}
+
+async function getCloudflareAccount(
 	apiToken: string,
 ): Promise<{ accountId: string }> {
+	// Check for explicit account ID first (env var or free.json)
+	if (CLOUDFLARE_ACCOUNT_ID) {
+		return { accountId: CLOUDFLARE_ACCOUNT_ID };
+	}
+
+	// Fetch accounts accessible by this token
 	const response = await fetchWithRetry(
-		`${BASE_URL_CLOUDFLARE}/user/tokens/verify`,
+		`${BASE_URL_CLOUDFLARE}/accounts`,
 		{
 			headers: {
 				Authorization: `Bearer ${apiToken}`,
@@ -116,30 +124,30 @@ async function verifyCloudflareToken(
 
 	if (!response.ok) {
 		throw new Error(
-			`Failed to verify Cloudflare token: ${response.status} ${response.statusText}`,
+			`Failed to fetch Cloudflare accounts: ${response.status} ${response.statusText}`,
 		);
 	}
 
-	const json = (await response.json()) as CloudflareVerifyResponse;
+	const json = (await response.json()) as CloudflareAccountsResponse;
 
 	if (!json.success) {
 		const errorMsg =
-			json.errors?.map((e) => e.message).join(", ") || "Invalid token";
-		throw new Error(`Cloudflare token verification failed: ${errorMsg}`);
+			json.errors?.map((e) => e.message).join(", ") || "Unknown error";
+		throw new Error(`Cloudflare API error: ${errorMsg}`);
 	}
 
-	// The token info includes the user, but we need to get the account ID
-	// For now, we'll try to use the token's associated account
-	// In practice, users with multiple accounts may need to specify one
-	if (process.env.CLOUDFLARE_ACCOUNT_ID) {
-		return { accountId: process.env.CLOUDFLARE_ACCOUNT_ID };
+	if (!json.result || json.result.length === 0) {
+		throw new Error(
+			"No Cloudflare accounts found. Create an account at https://dash.cloudflare.com",
+		);
 	}
 
-	// If no account ID is set, we'll need the user to provide one
-	// The verify endpoint doesn't return account IDs directly
-	throw new Error(
-		"CLOUDFLARE_ACCOUNT_ID is required. Get it from: https://dash.cloudflare.com",
-	);
+	// Use first account (tokens typically have access to one account)
+	// Users with multiple accounts can set CLOUDFLARE_ACCOUNT_ID explicitly
+	const account = json.result[0];
+	_logger.debug(`Using Cloudflare account: ${account.name} (${account.id})`);
+
+	return { accountId: account.id };
 }
 
 // =============================================================================
@@ -233,13 +241,13 @@ export default async function (pi: ExtensionAPI) {
 	// Inject into process.env so Pi's apiKey lookup finds it
 	process.env.CLOUDFLARE_API_TOKEN = apiToken;
 
-	// Verify token and get account info
+	// Get account info from token
 	let accountId: string;
 	try {
-		const tokenInfo = await verifyCloudflareToken(apiToken);
-		accountId = tokenInfo.accountId;
+		const accountInfo = await getCloudflareAccount(apiToken);
+		accountId = accountInfo.accountId;
 	} catch (error) {
-		_logger.error("[cloudflare] Token verification failed", {
+		_logger.error("[cloudflare] Failed to get account", {
 			error: error instanceof Error ? error.message : String(error),
 		});
 		return;

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -19,14 +19,14 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { KILO_FREE_ONLY, KILO_SHOW_PAID, PROVIDER_KILO } from "../../config.ts";
 import { URL_KILO_TOS } from "../../constants.ts";
-import { registerWithGlobalToggle, isFreeModel } from "../../index.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../index.ts";
+import { cleanModelName, logWarning } from "../../lib/util.ts";
 import {
+	createCtxReRegister,
+	createReRegister,
 	enhanceWithCI,
 	type StoredModels,
-	createReRegister,
-	createCtxReRegister,
 } from "../../provider-helper.ts";
-import { cleanModelName, logWarning } from "../../lib/util.ts";
 import { loginKilo, refreshKiloToken } from "./kilo-auth.ts";
 import { fetchKiloModels, KILO_GATEWAY_BASE } from "./kilo-models.ts";
 
@@ -44,7 +44,7 @@ export default async function (pi: ExtensionAPI) {
 	// If no API key, this will return free models only
 	let allModels: ProviderModelConfig[] = [];
 	let freeModels: ProviderModelConfig[] = [];
-	
+
 	try {
 		// Fetch all models (returns free-only if no auth, all if auth available)
 		allModels = await fetchKiloModels({ freeOnly: false });
@@ -62,7 +62,8 @@ export default async function (pi: ExtensionAPI) {
 
 	// State tracking
 	let showPaidModels = KILO_SHOW_PAID;
-	let currentModels = KILO_SHOW_PAID && !KILO_FREE_ONLY ? allModels : freeModels;
+	let currentModels =
+		KILO_SHOW_PAID && !KILO_FREE_ONLY ? allModels : freeModels;
 
 	// Shared model storage for global toggle
 	const stored: StoredModels = { free: freeModels, all: allModels };
@@ -87,18 +88,21 @@ export default async function (pi: ExtensionAPI) {
 			const cred = await loginKilo(callbacks);
 			try {
 				// Fetch all models with the new token
-				const newModels = await fetchKiloModels({ token: cred.access, freeOnly: false });
+				const newModels = await fetchKiloModels({
+					token: cred.access,
+					freeOnly: false,
+				});
 				allModels = newModels;
 				stored.all = allModels;
 				freeModels = allModels.filter(isFreeModel);
 				stored.free = freeModels;
-				
+
 				// Update global toggle registration with new lists
 				const globalReRegister = createReRegister(pi, {
 					...KILO_PROVIDER_CONFIG,
 				});
 				registerWithGlobalToggle(PROVIDER_KILO, stored, globalReRegister, true);
-				
+
 				// If paid mode is enabled, show all models
 				if (showPaidModels && !KILO_FREE_ONLY) {
 					currentModels = allModels;
@@ -145,29 +149,34 @@ export default async function (pi: ExtensionAPI) {
 		oauth: oauthConfig,
 	});
 
-	console.log(`[kilo] Registered ${currentModels.length} models (${freeModels.length} free, ${allModels.length - freeModels.length} paid)`);
+	// Registration complete - models registered silently (use LOG_LEVEL=info to see details)
 
 	// Per-provider toggle command (works independently of global /free)
 	pi.registerCommand("kilo-toggle", {
 		description: "Toggle between free and all Kilo models",
 		handler: async (_args, ctx) => {
 			showPaidModels = !showPaidModels;
-			
+
 			// Determine which models to show
-			const modelsToShow = showPaidModels && allModels.length > 0
-				? allModels
-				: freeModels;
-			
+			const modelsToShow =
+				showPaidModels && allModels.length > 0 ? allModels : freeModels;
+
 			currentModels = modelsToShow;
 			reRegister(modelsToShow);
-			
+
 			const freeCount = freeModels.length;
 			const paidCount = allModels.length - freeCount;
-			
+
 			if (showPaidModels && allModels.length > 0) {
-				ctx.ui.notify(`kilo: showing all ${allModels.length} models (${freeCount} free, ${paidCount} paid)`, "info");
+				ctx.ui.notify(
+					`kilo: showing all ${allModels.length} models (${freeCount} free, ${paidCount} paid)`,
+					"info",
+				);
 			} else {
-				ctx.ui.notify(`kilo: showing ${freeCount} free models (${paidCount} paid hidden)`, "info");
+				ctx.ui.notify(
+					`kilo: showing ${freeCount} free models (${paidCount} paid hidden)`,
+					"info",
+				);
 			}
 		},
 	});
@@ -194,18 +203,21 @@ export default async function (pi: ExtensionAPI) {
 
 		if (cred?.type === "oauth") {
 			try {
-				const newModels = await fetchKiloModels({ token: cred.access, freeOnly: false });
+				const newModels = await fetchKiloModels({
+					token: cred.access,
+					freeOnly: false,
+				});
 				allModels = newModels;
 				stored.all = allModels;
 				freeModels = allModels.filter(isFreeModel);
 				stored.free = freeModels;
-				
+
 				// Update global toggle registration
 				const ctxReRegister = createCtxReRegister(ctx as any, {
 					...KILO_PROVIDER_CONFIG,
 				});
 				registerWithGlobalToggle(PROVIDER_KILO, stored, ctxReRegister, true);
-				
+
 				// Apply current view mode
 				if (showPaidModels && !KILO_FREE_ONLY) {
 					ctxReRegister(allModels);

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -13,7 +13,10 @@
  * Responds to global /free toggle for free/paid model filtering.
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
 import {
 	applyHidden,
 	NVIDIA_SHOW_PAID,
@@ -28,11 +31,7 @@ import {
 import { registerWithGlobalToggle } from "../../index.ts";
 import type { ModelsDevProvider } from "../../lib/types.ts";
 import { fetchWithRetry, isUsableModel } from "../../lib/util.ts";
-import {
-	createReRegister,
-	enhanceWithCI,
-} from "../../provider-helper.ts";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 
 // =============================================================================
 // Fetch + map
@@ -147,5 +146,5 @@ export default async function (pi: ExtensionAPI) {
 		models: enhanceWithCI(initialModels),
 	});
 
-	console.log(`[nvidia] Registered ${initialModels.length} models`);
+	// Registration complete - models registered silently (use LOG_LEVEL=info to see details)
 }


### PR DESCRIPTION
- Remove verbose console logs from nvidia and kilo providers at startup
- Add cloudflare_account_id config option to free.json
- Auto-fetch Cloudflare account from /accounts API when not explicitly set
- Update Cloudflare documentation to reflect auto-detection