### PR TITLE
fix: add timeout handling to /probe-nvidia and /probe-ollama commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Probe commands timeout handling** — Added `fetchWithTimeout` with 10-second timeout to `/probe-nvidia` and `/probe-ollama` commands. Prevents the coding harness from freezing when individual model probe requests hang indefinitely.
+
 - **NVIDIA provider now sends `authHeader: true`** — Explicitly enables `Authorization: Bearer` header injection. Previously relied on pi's implicit behavior which could fail in some configurations.
 
 ### Removed

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -32,7 +32,11 @@ import {
 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import type { ModelsDevModel, ModelsDevProvider } from "../../lib/types.ts";
-import { fetchWithRetry, isUsableModel } from "../../lib/util.ts";
+import {
+	fetchWithRetry,
+	fetchWithTimeout,
+	isUsableModel,
+} from "../../lib/util.ts";
 import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 
 // =============================================================================
@@ -291,24 +295,28 @@ async function probeNvidiaModel(
 	modelId: string,
 ): Promise<boolean> {
 	try {
-		const response = await fetch(`${BASE_URL_NVIDIA}/chat/completions`, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"Content-Type": "application/json",
-				"User-Agent": "pi-free-providers",
+		const response = await fetchWithTimeout(
+			`${BASE_URL_NVIDIA}/chat/completions`,
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+					"User-Agent": "pi-free-providers",
+				},
+				body: JSON.stringify({
+					model: modelId,
+					messages: [{ role: "user", content: "hi" }],
+					max_tokens: 1,
+				}),
 			},
-			body: JSON.stringify({
-				model: modelId,
-				messages: [{ role: "user", content: "hi" }],
-				max_tokens: 1,
-			}),
-		});
+			10000, // 10 second timeout
+		);
 		// 404 = function not found (model not provisioned)
 		// 200/400/401/etc = at least routable
 		return response.status !== 404;
 	} catch {
-		return true; // Network errors are not "model not found"
+		return true; // Network errors / timeouts are not "model not found"
 	}
 }
 

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -38,7 +38,7 @@ import {
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, fetchWithTimeout } from "../../lib/util.ts";
 import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 
 const _logger = createLogger("ollama-cloud");
@@ -253,23 +253,28 @@ async function probeOllamaModel(
 	modelId: string,
 ): Promise<boolean> {
 	try {
-		const response = await fetch(`${BASE_URL_OLLAMA}/chat/completions`, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"Content-Type": "application/json",
-				"User-Agent": "pi-free-providers",
+		const response = await fetchWithTimeout(
+			`${BASE_URL_OLLAMA}/chat/completions`,
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+					"User-Agent": "pi-free-providers",
+				},
+				body: JSON.stringify({
+					model: modelId,
+					messages: [{ role: "user", content: "hi" }],
+					max_tokens: 1,
+				}),
 			},
-			body: JSON.stringify({
-				model: modelId,
-				messages: [{ role: "user", content: "hi" }],
-				max_tokens: 1,
-			}),
-		});
+			10000, // 10 second timeout
+		);
 		// 403 = access denied (model not provisioned)
 		// 200/400/401/etc = at least accessible
 		return response.status !== 403;
 	} catch {
-		return true; // Network errors are not "access denied"
+		// Network errors / timeouts are not "access denied"
+		return true;
 	}
 }


### PR DESCRIPTION
Add fetchWithTimeout with 10-second timeout to probeNvidiaModel and probeOllamaModel functions to prevent the coding harness from freezing when individual model probe requests hang indefinitely.

Also remove unused probeChatModel utility function from lib/util.ts.

Fixes freeze issue with /probe-nvidia command.