### PR TITLE
fix: correct imports and logger calls in ZenMux and CrofAI providers

### DIFF
--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -19,8 +19,12 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import { getCrofaiApiKey, PROVIDER_CROFAI } from "../../config.ts";
-import { BASE_URL_CROFAI, DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
+import { getCrofaiApiKey } from "../../config.ts";
+import {
+	BASE_URL_CROFAI,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_CROFAI,
+} from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
@@ -92,7 +96,7 @@ async function fetchCrofaiModels(
 	} catch (error) {
 		_logger.error(
 			"[crofai] Failed to fetch models:",
-			error instanceof Error ? error.message : String(error),
+			{ error: error instanceof Error ? error.message : String(error) },
 		);
 		return [];
 	}

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -20,8 +20,12 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
-import { getZenmuxApiKey, PROVIDER_ZENMUX } from "../../config.ts";
-import { BASE_URL_ZENMUX, DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
+import { getZenmuxApiKey } from "../../config.ts";
+import {
+	BASE_URL_ZENMUX,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_ZENMUX,
+} from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
@@ -94,7 +98,7 @@ async function fetchZenmuxModels(
 	} catch (error) {
 		_logger.error(
 			"[zenmux] Failed to fetch models:",
-			error instanceof Error ? error.message : String(error),
+			{ error: error instanceof Error ? error.message : String(error) },
 		);
 		return [];
 	}


### PR DESCRIPTION
Fixes CI errors from #112:

- Move PROVIDER_ZENMUX and PROVIDER_CROFAI imports from config.ts to constants.ts
- Fix _logger.error() calls to pass Record<string, unknown> instead of string

All 122 tests pass.