### PR TITLE
docs(readme): update Cloudflare docs for dynamic fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When you install pi-free, it:
 
 1. **Registers free-tier providers** with Pi's model picker — Kilo, Cline, NVIDIA, Cloudflare, Modal, Ollama Cloud, and more
 
-2. **Fetches models dynamically** for Pi's built-in providers when API keys are configured — Mistral, Groq, Cerebras, xAI, Hugging Face, OpenRouter
+2. **Fetches models dynamically** from provider APIs — Cloudflare Workers AI (30+ models), NVIDIA NIM, and Pi's built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face, OpenRouter) when API keys are configured
 
 3. **Filters to show only free models by default** for providers that expose pricing — You see only the models that cost $0 to use. Paid models are hidden until you explicitly toggle them on.
 
@@ -41,18 +41,21 @@ Start Pi and press `Ctrl+L` to open the model picker.
 Free models are shown by default — look for the provider prefixes:
 
 **✅ Offers Free Models (no usage limits, no payment required):**
+
 - `opencode/` — OpenCode models (no setup required; toggle with `/toggle-opencode`)
 - `kilo/` — Kilo models (free models available immediately, more after `/login kilo`)
 - `openrouter/` — OpenRouter models (free account required)
 - `cline/` — Cline models (run `/login cline` to use)
 
 **🔄 Freemium (free tier with limits, then paid):**
+
 - `nvidia/` — NVIDIA NIM models (1,000 free requests/month, then credits)
 - `cloudflare/` — Cloudflare Workers AI (10K Neurons/day free tier, then $0.011/1K Neurons)
 - `modal/` — GLM-5.1 FP8 via Modal (free promotional period until April 30, 2026)
 - `ollama-cloud/` — Ollama Cloud models (usage-based free tier, resets every 5 hours + 7 days)
 
 **🔧 Dynamic API Providers (fetched when API key configured):**
+
 - `mistral/` — Mistral models (when `MISTRAL_API_KEY` set)
 - `groq/` — Groq models (when `GROQ_API_KEY` set)
 - `cerebras/` — Cerebras models (when `CEREBRAS_API_KEY` set)
@@ -79,6 +82,7 @@ Want to see paid models too? Run the toggle command for your provider:
 ```
 
 **Notes:**
+
 - **Toggle commands are mainly for ✅ and 🔄 providers** — to switch between "free models only" vs "show paid models too"
 - **🔧 Dynamic providers** show all fetched models by default — the toggle filters the list when you have an API key configured
 - **Freemium providers** show all models by default; you manage your usage limits via their dashboards
@@ -92,6 +96,7 @@ You'll see a notification like: `opencode: showing free models` or `opencode: sh
 Some providers require a free account or API key.
 
 **The first time you run Pi after installing this extension, a config file is automatically created:**
+
 - **Linux/Mac:** `~/.pi/free.json`
 - **Windows:** `%USERPROFILE%\.pi\free.json`
 
@@ -102,6 +107,7 @@ Add your API keys to this file:
   "openrouter_api_key": "sk-or-v1-...",
   "nvidia_api_key": "nvapi-...",
   "cloudflare_api_token": "...",
+  "cloudflare_account_id": "...",
   "ollama_api_key": "...",
   "mistral_api_key": "...",
   "modal_api_key": "sk-modal-..."
@@ -116,14 +122,14 @@ See the [Providers That Need Authentication](#providers-that-need-authentication
 
 ### 5. Quick commands reference
 
-| Command | What it does |
-|---------|-------------|
+| Command              | What it does                                              |
+| -------------------- | --------------------------------------------------------- |
 | `/toggle-{provider}` | Switch between free-only and all models for that provider |
-| `/free-providers` | Show free/paid model counts for all providers |
-| `/login kilo` | Start OAuth flow for Kilo |
-| `/login cline` | Start OAuth flow for Cline |
-| `/logout kilo` | Clear Kilo OAuth credentials |
-| `/logout cline` | Clear Cline OAuth credentials |
+| `/free-providers`    | Show free/paid model counts for all providers             |
+| `/login kilo`        | Start OAuth flow for Kilo                                 |
+| `/login cline`       | Start OAuth flow for Cline                                |
+| `/logout kilo`       | Clear Kilo OAuth credentials                              |
+| `/logout cline`      | Clear Cline OAuth credentials                             |
 
 ---
 
@@ -149,6 +155,7 @@ Kilo shows free models immediately. To unlock all models, authenticate with Kilo
 ```
 
 This command will:
+
 1. Open your browser to Kilo's authorization page
 2. Show a device code in Pi's UI
 3. Wait for you to authorize in the browser
@@ -167,6 +174,7 @@ Cline models appear immediately in the model picker. To use them, authenticate w
 ```
 
 This command will:
+
 1. Open your browser to Cline's sign-in page
 2. Wait for you to complete sign-in
 3. Automatically complete login once approved
@@ -189,11 +197,13 @@ Some providers require a free account or API key to access their free tiers.
 Get a free API key at [openrouter.ai/keys](https://openrouter.ai/keys), then either:
 
 **Option A: Environment variable**
+
 ```bash
 export OPENROUTER_API_KEY="sk-or-v1-..."
 ```
 
 **Option B: Config file** (`~/.pi/free.json`)
+
 ```json
 {
   "openrouter_api_key": "sk-or-v1-..."
@@ -207,24 +217,29 @@ Then use `/toggle-openrouter` to switch between free-only and all models.
 NVIDIA provides **free monthly credits** (1000 requests/month) at [build.nvidia.com](https://build.nvidia.com).
 
 **Important:** Models have different "costs" per token:
+
 - **Zero-cost models**: Don't consume your credit balance (shown by default)
 - **Credit-costing models**: Consume credits faster (hidden by default)
 
 Get your API key and optionally enable all models:
 
 **Option A: Show only free models (default)**
+
 ```bash
 export NVIDIA_API_KEY="nvapi-..."
 ```
+
 Uses only zero-cost models → your 1000 credits last the full month
 
 **Option B: Show all models (uses credits faster)**
+
 ```bash
 export NVIDIA_API_KEY="nvapi-..."
 export NVIDIA_SHOW_PAID=true
 ```
 
 Or in `~/.pi/free.json`:
+
 ```json
 {
   "nvidia_api_key": "nvapi-...",
@@ -236,25 +251,30 @@ Toggle anytime with `/toggle-nvidia`
 
 ### Cloudflare Workers AI (10K Neurons/day Free Tier)
 
-Cloudflare provides **50+ open-source AI models** with a generous free tier:
+Cloudflare provides **30+ text generation models** (auto-discovered from their API) with a generous free tier:
+
 - **10,000 Neurons per day FREE** (resets daily at 00:00 UTC)
 - **$0.011 per 1,000 Neurons** beyond the free allocation
+- **Models auto-fetched** — All available chat models are discovered dynamically from Cloudflare's API
 
 Get your API token at [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens):
+
 1. Create a token with "Cloudflare AI" → "Read" permission
 2. Or use "My Account" → "Read" for broader access
 
 **Setup:**
+
 ```bash
+# New short env vars (recommended)
+export CF_API_TOKEN="your_token_here"
+export CF_ACCOUNT_ID="your_account_id"
+
+# Legacy env vars also work
 export CLOUDFLARE_API_TOKEN="your_token_here"
+export CLOUDFLARE_ACCOUNT_ID="your_account_id"
 ```
 
-The account ID is automatically derived from your token. Optionally, you can also set:
-```bash
-export CLOUDFLARE_ACCOUNT_ID="your_account_id"  # Optional
-```
-
-**Models available:** Llama 4, Mistral Small 3.1, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, and more.
+**Models available:** Llama 4/3.x, Mistral Small 3.1, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, Qwen 3/2.5, OpenAI GPT-OSS, and more.
 
 Toggle with `/toggle-cloudflare`
 
@@ -263,11 +283,13 @@ Toggle with `/toggle-cloudflare`
 Modal hosts GLM-5.1 FP8 with a free promotional period. Get an API key at [modal.com](https://modal.com), then:
 
 **Option A: Environment variable**
+
 ```bash
 export MODAL_API_KEY="sk-modal-..."
 ```
 
 **Option B: Config file** (`~/.pi/free.json`)
+
 ```json
 {
   "modal_api_key": "sk-modal-..."
@@ -277,6 +299,7 @@ export MODAL_API_KEY="sk-modal-..."
 Then select a `modal/` model in the model picker.
 
 **Details:**
+
 - Free promotional period until April 30, 2026
 - Model: GLM-5.1 FP8 (128k context, 16k max output)
 - No credit card required during the promotional period
@@ -286,12 +309,14 @@ Then select a `modal/` model in the model picker.
 Get an API key from [ollama.com/settings/keys](https://ollama.com/settings/keys), then:
 
 **Option A: Environment variable**
+
 ```bash
 export OLLAMA_API_KEY="..."
 export OLLAMA_SHOW_PAID=true
 ```
 
 **Option B: Config file** (`~/.pi/free.json`)
+
 ```json
 {
   "ollama_api_key": "YOUR_KEY",
@@ -317,20 +342,21 @@ export MISTRAL_API_KEY="..."
 
 Each provider has toggle commands to switch between free and all models:
 
-| Command | Action |
-|---------|--------|
-| `/toggle-opencode` | Toggle between free/all OpenCode models |
-| `/toggle-kilo` | Toggle between free/all Kilo models |
-| `/toggle-openrouter` | Toggle between free/all OpenRouter models |
-| `/toggle-cline` | Toggle between free/all Cline models |
-| `/toggle-nvidia` | Toggle between free/all NVIDIA models |
-| `/toggle-cloudflare` | Toggle between free/all Cloudflare models |
-| `/toggle-ollama` | Toggle between free/all Ollama Cloud models |
-| `/toggle-mistral` | Toggle between free/all Mistral models (🔧 dynamic) |
-| `/toggle-groq` | Toggle between free/all Groq models (🔧 dynamic) |
-| `/toggle-cerebras` | Toggle between free/all Cerebras models (🔧 dynamic) |
+| Command              | Action                                               |
+| -------------------- | ---------------------------------------------------- |
+| `/toggle-opencode`   | Toggle between free/all OpenCode models              |
+| `/toggle-kilo`       | Toggle between free/all Kilo models                  |
+| `/toggle-openrouter` | Toggle between free/all OpenRouter models            |
+| `/toggle-cline`      | Toggle between free/all Cline models                 |
+| `/toggle-nvidia`     | Toggle between free/all NVIDIA models                |
+| `/toggle-cloudflare` | Toggle between free/all Cloudflare models            |
+| `/toggle-ollama`     | Toggle between free/all Ollama Cloud models          |
+| `/toggle-mistral`    | Toggle between free/all Mistral models (🔧 dynamic)  |
+| `/toggle-groq`       | Toggle between free/all Groq models (🔧 dynamic)     |
+| `/toggle-cerebras`   | Toggle between free/all Cerebras models (🔧 dynamic) |
 
 **The toggle command:**
+
 - **For ✅ free providers**: Switches between showing only free models vs. all available models (including paid)
 - **For 🔄 freemium providers**: Shows all models by default; toggle switches between filtered and full list
 - **For 🔧 dynamic API providers**: Filters the model list when you have an API key configured
@@ -347,6 +373,8 @@ Create `~/.pi/free.json` in your home directory:
 {
   "openrouter_api_key": "YOUR_OPENROUTER_KEY",
   "nvidia_api_key": "YOUR_NVIDIA_KEY",
+  "cloudflare_api_token": "YOUR_CLOUDFLARE_TOKEN",
+  "cloudflare_account_id": "YOUR_ACCOUNT_ID",
   "mistral_api_key": "YOUR_MISTRAL_KEY",
   "opencode_api_key": "YOUR_OPENCODE_KEY",
   "ollama_api_key": "YOUR_OLLAMA_KEY",


### PR DESCRIPTION
README updates for Cloudflare dynamic model fetching:

- Add CF_API_TOKEN/CF_ACCOUNT_ID env vars (shorter alternatives)
- Update model count: 30+ text generation models (was 50+ total)
- Mention dynamic API discovery in intro bullet  
- Add cloudflare_account_id to config examples
- Update available models list (GPT-OSS, QwQ, etc.)