### PR TITLE
feat: update Cloudflare provider with 18 models and real pricing

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -61,6 +61,7 @@ interface PiFreeConfig {
 	modal_show_paid?: boolean;
 	// Built-in pi providers
 	openrouter_show_paid?: boolean;
+	opencode_show_paid?: boolean;
 }
 
 const CONFIG_TEMPLATE: PiFreeConfig = {
@@ -85,6 +86,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	modal_show_paid: false,
 	// Built-in pi providers - default to showing only free
 	openrouter_show_paid: false,
+	opencode_show_paid: false,
 };
 
 const PI_DIR = join(process.env.HOME || process.env.USERPROFILE || "", ".pi");
@@ -191,6 +193,10 @@ export const CLOUDFLARE_SHOW_PAID = resolveBool(
 export const OPENROUTER_SHOW_PAID = resolveBool(
 	"OPENROUTER_SHOW_PAID",
 	file.openrouter_show_paid,
+);
+export const OPENCODE_SHOW_PAID = resolveBool(
+	"OPENCODE_SHOW_PAID",
+	file.opencode_show_paid,
 );
 
 // Global free-only mode (new in v2.0) - applies to ALL providers

--- a/index.ts
+++ b/index.ts
@@ -63,9 +63,39 @@ export function registerWithGlobalToggle(
 	);
 }
 
-/** Check if a model is free (input cost is 0 or undefined) */
-export function isFreeModel(model: ProviderModelConfig): boolean {
-	return (model.cost?.input ?? 0) === 0;
+// Providers that expose actual per-model pricing via API
+const PRICING_EXPOSED_PROVIDERS = new Set([
+	"openrouter",
+	"opencode",
+	"kilo",
+	"cline",
+]);
+
+/**
+ * Check if a model is free.
+ *
+ * For providers with pricing APIs: uses cost (input === 0 && output === 0)
+ * For providers without pricing: ONLY uses name-based check (name includes "free")
+ */
+export function isFreeModel(
+	model: ProviderModelConfig & { provider?: string },
+): boolean {
+	const provider = model.provider;
+	const hasPricing = provider && PRICING_EXPOSED_PROVIDERS.has(provider);
+
+	// For providers WITH pricing API: cost-based check
+	if (hasPricing) {
+		if ((model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0) {
+			return true;
+		}
+	}
+
+	// For providers WITHOUT pricing API: ONLY name-based check
+	if (model.name.toLowerCase().includes("free")) {
+		return true;
+	}
+
+	return false;
 }
 
 /** Get current global free-only state */
@@ -166,13 +196,42 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 		handler: async (_args, ctx) => {
 			const lines = ["📊 Pi-Free Providers:", ""];
 
+			// Providers known to not expose pricing via API (all models show as "free")
+			// OpenRouter and OpenCode expose actual pricing
+			const noPricingApi = new Set([
+				"mistral",
+				"xai",
+				"huggingface",
+				"groq",
+				"cerebras",
+			]);
+			// Freemium providers - all models share a free tier quota
+			// Freemium providers - all models share a free tier quota
+			const freemiumProviders = new Set(["nvidia"]);
+
 			for (const [id, entry] of providerRegistry) {
 				const free = entry.stored.free.length;
 				const all = entry.stored.all.length || free;
 				const indicator = entry.hasKey ? "🔑" : "🆓";
-				lines.push(
-					`${indicator} ${id}: ${free} free / ${all - free} paid (${all} total)`,
-				);
+				const paid = all - free;
+
+				if (freemiumProviders.has(id)) {
+					// Freemium: all models share a free tier (e.g., 1,000 reqs/month)
+					lines.push(`${indicator} ${id}: ${all} models (freemium)`);
+				} else if (noPricingApi.has(id)) {
+					// Provider doesn't expose pricing - can't determine free vs paid
+					lines.push(
+						`${indicator} ${id}: ${all} models (pricing not exposed by API)`,
+					);
+				} else if (paid === 0 && free > 0) {
+					// All models are actually free
+					lines.push(`${indicator} ${id}: ${free} free models`);
+				} else {
+					// Mix of free and paid
+					lines.push(
+						`${indicator} ${id}: ${free} free / ${paid} paid (${all} total)`,
+					);
+				}
 			}
 
 			if (providerRegistry.size === 0) {

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -1,209 +1,371 @@
 /**
  * Cloudflare Workers AI Provider Extension
  *
- * Provides access to 50+ open-source models via Cloudflare's serverless GPU network.
+ * Provides access to Cloudflare's serverless GPU network with 18+ models.
  * All models use Cloudflare's "Neurons" pricing system:
  *   - 10,000 Neurons per day FREE (resets daily at 00:00 UTC)
  *   - $0.011 per 1,000 Neurons beyond free allocation
  *
- * Requires:
- *   1. CLOUDFLARE_API_TOKEN with Workers AI permission
- *      Get at: https://dash.cloudflare.com/profile/api-tokens
- *      Create token with "Cloudflare AI" > "Read" permission
- *   2. CLOUDFLARE_ACCOUNT_ID (RECOMMENDED - see below)
+ * Setup:
+ *   1. Create API token at https://dash.cloudflare.com/profile/api-tokens
+ *      with "Cloudflare AI" > "Read" permission
+ *   2. Get Account ID from https://dash.cloudflare.com (right sidebar)
+ *   3. Add credentials to ~/.pi/agent/auth.json or set env vars
  *
- * IMPORTANT: Set CLOUDFLARE_ACCOUNT_ID to avoid permission issues
- *   - Your API token needs "Account:Read" permission to auto-fetch accounts
- *   - Most AI-only tokens lack this permission, causing "No accounts found" errors
- *   - Set via: CLOUDFLARE_ACCOUNT_ID env var OR cloudflare_account_id in ~/.pi/free.json
- *   - Find your Account ID at: https://dash.cloudflare.com (right sidebar)
+ * Auth (in order of priority):
+ *   - Environment: CF_API_TOKEN and CF_ACCOUNT_ID
+ *   - Config file: ~/.pi/agent/auth.json
+ *     { "cloudflare-ai": { "access": "token", "account_id": "id" } }
+ *   - Legacy: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID env vars
  *
- * API Reference:
- *   List models:   GET /client/v4/accounts/{account_id}/ai/models
- *   Run model:     POST /client/v4/accounts/{account_id}/ai/run/{model_name}
- *   curl example:
- *     curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/$MODEL_NAME \
- *       -X POST \
- *       -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
- *
- * Responds to global /free toggle (shows models but warns they're freemium).
- *
- * Usage:
- *   pi install git:github.com/apmantza/pi-free
- *   # Set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID
- *   # Models appear in /model selector
- *   # Use /cloudflare-toggle to show all vs limited set
+ * Models can be customized via ~/.pi/cloudflare-models.json
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import {
-	applyHidden,
-	CLOUDFLARE_ACCOUNT_ID,
-	CLOUDFLARE_API_TOKEN,
-	CLOUDFLARE_SHOW_PAID,
-} from "../../config.ts";
-import {
-	BASE_URL_CLOUDFLARE,
-	DEFAULT_FETCH_TIMEOUT_MS,
-	PROVIDER_CLOUDFLARE,
-} from "../../constants.ts";
-import { registerWithGlobalToggle } from "../../index.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
-import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 
 const _logger = createLogger("cloudflare");
 
 // =============================================================================
-// Verified free-tier models from https://free-llm.com/provider/cloudflare-workers-ai
+// Auth Resolution
 // =============================================================================
 
+interface CloudflareAuth {
+	token?: string;
+	accountId?: string;
+}
+
+function getCloudflareAuth(): CloudflareAuth {
+	const result: CloudflareAuth = {};
+
+	// Check new env var names first
+	if (process.env.CF_API_TOKEN) result.token = process.env.CF_API_TOKEN;
+	if (process.env.CF_ACCOUNT_ID) result.accountId = process.env.CF_ACCOUNT_ID;
+
+	// Check legacy env var names
+	if (!result.token && process.env.CLOUDFLARE_API_TOKEN) {
+		result.token = process.env.CLOUDFLARE_API_TOKEN;
+	}
+	if (!result.accountId && process.env.CLOUDFLARE_ACCOUNT_ID) {
+		result.accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+	}
+
+	if (result.token && result.accountId) return result;
+
+	// Check ~/.pi/free.json (pi-free config)
+	try {
+		const configPath = join(homedir(), ".pi", "free.json");
+		if (existsSync(configPath)) {
+			const config = JSON.parse(readFileSync(configPath, "utf-8"));
+			if (!result.token && config.cloudflare_api_token) {
+				result.token = config.cloudflare_api_token;
+			}
+			if (!result.accountId && config.cloudflare_account_id) {
+				result.accountId = config.cloudflare_account_id;
+			}
+		}
+	} catch {
+		// Ignore config file errors
+	}
+
+	return result;
+}
+
 // =============================================================================
-// Fallback model list (when API fails)
-// Source: https://free-llm.com/provider/cloudflare-workers-ai
+// Compatibility Settings
 // =============================================================================
 
 /**
- * Verified free models from Cloudflare Workers AI.
- * All models use the 10K neurons/day free allocation.
+ * Cloudflare Workers AI compatibility settings.
+ * Prevents 413 Payload Too Large errors by disabling unsupported parameters.
  */
-const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
-	// Meta Llama Models (128K context)
+const CLOUDFLARE_COMPAT: {
+	supportsStore?: boolean;
+	supportsDeveloperRole?: boolean;
+	supportsReasoningEffort?: boolean;
+	supportsStrictMode?: boolean;
+	maxTokensField?: "max_tokens" | "max_completion_tokens";
+	requiresThinkingAsText?: boolean;
+} = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: false,
+	supportsStrictMode: false,
+	maxTokensField: "max_tokens",
+};
+
+// =============================================================================
+// Default Models (18 models from Cloudflare Workers AI)
+// =============================================================================
+
+interface ModelConfig extends ProviderModelConfig {
+	compat?: { requiresThinkingAsText?: boolean };
+	_remove?: boolean;
+}
+
+const DEFAULT_MODELS: ModelConfig[] = [
+	// Frontier models
+	{
+		id: "@cf/moonshotai/kimi-k2.5",
+		name: "Kimi K2.5",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0.6, output: 3.0, cacheRead: 0.1, cacheWrite: 0 },
+		contextWindow: 256000,
+		maxTokens: 8192,
+	},
+	{
+		id: "@cf/meta/llama-4-scout-17b-16e-instruct",
+		name: "Llama 4 Scout 17B",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0.27, output: 0.85, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
+	},
+	{
+		id: "@cf/nvidia/nemotron-3-120b-a12b",
+		name: "Nemotron 3 Super 120B",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0.5, output: 1.5, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 256000,
+		maxTokens: 8192,
+		compat: { requiresThinkingAsText: true },
+	},
+	{
+		id: "@cf/google/gemma-4-26b-a4b-it",
+		name: "Gemma 4 26B",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0.1, output: 0.3, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 256000,
+		maxTokens: 8192,
+		compat: { requiresThinkingAsText: true },
+	},
+	{
+		id: "@cf/google/gemma-3-12b-it",
+		name: "Gemma 3 12B",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0.345, output: 0.556, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 80000,
+		maxTokens: 8192,
+	},
+	{
+		id: "@cf/qwen/qwen3-30b-a3b-fp8",
+		name: "Qwen3 30B A3B",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0.051, output: 0.34, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 8192,
+		compat: { requiresThinkingAsText: true },
+	},
+	{
+		id: "@cf/zai-org/glm-4.7-flash",
+		name: "GLM-4.7 Flash",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.06, output: 0.4, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
+	},
+	// Popular models
+	{
+		id: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+		name: "Llama 3.3 70B (Fast)",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
+	},
 	{
 		id: "@cf/meta/llama-3.1-8b-instruct",
-		name: "Llama 3.1 8B Instruct",
+		name: "Llama 3.1 8B",
 		reasoning: false,
 		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128000,
-		maxTokens: 4096,
+		cost: { input: 0.1, output: 0.1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
 	},
 	{
-		id: "@cf/meta/llama-3.2-3b-instruct",
-		name: "Llama 3.2 3B Instruct",
+		id: "@cf/meta/llama-3.1-70b-instruct",
+		name: "Llama 3.1 70B",
 		reasoning: false,
 		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128000,
-		maxTokens: 4096,
+		cost: { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
 	},
-	// Mistral via Hugging Face (32K context, multilingual)
 	{
-		id: "@hf/mistral/mistral-7b-instruct-v0.2",
-		name: "Mistral 7B Instruct v0.2",
+		id: "@cf/meta/llama-3.1-405b-instruct",
+		name: "Llama 3.1 405B",
 		reasoning: false,
 		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 32000,
-		maxTokens: 4096,
+		cost: { input: 2.0, output: 2.0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
 	},
-	// Alibaba Qwen (32K context, Chinese)
 	{
-		id: "@cf/qwen/qwen1.5-7b-chat-awq",
-		name: "Qwen 1.5 7B Chat (AWQ)",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 32000,
-		maxTokens: 4096,
-	},
-	// DeepSeek Coder via Hugging Face (16K context, code-focused)
-	{
-		id: "@hf/thebloke/deepseek-coder-6.7b-instruct-awq",
-		name: "DeepSeek Coder 6.7B Instruct (AWQ)",
+		id: "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+		name: "DeepSeek R1 Distill Qwen 32B",
 		reasoning: true,
 		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 16000,
-		maxTokens: 4096,
+		cost: { input: 0.3, output: 0.3, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 8192,
+		compat: { requiresThinkingAsText: true },
 	},
-	// Microsoft Phi-2 (2K context, reasoning)
 	{
-		id: "@cf/microsoft/phi-2",
-		name: "Microsoft Phi-2",
+		id: "@cf/deepseek-ai/deepseek-math-7b-instruct",
+		name: "DeepSeek Math 7B",
 		reasoning: true,
 		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 2048,
-		maxTokens: 1024,
+		cost: { input: 0.1, output: 0.1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 16384,
+		maxTokens: 4096,
+	},
+	// Mistral models
+	{
+		id: "@cf/mistral/mistral-small-3.1-24b-instruct",
+		name: "Mistral Small 3.1 24B",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0.3, output: 0.3, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 8192,
+	},
+	{
+		id: "@cf/mistral/mistral-7b-instruct-v0.2-lora",
+		name: "Mistral 7B Instruct",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.1, output: 0.1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 4096,
+	},
+	{
+		id: "@cf/mistral/mixtral-8x7b-instruct-v0.1-awq",
+		name: "Mixtral 8x7B Instruct",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.3, output: 0.3, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 4096,
+	},
+	// Qwen and Gemma
+	{
+		id: "@cf/qwen/qwen1.5-14b-chat-awq",
+		name: "Qwen 1.5 14B Chat",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.2, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 8192,
+	},
+	{
+		id: "@cf/google/gemma-2b-it-lora",
+		name: "Gemma 2B",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.05, output: 0.05, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	},
+	{
+		id: "@cf/google/gemma-7b-it-lora",
+		name: "Gemma 7B",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.1, output: 0.1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
 	},
 ];
 
 // =============================================================================
-// Get models (static list - no API calls)
+// Model Customization (user overrides)
 // =============================================================================
 
-/**
- * Return the static list of verified free-tier models.
- * No API calls needed - these are known working models from free-llm.com
- */
-async function getCloudflareModels(): Promise<ProviderModelConfig[]> {
-	_logger.info(
-		`[cloudflare] Using ${FALLBACK_CLOUDFLARE_MODELS.length} verified free-tier models`,
-	);
-	return applyHidden(FALLBACK_CLOUDFLARE_MODELS);
+function getModels(): ProviderModelConfig[] {
+	// Apply Cloudflare compat settings to all default models
+	const defaults = DEFAULT_MODELS.map((m) => ({
+		...m,
+		compat: { ...CLOUDFLARE_COMPAT, ...m.compat },
+	})) as ProviderModelConfig[];
+
+	// Check for user overrides
+	const overridePath = join(homedir(), ".pi", "cloudflare-models.json");
+	if (!existsSync(overridePath)) return defaults;
+
+	try {
+		const override = JSON.parse(
+			readFileSync(overridePath, "utf-8"),
+		) as ModelConfig[];
+		const modelMap = new Map<string, any>(defaults.map((m) => [m.id, m]));
+
+		for (const model of override) {
+			if (model._remove) {
+				modelMap.delete(model.id);
+			} else {
+				// Apply Cloudflare compat settings to user overrides
+				model.compat = { ...CLOUDFLARE_COMPAT, ...model.compat };
+				modelMap.set(model.id, model);
+			}
+		}
+
+		return Array.from(modelMap.values()) as ProviderModelConfig[];
+	} catch (e) {
+		_logger.warn(
+			`[cloudflare] Failed to load ~/.pi/cloudflare-models.json: ${e instanceof Error ? e.message : String(e)}`,
+		);
+		return defaults;
+	}
 }
 
 // =============================================================================
 // Extension Entry Point
 // =============================================================================
 
-export default async function (pi: ExtensionAPI) {
-	const apiToken = CLOUDFLARE_API_TOKEN;
+export default async function cloudflareProvider(pi: ExtensionAPI) {
+	const { token: apiToken, accountId } = getCloudflareAuth();
 
 	if (!apiToken) {
 		_logger.info(
-			"[cloudflare] Skipping - CLOUDFLARE_API_TOKEN not set (env var or ~/.pi/free.json)",
+			"[cloudflare] CF_API_TOKEN or CLOUDFLARE_API_TOKEN not set. Provider will not be available.",
 		);
 		return;
 	}
 
-	// Inject into process.env so Pi's apiKey lookup finds it
+	if (!accountId) {
+		_logger.info(
+			"[cloudflare] CF_ACCOUNT_ID or CLOUDFLARE_ACCOUNT_ID not set. Provider will not be available.",
+		);
+		return;
+	}
+
+	// Also inject into process.env for pi's API key lookup
 	process.env.CLOUDFLARE_API_TOKEN = apiToken;
 
-	// Use configured account ID (required)
-	if (!CLOUDFLARE_ACCOUNT_ID) {
-		_logger.error(
-			"[cloudflare] CLOUDFLARE_ACCOUNT_ID not set. Add to ~/.pi/free.json or set env var.",
-		);
-		return;
-	}
-	const accountId = CLOUDFLARE_ACCOUNT_ID;
+	const models = getModels();
 
-	// Get models (static list - no API calls needed)
-	const allModels = await getCloudflareModels();
-
-	// For Cloudflare, all models share the same free tier
-	// So "free" and "all" are the same set
-	const freeModels = allModels;
-	const stored = { free: freeModels, all: allModels };
-	const hasKey = true; // We have the key since we checked above
-
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_CLOUDFLARE,
-		baseUrl: `${BASE_URL_CLOUDFLARE}/accounts/${accountId}/ai/v1`,
+	pi.registerProvider("cloudflare", {
+		baseUrl: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
 		apiKey: "CLOUDFLARE_API_TOKEN",
-	});
-
-	// Register with global toggle system
-	registerWithGlobalToggle(PROVIDER_CLOUDFLARE, stored, reRegister, hasKey);
-
-	// Register initial models
-	// Note: CLOUDFLARE_SHOW_PAID doesn't change the model list since all models
-	// use the same free tier pool. It's kept for consistency with other providers.
-	const initialModels = CLOUDFLARE_SHOW_PAID ? allModels : freeModels;
-	pi.registerProvider(PROVIDER_CLOUDFLARE, {
-		baseUrl: `${BASE_URL_CLOUDFLARE}/accounts/${accountId}/ai/v1`,
-		apiKey: "CLOUDFLARE_API_TOKEN",
-		api: "openai-completions" as const,
-		models: enhanceWithCI(initialModels),
+		api: "openai-completions",
+		authHeader: true,
+		models,
 	});
 
 	_logger.info(
-		`[cloudflare] Registered ${initialModels.length} models (10K Neurons/day free tier)`,
+		`[cloudflare] Provider registered with account: ${accountId.slice(0, 8)}... (${models.length} models)`,
 	);
 }

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -166,85 +166,71 @@ async function getCloudflareAccount(
 
 // =============================================================================
 // Fallback model list (when API fails)
+// Source: https://free-llm.com/provider/cloudflare-workers-ai
 // =============================================================================
 
 /**
- * Fallback models that work with Cloudflare Workers AI free tier.
- * These are Cloudflare-hosted models (prefix @cf/) that don't require
- * external provider setup. External models (Claude, OpenAI, etc.) need
- * separate API keys and aren't included in the 10K neurons/day free tier.
+ * Verified free models from Cloudflare Workers AI.
+ * All models use the 10K neurons/day free allocation.
  */
 const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
+	// Meta Llama Models (128K context)
 	{
 		id: "@cf/meta/llama-3.1-8b-instruct",
 		name: "Llama 3.1 8B Instruct",
 		reasoning: false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
+		contextWindow: 128000,
 		maxTokens: 4096,
 	},
 	{
-		id: "@cf/meta/llama-3.3-8b-instruct",
-		name: "Llama 3.3 8B Instruct",
+		id: "@cf/meta/llama-3.2-3b-instruct",
+		name: "Llama 3.2 3B Instruct",
 		reasoning: false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
+		contextWindow: 128000,
 		maxTokens: 4096,
 	},
+	// Mistral via Hugging Face (32K context, multilingual)
 	{
-		id: "@cf/mistral/mistral-7b-instruct-v0.2",
-		name: "Mistral 7B Instruct",
+		id: "@hf/mistral/mistral-7b-instruct-v0.2",
+		name: "Mistral 7B Instruct v0.2",
 		reasoning: false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
+		contextWindow: 32000,
 		maxTokens: 4096,
 	},
+	// Alibaba Qwen (32K context, Chinese)
 	{
-		id: "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-		name: "DeepSeek R1 Distill Qwen 32B",
+		id: "@cf/qwen/qwen1.5-7b-chat-awq",
+		name: "Qwen 1.5 7B Chat (AWQ)",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32000,
+		maxTokens: 4096,
+	},
+	// DeepSeek Coder via Hugging Face (16K context, code-focused)
+	{
+		id: "@hf/thebloke/deepseek-coder-6.7b-instruct-awq",
+		name: "DeepSeek Coder 6.7B Instruct (AWQ)",
 		reasoning: true,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 16384,
+		contextWindow: 16000,
 		maxTokens: 4096,
 	},
+	// Microsoft Phi-2 (2K context, reasoning)
 	{
-		id: "@cf/nousresearch/hermes-2-pro-mistral-7b",
-		name: "Hermes 2 Pro Mistral 7B",
-		reasoning: false,
+		id: "@cf/microsoft/phi-2",
+		name: "Microsoft Phi-2",
+		reasoning: true,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
-		maxTokens: 4096,
-	},
-	{
-		id: "@cf/meta/llama-3.1-70b-instruct",
-		name: "Llama 3.1 70B Instruct",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
-		maxTokens: 4096,
-	},
-	{
-		id: "@cf/meta/llama-guard-3-8b",
-		name: "Llama Guard 3 8B",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
-		maxTokens: 4096,
-	},
-	{
-		id: "@cf/baai/bge-base-en-v1.5",
-		name: "BGE Base EN v1.5 (Embeddings)",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 4096,
+		contextWindow: 2048,
 		maxTokens: 1024,
 	},
 ];

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -6,20 +6,22 @@
  *   - 10,000 Neurons per day FREE (resets daily at 00:00 UTC)
  *   - $0.011 per 1,000 Neurons beyond free allocation
  *
- * Requires CLOUDFLARE_API_TOKEN with Workers AI permission.
- * Get a free token at: https://dash.cloudflare.com/profile/api-tokens
- *   - Create token with "Cloudflare AI" > "Read" permission
- *   - Or use "My Account" > "Read" for all accounts
+ * Requires:
+ *   1. CLOUDFLARE_API_TOKEN with Workers AI permission
+ *      Get at: https://dash.cloudflare.com/profile/api-tokens
+ *      Create token with "Cloudflare AI" > "Read" permission
+ *   2. CLOUDFLARE_ACCOUNT_ID (RECOMMENDED - see below)
  *
- * The account ID is fetched automatically from the /accounts API using your token.
- * Optionally set CLOUDFLARE_ACCOUNT_ID (env var or free.json) to skip auto-detection
- * or to specify a particular account if you have multiple.
+ * IMPORTANT: Set CLOUDFLARE_ACCOUNT_ID to avoid permission issues
+ *   - Your API token needs "Account:Read" permission to auto-fetch accounts
+ *   - Most AI-only tokens lack this permission, causing "No accounts found" errors
+ *   - Set via: CLOUDFLARE_ACCOUNT_ID env var OR cloudflare_account_id in ~/.pi/free.json
+ *   - Find your Account ID at: https://dash.cloudflare.com (right sidebar)
  *
  * API Reference:
- *   List accounts: GET /client/v4/accounts
  *   List models:   GET /client/v4/accounts/{account_id}/ai/models
  *   Run model:     POST /client/v4/accounts/{account_id}/ai/run/{model_name}
- *   curl example (account ID auto-detected by the provider):
+ *   curl example:
  *     curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/$MODEL_NAME \
  *       -X POST \
  *       -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
@@ -28,8 +30,8 @@
  *
  * Usage:
  *   pi install git:github.com/apmantza/pi-free
- *   # Set CLOUDFLARE_API_TOKEN env var
- *   # Models appear in /model selector (account auto-detected)
+ *   # Set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID
+ *   # Models appear in /model selector
  *   # Use /cloudflare-toggle to show all vs limited set
  */
 
@@ -102,11 +104,18 @@ interface CloudflareAccountsResponse {
 
 async function getCloudflareAccount(
 	apiToken: string,
-): Promise<{ accountId: string }> {
+): Promise<{ accountId: string; source: "config" | "auto" }> {
 	// Check for explicit account ID first (env var or free.json)
 	if (CLOUDFLARE_ACCOUNT_ID) {
-		return { accountId: CLOUDFLARE_ACCOUNT_ID };
+		_logger.debug(
+			`[cloudflare] Using account ID from config: ${CLOUDFLARE_ACCOUNT_ID}`,
+		);
+		return { accountId: CLOUDFLARE_ACCOUNT_ID, source: "config" };
 	}
+
+	_logger.debug(
+		"[cloudflare] No CLOUDFLARE_ACCOUNT_ID set, attempting auto-detection...",
+	);
 
 	// Fetch accounts accessible by this token
 	const response = await fetchWithRetry(
@@ -138,16 +147,21 @@ async function getCloudflareAccount(
 
 	if (!json.result || json.result.length === 0) {
 		throw new Error(
-			"No Cloudflare accounts found. Create an account at https://dash.cloudflare.com",
+			"No Cloudflare accounts accessible with this token. " +
+				"Your API token may lack 'Account:Read' permission, or no accounts are associated with it. " +
+				"To fix this, set CLOUDFLARE_ACCOUNT_ID env var or add 'cloudflare_account_id' to ~/.pi/free.json",
 		);
 	}
 
 	// Use first account (tokens typically have access to one account)
 	// Users with multiple accounts can set CLOUDFLARE_ACCOUNT_ID explicitly
 	const account = json.result[0];
-	_logger.debug(`Using Cloudflare account: ${account.name} (${account.id})`);
+	_logger.info(
+		`[cloudflare] Auto-detected account: ${account.name} (${account.id}). ` +
+			`Consider setting CLOUDFLARE_ACCOUNT_ID to skip auto-detection.`,
+	);
 
-	return { accountId: account.id };
+	return { accountId: account.id, source: "auto" };
 }
 
 // =============================================================================

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -165,7 +165,113 @@ async function getCloudflareAccount(
 }
 
 // =============================================================================
-// Fetch + map
+// Fallback model list (when API fails)
+// =============================================================================
+
+const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
+	{
+		id: "@cf/meta/llama-3.1-8b-instruct",
+		name: "Llama 3.1 8B Instruct",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 4096,
+	},
+	{
+		id: "@cf/moonshotai/kimi-k2.6",
+		name: "Kimi K2.6",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+	},
+	{
+		id: "anthropic/claude-opus-4.7",
+		name: "Claude Opus 4.7",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 4096,
+	},
+	{
+		id: "alibaba/qwen3.5-397b-a17b",
+		name: "Qwen 3.5 397B",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	},
+	{
+		id: "alibaba/qwen3-max",
+		name: "Qwen 3 Max",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	},
+	{
+		id: "minimax/m2.7",
+		name: "MiniMax M2.7",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 4096,
+	},
+	{
+		id: "google/gemini-3-flash",
+		name: "Gemini 3 Flash",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000000,
+		maxTokens: 8192,
+	},
+	{
+		id: "google/gemini-3.1-flash-lite",
+		name: "Gemini 3.1 Flash Lite",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000000,
+		maxTokens: 8192,
+	},
+	{
+		id: "google/gemini-3.1-pro",
+		name: "Gemini 3.1 Pro",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 2000000,
+		maxTokens: 8192,
+	},
+	{
+		id: "openai/o4-mini",
+		name: "OpenAI o4-mini",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	},
+	{
+		id: "moonshotai/kimi-k2.5",
+		name: "Kimi K2.5",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 64000,
+	},
+];
+
+// =============================================================================
+// Fetch + map (with fallback)
 // =============================================================================
 
 async function fetchCloudflareModels(
@@ -174,68 +280,73 @@ async function fetchCloudflareModels(
 ): Promise<ProviderModelConfig[]> {
 	const url = `${BASE_URL_CLOUDFLARE}/accounts/${accountId}/ai/models`;
 
-	const response = await fetchWithRetry(
-		url,
-		{
-			headers: {
-				Authorization: `Bearer ${apiToken}`,
-				"Content-Type": "application/json",
-			},
-		},
-		3,
-		1000,
-		DEFAULT_FETCH_TIMEOUT_MS,
-	);
-
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch Cloudflare models: ${response.status} ${response.statusText}`,
-		);
-	}
-
-	const json = (await response.json()) as CloudflareModelsResponse;
-
-	if (!json.success || !json.result) {
-		const errorMsg =
-			json.errors?.map((e) => e.message).join(", ") || "Unknown error";
-		throw new Error(`Cloudflare API error: ${errorMsg}`);
-	}
-
-	// Filter to text-generation models only (chat models)
-	const chatModels = json.result.filter(
-		(m) => m.capabilities?.text_generation === true,
-	);
-
-	_logger.info(
-		`[cloudflare] Fetched ${chatModels.length} text generation models`,
-	);
-
-	const result = applyHidden(
-		chatModels.map(
-			(m): ProviderModelConfig => ({
-				id: m.id,
-				name: m.name,
-				// Cloudflare models don't explicitly declare reasoning
-				reasoning: m.id.includes("qwq") || m.id.includes("deepseek-r1"),
-				input: m.input_modalities?.includes("image")
-					? ["text", "image"]
-					: ["text"],
-				// Cloudflare uses "Neurons" not per-token pricing
-				// All models consume the same 10K Neurons/day free pool
-				// Mark as "free" for display purposes (freemium model)
-				cost: {
-					input: 0, // Freemium: 10K Neurons/day free
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
+	try {
+		const response = await fetchWithRetry(
+			url,
+			{
+				headers: {
+					Authorization: `Bearer ${apiToken}`,
+					"Content-Type": "application/json",
 				},
-				contextWindow: m.property?.context_window ?? 8192,
-				maxTokens: m.property?.max_output_tokens ?? 4096,
-			}),
-		),
-	);
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
 
-	return result;
+		if (!response.ok) {
+			throw new Error(
+				`Failed to fetch Cloudflare models: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		const json = (await response.json()) as CloudflareModelsResponse;
+
+		if (!json.success || !json.result) {
+			// API call succeeded but returned error - use fallback
+			_logger.warn(
+				`[cloudflare] Models API returned error, using fallback list: ${json.errors?.[0]?.message || "Unknown"}`,
+			);
+			return applyHidden(FALLBACK_CLOUDFLARE_MODELS);
+		}
+
+		// Filter to text-generation models only (chat models)
+		const chatModels = json.result.filter(
+			(m) => m.capabilities?.text_generation === true,
+		);
+
+		_logger.info(
+			`[cloudflare] Fetched ${chatModels.length} text generation models`,
+		);
+
+		const result = applyHidden(
+			chatModels.map(
+				(m): ProviderModelConfig => ({
+					id: m.id,
+					name: m.name,
+					reasoning: m.id.includes("qwq") || m.id.includes("deepseek-r1"),
+					input: m.input_modalities?.includes("image")
+						? ["text", "image"]
+						: ["text"],
+					cost: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+					},
+					contextWindow: m.property?.context_window ?? 8192,
+					maxTokens: m.property?.max_output_tokens ?? 4096,
+				}),
+			),
+		);
+
+		return result;
+	} catch (error) {
+		_logger.warn(
+			`[cloudflare] Failed to fetch models from API, using fallback list: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return applyHidden(FALLBACK_CLOUDFLARE_MODELS);
+	}
 }
 
 // =============================================================================

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -168,6 +168,12 @@ async function getCloudflareAccount(
 // Fallback model list (when API fails)
 // =============================================================================
 
+/**
+ * Fallback models that work with Cloudflare Workers AI free tier.
+ * These are Cloudflare-hosted models (prefix @cf/) that don't require
+ * external provider setup. External models (Claude, OpenAI, etc.) need
+ * separate API keys and aren't included in the 10K neurons/day free tier.
+ */
 const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
 	{
 		id: "@cf/meta/llama-3.1-8b-instruct",
@@ -179,44 +185,8 @@ const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
 		maxTokens: 4096,
 	},
 	{
-		id: "@cf/moonshotai/kimi-k2.6",
-		name: "Kimi K2.6",
-		reasoning: true,
-		input: ["text", "image"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 200000,
-		maxTokens: 64000,
-	},
-	{
-		id: "anthropic/claude-opus-4.7",
-		name: "Claude Opus 4.7",
-		reasoning: true,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 200000,
-		maxTokens: 4096,
-	},
-	{
-		id: "alibaba/qwen3.5-397b-a17b",
-		name: "Qwen 3.5 397B",
-		reasoning: true,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128000,
-		maxTokens: 8192,
-	},
-	{
-		id: "alibaba/qwen3-max",
-		name: "Qwen 3 Max",
-		reasoning: true,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128000,
-		maxTokens: 8192,
-	},
-	{
-		id: "minimax/m2.7",
-		name: "MiniMax M2.7",
+		id: "@cf/meta/llama-3.3-8b-instruct",
+		name: "Llama 3.3 8B Instruct",
 		reasoning: false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -224,49 +194,58 @@ const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
 		maxTokens: 4096,
 	},
 	{
-		id: "google/gemini-3-flash",
-		name: "Gemini 3 Flash",
+		id: "@cf/mistral/mistral-7b-instruct-v0.2",
+		name: "Mistral 7B Instruct",
 		reasoning: false,
-		input: ["text", "image"],
+		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 1000000,
-		maxTokens: 8192,
-	},
-	{
-		id: "google/gemini-3.1-flash-lite",
-		name: "Gemini 3.1 Flash Lite",
-		reasoning: false,
-		input: ["text", "image"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 1000000,
-		maxTokens: 8192,
-	},
-	{
-		id: "google/gemini-3.1-pro",
-		name: "Gemini 3.1 Pro",
-		reasoning: true,
-		input: ["text", "image"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 2000000,
-		maxTokens: 8192,
-	},
-	{
-		id: "openai/o4-mini",
-		name: "OpenAI o4-mini",
-		reasoning: true,
-		input: ["text", "image"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128000,
+		contextWindow: 8192,
 		maxTokens: 4096,
 	},
 	{
-		id: "moonshotai/kimi-k2.5",
-		name: "Kimi K2.5",
+		id: "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+		name: "DeepSeek R1 Distill Qwen 32B",
 		reasoning: true,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 200000,
-		maxTokens: 64000,
+		contextWindow: 16384,
+		maxTokens: 4096,
+	},
+	{
+		id: "@cf/nousresearch/hermes-2-pro-mistral-7b",
+		name: "Hermes 2 Pro Mistral 7B",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 4096,
+	},
+	{
+		id: "@cf/meta/llama-3.1-70b-instruct",
+		name: "Llama 3.1 70B Instruct",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 4096,
+	},
+	{
+		id: "@cf/meta/llama-guard-3-8b",
+		name: "Llama Guard 3 8B",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 4096,
+	},
+	{
+		id: "@cf/baai/bge-base-en-v1.5",
+		name: "BGE Base EN v1.5 (Embeddings)",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 4096,
+		maxTokens: 1024,
 	},
 ];
 

--- a/providers/cloudflare/cloudflare.ts
+++ b/providers/cloudflare/cloudflare.ts
@@ -58,111 +58,8 @@ import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 const _logger = createLogger("cloudflare");
 
 // =============================================================================
-// Types
+// Verified free-tier models from https://free-llm.com/provider/cloudflare-workers-ai
 // =============================================================================
-
-interface CloudflareModel {
-	id: string;
-	name: string;
-	description?: string;
-	capabilities: {
-		text_generation?: boolean;
-		image_generation?: boolean;
-		speech_recognition?: boolean;
-		text_to_speech?: boolean;
-		translation?: boolean;
-		image_classification?: boolean;
-	};
-	input_modalities?: string[];
-	output_modalities?: string[];
-	property?: {
-		context_window?: number;
-		max_output_tokens?: number;
-	};
-}
-
-interface CloudflareModelsResponse {
-	result?: CloudflareModel[];
-	success: boolean;
-	errors?: Array<{ code: number; message: string }>;
-}
-
-// =============================================================================
-// Verify token and get account info
-// =============================================================================
-
-interface CloudflareAccount {
-	id: string;
-	name: string;
-}
-
-interface CloudflareAccountsResponse {
-	result?: CloudflareAccount[];
-	success: boolean;
-	errors?: Array<{ code: number; message: string }>;
-}
-
-async function getCloudflareAccount(
-	apiToken: string,
-): Promise<{ accountId: string; source: "config" | "auto" }> {
-	// Check for explicit account ID first (env var or free.json)
-	if (CLOUDFLARE_ACCOUNT_ID) {
-		_logger.debug(
-			`[cloudflare] Using account ID from config: ${CLOUDFLARE_ACCOUNT_ID}`,
-		);
-		return { accountId: CLOUDFLARE_ACCOUNT_ID, source: "config" };
-	}
-
-	_logger.debug(
-		"[cloudflare] No CLOUDFLARE_ACCOUNT_ID set, attempting auto-detection...",
-	);
-
-	// Fetch accounts accessible by this token
-	const response = await fetchWithRetry(
-		`${BASE_URL_CLOUDFLARE}/accounts`,
-		{
-			headers: {
-				Authorization: `Bearer ${apiToken}`,
-				"Content-Type": "application/json",
-			},
-		},
-		3,
-		1000,
-		DEFAULT_FETCH_TIMEOUT_MS,
-	);
-
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch Cloudflare accounts: ${response.status} ${response.statusText}`,
-		);
-	}
-
-	const json = (await response.json()) as CloudflareAccountsResponse;
-
-	if (!json.success) {
-		const errorMsg =
-			json.errors?.map((e) => e.message).join(", ") || "Unknown error";
-		throw new Error(`Cloudflare API error: ${errorMsg}`);
-	}
-
-	if (!json.result || json.result.length === 0) {
-		throw new Error(
-			"No Cloudflare accounts accessible with this token. " +
-				"Your API token may lack 'Account:Read' permission, or no accounts are associated with it. " +
-				"To fix this, set CLOUDFLARE_ACCOUNT_ID env var or add 'cloudflare_account_id' to ~/.pi/free.json",
-		);
-	}
-
-	// Use first account (tokens typically have access to one account)
-	// Users with multiple accounts can set CLOUDFLARE_ACCOUNT_ID explicitly
-	const account = json.result[0];
-	_logger.info(
-		`[cloudflare] Auto-detected account: ${account.name} (${account.id}). ` +
-			`Consider setting CLOUDFLARE_ACCOUNT_ID to skip auto-detection.`,
-	);
-
-	return { accountId: account.id, source: "auto" };
-}
 
 // =============================================================================
 // Fallback model list (when API fails)
@@ -236,82 +133,18 @@ const FALLBACK_CLOUDFLARE_MODELS: ProviderModelConfig[] = [
 ];
 
 // =============================================================================
-// Fetch + map (with fallback)
+// Get models (static list - no API calls)
 // =============================================================================
 
-async function fetchCloudflareModels(
-	accountId: string,
-	apiToken: string,
-): Promise<ProviderModelConfig[]> {
-	const url = `${BASE_URL_CLOUDFLARE}/accounts/${accountId}/ai/models`;
-
-	try {
-		const response = await fetchWithRetry(
-			url,
-			{
-				headers: {
-					Authorization: `Bearer ${apiToken}`,
-					"Content-Type": "application/json",
-				},
-			},
-			3,
-			1000,
-			DEFAULT_FETCH_TIMEOUT_MS,
-		);
-
-		if (!response.ok) {
-			throw new Error(
-				`Failed to fetch Cloudflare models: ${response.status} ${response.statusText}`,
-			);
-		}
-
-		const json = (await response.json()) as CloudflareModelsResponse;
-
-		if (!json.success || !json.result) {
-			// API call succeeded but returned error - use fallback
-			_logger.warn(
-				`[cloudflare] Models API returned error, using fallback list: ${json.errors?.[0]?.message || "Unknown"}`,
-			);
-			return applyHidden(FALLBACK_CLOUDFLARE_MODELS);
-		}
-
-		// Filter to text-generation models only (chat models)
-		const chatModels = json.result.filter(
-			(m) => m.capabilities?.text_generation === true,
-		);
-
-		_logger.info(
-			`[cloudflare] Fetched ${chatModels.length} text generation models`,
-		);
-
-		const result = applyHidden(
-			chatModels.map(
-				(m): ProviderModelConfig => ({
-					id: m.id,
-					name: m.name,
-					reasoning: m.id.includes("qwq") || m.id.includes("deepseek-r1"),
-					input: m.input_modalities?.includes("image")
-						? ["text", "image"]
-						: ["text"],
-					cost: {
-						input: 0,
-						output: 0,
-						cacheRead: 0,
-						cacheWrite: 0,
-					},
-					contextWindow: m.property?.context_window ?? 8192,
-					maxTokens: m.property?.max_output_tokens ?? 4096,
-				}),
-			),
-		);
-
-		return result;
-	} catch (error) {
-		_logger.warn(
-			`[cloudflare] Failed to fetch models from API, using fallback list: ${error instanceof Error ? error.message : String(error)}`,
-		);
-		return applyHidden(FALLBACK_CLOUDFLARE_MODELS);
-	}
+/**
+ * Return the static list of verified free-tier models.
+ * No API calls needed - these are known working models from free-llm.com
+ */
+async function getCloudflareModels(): Promise<ProviderModelConfig[]> {
+	_logger.info(
+		`[cloudflare] Using ${FALLBACK_CLOUDFLARE_MODELS.length} verified free-tier models`,
+	);
+	return applyHidden(FALLBACK_CLOUDFLARE_MODELS);
 }
 
 // =============================================================================
@@ -331,29 +164,17 @@ export default async function (pi: ExtensionAPI) {
 	// Inject into process.env so Pi's apiKey lookup finds it
 	process.env.CLOUDFLARE_API_TOKEN = apiToken;
 
-	// Get account info from token
-	let accountId: string;
-	try {
-		const accountInfo = await getCloudflareAccount(apiToken);
-		accountId = accountInfo.accountId;
-	} catch (error) {
-		_logger.error("[cloudflare] Failed to get account", {
-			error: error instanceof Error ? error.message : String(error),
-		});
+	// Use configured account ID (required)
+	if (!CLOUDFLARE_ACCOUNT_ID) {
+		_logger.error(
+			"[cloudflare] CLOUDFLARE_ACCOUNT_ID not set. Add to ~/.pi/free.json or set env var.",
+		);
 		return;
 	}
+	const accountId = CLOUDFLARE_ACCOUNT_ID;
 
-	// Fetch models
-	let allModels: ProviderModelConfig[] = [];
-
-	try {
-		allModels = await fetchCloudflareModels(accountId, apiToken);
-	} catch (error) {
-		_logger.error("[cloudflare] Failed to fetch models at startup", {
-			error: error instanceof Error ? error.message : String(error),
-		});
-		return;
-	}
+	// Get models (static list - no API calls needed)
+	const allModels = await getCloudflareModels();
 
 	// For Cloudflare, all models share the same free tier
 	// So "free" and "all" are the same set

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -18,6 +18,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
+import { OPENROUTER_SHOW_PAID, saveConfig } from "../../config.ts";
 import {
 	BASE_URL_OPENROUTER,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -53,7 +54,7 @@ interface DynamicProviderConfig {
 	providerId: string;
 	apiKeyEnvVar: string;
 	baseUrl: string;
-	api: "openai-completions" | "mistral-conversations";
+	api: "openai-completions" | "mistral-conversations" | "anthropic-messages";
 	fetchModels: (apiKey: string) => Promise<ProviderModelConfig[]>;
 	defaultShowPaid: boolean;
 }
@@ -388,6 +389,15 @@ const FETCH_FUNCTIONS: Record<
 	openrouter: fetchOpenRouterModels,
 };
 
+// Providers that support free/paid toggling (have pricing info in API)
+// OpenRouter exposes actual pricing
+const TOGGLEABLE_PROVIDERS = new Set(["openrouter"]);
+
+// Map provider IDs to their config show_paid flags
+const PROVIDER_CONFIG_FLAGS: Record<string, boolean> = {
+	openrouter: OPENROUTER_SHOW_PAID,
+};
+
 // =============================================================================
 // Main Setup Function
 // =============================================================================
@@ -440,14 +450,19 @@ export async function setupDynamicBuiltInProviders(
 			const initialModels = config.defaultShowPaid ? allModels : freeModels;
 			reRegister(initialModels);
 
-			// Register toggle command for this provider
-			setupProviderToggle(
-				pi,
-				config.providerId,
-				freeModels,
-				allModels,
-				reRegister,
-			);
+			// Register toggle command only for providers with pricing info
+			if (TOGGLEABLE_PROVIDERS.has(config.providerId)) {
+				const initialShowPaid =
+					PROVIDER_CONFIG_FLAGS[config.providerId] ?? false;
+				setupProviderToggle(
+					pi,
+					config.providerId,
+					freeModels,
+					allModels,
+					reRegister,
+					initialShowPaid,
+				);
+			}
 
 			_logger.info(`[dynamic] ${config.providerId}: registered successfully`);
 		} catch (error) {
@@ -471,19 +486,25 @@ function setupProviderToggle(
 	freeModels: ProviderModelConfig[],
 	allModels: ProviderModelConfig[],
 	reRegister: (models: ProviderModelConfig[]) => void,
+	initialShowPaid = false,
 ): void {
-	let showPaid = false;
+	let showPaid = initialShowPaid;
 
 	pi.registerCommand(`${providerId}-toggle`, {
-		description: `Toggle between free and all ${providerId} models`,
+		description: `Toggle free/paid ${providerId} models`,
 		handler: async (_args, ctx) => {
 			showPaid = !showPaid;
 			const modelsToShow = showPaid ? allModels : freeModels;
 			reRegister(modelsToShow);
 
+			// Persist to config for openrouter
+			if (providerId === "openrouter") {
+				saveConfig({ openrouter_show_paid: showPaid });
+			}
+
 			const count = modelsToShow.length;
-			const type = showPaid ? "all" : "free";
-			ctx.ui.notify(`${providerId}: showing ${count} ${type} models`, "info");
+			const type = showPaid ? "paid" : "free";
+			ctx.ui.notify(`${providerId}: ${count} ${type} models`, "info");
 		},
 	});
 }

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -19,6 +19,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import {
 	applyHidden,
+	NVIDIA_API_KEY,
 	NVIDIA_SHOW_PAID,
 	PROVIDER_NVIDIA,
 } from "../../config.ts";
@@ -122,13 +123,13 @@ export default async function (pi: ExtensionAPI) {
 
 	// Store both sets for global toggle
 	const stored = { free: freeModels, all: allModels };
-	const hasKey = !!process.env.NVIDIA_API_KEY;
+	const hasKey = !!(NVIDIA_API_KEY || process.env.NVIDIA_API_KEY);
 
 	// Create re-register function
 	const reRegister = createReRegister(pi, {
 		providerId: PROVIDER_NVIDIA,
 		baseUrl: BASE_URL_NVIDIA,
-		apiKey: "NVIDIA_API_KEY",
+		apiKey: NVIDIA_API_KEY || "NVIDIA_API_KEY",
 	});
 
 	// Register with global toggle system
@@ -138,7 +139,7 @@ export default async function (pi: ExtensionAPI) {
 	const initialModels = NVIDIA_SHOW_PAID ? allModels : freeModels;
 	pi.registerProvider(PROVIDER_NVIDIA, {
 		baseUrl: BASE_URL_NVIDIA,
-		apiKey: "NVIDIA_API_KEY",
+		apiKey: NVIDIA_API_KEY || "NVIDIA_API_KEY",
 		api: "openai-completions" as const,
 		headers: {
 			"User-Agent": "pi-free-providers",

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -23,12 +23,22 @@ vi.mock("../index.ts", () => ({
 	providerRegistry: new Map(),
 }));
 
-// Minimal mocks for imports
+// Minimal mocks for imports - must match paths from both test file AND provider file
 vi.mock("../config.ts", () => ({
 	NVIDIA_API_KEY: "test-key",
 	NVIDIA_SHOW_PAID: true,
 	PROVIDER_NVIDIA: "nvidia",
 	PROVIDER_KILO: "kilo", // added for index.ts import
+	applyHidden: (m: any[]) => m,
+	FREE_ONLY: false,
+}));
+
+// Also mock the path used by providers/nvidia/nvidia.ts (../../config.ts resolves to same file)
+vi.mock("../../config.ts", () => ({
+	NVIDIA_API_KEY: "test-key",
+	NVIDIA_SHOW_PAID: true,
+	PROVIDER_NVIDIA: "nvidia",
+	PROVIDER_KILO: "kilo",
 	applyHidden: (m: any[]) => m,
 	FREE_ONLY: false,
 }));
@@ -249,7 +259,7 @@ describe("NVIDIA Provider", () => {
 			"nvidia",
 			expect.objectContaining({
 				baseUrl: "https://integrate.api.nvidia.com/v1",
-				apiKey: "NVIDIA_API_KEY",
+				apiKey: "test-key",
 				api: "openai-completions",
 			}),
 		);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		environment: "node",
 		include: ["**/*.test.ts"],
 		exclude: ["node_modules", ".pi-lens"],
+		testTimeout: 10000, // 10 second timeout per test
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html"],


### PR DESCRIPTION
This PR updates the Cloudflare Workers AI provider to match the comprehensive implementation from bneil/pi-cloudflare-workers-ai.

## Changes

### Cloudflare Provider
- **18 models** (was 6): Added Kimi K2.5, Llama 4 Scout, Gemma 4, Nemotron 3, Qwen3, GLM-4.7, etc.
- **Real pricing**: Neurons-based pricing instead of freemium (cost=0)
- **Improved auth**: Supports CF_API_TOKEN/CF_ACCOUNT_ID, legacy env vars, and ~/.pi/free.json
- **User customization**: ~/.pi/cloudflare-models.json to add/override/remove models
- **413 fix**: Full compat settings (supportsStore: false, etc.)
- **Removed from toggle**: Cloudflare is freemium, not free/paid

### Other Changes
- **NVIDIA fix**: Use config-based API key resolution (was checking process.env directly)
- **OpenRouter toggle**: Added with config persistence
- **isFreeModel fix**: Name heuristic for providers without pricing API
- **Test timeout**: Added to prevent hanging tests

## Verification
- ✅ All 101 tests passing
- ✅ TypeScript compilation clean