### PR TITLE
feat: provider-scoped hidden models

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -254,10 +254,30 @@ export function getOpenrouterApiKey(): string | undefined {
 // Hidden models (re-reads config on every call)
 // =============================================================================
 
-export function applyHidden<T extends { id: string }>(models: T[]): T[] {
+/**
+ * Apply hidden models filter with provider scoping.
+ * Hidden models can be specified as:
+ *   - "model-id" (global, applies to all providers - deprecated)
+ *   - "provider/model-id" (provider-specific, preferred)
+ */
+export function applyHidden<T extends { id: string }>(
+	models: T[],
+	providerId?: string,
+): T[] {
 	const hidden = new Set(loadConfigFile().hidden_models ?? []);
 	if (hidden.size === 0) return models;
-	return models.filter((m) => !hidden.has(m.id));
+
+	return models.filter((m) => {
+		// Check provider-scoped ID (preferred format: "provider/model-id")
+		if (providerId && hidden.has(`${providerId}/${m.id}`)) {
+			return false;
+		}
+		// Check global ID (legacy format, still supported for backward compat)
+		if (hidden.has(m.id)) {
+			return false;
+		}
+		return true;
+	});
 }
 
 // =============================================================================

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -272,6 +272,7 @@ async function fetchNvidiaModels(
 					maxTokens: m.limit.output,
 				}),
 			),
+		PROVIDER_NVIDIA,
 	);
 
 	return result;
@@ -383,10 +384,10 @@ export default async function (pi: ExtensionAPI) {
 				return;
 			}
 
-			// Auto-hide 404 models in config
+			// Auto-hide 404 models in config (provider-scoped)
 			const config = loadConfigFile();
 			const existingHidden = new Set(config.hidden_models ?? []);
-			for (const id of notFound) existingHidden.add(id);
+			for (const id of notFound) existingHidden.add(`${PROVIDER_NVIDIA}/${id}`);
 			saveConfig({ hidden_models: Array.from(existingHidden) });
 
 			// Re-register so hidden models disappear immediately

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -130,6 +130,7 @@ async function fetchOllamaModels(
 				maxTokens: 4096, // Default, varies by model
 			}),
 		),
+		PROVIDER_OLLAMA,
 	);
 
 	return result;
@@ -223,10 +224,10 @@ export default async function (pi: ExtensionAPI) {
 				return;
 			}
 
-			// Auto-hide 403 models in config
+			// Auto-hide 403 models in config (provider-scoped)
 			const config = loadConfigFile();
 			const existingHidden = new Set(config.hidden_models ?? []);
-			for (const id of notFound) existingHidden.add(id);
+			for (const id of notFound) existingHidden.add(`${PROVIDER_OLLAMA}/${id}`);
 			saveConfig({ hidden_models: Array.from(existingHidden) });
 
 			// Re-register so hidden models disappear immediately


### PR DESCRIPTION
Makes hidden_models provider-scoped so models can be hidden per-provider.

## Problem
Previously, hidden_models was global. If kimi-k2.6 403d on Ollama and was hidden, it would also be hidden from Cloudflare even if it works there.

## Solution
- applyHidden() now accepts optional providerId parameter
- Models saved as provider/model-id (e.g., ollama/kimi-k2.6)
- Backward compatible with old global format

## Changes
- config.ts: Updated applyHidden with provider scoping
- Ollama: Passes PROVIDER_OLLAMA, probe saves ollama/model-id
- NVIDIA: Passes PROVIDER_NVIDIA, probe saves nvidia/model-id

## Example
