### PR TITLE
fix: add PROVIDER_OLLAMA to ALL_UNIQUE_PROVIDERS

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -23,6 +23,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	/** @deprecated Qwen free tier no longer available */
 	PROVIDER_QWEN,
 	PROVIDER_MODAL,
+	PROVIDER_OLLAMA,
 ] as const;
 
 // =============================================================================

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,8 @@
  * - Kilo: OAuth-based free models
  * - Cline: Cline bot integration
  * - NVIDIA: NVIDIA NIM hosting (free tier available)
- * - Qwen: OAuth-based Qwen access
+ * - Ollama Cloud: Ollama's cloud-hosted models with usage-based free tier
+ * - Qwen: OAuth-based Qwen access (deprecated)
  * - Modal: Modal Labs hosting
  */
 


### PR DESCRIPTION
Adds the Ollama Cloud provider to the ALL_UNIQUE_PROVIDERS constant and updates the documentation to include Ollama Cloud in the list of unique providers.