### PR TITLE
fix(benchmark-lookup): strip all path prefixes for CI score lookup

### DIFF
--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -71,12 +71,12 @@ function normalizeSizeTokenOrder(id: string): string {
 
 /**
  * Extract the base model ID from a provider model ID.
- * Strips provider prefix ("openai/"), :free suffix, date suffixes, and version suffixes.
+ * Strips ALL provider prefixes ("openai/", "@cf/meta/", "@cf/qwen/"), :free suffix, date suffixes, and version suffixes.
  */
 function extractBaseModelId(modelId: string): string {
 	return modelId
 		.toLowerCase()
-		.replace(/^[^/]+\//, "") // Strip provider prefix like "openai/"
+		.replace(/^.*\//, "") // Strip ALL path prefixes - keep only last segment
 		.replace(/:free$/, "") // Strip :free suffix
 		.replace(/-\d{8}$/, "") // Strip date suffixes like -20250514
 		.replace(/-v\d+(\.\d+)?$/, "") // Strip version suffixes like -v1.1


### PR DESCRIPTION
## Problem
Cloudflare model IDs like  were not getting CI scores because  only stripped ONE path prefix level:
- Input: 
- After old regex:  (still has !)
- Benchmark key: 
- Result: No match found → no CI score

## Fix
Changed  to use  which strips ALL path prefixes:
-  → 
-  → 
-  → 

This ensures CI scores are properly looked up for Cloudflare models and any other multi-level provider IDs.