### PR TITLE
fix: review fixes - scope hooks, add toggle commands, auto-probe NVIDIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`provider-factory.ts` — `beforeProviderRequest` hook now scoped to owning provider** —
+  The hook was firing for **all** provider requests regardless of which provider the factory
+  was configuring. Now checks `evt.provider !== def.providerId` and returns early if the
+  event doesn't belong to the owning provider.
+
+- **`provider-factory.ts` — `reRegister` callback no longer corrupts stored model lists** —
+  When toggling between free/paid modes, the callback was overwriting `stored.all` with only
+  the filtered subset, losing the original full model list. Now preserves the original model
+  lists for correct subsequent toggling.
+
+- **`lib/types.ts` — Removed leftover `LspTestInterface`** — Removed a test interface that
+  was left in production code.
+
+- **`index.ts` — Removed redundant `.catch()` on deprecated Qwen provider** — The `.catch()`
+  was unnecessary since `Promise.allSettled` already handles rejections.
+
+### Added
+
+- **Toggle commands for dynamic built-in providers** — Added `/toggle-mistral`, `/toggle-groq`,
+  `/toggle-cerebras`, `/toggle-xai`, and `/toggle-huggingface` commands. These providers were
+  registered with the global toggle system but lacked per-provider toggle commands, making
+  free/paid switching inaccessible without editing config files.
+
+- **Lazy auto-probe for NVIDIA models** — Extracted `runNvidiaProbe()` into a shared function
+  called automatically on first `session_start` (once per session). Previously, users had to
+  manually run `/probe-nvidia` to discover 404 models. Now broken models are detected and
+  auto-hidden on first use.
+
 ## [2.0.2] - 2026-04-26
 
 ### Added
 
 - **Model matching debug logging** — Added `~/.pi/modelmatch.log` to diagnose which models get Coding Index scores and which don't:
+
   - Logs every matching attempt with provider, model ID, normalization strategy, and result
   - CSV-like format: `timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details`
   - Provider-specific normalizers for better matching:
@@ -26,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Enhanced benchmark lookup** — `enhanceModelNameWithCodingIndex()` now accepts optional `provider` parameter for provider-aware normalization
 
 - **Static 404 model blocklist for NVIDIA** — Probed all 136 models from `integrate.api.nvidia.com/v1/models` and identified 57 that return 404 "Function not found" on `/v1/chat/completions`. These are now hard-filtered so they never appear in the model selector:
+
   - Covers discontinued models (`databricks/dbrx-instruct`, `meta/codellama-70b`, `meta/llama2-70b`, `ibm/granite-*`, etc.)
   - Covers embedding-only models listed as chat-capable (`nvidia/nv-embed-v1`, `nvidia/nv-embedqa-*`, `snowflake/arctic-embed-l`, etc.)
   - Covers stale API catalog entries (`mistralai/mistral-large`, `mistralai/mistral-large-2-instruct`, `writer/palmyra-*`, etc.)
@@ -36,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`scripts/probe-nvidia.mjs`** — Standalone Node.js script to reproduce the probe. Reads `~/.pi/free.json` for the API key, batches 20 requests at a time with 10s timeout, and prints all broken model IDs for adding to the blocklist.
 
 - **Ollama Cloud 403 handling** — Same pattern as NVIDIA 404s for Ollama Cloud:
+
   - `OLLAMA_KNOWN_403_MODELS` blocklist for models that return 403 "access denied"
   - `/probe-ollama` command to test all models on-demand, auto-hide broken ones, and re-register
   - `scripts/probe-ollama.mjs` standalone script for blocklist maintenance
@@ -59,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Cloudflare provider now fetches models dynamically** — Replaced static 19-model hardcoded list with live API fetch from `api.cloudflare.com/client/v4/accounts/{account_id}/ai/models`:
+
   - Automatically discovers all 30+ text generation models (was manually maintaining 19)
   - Smart filtering excludes embeddings, image generation, speech, translation, and vision-only models via regex patterns
   - Metadata inference from model IDs: detects vision (`vision`/`multimodal`), reasoning (`r1`/`thinking`/`qwq`), context windows, and estimated costs
@@ -97,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **OpenRouter moved to built-in toggle system** — OpenRouter is now handled by `lib/built-in-toggle.ts` alongside OpenCode for a unified approach:
+
   - Removed from `providers/dynamic-built-in/index.ts`
   - Eliminated duplicate toggle command registration logic
   - Consolidated toggle persistence with other built-in providers
@@ -128,6 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - **Removed Fireworks provider** — Fireworks is now a built-in Pi provider (added in pi 0.68.1), so the extension's Fireworks provider has been removed to avoid conflicts:
+
   - Deleted `providers/fireworks/fireworks.ts` and `tests/fireworks.test.ts`
   - Removed all Fireworks configuration options from `config.ts` (`fireworks_api_key`, `fireworks_show_paid`)
   - Users should now use Pi's built-in Fireworks support with `FIREWORKS_API_KEY`
@@ -150,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **Removed paid model warning on selection** — Deleted the `model_select` event handler that showed:
+
   - `⚠️ Paid model selected (${model.id}). Use "/free off" to enable paid models.`
   - This warning was redundant since the global `/free` toggle and provider toggles already control model visibility
 
@@ -167,6 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Cloudflare Workers AI provider** — New provider for Cloudflare's serverless GPU platform:
+
   - 50+ open-source models: Llama 4, Mistral Small 3.1, Qwen 2.5/3, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, and more
   - **10,000 Neurons/day FREE tier** (resets daily at 00:00 UTC)
   - **$0.011 per 1,000 Neurons** beyond free allocation
@@ -175,6 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Create token at https://dash.cloudflare.com/profile/api-tokens
 
 - **Unified dynamic built-in providers module** — New `providers/dynamic-built-in/` module that dynamically fetches models from Pi's built-in providers when users have API keys:
+
   - **Mistral** (`MISTRAL_API_KEY`) — Fetches from `api.mistral.ai/v1/models`
   - **Groq** (`GROQ_API_KEY`) — Fetches from `api.groq.com/openai/v1/models`
   - **Cerebras** (`CEREBRAS_API_KEY`) — Fetches from `api.cerebras.ai/v1/models`

--- a/index.ts
+++ b/index.ts
@@ -112,9 +112,7 @@ export default async function (pi: ExtensionAPI) {
 		kilo(pi),
 		ollama(pi),
 		// Qwen is deprecated
-		qwen(pi).catch((err) => {
-			_logger.warn("[pi-free] Qwen provider failed to load (deprecated)", err);
-		}),
+		qwen(pi),
 		cline(pi),
 	]);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -99,10 +99,3 @@ export interface ZenGatewayModel {
 	id: string;
 	object?: string;
 }
-
-// Test: LSP should handle new interface
-export interface LspTestInterface {
-	name: string;
-	value: number;
-	enabled: boolean;
-}

--- a/provider-factory.ts
+++ b/provider-factory.ts
@@ -148,7 +148,7 @@ export async function createProvider(
 	}
 
 	// 5. Build storage (free/all or single set)
-	const stored: StoredModels = def.hasFreeTier
+	let stored: StoredModels = def.hasFreeTier
 		? {
 				free: models.filter((m) => (m.cost?.input ?? 0) === 0),
 				all: models,
@@ -182,9 +182,12 @@ export async function createProvider(
 			providerId: def.providerId,
 			tosUrl: def.tosUrl,
 			initialShowPaid: def.isPaidMode ?? !!def.showPaidFlag,
-			reRegister: (m: ProviderModelConfig[]) => {
-				stored.free = m;
-				stored.all = m;
+			reRegister: (m: ProviderModelConfig[], _stored?: StoredModels) => {
+				// Keep stored as the original model lists for global toggle lookups;
+				// m is the CI-enhanced subset that gets registered with pi.
+				if (_stored) {
+					stored = _stored;
+				}
 				reRegister(m);
 			},
 			skipToggle: def.skipToggle,
@@ -192,13 +195,19 @@ export async function createProvider(
 		stored,
 	);
 
-	// 8. Optional: before_provider_request hook
+	// 8. Optional: before_provider_request hook (scoped to this provider)
 	if (def.beforeProviderRequest) {
 		const hook = def.beforeProviderRequest;
 		(pi.on as (event: string, handler: (e: unknown) => unknown) => void)(
 			"before_provider_request",
 			(event: unknown) => {
-				const evt = event as { type: string; payload: unknown };
+				const evt = event as {
+					type: string;
+					provider?: string;
+					payload: unknown;
+				};
+				// Only apply to this provider's requests
+				if (evt.provider !== def.providerId) return;
 				const payload = evt.payload as Record<string, unknown>;
 				return hook(payload);
 			},

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -28,6 +28,7 @@ import {
 import { DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { createToggleState } from "../../lib/toggle-state.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
 import { enhanceWithCI } from "../../provider-helper.ts";
 
@@ -408,6 +409,32 @@ export async function setupDynamicBuiltInProviders(
 				});
 			};
 
+			// Create per-provider toggle state
+			const toggleState = createToggleState({
+				providerId: config.providerId,
+				initialShowPaid: config.defaultShowPaid,
+				initialModels: { free: freeModels, all: allModels },
+			});
+
+			// Register toggle command for this provider
+			pi.registerCommand(`toggle-${config.providerId}`, {
+				description: `Toggle between free and all ${config.providerId} models`,
+				handler: async (_args, ctx) => {
+					const applied = toggleState.toggle(reRegister);
+					if (applied.mode === "all") {
+						ctx.ui.notify(
+							`${config.providerId}: showing all ${allModels.length} models`,
+							"info",
+						);
+					} else {
+						ctx.ui.notify(
+							`${config.providerId}: showing ${freeModels.length} free models`,
+							"info",
+						);
+					}
+				},
+			});
+
 			// Register with global toggle
 			registerWithGlobalToggle(
 				config.providerId,
@@ -416,9 +443,8 @@ export async function setupDynamicBuiltInProviders(
 				true, // hasKey
 			);
 
-			// Initial registration (default to free)
-			const initialModels = config.defaultShowPaid ? allModels : freeModels;
-			reRegister(initialModels);
+			// Initial registration (respect config state)
+			toggleState.applyCurrent(reRegister);
 
 			_logger.info(`[dynamic] ${config.providerId}: registered successfully`);
 		} catch (error) {

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -30,6 +30,7 @@ import {
 	NVIDIA_MIN_SIZE_B,
 	URL_MODELS_DEV,
 } from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import type { ModelsDevModel, ModelsDevProvider } from "../../lib/types.ts";
 import {
@@ -320,6 +321,56 @@ async function probeNvidiaModel(
 	}
 }
 
+const _nvidiaLogger = createLogger("nvidia");
+
+/**
+ * Run probe on a list of models and auto-hide 404s.
+ * Shared between the /probe-nvidia command and auto-probe on session_start.
+ */
+async function runNvidiaProbe(
+	apiKey: string,
+	modelsToTest: ProviderModelConfig[],
+	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] },
+	reRegister: (models: ProviderModelConfig[]) => void,
+): Promise<void> {
+	const notFound: string[] = [];
+	const batchSize = 5;
+
+	for (let i = 0; i < modelsToTest.length; i += batchSize) {
+		const batch = modelsToTest.slice(i, i + batchSize);
+		const results = await Promise.all(
+			batch.map(async (m) => {
+				const ok = await probeNvidiaModel(apiKey, m.id);
+				return { id: m.id, ok };
+			}),
+		);
+		for (const r of results) {
+			if (!r.ok) notFound.push(r.id);
+		}
+	}
+
+	if (notFound.length === 0) {
+		_nvidiaLogger.info("Auto-probe: all NVIDIA models are routable");
+		return;
+	}
+
+	// Auto-hide 404 models in config (provider-scoped)
+	const cfg = loadConfigFile();
+	const existingHidden = new Set(cfg.hidden_models ?? []);
+	for (const id of notFound) existingHidden.add(`${PROVIDER_NVIDIA}/${id}`);
+	saveConfig({ hidden_models: Array.from(existingHidden) });
+
+	// Re-register so hidden models disappear immediately
+	const filtered = await fetchNvidiaModels(apiKey);
+	stored.free = filtered;
+	stored.all = filtered;
+	reRegister(filtered);
+
+	_nvidiaLogger.info(
+		`Auto-probe: found ${notFound.length} broken models (auto-hidden)`,
+	);
+}
+
 export default async function (pi: ExtensionAPI) {
 	const apiKey = getNvidiaApiKey();
 	const hasKey = !!apiKey;
@@ -359,6 +410,19 @@ export default async function (pi: ExtensionAPI) {
 		models: enhanceWithCI(initialModels),
 	});
 
+	// ── Lazy auto-probe on first session_start ──────────────────────
+	let _autoProbeDone = false;
+	pi.on("session_start", async () => {
+		if (_autoProbeDone || !apiKey) return;
+		_autoProbeDone = true;
+		_nvidiaLogger.info("Starting lazy auto-probe of NVIDIA models...");
+		runNvidiaProbe(apiKey, allModels, stored, reRegister).catch((err) => {
+			_nvidiaLogger.warn("Auto-probe failed", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		});
+	});
+
 	// ── Probe command: test all registered models for 404s ─────────────
 	pi.registerCommand("probe-nvidia", {
 		description: "Test all NVIDIA models for 404 'Function not found' errors",
@@ -371,43 +435,21 @@ export default async function (pi: ExtensionAPI) {
 			const modelsToTest = allModels;
 			ctx.ui.notify(`Probing ${modelsToTest.length} NVIDIA models…`, "info");
 
-			const notFound: string[] = [];
-			const batchSize = 5;
+			await runNvidiaProbe(apiKey, modelsToTest, stored, reRegister);
 
-			for (let i = 0; i < modelsToTest.length; i += batchSize) {
-				const batch = modelsToTest.slice(i, i + batchSize);
-				const results = await Promise.all(
-					batch.map(async (m) => {
-						const ok = await probeNvidiaModel(apiKey, m.id);
-						return { id: m.id, ok };
-					}),
-				);
-				for (const r of results) {
-					if (!r.ok) notFound.push(r.id);
-				}
-			}
-
-			if (notFound.length === 0) {
-				ctx.ui.notify("All NVIDIA models are routable ✅", "info");
-				return;
-			}
-
-			// Auto-hide 404 models in config (provider-scoped)
-			const config = loadConfigFile();
-			const existingHidden = new Set(config.hidden_models ?? []);
-			for (const id of notFound) existingHidden.add(`${PROVIDER_NVIDIA}/${id}`);
-			saveConfig({ hidden_models: Array.from(existingHidden) });
-
-			// Re-register so hidden models disappear immediately
-			const filtered = await fetchNvidiaModels(apiKey);
-			stored.free = filtered;
-			stored.all = filtered;
-			reRegister(filtered);
-
-			ctx.ui.notify(
-				`Found ${notFound.length} broken models (auto-hidden):\n${notFound.join("\n")}`,
-				"warning",
+			// Check if any were hidden (re-read config)
+			const cfgAfter = loadConfigFile();
+			const newHidden = (cfgAfter.hidden_models ?? []).filter((h) =>
+				h.startsWith(`${PROVIDER_NVIDIA}/`),
 			);
+			if (newHidden.length > 0) {
+				ctx.ui.notify(
+					`Found ${newHidden.length} broken models (auto-hidden):\n${newHidden.join("\n")}`,
+					"warning",
+				);
+			} else {
+				ctx.ui.notify("All NVIDIA models are routable ✅", "info");
+			}
 		},
 	});
 


### PR DESCRIPTION
## Changes

### Fixes
- **provider-factory.ts** — Scoped `beforeProviderRequest` hook to owning provider; fixed `reRegister` callback corrupting `stored.all` on toggle
- **index.ts** — Removed redundant `.catch()` on deprecated Qwen provider inside `Promise.allSettled`
- **lib/types.ts** — Removed leftover test interface `LspTestInterface` from production types

### Additions
- **dynamic-built-in providers** — Added `/toggle-mistral`, `/toggle-groq`, `/toggle-cerebras`, `/toggle-xai`, `/toggle-huggingface` commands
- **NVIDIA auto-probe** — Lazy auto-probe on first `session_start` to detect and auto-hide 404 models, extracted shared `runNvidiaProbe()` function

### Changelog
- Updated unreleased section with all entries

## Verification
- ✅ TypeScript compilation: 0 errors
- ✅ Tests: 72/72 passed