### PR TITLE
feat(ollama): add 403 handling similar to NVIDIA 404s

### DIFF
--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -42,6 +42,16 @@ import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 const _logger = createLogger("ollama-cloud");
 
 // =============================================================================
+// Known 403 models (listed but return "access denied" on /v1/chat/completions)
+// These are models that appear in /v1/models but aren't provisioned for chat.
+// Add new IDs here as they surface via /probe-ollama command.
+// =============================================================================
+const OLLAMA_KNOWN_403_MODELS: ReadonlySet<string> = new Set([
+	// Example entries - populate via probe-ollama.mjs
+	// "model-id-that-403s",
+]);
+
+// =============================================================================
 // Fetch + map
 // =============================================================================
 
@@ -79,12 +89,20 @@ async function fetchOllamaModels(
 	);
 
 	// Filter to chat/text generation models only
-	const chatModels = models.filter((m) => {
-		// Skip embedding-only models (typically have "embed" in name)
-		const name = m.id.toLowerCase();
-		if (name.includes("embed")) return false;
-		return true;
-	});
+	const chatModels = models
+		.filter((m) => {
+			// Skip embedding-only models (typically have "embed" in name)
+			const name = m.id.toLowerCase();
+			if (name.includes("embed")) return false;
+			return true;
+		})
+		// Filter out known 403 models (listed but not provisioned for chat)
+		.filter((m) => {
+			if (OLLAMA_KNOWN_403_MODELS.has(m.id)) {
+				return false;
+			}
+			return true;
+		});
 
 	const result = applyHidden(
 		chatModels.map(
@@ -169,4 +187,74 @@ export default async function (pi: ExtensionAPI) {
 	_logger.info(
 		`[ollama-cloud] Registered ${initialModels.length} models (usage-based free tier)`,
 	);
+
+	// ── Probe command: test all registered models for 403s ─────────────
+	pi.registerCommand("probe-ollama", {
+		description: "Test all Ollama Cloud models for 403 'access denied' errors",
+		handler: async (_args, ctx) => {
+			if (!apiKey) {
+				ctx.ui.notify("OLLAMA_API_KEY not set", "error");
+				return;
+			}
+
+			const modelsToTest = allModels;
+			ctx.ui.notify(`Probing ${modelsToTest.length} Ollama models…`, "info");
+
+			const notFound: string[] = [];
+			const batchSize = 5;
+
+			for (let i = 0; i < modelsToTest.length; i += batchSize) {
+				const batch = modelsToTest.slice(i, i + batchSize);
+				const results = await Promise.all(
+					batch.map(async (m) => {
+						const ok = await probeOllamaModel(apiKey, m.id);
+						return { id: m.id, ok };
+					}),
+				);
+				for (const r of results) {
+					if (!r.ok) notFound.push(r.id);
+				}
+			}
+
+			if (notFound.length === 0) {
+				ctx.ui.notify("All Ollama models are accessible ✅", "info");
+				return;
+			}
+
+			ctx.ui.notify(
+				`Found ${notFound.length} broken models:\n${notFound.join("\n")}`,
+				"warning",
+			);
+		},
+	});
+}
+
+/**
+ * Probe a single Ollama model with a minimal chat request.
+ * Returns true if the model is accessible (not 403), false if it 403s.
+ */
+async function probeOllamaModel(
+	apiKey: string,
+	modelId: string,
+): Promise<boolean> {
+	try {
+		const response = await fetch(`${BASE_URL_OLLAMA}/chat/completions`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+				"User-Agent": "pi-free-providers",
+			},
+			body: JSON.stringify({
+				model: modelId,
+				messages: [{ role: "user", content: "hi" }],
+				max_tokens: 1,
+			}),
+		});
+		// 403 = access denied (model not provisioned)
+		// 200/400/401/etc = at least accessible
+		return response.status !== 403;
+	} catch {
+		return true; // Network errors are not "access denied"
+	}
 }

--- a/scripts/probe-ollama.mjs
+++ b/scripts/probe-ollama.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Probe Ollama Cloud models for 403 "access denied" errors.
+ *
+ * Usage:
+ *   OLLAMA_API_KEY=xxx node scripts/probe-ollama.mjs
+ *
+ * This tests every model returned by GET /v1/models with a minimal
+ * POST /v1/chat/completions request. Any model that 403s is reported
+ * and can be added to OLLAMA_KNOWN_403_MODELS in providers/ollama/ollama.ts.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function getApiKey() {
+	if (process.env.OLLAMA_API_KEY) return process.env.OLLAMA_API_KEY;
+	try {
+		const config = JSON.parse(
+			readFileSync(join(homedir(), ".pi", "free.json"), "utf8"),
+		);
+		if (config.ollama_api_key) return config.ollama_api_key;
+	} catch {}
+	return null;
+}
+
+const API_KEY = getApiKey();
+if (!API_KEY) {
+	console.error(
+		"OLLAMA_API_KEY not found. Set env var or add ollama_api_key to ~/.pi/free.json",
+	);
+	process.exit(1);
+}
+
+const BASE_URL = "https://ollama.com/v1";
+
+async function fetchModels() {
+	const res = await fetch(`${BASE_URL}/models`, {
+		headers: { Authorization: `Bearer ${API_KEY}` },
+	});
+	if (!res.ok) throw new Error(`Failed to fetch models: ${res.status}`);
+	const json = await res.json();
+	return json.data.map((m) => m.id);
+}
+
+async function probeModel(modelId) {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 10000);
+	try {
+		const res = await fetch(`${BASE_URL}/chat/completions`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${API_KEY}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				model: modelId,
+				messages: [{ role: "user", content: "hi" }],
+				max_tokens: 1,
+			}),
+			signal: controller.signal,
+		});
+		return res.status;
+	} catch (err) {
+		if (err.name === "AbortError") return "TIMEOUT";
+		return `ERR: ${err.message}`;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+async function main() {
+	const models = await fetchModels();
+	console.log(`Probing ${models.length} models…\n`);
+
+	const broken = [];
+	const batchSize = 20;
+
+	for (let i = 0; i < models.length; i += batchSize) {
+		const batch = models.slice(i, i + batchSize);
+		const results = await Promise.all(
+			batch.map(async (id) => {
+				const status = await probeModel(id);
+				const ok = status !== 403;
+				return { id, status, ok };
+			}),
+		);
+
+		for (const r of results) {
+			const icon = r.ok ? "✅" : "❌";
+			process.stdout.write(`${icon} ${r.id} → ${r.status}\n`);
+			if (!r.ok) broken.push(r.id);
+		}
+	}
+
+	console.log(`\n${"=".repeat(60)}`);
+	if (broken.length === 0) {
+		console.log("All models are accessible — no 403s found!");
+	} else {
+		console.log(`Found ${broken.length} broken model(s):`);
+		for (const id of broken) console.log(`  "${id}",`);
+		console.log(
+			`\nCopy these into OLLAMA_KNOWN_403_MODELS in providers/ollama/ollama.ts`,
+		);
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});


### PR DESCRIPTION
Adds the same 404-handling pattern from NVIDIA to Ollama Cloud for 403 errors:

## Changes
- OLLAMA_KNOWN_403_MODELS blocklist (empty initially, populate via probe)
- Filter in fetchOllamaModels to exclude known 403 models
- /probe-ollama command to test all models on-demand
- scripts/probe-ollama.mjs standalone script

## Usage
Run /probe-ollama in Pi or node scripts/probe-ollama.mjs to identify models that 403. Copy IDs into OLLAMA_KNOWN_403_MODELS to filter them.