### PR TITLE
fix(dynamic-built-in): add CI scores to OpenRouter and other dynamic providers

### DIFF
--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -29,6 +29,7 @@ import { DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
+import { enhanceWithCI } from "../../provider-helper.ts";
 
 const _logger = createLogger("dynamic-built-in");
 
@@ -403,7 +404,7 @@ export async function setupDynamicBuiltInProviders(
 					baseUrl: config.baseUrl,
 					apiKey,
 					api: config.api,
-					models,
+					models: enhanceWithCI(models),
 				});
 			};
 


### PR DESCRIPTION
## Problem
OpenRouter, Mistral, Groq, Cerebras, xAI, and Hugging Face models were not showing CI (Coding Index) scores.

## Root Cause
The dynamic-built-in provider was calling pi.registerProvider directly without wrapping models in enhanceWithCI().

## Fix
- Import enhanceWithCI from provider-helper.ts
- Wrap models with enhanceWithCI in the reRegister function

## Providers Fixed
- openrouter/ (OpenRouter)
- mistral/ (Mistral)
- groq/ (Groq)
- cerebras/ (Cerebras)
- xai/ (xAI)
- huggingface/ (Hugging Face)