### PR TITLE
refactor(nvidia): query NVIDIA API directly as source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **NVIDIA provider now queries NVIDIA's API directly** — Source of truth switched from `models.dev` curated JSON to `https://integrate.api.nvidia.com/v1/models`:
+  - Eliminates 57 missing models and 25 stale entries from the old third-party source
+  - Models not in `models.dev` get inferred metadata (128k context, 4k output, vision/reasoning heuristics)
+  - Added regex-based non-chat model filtering for unknown models (embeddings, whisper, reward models, safety guards, parsers, detectors, etc.)
+  - Graceful fallback to `models.dev` if NVIDIA API is unreachable
+  - Removed paid/free toggle filtering — NVIDIA is freemium (all models use free credits)
+
+## [2.0.2] - 2026-04-24
+
+### Fixed
+
+- **Provider toggle state now persists reliably** — Follow-up fixes to the new `toggle-{provider}` flow ensure saved free-vs-all preferences are restored consistently across sessions for built-in and extension-managed providers.
+- **Config parse errors are now logged** — Invalid `~/.pi/free.json` content is no longer ignored silently; startup parse failures are written to `~/.pi/free.log` to make misconfiguration easier to diagnose.
+
+### Changed
+
+- **README refreshed** — Clarified that provider toggle changes apply immediately, persist across restarts, and that malformed config is surfaced in the extension log.
+
 ## [2.0.1] - 2026-04-24
 
 ### Added
+
 - **Built-in provider toggle support** (`lib/built-in-toggle.ts`) — Enables free/paid filtering for Pi's built-in providers that expose per-model pricing:
   - **OpenCode (`/toggle-opencode`)** — Captures built-in OpenCode models on session start and filters to free-only by default
   - **OpenRouter (`/toggle-openrouter`)** — Now uses the built-in toggle system for consistency
@@ -17,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Persisted via `opencode_show_paid` and `openrouter_show_paid` in `~/.pi/free.json`
 
 ### Changed
+
 - **OpenRouter moved to built-in toggle system** — OpenRouter is now handled by `lib/built-in-toggle.ts` alongside OpenCode for a unified approach:
   - Removed from `providers/dynamic-built-in/index.ts`
   - Eliminated duplicate toggle command registration logic
@@ -35,16 +57,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `/toggle-opencode` (new)
 
 ### Fixed
+
 - **Ollama Cloud model fetching endpoint** — Corrected the `/v1/models` → `/models` endpoint path in `providers/ollama/ollama.ts`:
   - The previous fix (2.0.0) incorrectly used `/v1/models`; Ollama Cloud's models endpoint is `/v1/models` for chat completions but `/models` for listing
   - This ensures model fetching works correctly with the OpenAI-compatible API
 
 ### Removed
+
 - **Global `/free` command** — Removed the global free-only toggle. Per-provider toggles (`/toggle-{provider}`) are now the only way to switch between free and paid models. The `/free-providers` status command remains.
 
 ## [2.0.0] - 2026-04-23
 
 ### Breaking Changes
+
 - **Removed Fireworks provider** — Fireworks is now a built-in Pi provider (added in pi 0.68.1), so the extension's Fireworks provider has been removed to avoid conflicts:
   - Deleted `providers/fireworks/fireworks.ts` and `tests/fireworks.test.ts`
   - Removed all Fireworks configuration options from `config.ts` (`fireworks_api_key`, `fireworks_show_paid`)
@@ -55,15 +80,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All log messages and documentation now reference "Ollama Cloud"
 
 ### Removed
+
 - **Dropped `@sinclair/typebox` peer dependency** — Pi 0.69.0 migrated from `@sinclair/typebox` to `typebox` 1.x. The extension didn't directly import this package, so it was removed from `peerDependencies` to avoid potential conflicts.
 
 ### Fixed
+
 - **Ollama Cloud API endpoint** — Fixed broken Ollama Cloud integration:
   - Changed `BASE_URL_OLLAMA` from `https://ollama.com` to `https://ollama.com/v1` — the OpenAI-compatible API endpoint
   - Fixed model fetching to use `/v1/models` instead of `/api/tags` — ensures model IDs work with chat completions endpoint
   - Previously calls went to HTML homepage instead of API endpoints, causing 404 errors
 
 ### Removed
+
 - **Removed paid model warning on selection** — Deleted the `model_select` event handler that showed:
   - `⚠️ Paid model selected (${model.id}). Use "/free off" to enable paid models.`
   - This warning was redundant since the global `/free` toggle and provider toggles already control model visibility
@@ -73,12 +101,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Modal provider now sets `skipToggle: true` to prevent toggle command creation
 
 ### Changed
+
 - **Marked Qwen provider as fully deprecated** — Updated messaging to clarify the provider is broken:
   - Changed model name from `"Qwen Coder — Free 1k/day"` to `"Qwen Coder — DEPRECATED (free tier discontinued)"`
   - Updated all JSDoc comments to clearly state auth is broken and free tier is no longer available
   - Provider remains for backward compatibility but should not be used
 
 ### Added
+
 - **Cloudflare Workers AI provider** — New provider for Cloudflare's serverless GPU platform:
   - 50+ open-source models: Llama 4, Mistral Small 3.1, Qwen 2.5/3, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, and more
   - **10,000 Neurons/day FREE tier** (resets daily at 00:00 UTC)
@@ -103,12 +133,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Providers register via `registerWithGlobalToggle()` for unified filtering
 
 ### Fixed
+
 - **Toggle commands now actually filter models from UI** — Previously, toggle commands only showed notifications but didn't remove paid models from the model picker:
   - **OpenRouter (`/openrouter-toggle`)**: Now uses `registerProvider`/`unregisterProvider` to actually filter models from the picker UI
   - **NVIDIA (`/nvidia-toggle`)**: Added dynamic `showPaid` parameter to `fetchNvidiaModels()` so toggle properly switches between free and paid model sets
   - **Fireworks**: Removed broken toggle command — all models are paid with no free tier, so there was nothing to toggle
 
 ### Added
+
 - **OpenRouter per-provider free model toggle** — Added `/openrouter-toggle` command for the built-in OpenRouter provider:
   - `/openrouter-toggle` — Switch between showing only free models vs all models (including paid)
   - New config flag `openrouter_show_paid` in `~/.pi/free.json` (default: `false`)
@@ -116,6 +148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This brings OpenRouter (a built-in pi provider) in line with extension providers that have per-provider toggles
 
 ### Deprecated
+
 - **Qwen provider** — The 1,000 requests/day free tier is no longer available from Qwen/DashScope. The provider code remains for backward compatibility but is now deprecated:
   - Added `@deprecated` JSDoc tags to all Qwen-related exports
   - Added deprecation warning when Qwen provider loads
@@ -123,11 +156,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Consider migrating to other free providers: Kilo, Cline, NVIDIA, or Modal
 
 ### Added
+
 - **Go provider** — OpenCode Go subscription gateway (⚠️ paid only — $5 first month, then $10/month, no free tier) with models: GLM-5, Kimi K2.5, MiMo-V2-Pro, MiMo-V2-Omni, MiniMax M2.7, MiniMax M2.5
   - Set `OPENCODE_GO_API_KEY` or `opencode_go_api_key` in `~/.pi/free.json`
   - Toggle with `/go-toggle`
 
 ### Fixed
+
 - **All providers now show Coding Index scores in model selector** — Added `enhanceWithCI()` to factory-based providers (nvidia, fireworks, mistral, modal, ollama) and cline. Now all providers display CI scores in `/models` command (pi-models extension).
 
 - **All providers now show in `--list-models`** — Providers (zen, openrouter, go) that registered models only in `session_start` were missing from `pi --list-models` which runs before session starts. Added immediate registration for these providers:
@@ -137,22 +172,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All 11 providers now visible in `--list-models`
 
 ### Changed
+
 - Updated README with clear free vs paid provider distinction (9 free + 2 paid-only: Go, Fireworks)
 - Added Go and Fireworks provider documentation under new "💳 Paid-Only Providers" section
 - Added `opencode_go_api_key` to config file template
 - Updated package.json description and keywords to include all 11 providers
 
 ### Added
+
 - **Provider model cache** (`lib/provider-cache.ts`) — New utility for caching provider model lists to `~/.pi/provider-cache.json`. Used by zen provider for faster startup and offline access after first successful fetch.
 
 ## [1.0.9] - 2026-04-14
 
 ### Fixed
+
 - **Qwen OAuth breaks other OAuth providers** — `modifyModels` receives all models across every registered provider, not just Qwen's. The previous `map()` stamped the Qwen dashscope `baseUrl` onto every model, causing other OAuth providers (Kilo, OpenRouter, etc.) to return 404 after a `/login qwen` flow. Now only models with `provider === PROVIDER_QWEN` are patched; others pass through unchanged.
 
 ## [1.0.8] - 2026-04-13
 
 ### Added
+
 - **Modal provider** — Free access to GLM-5.1 FP8 (128k context, 16k max output) during promotional period (free until April 30, 2026)
   - Requires a free Modal API key (`MODAL_API_KEY` or `modal_api_key` in `~/.pi/free.json`)
   - Model: `zai-org/GLM-5.1-FP8` — 128k context window, 16k max output tokens
@@ -162,6 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 131k context window, 16k max output tokens, zero cost
 
 ### Fixed
+
 - **Qwen OAuth browser launch on Windows** — URLs with `&` query params were truncated by `cmd.exe`'s `&` command separator; switched to `powershell.exe Start-Process` which passes the URL as a literal string
 - **Qwen API endpoint** — Replicates qwen-code's `getCurrentEndpoint()` logic: uses `resource_url` from OAuth token response (`dashscope.aliyuncs.com` for Chinese accounts, `portal.qwen.ai` for international), with fallback to `dashscope.aliyuncs.com/compatible-mode/v1`
 - **Qwen DashScope headers** — Added all headers required by DashScope's OpenAI-compatible API: `X-DashScope-AuthType: qwen-oauth`, `X-DashScope-CacheControl: enable`, `X-DashScope-UserAgent`, `Client-Code: QwenCode`
@@ -170,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.5] - 2025-04-03
 
 ### Fixed
+
 - **NVIDIA provider non-chat model filtering** (comment/implementation mismatch)
   - Added modalities-based filtering to exclude embedding, speech-to-text, OCR, and image-gen models
   - Filters models where `output` is not `["text"]` (e.g., image generation like `black-forest-labs/flux.1-dev`)
@@ -180,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.4] - 2025-04-03
 
 ### Fixed
+
 - **All tests now passing** (127/127)
   - Fixed mock paths in kilo.test.ts, zen.test.ts, ollama.test.ts
   - Fixed createCtxReRegister mocks in zen.test.ts and openrouter.test.ts
@@ -187,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added missing DEFAULT_MIN_SIZE_B constant to openrouter mock
 
 ### Changed
+
 - **Code quality improvements**
   - Refactored usage modules to break circular dependency (limits.ts ↔ formatters.ts)
   - Created usage/types.ts with shared interfaces (FreeTierLimit, FreeTierUsage)
@@ -195,12 +238,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.3] - 2025-04-03
 
 ### Changed
+
 - Updated package.json metadata (name, description, keywords, repository URL)
 - Updated .npmignore for cleaner publishes
 
 ## [1.0.0] - 2024-03-28
 
 ### Added
+
 - Initial release with 6 providers: Kilo, Zen, OpenRouter, NVIDIA, Cline, Fireworks
 - Free tier usage tracking across all sessions
 - Provider failover with model hopping
@@ -210,12 +255,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardcoded benchmark data from Artificial Analysis
 
 ### Changed
-- **Major refactoring**: Split free-tier-limits.ts into usage/* modules
+
+- **Major refactoring**: Split free-tier-limits.ts into usage/\* modules
   - usage/tracking.ts - runtime session tracking
   - usage/cumulative.ts - persistent storage
   - usage/formatters.ts - display formatting
   - 77% line reduction (741 → 166 lines)
-- **Major refactoring**: Split usage-widget.ts into widget/* modules
+- **Major refactoring**: Split usage-widget.ts into widget/\* modules
   - widget/data.ts - data collection
   - widget/format.ts - formatting utilities
   - widget/render.ts - HTML generation
@@ -240,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added resetUsageStats() for test isolation
 
 ### Fixed
+
 - fetchWithRetry() now properly throws after exhausting retries
 - Auth error pattern matching now handles more message variants
 - Test isolation for free-tier-limits tests

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -17,12 +17,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import {
-	applyHidden,
-	getNvidiaApiKey,
-	getNvidiaShowPaid,
-	PROVIDER_NVIDIA,
-} from "../../config.ts";
+import { applyHidden, getNvidiaApiKey, PROVIDER_NVIDIA } from "../../config.ts";
 import {
 	BASE_URL_NVIDIA,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -30,43 +25,144 @@ import {
 	URL_MODELS_DEV,
 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import type { ModelsDevProvider } from "../../lib/types.ts";
+import type { ModelsDevModel, ModelsDevProvider } from "../../lib/types.ts";
 import { fetchWithRetry, isUsableModel } from "../../lib/util.ts";
 import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
+
+// =============================================================================
+// Non-chat model heuristics for models not in models.dev
+// =============================================================================
+
+const NVIDIA_NON_CHAT_PATTERNS: RegExp[] = [
+	/embed(?!.*instruct)/i,
+	/whisper/i,
+	/reward/i,
+	/ocr(?!.*instruct)/i,
+	/safety-guard|content-safety|nemoguard/i,
+	/retriever-parse|nemotron-parse(?!.*instruct)/i,
+	/detector/i,
+	/deplot/i,
+	/nvclip/i,
+	/vila$/i,
+	/neva(?!.*instruct)/i,
+	/translate/i,
+	/cosmos-reason/i,
+	/kosmos/i,
+	/bge-/i,
+	/arctic-embed/i,
+	/gliner/i,
+	/nv-embed/i,
+	/embedqa/i,
+	/embedcode/i,
+];
+
+/**
+ * Infer model metadata from a NVIDIA model ID for models not present in
+ * models.dev. Returns null if the ID matches known non-chat patterns.
+ */
+function inferModelFromId(id: string): ModelsDevModel | null {
+	for (const pattern of NVIDIA_NON_CHAT_PATTERNS) {
+		if (pattern.test(id)) return null;
+	}
+
+	const name = id
+		.split("/")
+		.pop()!
+		.replace(/-/g, " ")
+		.replace(/\b\w/g, (c) => c.toUpperCase())
+		.replace(/\b(\d+(?:\.\d+)?)b\b/gi, "$1B");
+
+	const hasVision = /vision|multimodal|vl/i.test(id);
+	const hasReasoning = /reason|r1|thinking/i.test(id);
+
+	return {
+		id,
+		name,
+		reasoning: hasReasoning,
+		limit: { context: 128_000, output: 4096 },
+		modalities: {
+			input: hasVision ? ["text", "image"] : ["text"],
+			output: ["text"],
+		},
+		cost: { input: 0, output: 0 },
+	};
+}
 
 // =============================================================================
 // Fetch + map
 // =============================================================================
 
 async function fetchNvidiaModels(
-	showPaid = false,
+	apiKey?: string,
 ): Promise<ProviderModelConfig[]> {
-	const response = await fetchWithRetry(
-		URL_MODELS_DEV,
-		{
-			headers: { "User-Agent": "pi-free-providers" },
-		},
-		3,
-		1000,
-		DEFAULT_FETCH_TIMEOUT_MS,
-	);
-
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch models.dev: ${response.status} ${response.statusText}`,
-		);
+	// ── 1. Query NVIDIA's actual API (source of truth) ─────────────────
+	let apiModelIds = new Set<string>();
+	if (apiKey) {
+		try {
+			const response = await fetchWithRetry(
+				`${BASE_URL_NVIDIA}/models`,
+				{
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						"User-Agent": "pi-free-providers",
+					},
+				},
+				3,
+				1000,
+				DEFAULT_FETCH_TIMEOUT_MS,
+			);
+			if (response.ok) {
+				const json = (await response.json()) as {
+					data?: Array<{ id: string }>;
+				};
+				if (json.data) {
+					apiModelIds = new Set(json.data.map((m) => m.id));
+				}
+			}
+		} catch (error) {
+			console.error("[nvidia] Failed to fetch models from NVIDIA API", error);
+		}
 	}
 
-	const json = (await response.json()) as Record<string, ModelsDevProvider>;
-	const provider = Object.values(json).find((p) => p?.id === "nvidia");
-	if (!provider?.models)
-		throw new Error("nvidia provider not found in models.dev");
+	// ── 2. Fetch models.dev for rich metadata (cost, limits, etc.) ─────
+	const devModels = new Map<string, ModelsDevModel>();
+	try {
+		const response = await fetchWithRetry(
+			URL_MODELS_DEV,
+			{
+				headers: { "User-Agent": "pi-free-providers" },
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
+		if (response.ok) {
+			const json = (await response.json()) as Record<string, ModelsDevProvider>;
+			const provider = Object.values(json).find((p) => p?.id === "nvidia");
+			if (provider?.models) {
+				for (const m of Object.values(provider.models)) {
+					devModels.set(m.id, m);
+				}
+			}
+		}
+	} catch (error) {
+		console.error("[nvidia] Failed to fetch models.dev", error);
+	}
+
+	// ── 3. Build unified list (NVIDIA API wins; fallback to models.dev) ─
+	const modelIds =
+		apiModelIds.size > 0 ? [...apiModelIds] : [...devModels.keys()];
 
 	const result = applyHidden(
-		Object.values(provider.models)
+		modelIds
+			.map((id) => {
+				const dev = devModels.get(id);
+				if (dev) return dev;
+				return inferModelFromId(id);
+			})
+			.filter((m): m is ModelsDevModel => m !== null)
 			.filter((m) => isUsableModel(m.id, NVIDIA_MIN_SIZE_B))
 			.filter((m) => {
-				// Filter non-chat models by modalities
 				const modalities = m.modalities;
 				if (modalities) {
 					const output = modalities.output ?? [];
@@ -76,11 +172,8 @@ async function fetchNvidiaModels(
 				}
 				return true;
 			})
-			.filter((m) => {
-				// Filter by cost - free models have input cost of 0
-				if (!showPaid && (m.cost?.input ?? 0) > 0) return false;
-				return true;
-			})
+			// NVIDIA is freemium — all models are usable with free credits.
+			// No cost filtering applied.
 			.map(
 				(m): ProviderModelConfig => ({
 					id: m.id,
@@ -109,22 +202,20 @@ async function fetchNvidiaModels(
 // =============================================================================
 
 export default async function (pi: ExtensionAPI) {
-	// Fetch both free and all models
-	let freeModels: ProviderModelConfig[] = [];
+	const apiKey = getNvidiaApiKey();
+	const hasKey = !!apiKey;
+
 	let allModels: ProviderModelConfig[] = [];
 
 	try {
-		freeModels = await fetchNvidiaModels(false);
-		allModels = await fetchNvidiaModels(true);
+		allModels = await fetchNvidiaModels(apiKey);
 	} catch (error) {
 		console.error("[nvidia] Failed to fetch models at startup", error);
 		return;
 	}
 
-	// Store both sets for global toggle
-	const stored = { free: freeModels, all: allModels };
-	const apiKey = getNvidiaApiKey();
-	const hasKey = !!(apiKey || process.env.NVIDIA_API_KEY);
+	// Store both sets for global toggle (same list — NVIDIA is freemium)
+	const stored = { free: allModels, all: allModels };
 
 	// Create re-register function
 	const reRegister = createReRegister(pi, {
@@ -137,7 +228,7 @@ export default async function (pi: ExtensionAPI) {
 	registerWithGlobalToggle(PROVIDER_NVIDIA, stored, reRegister, hasKey);
 
 	// Register initial models (global toggle will apply filter if needed)
-	const initialModels = getNvidiaShowPaid() ? allModels : freeModels;
+	const initialModels = allModels;
 	pi.registerProvider(PROVIDER_NVIDIA, {
 		baseUrl: BASE_URL_NVIDIA,
 		apiKey: apiKey || "NVIDIA_API_KEY",

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -4,7 +4,6 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ModelsDevModel } from "../lib/types.ts";
 
 let capturedToggleArgs: any = null;
 
@@ -38,202 +37,76 @@ vi.mock("../constants.ts", () => ({
 	URL_MODELS_DEV: "https://models.dev/api.json",
 }));
 
+vi.mock("../lib/util.ts", () => ({
+	fetchWithRetry: vi.fn(),
+	isUsableModel: vi.fn((id: string, minSize?: number) => {
+		// Simple size check for testing
+		if (minSize !== undefined) {
+			const sizeMatch = id.match(/(\d+(?:\.\d+)?)b(?!\w)/i);
+			if (sizeMatch) {
+				const size = Number.parseFloat(sizeMatch[1]);
+				if (size < minSize) return false;
+			}
+		}
+		return true;
+	}),
+}));
+
+import { fetchWithRetry } from "../lib/util.ts";
 import nvidiaProvider from "../providers/nvidia/nvidia.ts";
+
+function mockNvidiaApiResponse(modelIds: string[]) {
+	return {
+		ok: true,
+		json: async () => ({ data: modelIds.map((id) => ({ id })) }),
+	};
+}
+
+function mockModelsDevResponse(models: Record<string, any>) {
+	return {
+		ok: true,
+		json: async () => ({
+			nvidia: {
+				id: "nvidia",
+				api: "openai-completions",
+				models,
+			},
+		}),
+	};
+}
 
 describe("NVIDIA Provider", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		capturedToggleArgs = null;
+		vi.mocked(fetchWithRetry).mockReset();
 	});
 
-	describe("model filtering logic", () => {
-		// Helper to simulate the filtering logic from fetchNvidiaModels
-		function filterModels(models: ModelsDevModel[]): ModelsDevModel[] {
-			return models
-				.filter((m) => {
-					// Size filtering (from isUsableModel with NVIDIA_MIN_SIZE_B = 70)
-					const sizeMatch = m.id.match(/(\d+(?:\.\d+)?)b(?!\w)/i);
-					if (sizeMatch) {
-						const size = Number.parseFloat(sizeMatch[1]);
-						if (size < 70) return false;
-					}
-					return true;
-				})
-				.filter((m) => {
-					// Modalities filtering - non-chat models
-					const modalities = m.modalities;
-					if (modalities) {
-						const output = modalities.output ?? [];
-						const input = modalities.input ?? [];
-						if (!output.includes("text")) return false;
-						if (!input.includes("text")) return false;
-					}
-					return true;
-				})
-				.filter((m) => {
-					// Cost filtering
-					if ((m.cost?.input ?? 0) > 0) return false;
-					return true;
-				});
-		}
-
-		it("should include chat models with text input/output", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/chat-70b",
-					name: "Chat Model",
-					reasoning: false,
-					limit: { context: 128000, output: 4096 },
-					modalities: { input: ["text"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(1);
-			expect(filtered[0].id).toBe("test/chat-70b");
+	it("should include models from NVIDIA API with models.dev metadata enrichment", async () => {
+		vi.mocked(fetchWithRetry).mockImplementation(async (url: string) => {
+			if (url.includes("integrate.api.nvidia.com/v1/models")) {
+				return mockNvidiaApiResponse([
+					"nvidia/llama-3.1-70b-instruct",
+					"deepseek-ai/deepseek-v4-flash",
+					"nvidia/nv-embed-v1",
+					"mistralai/mistral-large",
+				]) as any;
+			}
+			if (url.includes("models.dev")) {
+				return mockModelsDevResponse({
+					"llama-3.1-70b-instruct": {
+						id: "nvidia/llama-3.1-70b-instruct",
+						name: "Llama 3.1 70B Instruct",
+						reasoning: false,
+						limit: { context: 128000, output: 4096 },
+						modalities: { input: ["text"], output: ["text"] },
+						cost: { input: 0, output: 0 },
+					},
+				}) as any;
+			}
+			throw new Error("Unexpected URL: " + url);
 		});
 
-		it("should include vision models (text+image input, text output)", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/vision-70b",
-					name: "Vision Model",
-					reasoning: false,
-					limit: { context: 128000, output: 4096 },
-					modalities: { input: ["text", "image"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(1);
-			expect(filtered[0].id).toBe("test/vision-70b");
-		});
-
-		it("should filter out image generation models (image output)", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/image-gen-70b",
-					name: "Image Gen Model",
-					reasoning: false,
-					limit: { context: 4096, output: 0 },
-					modalities: { input: ["text"], output: ["image"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(0);
-		});
-
-		it("should filter out OCR models (image-only input)", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/ocr-70b",
-					name: "OCR Model",
-					reasoning: false,
-					limit: { context: 0, output: 4096 },
-					modalities: { input: ["image"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(0);
-		});
-
-		it("should filter out speech-to-text models (audio-only input)", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/speech-70b",
-					name: "Speech Model",
-					reasoning: false,
-					limit: { context: 0, output: 4096 },
-					modalities: { input: ["audio"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(0);
-		});
-
-		it("should filter small models (< 70B)", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/chat-8b",
-					name: "Small Chat Model",
-					reasoning: false,
-					limit: { context: 128000, output: 4096 },
-					modalities: { input: ["text"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(0);
-		});
-
-		it("should filter paid models when cost > 0", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "test/paid-70b",
-					name: "Paid Model",
-					reasoning: false,
-					limit: { context: 128000, output: 4096 },
-					modalities: { input: ["text"], output: ["text"] },
-					cost: { input: 0.5, output: 1.0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(0);
-		});
-
-		it("should handle mixed model list correctly", () => {
-			const models: ModelsDevModel[] = [
-				{
-					id: "nvidia/chat-70b",
-					name: "Chat 70B",
-					reasoning: false,
-					limit: { context: 128000, output: 4096 },
-					modalities: { input: ["text"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-				{
-					id: "openai/whisper-large-v3",
-					name: "Whisper",
-					reasoning: false,
-					limit: { context: 0, output: 4096 },
-					modalities: { input: ["audio"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-				{
-					id: "black-forest-labs/flux.1-dev",
-					name: "FLUX.1",
-					reasoning: false,
-					limit: { context: 4096, output: 0 },
-					modalities: { input: ["text"], output: ["image"] },
-					cost: { input: 0, output: 0 },
-				},
-				{
-					id: "nvidia/nemoretriever-ocr-v1",
-					name: "OCR",
-					reasoning: false,
-					limit: { context: 0, output: 4096 },
-					modalities: { input: ["image"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-				{
-					id: "nvidia/nemotron-8b",
-					name: "Small Model",
-					reasoning: false,
-					limit: { context: 128000, output: 4096 },
-					modalities: { input: ["text"], output: ["text"] },
-					cost: { input: 0, output: 0 },
-				},
-			];
-			const filtered = filterModels(models);
-			expect(filtered).toHaveLength(1);
-			expect(filtered[0].id).toBe("nvidia/chat-70b");
-		});
-	});
-
-	it("should configure provider correctly with toggle support", async () => {
 		const mockPi = {
 			registerProvider: vi.fn(),
 			on: vi.fn(),
@@ -242,7 +115,194 @@ describe("NVIDIA Provider", () => {
 
 		await nvidiaProvider(mockPi);
 
-		// Should call registerProvider with nvidia provider
+		const registeredModels = (mockPi.registerProvider as any).mock.calls[0][1]
+			.models;
+
+		expect(
+			registeredModels.some(
+				(m: any) => m.id === "nvidia/llama-3.1-70b-instruct",
+			),
+		).toBe(true);
+		expect(
+			registeredModels.find(
+				(m: any) => m.id === "nvidia/llama-3.1-70b-instruct",
+			).name,
+		).toBe("Llama 3.1 70B Instruct");
+		expect(
+			registeredModels.some(
+				(m: any) => m.id === "deepseek-ai/deepseek-v4-flash",
+			),
+		).toBe(true);
+		expect(
+			registeredModels.some((m: any) => m.id === "mistralai/mistral-large"),
+		).toBe(true);
+		expect(
+			registeredModels.some((m: any) => m.id === "nvidia/nv-embed-v1"),
+		).toBe(false);
+	});
+
+	it("should infer metadata for models not present in models.dev", async () => {
+		vi.mocked(fetchWithRetry).mockImplementation(async (url: string) => {
+			if (url.includes("integrate.api.nvidia.com/v1/models")) {
+				return mockNvidiaApiResponse(["deepseek-ai/deepseek-v4-flash"]) as any;
+			}
+			if (url.includes("models.dev")) {
+				return mockModelsDevResponse({}) as any;
+			}
+			throw new Error("Unexpected URL: " + url);
+		});
+
+		const mockPi = {
+			registerProvider: vi.fn(),
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		await nvidiaProvider(mockPi);
+
+		const registeredModels = (mockPi.registerProvider as any).mock.calls[0][1]
+			.models;
+		const model = registeredModels.find(
+			(m: any) => m.id === "deepseek-ai/deepseek-v4-flash",
+		);
+
+		expect(model).toBeDefined();
+		expect(model.name).toBe("Deepseek V4 Flash");
+		expect(model.reasoning).toBe(false);
+		expect(model.contextWindow).toBe(128000);
+		expect(model.maxTokens).toBe(4096);
+		expect(model.input).toEqual(["text"]);
+		expect(model.cost.input).toBe(0);
+	});
+
+	it("should exclude non-chat models via ID heuristics", async () => {
+		vi.mocked(fetchWithRetry).mockImplementation(async (url: string) => {
+			if (url.includes("integrate.api.nvidia.com/v1/models")) {
+				return mockNvidiaApiResponse([
+					"nvidia/nv-embed-v1",
+					"openai/whisper-large-v3",
+					"nvidia/nemotron-parse",
+					"nvidia/llama-3.1-70b-instruct",
+				]) as any;
+			}
+			if (url.includes("models.dev")) {
+				return mockModelsDevResponse({}) as any;
+			}
+			throw new Error("Unexpected URL: " + url);
+		});
+
+		const mockPi = {
+			registerProvider: vi.fn(),
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		await nvidiaProvider(mockPi);
+
+		const registeredModels = (mockPi.registerProvider as any).mock.calls[0][1]
+			.models;
+		expect(registeredModels.map((m: any) => m.id)).toEqual([
+			"nvidia/llama-3.1-70b-instruct",
+		]);
+	});
+
+	it("should not filter paid models since NVIDIA is freemium", async () => {
+		vi.mocked(fetchWithRetry).mockImplementation(async (url: string) => {
+			if (url.includes("integrate.api.nvidia.com/v1/models")) {
+				return mockNvidiaApiResponse([
+					"ai21labs/jamba-1.5-large-instruct",
+				]) as any;
+			}
+			if (url.includes("models.dev")) {
+				return mockModelsDevResponse({
+					"jamba-1.5-large-instruct": {
+						id: "ai21labs/jamba-1.5-large-instruct",
+						name: "Jamba 1.5 Large",
+						reasoning: false,
+						limit: { context: 256000, output: 8192 },
+						modalities: { input: ["text"], output: ["text"] },
+						cost: { input: 2.0, output: 6.0 },
+					},
+				}) as any;
+			}
+			throw new Error("Unexpected URL: " + url);
+		});
+
+		const mockPi = {
+			registerProvider: vi.fn(),
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		await nvidiaProvider(mockPi);
+
+		const registeredModels = (mockPi.registerProvider as any).mock.calls[0][1]
+			.models;
+		const model = registeredModels.find(
+			(m: any) => m.id === "ai21labs/jamba-1.5-large-instruct",
+		);
+
+		expect(model).toBeDefined();
+		expect(model.cost.input).toBe(2.0);
+		expect(model.cost.output).toBe(6.0);
+	});
+
+	it("should fall back to models.dev when NVIDIA API is unreachable", async () => {
+		vi.mocked(fetchWithRetry).mockImplementation(async (url: string) => {
+			if (url.includes("integrate.api.nvidia.com/v1/models")) {
+				return { ok: false, status: 500, statusText: "Server Error" } as any;
+			}
+			if (url.includes("models.dev")) {
+				return mockModelsDevResponse({
+					"llama-3.1-70b-instruct": {
+						id: "nvidia/llama-3.1-70b-instruct",
+						name: "Llama 3.1 70B Instruct",
+						reasoning: false,
+						limit: { context: 128000, output: 4096 },
+						modalities: { input: ["text"], output: ["text"] },
+						cost: { input: 0, output: 0 },
+					},
+				}) as any;
+			}
+			throw new Error("Unexpected URL: " + url);
+		});
+
+		const mockPi = {
+			registerProvider: vi.fn(),
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		await nvidiaProvider(mockPi);
+
+		const registeredModels = (mockPi.registerProvider as any).mock.calls[0][1]
+			.models;
+		expect(
+			registeredModels.some(
+				(m: any) => m.id === "nvidia/llama-3.1-70b-instruct",
+			),
+		).toBe(true);
+	});
+
+	it("should configure provider correctly with toggle support", async () => {
+		vi.mocked(fetchWithRetry).mockImplementation(async (url: string) => {
+			if (url.includes("integrate.api.nvidia.com/v1/models")) {
+				return mockNvidiaApiResponse(["nvidia/llama-3.1-70b-instruct"]) as any;
+			}
+			if (url.includes("models.dev")) {
+				return mockModelsDevResponse({}) as any;
+			}
+			throw new Error("Unexpected URL: " + url);
+		});
+
+		const mockPi = {
+			registerProvider: vi.fn(),
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		await nvidiaProvider(mockPi);
+
 		expect(mockPi.registerProvider).toHaveBeenCalledWith(
 			"nvidia",
 			expect.objectContaining({
@@ -252,16 +312,15 @@ describe("NVIDIA Provider", () => {
 			}),
 		);
 
-		// Should call registerWithGlobalToggle with both free and all model sets
 		expect(capturedToggleArgs).toBeDefined();
-		expect(capturedToggleArgs[0]).toBe("nvidia"); // providerId
+		expect(capturedToggleArgs[0]).toBe("nvidia");
 		expect(capturedToggleArgs[1]).toMatchObject({
 			free: expect.any(Array),
 			all: expect.any(Array),
 		});
-		expect(capturedToggleArgs[1].free.length).toBeGreaterThanOrEqual(0);
-		expect(capturedToggleArgs[1].all.length).toBeGreaterThanOrEqual(
-			capturedToggleArgs[1].free.length,
+		// NVIDIA is freemium — free and all should be identical
+		expect(capturedToggleArgs[1].free.length).toBe(
+			capturedToggleArgs[1].all.length,
 		);
 	});
 });


### PR DESCRIPTION
- Fetch models from integrate.api.nvidia.com/v1/models instead of relying solely on models.dev curated JSON
- Enrich NVIDIA API models with models.dev metadata where available
- Infer metadata for models missing from models.dev
- Add regex heuristics to exclude non-chat models
- Remove stale models not present in NVIDIA's API
- Remove paid/free filtering — NVIDIA is freemium
- Update tests and CHANGELOG