### PR TITLE
feat: model matching debug logging and provider-specific normalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Model matching debug logging** — Added `~/.pi/modelmatch.log` to diagnose which models get Coding Index scores and which don't:
+  - Logs every matching attempt with provider, model ID, normalization strategy, and result
+  - CSV-like format: `timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details`
+  - Provider-specific normalizers for better matching:
+    - **NVIDIA**: Strips vendor prefixes (`meta/`, `mistralai/`, `microsoft/`, `qwen/`, etc.)
+    - **Cloudflare**: Strips `@cf/namespace/` prefixes
+    - **Groq**: Removes `-versatile` and numeric context suffixes (`-32768`)
+    - **Cerebras**: Normalizes `llama3.1` → `llama-3.1`, auto-adds `instruct` suffix
+    - **Mistral**: Strips `-latest` suffix
+    - **Ollama**: Converts `model:tag` → `model-tag`
+  - Common suffix stripping: `:free`, date codes (`-20250514`), versions (`-v1.1`), `-it`, `-fp8`/`-bf16`
+
+- **Enhanced benchmark lookup** — `enhanceModelNameWithCodingIndex()` now accepts optional `provider` parameter for provider-aware normalization
+
 - **Static 404 model blocklist for NVIDIA** — Probed all 136 models from `integrate.api.nvidia.com/v1/models` and identified 57 that return 404 "Function not found" on `/v1/chat/completions`. These are now hard-filtered so they never appear in the model selector:
   - Covers discontinued models (`databricks/dbrx-instruct`, `meta/codellama-70b`, `meta/llama2-70b`, `ibm/granite-*`, etc.)
   - Covers embedding-only models listed as chat-capable (`nvidia/nv-embed-v1`, `nvidia/nv-embedqa-*`, `snowflake/arctic-embed-l`, etc.)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ Every model shows a **Coding Index score** (e.g., `CI: 52.3`) in the model picke
 - **Quality indicator** — Higher scores = better coding performance
 - **All providers** — Applied to every model from every provider (NVIDIA, Cloudflare, Mistral, Groq, etc.)
 
+**Missing CI scores?** Provider model IDs often don't match benchmark database keys exactly. pi-free applies provider-specific normalization to improve matching:
+
+| Provider       | Normalization Applied                                              |
+| -------------- | ------------------------------------------------------------------ |
+| **NVIDIA**     | Strips vendor prefixes (`meta/`, `mistralai/`, `microsoft/`, etc.) |
+| **Cloudflare** | Strips `@cf/namespace/` prefixes                                   |
+| **Groq**       | Removes `-versatile` and numeric suffixes (`-32768`)               |
+| **Cerebras**   | Normalizes `llama3.1` → `llama-3.1`, adds `instruct` suffix        |
+| **Mistral**    | Strips `-latest` suffix                                            |
+| **Ollama**     | Converts `model:tag` → `model-tag`                                 |
+
+**Debug missing scores:** Check `~/.pi/modelmatch.log` to see which models matched/didn't match and what normalization was applied.
+
 ### 🔄 Free/Paid Model Toggling
 
 Providers have different pricing models. pi-free handles them all:
@@ -466,12 +479,10 @@ export NVIDIA_API_KEY="..."
 
 ## Logging & Debugging
 
-pi-free now writes extension logs to:
+pi-free writes extension logs to:
 
 - **Windows:** `%USERPROFILE%\.pi\free.log`
 - **Linux/macOS:** `~/.pi/free.log`
-
-Useful env vars:
 
 If the extension fails to read `~/.pi/free.json`, check this log first — config parse errors are written here.
 
@@ -487,6 +498,45 @@ PI_FREE_LOG_PATH=/tmp/pi-free.log
 
 # Disable file logging
 PI_FREE_FILE_LOG=false
+```
+
+### Model Matching Debug Log
+
+To diagnose why some models don't show Coding Index scores, pi-free writes detailed matching diagnostics to:
+
+- **Windows:** `%USERPROFILE%\.pi\modelmatch.log`
+- **Linux/macOS:** `~/.pi/modelmatch.log`
+
+**Log format:**
+
+```
+timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details
+```
+
+**Example entries:**
+
+```
+2026-04-26T10:30:00Z|nvidia|meta/llama-3.1-405b-instruct|Llama 3.1 405B|match|provider-normalized:strip-nvidia-prefix|llama-3.1-405b-instruct|llama-3.1-instruct-405b|52.3|
+2026-04-26T10:30:01Z|groq|llama-3.1-70b-versatile|Llama 3.1 70B Versatile|match|strip-groq-versatile|llama-3.1-70b|llama-3.1-instruct-70b|48.5|
+2026-04-26T10:30:02Z|cloudflare|@cf/meta/llama-3.1-70b|Llama 3.1 70B|miss|all-strategies-failed|llama-3.1-70b|||
+```
+
+**Common mismatch patterns:**
+
+- `miss` + `all-strategies-failed` = Model not in benchmark database or ID format not recognized
+- Check `normalizedId` column to see what the lookup tried against
+
+**View the log:**
+
+```bash
+# Pretty-print with column alignment
+cat ~/.pi/modelmatch.log | column -t -s '|'
+
+# See only misses (models without CI scores)
+grep '|miss|' ~/.pi/modelmatch.log
+
+# See stats for specific provider
+grep '|nvidia|' ~/.pi/modelmatch.log | grep -c '|match|'
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "1.0.9",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "1.0.9",
+			"version": "2.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^1.0.0",
@@ -20,8 +20,7 @@
 			"peerDependencies": {
 				"@mariozechner/pi-ai": "*",
 				"@mariozechner/pi-coding-agent": "*",
-				"@mariozechner/pi-tui": "*",
-				"@sinclair/typebox": "*"
+				"@mariozechner/pi-tui": "*"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -774,14 +773,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+			"integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.13.1",
-				"fast-xml-parser": "5.5.8",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1626,6 +1625,19 @@
 				"zod-to-json-schema": "^3.24.1"
 			}
 		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2106,6 +2118,7 @@
 			"version": "0.27.10",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
 			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@smithy/config-resolver": {
@@ -2542,9 +2555,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3118,9 +3131,9 @@
 			"peer": true
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-			"integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -3704,9 +3717,9 @@
 			"peer": true
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3720,9 +3733,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.5.8",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+			"integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3732,9 +3745,10 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"fast-xml-builder": "^1.1.4",
-				"path-expression-matcher": "^1.2.0",
-				"strnum": "^2.2.0"
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.5",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -4750,9 +4764,9 @@
 			"peer": true
 		},
 		"node_modules/path-expression-matcher": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-			"integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -4856,9 +4870,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4929,9 +4943,9 @@
 			"peer": true
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
@@ -5384,9 +5398,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-			"integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
 			"funding": [
 				{
 					"type": "github",

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -5,8 +5,13 @@
  * This module re-exports everything consumers currently import from
  * hardcoded-benchmarks, so you can switch imports to this file without
  * breaking anything.
+ *
+ * ENHANCED: Added debug logging and provider-specific normalizers
  */
 
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
 	HARDCODED_BENCHMARKS,
 	type HardcodedBenchmark,
@@ -14,6 +19,206 @@ import {
 
 // Re-export the type and data so callers can migrate imports here
 export { HARDCODED_BENCHMARKS, type HardcodedBenchmark };
+
+// =============================================================================
+// Debug Logging
+// =============================================================================
+
+const LOG_DIR = join(homedir(), ".pi");
+const LOG_FILE = join(LOG_DIR, "modelmatch.log");
+let debugEnabled = true;
+
+/**
+ * Enable/disable debug logging
+ */
+export function setDebugLogging(enabled: boolean): void {
+	debugEnabled = enabled;
+}
+
+/**
+ * Log a message to the modelmatch.log file
+ */
+function logDebug(entry: {
+	provider?: string;
+	modelId: string;
+	modelName: string;
+	action: "attempt" | "match" | "miss" | "normalized";
+	strategy?: string;
+	normalizedId?: string;
+	matchKey?: string;
+	codingIndex?: number;
+	details?: string;
+}): void {
+	if (!debugEnabled) return;
+
+	try {
+		// Ensure log directory exists
+		if (!existsSync(LOG_DIR)) {
+			mkdirSync(LOG_DIR, { recursive: true });
+		}
+
+		// Initialize log file with header if it doesn't exist
+		if (!existsSync(LOG_FILE)) {
+			writeFileSync(
+				LOG_FILE,
+				"timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details\n",
+			);
+		}
+
+		const timestamp = new Date().toISOString();
+		const line = [
+			timestamp,
+			entry.provider || "unknown",
+			entry.modelId,
+			entry.modelName,
+			entry.action,
+			entry.strategy || "",
+			entry.normalizedId || "",
+			entry.matchKey || "",
+			entry.codingIndex !== undefined ? entry.codingIndex.toFixed(1) : "",
+			entry.details || "",
+		]
+			.map((f) => f.replace(/\|/g, "\\|")) // Escape pipes
+			.join("|");
+
+		appendFileSync(LOG_FILE, `${line}\n`);
+	} catch {
+		// Silently fail - don't break functionality for logging issues
+	}
+}
+
+/**
+ * Get the path to the log file for user reference
+ */
+export function getMatchLogPath(): string {
+	return LOG_FILE;
+}
+
+/**
+ * Clear the match log
+ */
+export function clearMatchLog(): void {
+	try {
+		if (existsSync(LOG_FILE)) {
+			writeFileSync(
+				LOG_FILE,
+				"timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details\n",
+			);
+		}
+	} catch {
+		// Ignore errors
+	}
+}
+
+// =============================================================================
+// Provider-Specific Normalizers
+// =============================================================================
+
+/**
+ * Apply provider-specific ID normalization to handle naming conventions
+ */
+function applyProviderNormalization(
+	modelId: string,
+	provider?: string,
+): { normalized: string; strategy: string } {
+	let normalized = modelId.toLowerCase();
+	const strategies: string[] = [];
+
+	// Provider-specific prefix stripping
+	if (provider === "nvidia") {
+		// NVIDIA uses prefixes like meta/, mistralai/, microsoft/, qwen/
+		const prefixMatch = normalized.match(
+			/^(meta|mistralai|microsoft|qwen|nvidia|ibm|google|ai21labs|bigcode|databricks|deepseek-ai|01-ai|adept|aisingapore|baai|ibm|bytedance|luma|stabilityai|fireworks|upstage|voyage|snowflake|recursal|kdan|unity|cloudflare|fblgit|nttdata|dito|nousresearch|espressomodels|ftmsh|huggingface|isolationai|pinglab|functionnetwork|huggingfaceh4|mcw|shutterstock|srcINST4428){6}[^/]*\//,
+		);
+		if (prefixMatch) {
+			normalized = normalized.replace(/^[^/]+\//, "");
+			strategies.push("strip-nvidia-prefix");
+		}
+	}
+
+	if (provider === "cloudflare") {
+		// Cloudflare uses @cf/namespace/model format
+		if (normalized.startsWith("@cf/")) {
+			normalized = normalized.replace(/^@cf\/[^/]+\//, "");
+			strategies.push("strip-cf-namespace");
+		}
+	}
+
+	// Provider-agnostic normalization
+	// Strip :free suffix (common in OpenRouter)
+	if (normalized.includes(":free")) {
+		normalized = normalized.replace(/:free$/, "");
+		strategies.push("strip-free-suffix");
+	}
+
+	// Handle Ollama format (model:tag)
+	if (provider === "ollama" && normalized.includes(":")) {
+		normalized = normalized.replace(/:/g, "-");
+		strategies.push("ollama-colon-to-dash");
+	}
+
+	// Handle Groq suffixes
+	if (provider === "groq") {
+		if (/-\d+$/.test(normalized)) {
+			// Strip numeric suffixes like -32768, -131072
+			normalized = normalized.replace(/-\d+$/, "");
+			strategies.push("strip-groq-numeric-suffix");
+		}
+		if (normalized.includes("-versatile")) {
+			normalized = normalized.replace(/-versatile$/, "");
+			strategies.push("strip-groq-versatile");
+		}
+	}
+
+	// Handle Cerebras format (llama3.1-8b -> llama-3.1-8b)
+	if (provider === "cerebras") {
+		if (/^llama\d/.test(normalized)) {
+			normalized = normalized.replace(/^llama(\d)/, "llama-$1");
+			strategies.push("cerebras-llama-dash");
+		}
+		// Add instruct if missing for llama models
+		if (
+			/^llama-[\d.]+-\d+b$/.test(normalized) &&
+			!normalized.includes("instruct")
+		) {
+			normalized = normalized.replace(/^(llama-[\d.]+-\d+b)/, "$1-instruct");
+			strategies.push("add-instruct-suffix");
+		}
+	}
+
+	// Handle Mistral -latest suffix
+	if (provider === "mistral" && normalized.includes("-latest")) {
+		normalized = normalized.replace(/-latest$/, "");
+		strategies.push("strip-mistral-latest");
+	}
+
+	// Strip common suffixes that aren't in benchmark keys
+	const suffixesToStrip = [
+		/-\d{8}$/, // Date suffixes like -20250514
+		/-v\d+(\.\d+)?$/, // Version suffixes like -v1.1
+		/-\d{3,}$/, // Numeric suffixes like -001, -2603
+		/-it$/, // -it (Gemma convention)
+		/-fp\d+$/, // -fp8, -fp16
+		/-bf\d+$/, // -bf16
+		/-preview$/, // -preview
+		/-exp$/, // -exp (experimental)
+		/-instruct-0\.\d+$/, // HuggingFace revision tags
+	];
+
+	for (const pattern of suffixesToStrip) {
+		if (pattern.test(normalized)) {
+			normalized = normalized.replace(pattern, "");
+			strategies.push(
+				`strip-${pattern.source.replace(/[\\^$.*+?()[\]{}|]/g, "").slice(0, 10)}`,
+			);
+		}
+	}
+
+	return {
+		normalized,
+		strategy: strategies.join(","),
+	};
+}
 
 // =============================================================================
 // Prefix fallback helpers
@@ -93,7 +298,11 @@ function extractBaseModelId(modelId: string): string {
  * (same base model with effort/reasoning/date qualifiers) and returns the
  * variant with the highest codingIndex.
  */
-function findBestVariantByPrefix(baseId: string): HardcodedBenchmark | null {
+function findBestVariantByPrefix(
+	baseId: string,
+	provider?: string,
+	originalId?: string,
+): HardcodedBenchmark | null {
 	const prefixKey = baseId + "-";
 	const candidates: { key: string; data: HardcodedBenchmark }[] = [];
 
@@ -103,7 +312,18 @@ function findBestVariantByPrefix(baseId: string): HardcodedBenchmark | null {
 	][]) {
 		// Exact match
 		if (key === baseId) {
-			if (data.codingIndex !== undefined) return data;
+			if (data.codingIndex !== undefined) {
+				logDebug({
+					provider,
+					modelId: originalId || baseId,
+					modelName: "",
+					action: "match",
+					strategy: "exact-prefix-match",
+					matchKey: key,
+					codingIndex: data.codingIndex,
+				});
+				return data;
+			}
 			continue;
 		}
 
@@ -132,6 +352,17 @@ function findBestVariantByPrefix(baseId: string): HardcodedBenchmark | null {
 
 	// Only return if the best candidate has a codingIndex
 	if (candidates[0]!.data.codingIndex !== undefined) {
+		logDebug({
+			provider,
+			modelId: originalId || baseId,
+			modelName: "",
+			action: "match",
+			strategy: "variant-prefix-match",
+			normalizedId: baseId,
+			matchKey: candidates[0]!.key,
+			codingIndex: candidates[0]!.data.codingIndex,
+			details: `${candidates.length} candidates`,
+		});
 		return candidates[0]!.data;
 	}
 
@@ -145,8 +376,16 @@ function findBestVariantByPrefix(baseId: string): HardcodedBenchmark | null {
 export function findHardcodedBenchmark(
 	modelName: string,
 	modelId: string,
+	provider?: string,
 ): HardcodedBenchmark | null {
 	const search = `${modelName} ${modelId}`.toLowerCase();
+
+	logDebug({
+		provider,
+		modelId,
+		modelName,
+		action: "attempt",
+	});
 
 	// 1. Direct lookup — check if any benchmark key is a substring of the search
 	for (const [key, data] of Object.entries(HARDCODED_BENCHMARKS) as [
@@ -154,6 +393,15 @@ export function findHardcodedBenchmark(
 		HardcodedBenchmark,
 	][]) {
 		if (search.includes(key.toLowerCase())) {
+			logDebug({
+				provider,
+				modelId,
+				modelName,
+				action: "match",
+				strategy: "direct-substring",
+				matchKey: key,
+				codingIndex: data.codingIndex,
+			});
 			return data;
 		}
 	}
@@ -196,26 +444,91 @@ export function findHardcodedBenchmark(
 
 	for (const [canonical, names] of Object.entries(variants)) {
 		if (names.some((n) => search.includes(n.toLowerCase()))) {
-			return HARDCODED_BENCHMARKS[canonical] || null;
+			const data = HARDCODED_BENCHMARKS[canonical];
+			if (data) {
+				logDebug({
+					provider,
+					modelId,
+					modelName,
+					action: "match",
+					strategy: "variant-alias",
+					matchKey: canonical,
+					codingIndex: data.codingIndex,
+				});
+				return data;
+			}
 		}
 	}
 
-	// 3. Prefix fallback — extract base model ID and find best variant
+	// 3. Provider-specific normalization
+	const { normalized: providerNormalized, strategy: providerStrategy } =
+		applyProviderNormalization(modelId, provider);
+
+	if (providerNormalized !== modelId.toLowerCase()) {
+		logDebug({
+			provider,
+			modelId,
+			modelName,
+			action: "normalized",
+			strategy: providerStrategy,
+			normalizedId: providerNormalized,
+		});
+
+		// Try exact match on normalized ID
+		for (const [key, data] of Object.entries(HARDCODED_BENCHMARKS) as [
+			string,
+			HardcodedBenchmark,
+		][]) {
+			if (providerNormalized.includes(key.toLowerCase())) {
+				logDebug({
+					provider,
+					modelId,
+					modelName,
+					action: "match",
+					strategy: `provider-normalized:${providerStrategy}`,
+					matchKey: key,
+					codingIndex: data.codingIndex,
+				});
+				return data;
+			}
+		}
+	}
+
+	// 4. Prefix fallback — extract base model ID and find best variant
 	//    Handles cases where benchmark keys have variant suffixes
 	//    (reasoning/non-reasoning, effort levels, dates) that the model ID lacks
-	const baseId = extractBaseModelId(modelId);
+	const baseId = extractBaseModelId(providerNormalized);
 	if (baseId) {
-		let best = findBestVariantByPrefix(baseId);
+		let best = findBestVariantByPrefix(baseId, provider, modelId);
 		if (best) return best;
 
-		// 3b. Try with word-order normalization
+		// 4b. Try with word-order normalization
 		//     (e.g., llama-3.3-70b-instruct → llama-3.3-instruct-70b)
 		const normalizedId = normalizeSizeTokenOrder(baseId);
 		if (normalizedId !== baseId) {
-			best = findBestVariantByPrefix(normalizedId);
+			logDebug({
+				provider,
+				modelId,
+				modelName,
+				action: "normalized",
+				strategy: "size-token-reorder",
+				normalizedId: normalizedId,
+			});
+			best = findBestVariantByPrefix(normalizedId, provider, modelId);
 			if (best) return best;
 		}
 	}
+
+	// No match found
+	logDebug({
+		provider,
+		modelId,
+		modelName,
+		action: "miss",
+		strategy: "all-strategies-failed",
+		normalizedId: baseId || providerNormalized,
+		details: `Final normalized: ${baseId || providerNormalized}`,
+	});
 
 	return null;
 }
@@ -226,8 +539,9 @@ export function findHardcodedBenchmark(
 export function getHardcodedScore(
 	modelName: string,
 	modelId: string,
+	provider?: string,
 ): number | null {
-	const benchmark = findHardcodedBenchmark(modelName, modelId);
+	const benchmark = findHardcodedBenchmark(modelName, modelId, provider);
 	return benchmark?.normalizedScore ?? null;
 }
 
@@ -238,10 +552,86 @@ export function getHardcodedScore(
 export function enhanceModelNameWithCodingIndex(
 	modelName: string,
 	modelId: string,
+	provider?: string,
 ): string {
-	const benchmark = findHardcodedBenchmark(modelName, modelId);
+	const benchmark = findHardcodedBenchmark(modelName, modelId, provider);
 	if (benchmark?.codingIndex !== undefined) {
 		return `${modelName} [CI: ${benchmark.codingIndex.toFixed(1)}]`;
 	}
 	return modelName;
 }
+
+// =============================================================================
+// Stats and Reporting
+// =============================================================================
+
+/**
+ * Get statistics about model matching from the current session
+ * Note: This reads the log file and computes stats
+ */
+export function getMatchingStats(): {
+	totalAttempts: number;
+	matches: number;
+	misses: number;
+	matchRate: number;
+	byProvider: Record<
+		string,
+		{ attempts: number; matches: number; misses: number }
+	>;
+} {
+	const stats = {
+		totalAttempts: 0,
+		matches: 0,
+		misses: 0,
+		matchRate: 0,
+		byProvider: {} as Record<
+			string,
+			{ attempts: number; matches: number; misses: number }
+		>,
+	};
+
+	try {
+		if (!existsSync(LOG_FILE)) {
+			return stats;
+		}
+
+		const content = readFileSync(LOG_FILE, "utf-8");
+		const lines = content.split("\n").slice(1); // Skip header
+
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			const parts = line.split("|");
+			if (parts.length < 5) continue;
+
+			const provider = parts[1] || "unknown";
+			const action = parts[4];
+
+			if (!stats.byProvider[provider]) {
+				stats.byProvider[provider] = { attempts: 0, matches: 0, misses: 0 };
+			}
+
+			if (action === "attempt") {
+				stats.totalAttempts++;
+				stats.byProvider[provider].attempts++;
+			} else if (action === "match") {
+				stats.matches++;
+				stats.byProvider[provider].matches++;
+			} else if (action === "miss") {
+				stats.misses++;
+				stats.byProvider[provider].misses++;
+			}
+		}
+
+		stats.matchRate =
+			stats.totalAttempts > 0
+				? Math.round((stats.matches / (stats.matches + stats.misses)) * 100)
+				: 0;
+	} catch {
+		// Return empty stats on error
+	}
+
+	return stats;
+}
+
+// Need to import readFileSync for stats
+import { readFileSync } from "node:fs";

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -79,10 +79,11 @@ export interface OpenAICompatibleConfig {
  */
 export function enhanceWithCI(
 	models: ProviderModelConfig[],
+	providerId?: string,
 ): ProviderModelConfig[] {
 	return models.map((m) => ({
 		...m,
-		name: enhanceModelNameWithCodingIndex(m.name, m.id),
+		name: enhanceModelNameWithCodingIndex(m.name, m.id, providerId),
 	}));
 }
 
@@ -105,7 +106,7 @@ export function registerOpenAICompatible(
 			"User-Agent": "pi-free-providers",
 			...headers,
 		},
-		models: enhanceWithCI(models),
+		models: enhanceWithCI(models, providerId),
 		...(oauth && { oauth: oauth as any }),
 	});
 }
@@ -144,7 +145,7 @@ export function createCtxReRegister(
 				"User-Agent": "pi-free-providers",
 				...headers,
 			},
-			models: enhanceWithCI(models),
+			models: enhanceWithCI(models, providerId),
 			...(oauth && { oauth: oauth as any }),
 		});
 	};
@@ -169,7 +170,7 @@ export function setupProvider(
 
 	// Wrap reRegister to automatically add CI scores to all models
 	const reRegister = (models: ProviderModelConfig[], _s: StoredModels) => {
-		const enhanced = enhanceWithCI(models);
+		const enhanced = enhanceWithCI(models, providerId);
 		config.reRegister(enhanced, _s);
 	};
 

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -404,7 +404,7 @@ export async function setupDynamicBuiltInProviders(
 					baseUrl: config.baseUrl,
 					apiKey,
 					api: config.api,
-					models: enhanceWithCI(models),
+					models: enhanceWithCI(models, config.providerId),
 				});
 			};
 


### PR DESCRIPTION
## Summary

Adds comprehensive debug logging and provider-specific model ID normalization to improve Coding Index (CI) score matching across all providers.

## Changes

### Debug Logging
- Creates \~/.pi/modelmatch.log\ with detailed matching diagnostics
- CSV format: timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details
- Tracks every attempt, match, miss, and normalization strategy applied

### Provider-Specific Normalizers
| Provider | Normalization |
|----------|--------------|
| NVIDIA | Strip vendor prefixes (meta/, mistralai/, microsoft/, etc.) |
| Cloudflare | Strip @cf/namespace/ prefixes |
| Groq | Remove -versatile and numeric suffixes (-32768) |
| Cerebras | Normalize llama3.1 → llama-3.1, add instruct suffix |
| Mistral | Strip -latest suffix |
| Ollama | Convert model:tag → model-tag |

### Common Normalizations
- Strip :free, date codes (-20250514), versions (-v1.1)
- Remove -it, -fp8, -bf16 suffixes
- Size token reordering: 70b-instruct → instruct-70b

### Documentation
- Updated README with debugging section
- Updated CHANGELOG under [Unreleased]
- Added troubleshooting guide for missing CI scores

## Testing
- All 72 tests pass ✓
- No regressions
