### PR TITLE
docs: update CHANGELOG and README with probe commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`scripts/probe-nvidia.mjs`** — Standalone Node.js script to reproduce the probe. Reads `~/.pi/free.json` for the API key, batches 20 requests at a time with 10s timeout, and prints all broken model IDs for adding to the blocklist.
 
+- **Ollama Cloud 403 handling** — Same pattern as NVIDIA 404s for Ollama Cloud:
+  - `OLLAMA_KNOWN_403_MODELS` blocklist for models that return 403 "access denied"
+  - `/probe-ollama` command to test all models on-demand, auto-hide broken ones, and re-register
+  - `scripts/probe-ollama.mjs` standalone script for blocklist maintenance
+
+- **Provider-scoped hidden models** — Hidden models are now provider-specific:
+  - Format: `"provider/model-id"` (e.g., `"ollama/kimi-k2.6"`, `"nvidia/broken-model"`)
+  - A model hidden from one provider doesn't hide it from other providers
+  - Backward compatible with old global `"model-id"` format
+  - All providers updated: NVIDIA, Ollama, Cloudflare, Cline, Kilo, Modal
+
 ### Fixed
 
 - **NVIDIA provider now sends `authHeader: true`** — Explicitly enables `Authorization: Bearer` header injection. Previously relied on pi's implicit behavior which could fail in some configurations.

--- a/README.md
+++ b/README.md
@@ -415,6 +415,25 @@ Each provider has toggle commands to switch between free and all models:
 - **Persists your preference** to `~/.pi/free.json` for next startup
 - Shows a notification: "opencode: showing free models" or "opencode: showing all models"
 
+### Probe Commands (Health Check)
+
+Test models for 404/403 errors and auto-hide broken ones:
+
+| Command         | What it does                                                |
+| --------------- | ----------------------------------------------------------- |
+| `/probe-nvidia` | Test all NVIDIA models, auto-hide 404s in `~/.pi/free.json` |
+| `/probe-ollama` | Test all Ollama models, auto-hide 403s in `~/.pi/free.json` |
+
+**How it works:**
+
+1. Sends a minimal test request to every model
+2. Identifies broken models (404/403 responses)
+3. **Auto-hides** broken models in your config (provider-scoped: `"ollama/kimi-k2.6"`)
+4. Re-registers the provider so broken models disappear immediately
+5. Hidden models persist across Pi restarts
+
+Use these when you see models that appear in the picker but fail when you try to use them.
+
 ---
 
 ## Configuration


### PR DESCRIPTION
Updates documentation for recent features:

## CHANGELOG
- Ollama Cloud 403 handling with /probe-ollama command
- Provider-scoped hidden models (provider/model-id format)

## README  
- New 'Probe Commands' section in Slash Commands
- Documents /probe-nvidia and /probe-ollama
- Explains auto-hide behavior and provider-scoped format