### PR TITLE
feat: provider-scoped hidden models for remaining providers

### DIFF
--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -10,6 +10,7 @@ import {
 	BASE_URL_OPENROUTER,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	DEFAULT_MIN_SIZE_B,
+	PROVIDER_CLINE,
 } from "../../constants.ts";
 import type { ProviderModelConfig } from "../../lib/types.ts";
 import {
@@ -117,7 +118,7 @@ export async function fetchClineModels(
 		});
 	}
 
-	return applyHidden(models);
+	return applyHidden(models, PROVIDER_CLINE);
 }
 
 /**

--- a/providers/kilo/kilo-models.ts
+++ b/providers/kilo/kilo-models.ts
@@ -3,6 +3,7 @@
  */
 
 import { applyHidden } from "../../config.ts";
+import { PROVIDER_KILO } from "../../constants.ts";
 import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 
 const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
@@ -22,5 +23,5 @@ export async function fetchKiloModels(options?: {
 		freeOnly: options?.freeOnly,
 	});
 
-	return applyHidden(models);
+	return applyHidden(models, PROVIDER_KILO);
 }

--- a/providers/modal/modal.ts
+++ b/providers/modal/modal.ts
@@ -13,18 +13,21 @@ import { BASE_URL_MODAL, URL_MODAL_TOS } from "../../constants.ts";
 import { createProvider } from "../../provider-factory.ts";
 
 function getModalModels(): ProviderModelConfig[] {
-	return applyHidden([
-		{
-			id: "zai-org/GLM-5.1-FP8",
-			name: "GLM-5.1 FP8 (Modal)",
-			reasoning: true,
-			input: ["text"],
-			// Promotional/free-period pricing may change; keep conservative placeholders.
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 16384,
-		},
-	]);
+	return applyHidden(
+		[
+			{
+				id: "zai-org/GLM-5.1-FP8",
+				name: "GLM-5.1 FP8 (Modal)",
+				reasoning: true,
+				input: ["text"],
+				// Promotional/free-period pricing may change; keep conservative placeholders.
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 16384,
+			},
+		],
+		PROVIDER_MODAL,
+	);
 }
 
 export default function (pi: Parameters<typeof createProvider>[0]) {


### PR DESCRIPTION
Updates remaining providers to use provider-scoped hidden models:

- cline/cline-models.ts: applyHidden(models, PROVIDER_CLINE)
- kilo/kilo-models.ts: applyHidden(models, PROVIDER_KILO)
- modal/modal.ts: applyHidden([...], PROVIDER_MODAL)

All providers now consistently use provider-scoped hiding format:
