### PR TITLE
feat(ollama): add auto-hide and per-user persistence to /probe-ollama

### DIFF
--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -28,6 +28,8 @@ import {
 	applyHidden,
 	getOllamaApiKey,
 	getOllamaShowPaid,
+	loadConfigFile,
+	saveConfig,
 } from "../../config.ts";
 import {
 	BASE_URL_OLLAMA,
@@ -221,8 +223,20 @@ export default async function (pi: ExtensionAPI) {
 				return;
 			}
 
+			// Auto-hide 403 models in config
+			const config = loadConfigFile();
+			const existingHidden = new Set(config.hidden_models ?? []);
+			for (const id of notFound) existingHidden.add(id);
+			saveConfig({ hidden_models: Array.from(existingHidden) });
+
+			// Re-register so hidden models disappear immediately
+			const filtered = await fetchOllamaModels(apiKey);
+			stored.free = filtered;
+			stored.all = filtered;
+			reRegister(filtered);
+
 			ctx.ui.notify(
-				`Found ${notFound.length} broken models:\n${notFound.join("\n")}`,
+				`Found ${notFound.length} broken models (auto-hidden):\n${notFound.join("\n")}`,
 				"warning",
 			);
 		},


### PR DESCRIPTION
Makes /probe-ollama consistent with /probe-nvidia:

- Auto-hide newly discovered 403 models in ~/.pi/free.json hidden_models
- Re-register provider immediately so broken models disappear from picker  
- Update notification to show (auto-hidden) status

Now when users run /probe-ollama:
1. Broken models are identified
2. Auto-added to their personal hidden_models list
3. Provider re-registered immediately
4. Broken models disappear from model picker
5. Hidden list persists across Pi restarts