### PR TITLE
feat: toggle-opencode + standardize toggle-[provider] naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-04-23
 
 ### Breaking Changes
 - **Removed Fireworks provider** — Fireworks is now a built-in Pi provider (added in pi 0.68.1), so the extension's Fireworks provider has been removed to avoid conflicts:

--- a/config.ts
+++ b/config.ts
@@ -6,7 +6,7 @@
  *   2. ~/.pi/free.json
  *
  * All exported values are getter functions so that runtime changes
- * (e.g. after /{provider}-toggle or /free) are visible immediately.
+ * (e.g. after toggle-{provider}) are visible immediately.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { setupBuiltInProviderToggles } from "./lib/built-in-toggle.ts";
 import { createLogger } from "./lib/logger.ts";
 import {
 	applyGlobalFilter,
@@ -37,49 +38,6 @@ const _logger = createLogger("pi-free");
 // =============================================================================
 
 function setupGlobalCommands(pi: ExtensionAPI) {
-	// /free - Global toggle for ALL providers
-	pi.registerCommand("free", {
-		description: "Toggle free-only mode for ALL providers (on/off/status)",
-		handler: async (args, ctx) => {
-			const arg = args.trim().toLowerCase();
-			const registry = getProviderRegistry();
-
-			if (arg === "on" || arg === "true" || arg === "yes") {
-				applyGlobalFilter(pi, true);
-				ctx.ui.notify(
-					"✓ Free-only mode enabled - paid models hidden for all providers",
-					"info",
-				);
-			} else if (arg === "off" || arg === "false" || arg === "no") {
-				applyGlobalFilter(pi, false);
-				ctx.ui.notify(
-					"✓ Paid models enabled - all models visible for all providers",
-					"info",
-				);
-			} else if (arg === "status" || arg === "" || !arg) {
-				const available = await ctx.modelRegistry.getAvailable();
-				const freeCount = available.filter(isFreeModel).length;
-				const status = getGlobalFreeOnly() ? "enabled" : "disabled";
-
-				// Count by provider
-				const lines = [
-					`Free-only mode: ${status}`,
-					`${freeCount}/${available.length} models free`,
-					"",
-				];
-				for (const [id, entry] of registry) {
-					const free = entry.stored.free.length;
-					const all = entry.stored.all.length || free;
-					lines.push(`${id}: ${free}/${all} free`);
-				}
-
-				ctx.ui.notify(lines.join("\n"), "info");
-			} else {
-				ctx.ui.notify("Usage: /free [on|off|status]", "warning");
-			}
-		},
-	});
-
 	// /free-providers - Show free model counts by provider
 	pi.registerCommand("free-providers", {
 		description: "Show free/paid model counts for all pi-free providers",
@@ -165,6 +123,9 @@ export default async function (pi: ExtensionAPI) {
 		"./providers/dynamic-built-in/index.ts"
 	);
 	await setupDynamicBuiltInProviders(pi);
+
+	// Setup toggles for pi's built-in providers (e.g., OpenCode)
+	setupBuiltInProviderToggles(pi);
 
 	// Apply initial global filter if free-only mode is enabled
 	if (globalFreeOnly) {

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -1,0 +1,203 @@
+/**
+ * Built-in Provider Toggle Support
+ *
+ * Captures pi's built-in providers after session start and enables
+ * free/paid toggling for them via the global registry.
+ *
+ * Currently supports:
+ * - opencode (OpenCode / Zen gateway)
+ *
+ * OpenRouter is intentionally excluded here because it is already
+ * handled by providers/dynamic-built-in/index.ts.
+ *
+ * Usage: /toggle-opencode
+ */
+
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { getOpencodeShowPaid, saveConfig } from "../config.ts";
+import { createLogger } from "./logger.ts";
+import {
+	getGlobalFreeOnly,
+	isFreeModel,
+	registerWithGlobalToggle,
+} from "./registry.ts";
+
+const _logger = createLogger("built-in-toggle");
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+interface BuiltInToggleConfig {
+	id: string;
+	getShowPaid: () => boolean;
+}
+
+const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
+	{ id: "opencode", getShowPaid: getOpencodeShowPaid },
+];
+
+// =============================================================================
+// State
+// =============================================================================
+
+interface BuiltInProviderState {
+	free: ProviderModelConfig[];
+	all: ProviderModelConfig[];
+	reRegister: (models: ProviderModelConfig[]) => void;
+	showPaid: boolean;
+}
+
+const providerStates = new Map<string, BuiltInProviderState>();
+let commandsRegistered = false;
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
+	// Register toggle commands once (available even before models load)
+	if (!commandsRegistered) {
+		for (const config of BUILT_IN_TOGGLE_PROVIDERS) {
+			registerToggleCommand(pi, config);
+		}
+		commandsRegistered = true;
+	}
+
+	// Capture built-in models on session start and apply initial filter
+	pi.on("session_start", async (_event, ctx) => {
+		const available = ctx.modelRegistry.getAvailable();
+
+		for (const config of BUILT_IN_TOGGLE_PROVIDERS) {
+			if (providerStates.has(config.id)) {
+				// Already captured this session — skip to avoid re-registering
+				continue;
+			}
+
+			const providerModels = available.filter(
+				(m: Model<Api>) => m.provider === config.id,
+			);
+			if (providerModels.length === 0) continue;
+
+			const allModels = providerModels.map(modelToProviderConfig);
+			const freeModels = allModels.filter(isFreeModel);
+
+			const baseUrl = providerModels[0].baseUrl;
+			const api = providerModels[0].api;
+			const apiKeyEnv = getApiKeyEnvForProvider(config.id);
+
+			const reRegister = (models: ProviderModelConfig[]) => {
+				pi.registerProvider(config.id, {
+					baseUrl,
+					apiKey: apiKeyEnv,
+					api,
+					models,
+				});
+			};
+
+			providerStates.set(config.id, {
+				free: freeModels,
+				all: allModels,
+				reRegister,
+				showPaid: config.getShowPaid(),
+			});
+
+			// Register with global free-only filter
+			registerWithGlobalToggle(
+				config.id,
+				{ free: freeModels, all: allModels },
+				reRegister,
+				true,
+			);
+
+			_logger.info(
+				`[built-in-toggle] ${config.id}: captured ${allModels.length} models (${freeModels.length} free)`,
+			);
+
+			// Respect global free-only setting at capture time
+			if (!getGlobalFreeOnly() && !config.getShowPaid()) {
+				// Default: show free only (same as other pi-free providers)
+				if (freeModels.length > 0) {
+					reRegister(freeModels);
+					_logger.info(
+						`[built-in-toggle] ${config.id}: applied free-only filter`,
+					);
+				}
+			}
+		}
+	});
+}
+
+// =============================================================================
+// Per-provider toggle command
+// =============================================================================
+
+function registerToggleCommand(
+	pi: ExtensionAPI,
+	config: BuiltInToggleConfig,
+): void {
+	const commandName = `${config.id}-toggle`;
+	pi.registerCommand(commandName, {
+		description: `Toggle free/paid ${config.id} models`,
+		handler: async (_args, ctx) => {
+			const state = providerStates.get(config.id);
+			if (!state) {
+				ctx.ui.notify(
+					`${config.id}: models not loaded yet. Start a session first.`,
+					"warning",
+				);
+				return;
+			}
+
+			state.showPaid = !state.showPaid;
+
+			// Persist preference
+			saveConfig({ [`${config.id}_show_paid`]: state.showPaid });
+
+			if (state.showPaid) {
+				state.reRegister(state.all);
+				ctx.ui.notify(
+					`${config.id}: showing all ${state.all.length} models`,
+					"info",
+				);
+			} else {
+				state.reRegister(state.free);
+				ctx.ui.notify(
+					`${config.id}: showing ${state.free.length} free models`,
+					"info",
+				);
+			}
+		},
+	});
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function modelToProviderConfig(m: Model<Api>): ProviderModelConfig {
+	return {
+		id: m.id,
+		name: m.name,
+		api: m.api,
+		reasoning: m.reasoning,
+		input: m.input,
+		cost: m.cost,
+		contextWindow: m.contextWindow,
+		maxTokens: m.maxTokens,
+		headers: m.headers,
+		compat: (m as any).compat,
+	};
+}
+
+function getApiKeyEnvForProvider(providerId: string): string {
+	const envMap: Record<string, string> = {
+		opencode: "OPENCODE_API_KEY",
+		openrouter: "OPENROUTER_API_KEY",
+	};
+	return envMap[providerId] || `${providerId.toUpperCase()}_API_KEY`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "1.0.9",
+	"version": "2.0.0",
 	"type": "module",
 	"description": "AIO free models for PI: Kilo, Cline, Nvidia, Ollama Cloud and others",
 	"keywords": [

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -1,7 +1,7 @@
 /**
  * Shared provider setup helpers for pi-free-providers.
  * Extracts the common boilerplate pattern repeated across providers:
- *   - /{provider}-toggle command to switch between free/paid models
+ *   - toggle-{provider} command to switch between free/paid models
  *   - model_select handler (clear status for other providers)
  *   - turn_end handler (provider-specific error hook)
  *   - before_agent_start handler (one-time ToS notice)
@@ -31,7 +31,7 @@ export interface ProviderSetupConfig {
 	/** Initial mode - auto-detected from config at startup. */
 	initialShowPaid?: boolean;
 	/**
-	 * Called by /{provider}-toggle command to re-register
+	 * Called by toggle-{provider} command to re-register
 	 * the provider with the given model set.
 	 */
 	reRegister: (models: ProviderModelConfig[], stored: StoredModels) => void;
@@ -42,7 +42,7 @@ export interface ProviderSetupConfig {
 			ui: { notify: (m: string, t: "info" | "warning" | "error") => void };
 		},
 	) => Promise<boolean>;
-	/** When true, skips creating the /{provider}-toggle command. Useful for providers with only one model. */
+	/** When true, skips creating the toggle-{provider} command. Useful for providers with only one model. */
 	skipToggle?: boolean;
 }
 
@@ -176,7 +176,7 @@ export function setupProvider(
 	// ── Single toggle command (skip if requested) ──────────────────────
 
 	if (!config.skipToggle) {
-		pi.registerCommand(`${providerId}-toggle`, {
+		pi.registerCommand(`toggle-${providerId}`, {
 			description: `Toggle between free and all ${providerId} models`,
 			handler: async (_args, ctx) => {
 				// Toggle the mode

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -2,7 +2,7 @@
  * Cline model fetching.
  *
  * Fetches ALL models from OpenRouter (Cline's gateway).
- * Free/paid filtering is handled by the global /free toggle.
+ * Free/paid filtering is handled by the global free-only filter.
  */
 
 import { applyHidden } from "../../config.ts";

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -7,7 +7,7 @@
  *
  * Auth flow based on pi-cline's proven implementation.
  *
- * Responds to global /free toggle (though Cline only provides free models without auth).
+ * Responds to global free-only filter (though Cline only provides free models without auth).
  *
  * Usage:
  *   pi install git:github.com/apmantza/pi-free
@@ -193,13 +193,13 @@ function shapeMessagesForCline(messages: any[]): any[] {
 
 export default async function (pi: ExtensionAPI) {
 	// Fetch ALL models from OpenRouter (free and paid)
-	// The global /free toggle will filter based on cost.input
+	// The global free-only filter will filter based on cost.input
 	let allModels = await fetchClineModels(false).catch((err) => {
 		logWarning("cline", "Failed to fetch models at startup", err);
 		return [];
 	});
 
-	// Also fetch free-only list for the global toggle's free filter
+	// Also fetch free-only list for the global free-only filter
 	let freeModels = allModels.filter((m) => m.cost.input === 0);
 
 	// Create re-register function for global toggle
@@ -230,10 +230,9 @@ export default async function (pi: ExtensionAPI) {
 	// Initial registration with all models
 	reRegister(allModels);
 
-	// Per-provider toggle command (works independently of global /free)
+	// Per-provider toggle command
 	let showPaidModels = false;
-	let currentModels = allModels;
-	pi.registerCommand("cline-toggle", {
+	pi.registerCommand("toggle-cline", {
 		description: "Toggle between free and all Cline models",
 		handler: async (_args, ctx) => {
 			showPaidModels = !showPaidModels;
@@ -242,7 +241,6 @@ export default async function (pi: ExtensionAPI) {
 			const modelsToShow =
 				showPaidModels && allModels.length > 0 ? allModels : freeModels;
 
-			currentModels = modelsToShow;
 			reRegister(modelsToShow);
 
 			const freeCount = freeModels.length;

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -493,7 +493,7 @@ function setupProviderToggle(
 ): void {
 	let showPaid = initialShowPaid;
 
-	pi.registerCommand(`${providerId}-toggle`, {
+	pi.registerCommand(`toggle-${providerId}`, {
 		description: `Toggle free/paid ${providerId} models`,
 		handler: async (_args, ctx) => {
 			showPaid = !showPaid;

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -3,9 +3,9 @@
  *
  * Provides access to 300+ AI models via the Kilo Gateway (OpenRouter-compatible).
  * Fetches ALL models at startup (like Cline/OpenRouter), defaults to free-only view.
- * Run /login kilo or use /kilo-toggle to access paid models.
+ * Run /login kilo or use /toggle-kilo to access paid models.
  *
- * Responds to global /free toggle for free/paid model filtering.
+ * Responds to global free-only filter for free/paid model filtering.
  *
  * Usage:
  *   pi install git:github.com/apmantza/pi-free
@@ -156,8 +156,8 @@ export default async function (pi: ExtensionAPI) {
 
 	// Registration complete - models registered silently (use LOG_LEVEL=info to see details)
 
-	// Per-provider toggle command (works independently of global /free)
-	pi.registerCommand("kilo-toggle", {
+	// Per-provider toggle command
+	pi.registerCommand("toggle-kilo", {
 		description: "Toggle between free and all Kilo models",
 		handler: async (_args, ctx) => {
 			showPaidModels = !showPaidModels;
@@ -196,7 +196,7 @@ export default async function (pi: ExtensionAPI) {
 		const paidCount = allModels.length - freeModels.length;
 		if (paidCount > 0) {
 			ctx.ui.notify(
-				`Kilo: ${freeModels.length} free models shown. Use /kilo-toggle or /login kilo for ${paidCount} paid models. Terms: ${URL_KILO_TOS}`,
+				`Kilo: ${freeModels.length} free models shown. Use /toggle-kilo or /login kilo for ${paidCount} paid models. Terms: ${URL_KILO_TOS}`,
 				"info",
 			);
 		}

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -10,7 +10,7 @@
  * image-gen) are filtered by their modalities (output must be ["text"],
  * input must include "text").
  *
- * Responds to global /free toggle for free/paid model filtering.
+ * Responds to global free-only filter for free/paid model filtering.
  */
 
 import type {

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -11,13 +11,13 @@
  * Requires OLLAMA_API_KEY with cloud access.
  * Get a free key at: https://ollama.com/settings/keys
  *
- * Responds to global /free toggle (shows models but warns they're freemium).
+ * Responds to global free-only filter (shows models but warns they're freemium).
  *
  * Usage:
  *   pi install git:github.com/apmantza/pi-free
  *   # Set OLLAMA_API_KEY env var
  *   # Models appear in /model selector
- *   # Use /ollama-toggle to show all vs limited set
+ *   # Use /toggle-ollama to show all vs limited set
  */
 
 import type {


### PR DESCRIPTION
- Add `/toggle-opencode` for pi's built-in OpenCode provider (filters to free models in current session)
- Rename all provider toggles to `toggle-[provider]` (e.g. `/toggle-kilo`, `/toggle-cline`, `/toggle-openrouter`)
- Remove global `/free` command (per-provider toggles are the new pattern)