### PR TITLE
fix: log config parse errors instead of silently swallowing them

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -112,7 +112,11 @@ function ensureConfigFile(): void {
 export function loadConfigFile(): PiFreeConfig {
 	try {
 		return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as PiFreeConfig;
-	} catch {
+	} catch (err) {
+		_logger.warn("Could not parse config file — returning empty config", {
+			path: CONFIG_PATH,
+			error: err instanceof Error ? err.message : String(err),
+		});
 		return {};
 	}
 }


### PR DESCRIPTION
When `~/.pi/free.json` contains invalid JSON (e.g. trailing commas), `loadConfigFile()` silently returns `{}`. This makes it impossible to diagnose why API keys aren't being loaded and providers silently fail to register.

This change adds a warning log when config file parsing fails, making it easy to spot broken JSON.