### PR TITLE
fix: persist provider toggle state

### DIFF
--- a/docs/plans/2026-04-24-toggle-persistence-plan.md
+++ b/docs/plans/2026-04-24-toggle-persistence-plan.md
@@ -1,0 +1,163 @@
+# Toggle Persistence Implementation Plan
+
+> **For Pi:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Make provider toggles persist correctly and toggle from the actual current display state for built-in providers and Cline.
+
+**Architecture:** Introduce a narrow shared toggle-state helper that owns persisted `*_show_paid` state, current visible mode, model selection, and re-application after refresh. Keep provider-specific fetching, auth, and registration behavior in each provider.
+
+**Tech Stack:** TypeScript, Vitest, Pi extension APIs
+
+---
+
+### Task 1: Add toggle-state regression tests
+
+**Files:**
+- Create: `tests/toggle-state.test.ts`
+- Modify: `tests/cline.test.ts`
+- Modify: `tests/built-in-toggle.test.ts` (new if missing)
+
+**Step 1: Write failing tests**
+- Verify saved `show_paid` state is restored for built-in providers after capture.
+- Verify Cline persists `cline_show_paid` and re-applies the chosen model set after `session_start` and `before_agent_start`.
+- Verify toggling flips from actual current mode, not from an assumed boolean.
+
+**Step 2: Run tests to verify they fail**
+Run: `npm test -- tests/toggle-state.test.ts tests/cline.test.ts tests/built-in-toggle.test.ts`
+
+Expected: failures showing persistence/re-application is not implemented.
+
+**Step 3: Commit**
+```bash
+git add tests/toggle-state.test.ts tests/cline.test.ts tests/built-in-toggle.test.ts
+git commit -m "test: cover toggle persistence regressions"
+```
+
+**Verification:**
+- [ ] Tests capture built-in restore behavior
+- [ ] Tests capture Cline persistence
+- [ ] At least one test fails before implementation
+
+---
+
+### Task 2: Add shared toggle-state helper
+
+**Files:**
+- Create: `lib/toggle-state.ts`
+- Modify: `config.ts`
+
+**Step 1: Write minimal helper**
+- Add helper to initialize persisted mode from config.
+- Add helper methods to set stored models, apply current mode, and toggle from actual current state.
+- Add generic config getter/setter support if needed for provider `*_show_paid` flags.
+
+**Step 2: Run focused tests**
+Run: `npm test -- tests/toggle-state.test.ts`
+
+Expected: PASS.
+
+**Step 3: Commit**
+```bash
+git add lib/toggle-state.ts config.ts tests/toggle-state.test.ts
+git commit -m "refactor: add shared toggle state helper"
+```
+
+**Verification:**
+- [ ] Helper persists state updates
+- [ ] Helper tracks actual current mode
+- [ ] Helper chooses correct model list
+
+---
+
+### Task 3: Integrate built-in providers with shared helper
+
+**Files:**
+- Modify: `lib/built-in-toggle.ts`
+- Test: `tests/built-in-toggle.test.ts`
+
+**Step 1: Replace ad-hoc built-in state logic**
+- Use the shared helper per built-in provider.
+- On `session_start`, capture models and immediately apply persisted mode.
+- Make `/toggle-{provider}` flip from the helper’s current mode.
+
+**Step 2: Run tests**
+Run: `npm test -- tests/built-in-toggle.test.ts`
+
+Expected: PASS.
+
+**Step 3: Commit**
+```bash
+git add lib/built-in-toggle.ts tests/built-in-toggle.test.ts
+git commit -m "fix: persist built-in provider toggles"
+```
+
+**Verification:**
+- [ ] Saved state restored on startup
+- [ ] Toggle reflects actual current mode
+- [ ] No hardcoded dependency on `globalFreeOnly` for per-provider state
+
+---
+
+### Task 4: Integrate Cline with shared helper
+
+**Files:**
+- Modify: `providers/cline/cline.ts`
+- Modify: `tests/cline.test.ts`
+
+**Step 1: Replace local `showPaidModels` flag**
+- Initialize from persisted `cline_show_paid`.
+- Re-apply selected mode after model refresh and before-agent re-registration.
+- Persist changes through shared helper.
+
+**Step 2: Run tests**
+Run: `npm test -- tests/cline.test.ts`
+
+Expected: PASS.
+
+**Step 3: Commit**
+```bash
+git add providers/cline/cline.ts tests/cline.test.ts
+git commit -m "fix: persist cline toggle state"
+```
+
+**Verification:**
+- [ ] Cline toggle persists
+- [ ] Lifecycle hooks preserve selected mode
+- [ ] Notifications match actual state
+
+---
+
+### Task 5: Full verification
+
+**Files:**
+- Modify: any touched files as needed
+
+**Step 1: Run targeted regression suite**
+Run: `npm test -- tests/toggle-state.test.ts tests/built-in-toggle.test.ts tests/cline.test.ts tests/kilo-toggle.test.ts`
+
+**Step 2: Run full test suite**
+Run: `npm test -- --run`
+
+Expected: all tests passing.
+
+**Step 3: Commit**
+```bash
+git add lib/toggle-state.ts lib/built-in-toggle.ts providers/cline/cline.ts config.ts tests/
+git commit -m "fix: make provider toggles persist correctly"
+```
+
+**Verification:**
+- [ ] Targeted tests pass
+- [ ] Full test suite passes
+- [ ] No regressions in existing toggle behavior
+
+---
+
+## Execution
+
+Implement with TDD:
+1. Write the failing regression tests first
+2. Run them and confirm failure
+3. Implement minimal helper and integrations
+4. Re-run targeted tests
+5. Re-run full suite

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -16,17 +16,10 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import {
-	getOpencodeShowPaid,
-	getOpenrouterShowPaid,
-	saveConfig,
-} from "../config.ts";
+import { getOpencodeShowPaid, getOpenrouterShowPaid } from "../config.ts";
 import { createLogger } from "./logger.ts";
-import {
-	getGlobalFreeOnly,
-	isFreeModel,
-	registerWithGlobalToggle,
-} from "./registry.ts";
+import { isFreeModel, registerWithGlobalToggle } from "./registry.ts";
+import { createToggleState } from "./toggle-state.ts";
 
 const _logger = createLogger("built-in-toggle");
 
@@ -49,10 +42,9 @@ const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
 // =============================================================================
 
 interface BuiltInProviderState {
-	free: ProviderModelConfig[];
-	all: ProviderModelConfig[];
+	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] };
 	reRegister: (models: ProviderModelConfig[]) => void;
-	showPaid: boolean;
+	toggleState: ReturnType<typeof createToggleState<ProviderModelConfig>>;
 }
 
 const providerStates = new Map<string, BuiltInProviderState>();
@@ -102,35 +94,29 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 				});
 			};
 
-			providerStates.set(config.id, {
-				free: freeModels,
-				all: allModels,
-				reRegister,
-				showPaid: config.getShowPaid(),
+			const stored = { free: freeModels, all: allModels };
+			const toggleState = createToggleState<ProviderModelConfig>({
+				providerId: config.id,
+				initialShowPaid: config.getShowPaid(),
+				initialModels: stored,
 			});
 
-			// Register with global free-only filter
-			registerWithGlobalToggle(
-				config.id,
-				{ free: freeModels, all: allModels },
+			providerStates.set(config.id, {
+				stored,
 				reRegister,
-				true,
-			);
+				toggleState,
+			});
+
+			registerWithGlobalToggle(config.id, stored, reRegister, true);
 
 			_logger.info(
 				`[built-in-toggle] ${config.id}: captured ${allModels.length} models (${freeModels.length} free)`,
 			);
 
-			// Respect global free-only setting at capture time
-			if (!getGlobalFreeOnly() && !config.getShowPaid()) {
-				// Default: show free only (same as other pi-free providers)
-				if (freeModels.length > 0) {
-					reRegister(freeModels);
-					_logger.info(
-						`[built-in-toggle] ${config.id}: applied free-only filter`,
-					);
-				}
-			}
+			const applied = toggleState.applyCurrent(reRegister);
+			_logger.info(
+				`[built-in-toggle] ${config.id}: applied ${applied.mode} mode with ${applied.models.length} models`,
+			);
 		}
 	});
 }
@@ -156,21 +142,16 @@ function registerToggleCommand(
 				return;
 			}
 
-			state.showPaid = !state.showPaid;
+			const applied = state.toggleState.toggle(state.reRegister);
 
-			// Persist preference
-			saveConfig({ [`${config.id}_show_paid`]: state.showPaid });
-
-			if (state.showPaid) {
-				state.reRegister(state.all);
+			if (applied.mode === "all") {
 				ctx.ui.notify(
-					`${config.id}: showing all ${state.all.length} models`,
+					`${config.id}: showing all ${state.stored.all.length} models`,
 					"info",
 				);
 			} else {
-				state.reRegister(state.free);
 				ctx.ui.notify(
-					`${config.id}: showing ${state.free.length} free models`,
+					`${config.id}: showing ${state.stored.free.length} free models`,
 					"info",
 				);
 			}

--- a/lib/toggle-state.ts
+++ b/lib/toggle-state.ts
@@ -1,0 +1,86 @@
+import { saveConfig } from "../config.ts";
+
+export type ToggleMode = "free" | "all";
+
+export interface ToggleModelStore<T> {
+	free: T[];
+	all: T[];
+}
+
+interface CreateToggleStateOptions<T> {
+	providerId: string;
+	initialShowPaid: boolean;
+	save?: typeof saveConfig;
+	initialModels?: ToggleModelStore<T>;
+}
+
+interface ToggleResult<T> {
+	mode: ToggleMode;
+	models: T[];
+}
+
+export function createToggleState<T>({
+	providerId,
+	initialShowPaid,
+	save = saveConfig,
+	initialModels,
+}: CreateToggleStateOptions<T>) {
+	let stored: ToggleModelStore<T> = initialModels ?? { free: [], all: [] };
+	let currentMode: ToggleMode = initialShowPaid ? "all" : "free";
+
+	function resolveMode(mode: ToggleMode): ToggleResult<T> {
+		if (mode === "all") {
+			if (stored.all.length > 0) {
+				return { mode: "all", models: stored.all };
+			}
+			return { mode: "free", models: stored.free };
+		}
+
+		if (stored.free.length > 0) {
+			return { mode: "free", models: stored.free };
+		}
+		return { mode: "all", models: stored.all };
+	}
+
+	function persist(mode: ToggleMode): void {
+		save({ [`${providerId}_show_paid`]: mode === "all" });
+	}
+
+	function applyMode(
+		mode: ToggleMode,
+		apply?: (models: T[]) => void,
+	): ToggleResult<T> {
+		const resolved = resolveMode(mode);
+		currentMode = resolved.mode;
+		if (apply) apply(resolved.models);
+		return resolved;
+	}
+
+	return {
+		setModels(next: ToggleModelStore<T>): ToggleModelStore<T> {
+			stored = next;
+			const resolved = resolveMode(currentMode);
+			currentMode = resolved.mode;
+			return stored;
+		},
+		getStored(): ToggleModelStore<T> {
+			return stored;
+		},
+		getCurrentMode(): ToggleMode {
+			return currentMode;
+		},
+		getCurrentModels(): T[] {
+			return resolveMode(currentMode).models;
+		},
+		applyCurrent(apply?: (models: T[]) => void): ToggleResult<T> {
+			return applyMode(currentMode, apply);
+		},
+		applyMode,
+		toggle(apply?: (models: T[]) => void): ToggleResult<T> {
+			const nextMode = currentMode === "all" ? "free" : "all";
+			const resolved = applyMode(nextMode, apply);
+			persist(resolved.mode);
+			return resolved;
+		},
+	};
+}

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -16,8 +16,10 @@
 
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { createToggleState } from "../../lib/toggle-state.ts";
 import { logWarning } from "../../lib/util.ts";
 import { enhanceWithCI } from "../../provider-helper.ts";
 import { loginCline, refreshClineToken } from "./cline-auth.ts";
@@ -192,17 +194,18 @@ function shapeMessagesForCline(messages: any[]): any[] {
 // =============================================================================
 
 export default async function (pi: ExtensionAPI) {
-	// Fetch ALL models from OpenRouter (free and paid)
-	// The global free-only filter will filter based on cost.input
 	let allModels = await fetchClineModels(false).catch((err) => {
 		logWarning("cline", "Failed to fetch models at startup", err);
 		return [];
 	});
-
-	// Also fetch free-only list for the global free-only filter
 	let freeModels = allModels.filter((m) => m.cost.input === 0);
+	const stored = { free: freeModels, all: allModels };
+	const toggleState = createToggleState({
+		providerId: PROVIDER_CLINE,
+		initialShowPaid: getClineShowPaid(),
+		initialModels: stored,
+	});
 
-	// Create re-register function for global toggle
 	const reRegister = (m: typeof allModels) => {
 		pi.registerProvider(PROVIDER_CLINE, {
 			baseUrl: BASE_URL_CLINE,
@@ -219,36 +222,19 @@ export default async function (pi: ExtensionAPI) {
 		});
 	};
 
-	// Register with global toggle (separate free and all lists)
-	registerWithGlobalToggle(
-		PROVIDER_CLINE,
-		{ free: freeModels, all: allModels },
-		(m) => reRegister(m),
-		false, // no key until OAuth
-	);
+	registerWithGlobalToggle(PROVIDER_CLINE, stored, (m) => reRegister(m), false);
+	toggleState.applyCurrent(reRegister);
 
-	// Initial registration with all models
-	reRegister(allModels);
-
-	// Per-provider toggle command
-	let showPaidModels = false;
 	pi.registerCommand("toggle-cline", {
 		description: "Toggle between free and all Cline models",
 		handler: async (_args, ctx) => {
-			showPaidModels = !showPaidModels;
+			const applied = toggleState.toggle(reRegister);
+			const freeCount = stored.free.length;
+			const paidCount = stored.all.length - freeCount;
 
-			// Determine which models to show
-			const modelsToShow =
-				showPaidModels && allModels.length > 0 ? allModels : freeModels;
-
-			reRegister(modelsToShow);
-
-			const freeCount = freeModels.length;
-			const paidCount = allModels.length - freeCount;
-
-			if (showPaidModels && allModels.length > 0) {
+			if (applied.mode === "all") {
 				ctx.ui.notify(
-					`cline: showing all ${allModels.length} models (${freeCount} free, ${paidCount} paid)`,
+					`cline: showing all ${stored.all.length} models (${freeCount} free, ${paidCount} paid)`,
 					"info",
 				);
 			} else {
@@ -260,31 +246,31 @@ export default async function (pi: ExtensionAPI) {
 		},
 	});
 
-	// Cline-specific: refresh task ID and re-register headers before each agent run
 	pi.on("before_agent_start", async (_event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		_currentTaskId = generateUlid();
-		reRegister(freeModels);
+		toggleState.applyCurrent(reRegister);
 	});
 
-	// Cline-specific: shape messages to Cline's expected envelope format
 	pi.on("context", async (event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		const sourceMessages = Array.isArray(event.messages) ? event.messages : [];
 		return { messages: shapeMessagesForCline(sourceMessages) };
 	});
 
-	// Cline-specific: refresh model list at session start
 	pi.on("session_start", async (_event, ctx) => {
 		try {
 			const fresh = await fetchClineModels(false);
 			if (fresh.length > 0) {
 				allModels = fresh;
 				freeModels = allModels.filter((m) => m.cost.input === 0);
-				reRegister(allModels);
+				stored.all = allModels;
+				stored.free = freeModels;
+				toggleState.setModels(stored);
+				toggleState.applyCurrent(reRegister);
 				if (ctx.model?.provider === PROVIDER_CLINE) {
-					const freeCount = freeModels.length;
-					const paidCount = allModels.length - freeCount;
+					const freeCount = stored.free.length;
+					const paidCount = stored.all.length - freeCount;
 					ctx.ui.notify(
 						`Cline: ${freeCount} free, ${paidCount} paid models available`,
 						"info",

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -1,0 +1,162 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetGlobalFreeOnly = vi.fn();
+const mockGetOpencodeShowPaid = vi.fn();
+const mockGetOpenrouterShowPaid = vi.fn();
+const mockSaveConfig = vi.fn();
+const mockRegisterWithGlobalToggle = vi.fn();
+
+vi.mock("../config.ts", () => ({
+	getOpencodeShowPaid: () => mockGetOpencodeShowPaid(),
+	getOpenrouterShowPaid: () => mockGetOpenrouterShowPaid(),
+	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
+		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
+	registerWithGlobalToggle: (...args: unknown[]) =>
+		mockRegisterWithGlobalToggle(...args),
+}));
+
+describe("built-in provider toggles", () => {
+	let mockPi: ExtensionAPI;
+	let handlers: Record<string, Function>;
+	let commands: Record<string, Function>;
+	let mockRegisterProvider: ReturnType<typeof vi.fn>;
+	let setupBuiltInProviderToggles: typeof import("../lib/built-in-toggle.ts")["setupBuiltInProviderToggles"];
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		handlers = {};
+		commands = {};
+		mockRegisterProvider = vi.fn();
+		mockGetGlobalFreeOnly.mockReturnValue(true);
+		mockGetOpencodeShowPaid.mockReturnValue(false);
+		mockGetOpenrouterShowPaid.mockReturnValue(false);
+
+		mockPi = {
+			registerCommand: vi.fn((name: string, config: { handler: Function }) => {
+				commands[name] = config.handler;
+			}),
+			registerProvider: mockRegisterProvider,
+			on: vi.fn((event: string, handler: Function) => {
+				handlers[event] = handler;
+			}),
+		} as unknown as ExtensionAPI;
+
+		({ setupBuiltInProviderToggles } = await import(
+			"../lib/built-in-toggle.ts"
+		));
+	});
+
+	it("applies saved show-paid mode after capturing built-in models", async () => {
+		mockGetOpencodeShowPaid.mockReturnValue(true);
+		setupBuiltInProviderToggles(mockPi);
+
+		const allModels = [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+			{
+				provider: "opencode",
+				id: "paid-model",
+				name: "Paid Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+
+		await handlers.session_start(
+			{},
+			{
+				modelRegistry: {
+					getAvailable: () => allModels,
+				},
+			},
+		);
+
+		expect(mockRegisterProvider).toHaveBeenCalledWith(
+			"opencode",
+			expect.objectContaining({
+				models: expect.arrayContaining([
+					expect.objectContaining({ id: "free-model" }),
+					expect.objectContaining({ id: "paid-model" }),
+				]),
+			}),
+		);
+	});
+
+	it("toggles from the actual current mode instead of an assumed boolean", async () => {
+		mockGetOpencodeShowPaid.mockReturnValue(true);
+		setupBuiltInProviderToggles(mockPi);
+
+		const allModels = [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+			{
+				provider: "opencode",
+				id: "paid-model",
+				name: "Paid Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+
+		await handlers.session_start(
+			{},
+			{
+				modelRegistry: {
+					getAvailable: () => allModels,
+				},
+			},
+		);
+
+		const notify = vi.fn();
+		await commands["toggle-opencode"]({}, { ui: { notify } });
+
+		expect(mockSaveConfig).toHaveBeenCalledWith({ opencode_show_paid: false });
+		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
+			"opencode",
+			expect.objectContaining({
+				models: [expect.objectContaining({ id: "free-model" })],
+			}),
+		);
+		expect(notify).toHaveBeenCalledWith(
+			"opencode: showing 1 free models",
+			"info",
+		);
+	});
+});

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -17,8 +17,16 @@ vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => false,
 }));
 
+const mockGetClineShowPaid = vi.fn();
+const mockSaveConfig = vi.fn();
+
 vi.mock("../lib/util.ts", () => ({
 	logWarning: vi.fn(),
+}));
+
+vi.mock("../config.ts", () => ({
+	getClineShowPaid: () => mockGetClineShowPaid(),
+	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
 }));
 
 vi.mock("../providers/cline/cline-auth.ts", () => ({
@@ -42,16 +50,21 @@ describe("Cline Provider", () => {
 	let mockPi: ExtensionAPI;
 	let mockRegisterProvider: ReturnType<typeof vi.fn>;
 	let mockOn: ReturnType<typeof vi.fn>;
+	let commandHandlers: Record<string, Function>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockRegisterProvider = vi.fn();
 		mockOn = vi.fn();
+		commandHandlers = {};
+		mockGetClineShowPaid.mockReturnValue(false);
 
 		mockPi = {
 			registerProvider: mockRegisterProvider,
 			on: mockOn,
-			registerCommand: vi.fn(),
+			registerCommand: vi.fn((name: string, config: { handler: Function }) => {
+				commandHandlers[name] = config.handler;
+			}),
 		} as unknown as ExtensionAPI;
 	});
 
@@ -132,6 +145,84 @@ describe("Cline Provider", () => {
 	});
 
 	describe("request handling", () => {
+		it("should persist and re-apply paid mode across lifecycle hooks", async () => {
+			const initialModels = [
+				{
+					id: "free-model",
+					name: "Free Model",
+					reasoning: false,
+					input: ["text" as const],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+				{
+					id: "paid-model",
+					name: "Paid Model",
+					reasoning: false,
+					input: ["text" as const],
+					cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+			];
+			vi.mocked(fetchClineModels)
+				.mockResolvedValueOnce(initialModels)
+				.mockResolvedValueOnce(initialModels);
+
+			await clineProvider(mockPi);
+			mockRegisterProvider.mockClear();
+
+			const notify = vi.fn();
+			await commandHandlers["toggle-cline"]({}, { ui: { notify } });
+
+			expect(mockSaveConfig).toHaveBeenCalledWith({ cline_show_paid: true });
+			expect(mockRegisterProvider).toHaveBeenLastCalledWith(
+				"cline",
+				expect.objectContaining({
+					models: expect.arrayContaining([
+						expect.objectContaining({ id: "free-model" }),
+						expect.objectContaining({ id: "paid-model" }),
+					]),
+				}),
+			);
+
+			mockRegisterProvider.mockClear();
+			const beforeRequestHandler = mockOn.mock.calls.find(
+				(call) => call[0] === "before_agent_start",
+			)?.[1];
+			await beforeRequestHandler({}, { model: { provider: "cline" } });
+
+			expect(mockRegisterProvider).toHaveBeenCalledWith(
+				"cline",
+				expect.objectContaining({
+					models: expect.arrayContaining([
+						expect.objectContaining({ id: "free-model" }),
+						expect.objectContaining({ id: "paid-model" }),
+					]),
+				}),
+			);
+
+			mockRegisterProvider.mockClear();
+			const sessionStartHandler = mockOn.mock.calls.find(
+				(call) => call[0] === "session_start",
+			)?.[1];
+			await sessionStartHandler(
+				{},
+				{ model: { provider: "cline" }, ui: { notify } },
+			);
+
+			expect(mockRegisterProvider).toHaveBeenCalledWith(
+				"cline",
+				expect.objectContaining({
+					models: expect.arrayContaining([
+						expect.objectContaining({ id: "free-model" }),
+						expect.objectContaining({ id: "paid-model" }),
+					]),
+				}),
+			);
+		});
+
 		it("should re-register provider with fresh headers on before_agent_start", async () => {
 			vi.mocked(fetchClineModels).mockResolvedValue([]);
 

--- a/tests/toggle-state.test.ts
+++ b/tests/toggle-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createToggleState } from "../lib/toggle-state.ts";
+
+describe("toggle-state helper", () => {
+	it("toggles from the actual currently applied mode", () => {
+		const save = vi.fn();
+		const state = createToggleState({
+			providerId: "cline",
+			initialShowPaid: false,
+			save,
+		});
+
+		state.setModels({
+			free: [{ id: "free" }],
+			all: [{ id: "free" }, { id: "paid" }],
+		});
+
+		state.applyMode("all");
+		const next = state.toggle();
+
+		expect(next.mode).toBe("free");
+		expect(next.models).toEqual([{ id: "free" }]);
+		expect(save).toHaveBeenCalledWith({ cline_show_paid: false });
+	});
+
+	it("re-applies persisted show-paid mode after model refresh", () => {
+		const state = createToggleState({
+			providerId: "cline",
+			initialShowPaid: true,
+			save: vi.fn(),
+		});
+
+		state.setModels({
+			free: [{ id: "free" }],
+			all: [{ id: "free" }, { id: "paid" }],
+		});
+
+		expect(state.getCurrentMode()).toBe("all");
+		expect(state.getCurrentModels()).toEqual([{ id: "free" }, { id: "paid" }]);
+	});
+});


### PR DESCRIPTION
## Summary
- add a shared toggle-state helper for persisted provider toggle state
- fix built-in and Cline provider toggles so saved mode is restored and lifecycle hooks preserve selection
- add regression tests for built-in toggles, shared toggle state, and Cline lifecycle behavior

## Test Plan
- [x] npm test -- --run
