### PR TITLE
refactor: move OpenRouter to built-in-toggle system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Built-in provider toggle support** (`lib/built-in-toggle.ts`) — Enables free/paid filtering for Pi's built-in providers that expose per-model pricing:
   - **OpenCode (`/toggle-opencode`)** — Captures built-in OpenCode models on session start and filters to free-only by default
+  - **OpenRouter (`/toggle-openrouter`)** — Now uses the built-in toggle system for consistency
   - Toggle works in the current session (no restart needed)
-  - Persisted via `opencode_show_paid` in `~/.pi/free.json`
+  - Persisted via `opencode_show_paid` and `openrouter_show_paid` in `~/.pi/free.json`
 
 ### Changed
+- **OpenRouter moved to built-in toggle system** — OpenRouter is now handled by `lib/built-in-toggle.ts` alongside OpenCode for a unified approach:
+  - Removed from `providers/dynamic-built-in/index.ts`
+  - Eliminated duplicate toggle command registration logic
+  - Consolidated toggle persistence with other built-in providers
+
 - **Standardized all toggle commands to `toggle-{provider}`** — Renamed from `{provider}-toggle` for consistency:
   - `/kilo-toggle` → `/toggle-kilo`
   - `/cline-toggle` → `/toggle-cline`
@@ -25,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `/groq-toggle` → `/toggle-groq`
   - `/cerebras-toggle` → `/toggle-cerebras`
   - `/toggle-opencode` (new)
+
+### Fixed
+- **Ollama Cloud model fetching endpoint** — Corrected the `/v1/models` → `/models` endpoint path in `providers/ollama/ollama.ts`:
+  - The previous fix (2.0.0) incorrectly used `/v1/models`; Ollama Cloud's models endpoint is `/v1/models` for chat completions but `/models` for listing
+  - This ensures model fetching works correctly with the OpenAI-compatible API
 
 ### Removed
 - **Global `/free` command** — Removed the global free-only toggle. Per-provider toggles (`/toggle-{provider}`) are now the only way to switch between free and paid models. The `/free-providers` status command remains.

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -6,9 +6,7 @@
  *
  * Currently supports:
  * - opencode (OpenCode / Zen gateway)
- *
- * OpenRouter is intentionally excluded here because it is already
- * handled by providers/dynamic-built-in/index.ts.
+ * - openrouter (OpenRouter)
  *
  * Usage: /toggle-opencode
  */
@@ -18,7 +16,11 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import { getOpencodeShowPaid, saveConfig } from "../config.ts";
+import {
+	getOpencodeShowPaid,
+	getOpenrouterShowPaid,
+	saveConfig,
+} from "../config.ts";
 import { createLogger } from "./logger.ts";
 import {
 	getGlobalFreeOnly,
@@ -39,6 +41,7 @@ interface BuiltInToggleConfig {
 
 const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
 	{ id: "opencode", getShowPaid: getOpencodeShowPaid },
+	{ id: "openrouter", getShowPaid: getOpenrouterShowPaid },
 ];
 
 // =============================================================================

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -23,37 +23,14 @@ import {
 	getGroqApiKey,
 	getHfToken,
 	getMistralApiKey,
-	getOpenrouterApiKey,
-	getOpenrouterShowPaid,
 	getXaiApiKey,
-	saveConfig,
 } from "../../config.ts";
-import {
-	BASE_URL_OPENROUTER,
-	DEFAULT_FETCH_TIMEOUT_MS,
-} from "../../constants.ts";
+import { DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
-import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 
 const _logger = createLogger("dynamic-built-in");
-
-// =============================================================================
-// OpenRouter Fetcher
-// =============================================================================
-
-async function fetchOpenRouterModels(
-	apiKey: string,
-): Promise<ProviderModelConfig[]> {
-	const models = await fetchOpenRouterCompatibleModels({
-		baseUrl: BASE_URL_OPENROUTER,
-		apiKey: apiKey || undefined,
-		freeOnly: false,
-	});
-	_logger.info(`[dynamic] Fetched ${models.length} models from OpenRouter`);
-	return models;
-}
 
 // =============================================================================
 // Provider Configurations
@@ -376,13 +353,6 @@ const DYNAMIC_PROVIDERS: Omit<DynamicProviderConfig, "fetchModels">[] = [
 		api: "openai-completions",
 		defaultShowPaid: false,
 	},
-	{
-		providerId: "openrouter",
-		getApiKey: getOpenrouterApiKey,
-		baseUrl: BASE_URL_OPENROUTER,
-		api: "openai-completions",
-		defaultShowPaid: false,
-	},
 ];
 
 // Map provider IDs to their fetch functions
@@ -395,12 +365,7 @@ const FETCH_FUNCTIONS: Record<
 	cerebras: fetchCerebrasModels,
 	xai: fetchXAIModels,
 	huggingface: fetchHuggingFaceModels,
-	openrouter: fetchOpenRouterModels,
 };
-
-// Providers that support free/paid toggling (have pricing info in API)
-// OpenRouter exposes actual pricing
-const TOGGLEABLE_PROVIDERS = new Set(["openrouter"]);
 
 // =============================================================================
 // Main Setup Function
@@ -454,19 +419,6 @@ export async function setupDynamicBuiltInProviders(
 			const initialModels = config.defaultShowPaid ? allModels : freeModels;
 			reRegister(initialModels);
 
-			// Register toggle command only for providers with pricing info
-			if (TOGGLEABLE_PROVIDERS.has(config.providerId)) {
-				const initialShowPaid = getOpenrouterShowPaid();
-				setupProviderToggle(
-					pi,
-					config.providerId,
-					freeModels,
-					allModels,
-					reRegister,
-					initialShowPaid,
-				);
-			}
-
 			_logger.info(`[dynamic] ${config.providerId}: registered successfully`);
 		} catch (error) {
 			_logger.error(
@@ -477,37 +429,4 @@ export async function setupDynamicBuiltInProviders(
 			);
 		}
 	}
-}
-
-// =============================================================================
-// Per-Provider Toggle Command
-// =============================================================================
-
-function setupProviderToggle(
-	pi: ExtensionAPI,
-	providerId: string,
-	freeModels: ProviderModelConfig[],
-	allModels: ProviderModelConfig[],
-	reRegister: (models: ProviderModelConfig[]) => void,
-	initialShowPaid = false,
-): void {
-	let showPaid = initialShowPaid;
-
-	pi.registerCommand(`toggle-${providerId}`, {
-		description: `Toggle free/paid ${providerId} models`,
-		handler: async (_args, ctx) => {
-			showPaid = !showPaid;
-			const modelsToShow = showPaid ? allModels : freeModels;
-			reRegister(modelsToShow);
-
-			// Persist to config for openrouter
-			if (providerId === "openrouter") {
-				saveConfig({ openrouter_show_paid: showPaid });
-			}
-
-			const count = modelsToShow.length;
-			const type = showPaid ? "paid" : "free";
-			ctx.ui.notify(`${providerId}: ${count} ${type} models`, "info");
-		},
-	});
 }

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -51,7 +51,7 @@ async function fetchOllamaModels(
 	// Use OpenAI-compatible /v1/models endpoint for consistency
 	// The native /api/tags returns :cloud suffixes that may not work with /v1/chat/completions
 	const response = await fetchWithRetry(
-		`${BASE_URL_OLLAMA}/v1/models`,
+		`${BASE_URL_OLLAMA}/models`,
 		{
 			headers: {
 				Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
- Migrate OpenRouter from dynamic-built-in to built-in-toggle for consistency with OpenCode
- Remove duplicate toggle logic from dynamic-built-in provider  
- Fix Ollama Cloud endpoint path (remove /v1 prefix from models endpoint)
- Update changelog with changes