### PR TITLE
Add shared DeepSeek proxy compat helper

### DIFF
--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -1,0 +1,45 @@
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+
+export interface ProviderModelIdentity {
+	id: string;
+	name?: string;
+}
+
+export const DEEPSEEK_PROXY_COMPAT: NonNullable<ProviderModelConfig["compat"]> =
+	{
+		supportsStore: false,
+		supportsDeveloperRole: false,
+		supportsReasoningEffort: true,
+		thinkingFormat: "openai",
+	};
+
+export function isDeepSeekModel(model: ProviderModelIdentity): boolean {
+	const haystack = `${model.id} ${model.name ?? ""}`.toLowerCase();
+	return haystack.includes("deepseek");
+}
+
+export function isLikelyReasoningModel(model: ProviderModelIdentity): boolean {
+	const haystack = `${model.id} ${model.name ?? ""}`.toLowerCase();
+	return (
+		isDeepSeekModel(model) ||
+		haystack.includes("thinking") ||
+		haystack.includes("reasoning") ||
+		haystack.includes("reasoner") ||
+		haystack.includes("r1") ||
+		haystack.includes("qwq")
+	);
+}
+
+/**
+ * For gateway/proxy providers that mask the upstream DeepSeek base URL,
+ * add explicit compat so pi-ai preserves and replays reasoning_content.
+ */
+export function getProxyModelCompat(
+	model: ProviderModelIdentity,
+): ProviderModelConfig["compat"] | undefined {
+	if (isDeepSeekModel(model)) {
+		return DEEPSEEK_PROXY_COMPAT;
+	}
+
+	return undefined;
+}

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -26,13 +26,13 @@ import {
 	PROVIDER_CROFAI,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import {
+	getProxyModelCompat,
+	isLikelyReasoningModel,
+} from "../../lib/provider-compat.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
-import {
-	createReRegister,
-	enhanceWithCI,
-	setupProvider,
-} from "../../provider-helper.ts";
+import { createReRegister, setupProvider } from "../../provider-helper.ts";
 
 const _logger = createLogger("crofai");
 
@@ -77,11 +77,12 @@ async function fetchCrofaiModels(
 
 		return models
 			.filter((m) => m.id) // Filter out any empty entries
-			.map(
-				(m): ProviderModelConfig => ({
+			.map((m) => {
+				const name = m.id.split("/").pop() || m.id;
+				return {
 					id: m.id,
-					name: m.id.split("/").pop() || m.id, // Use last part of ID as name
-					reasoning: m.id.includes("reasoning") || m.id.includes("think"),
+					name,
+					reasoning: isLikelyReasoningModel({ id: m.id, name }),
 					input: ["text"],
 					cost: {
 						input: 0, // CrofAI doesn't expose pricing via API
@@ -91,13 +92,13 @@ async function fetchCrofaiModels(
 					},
 					contextWindow: 128000, // Default, varies by model
 					maxTokens: 4096,
-				}),
-			);
+					compat: getProxyModelCompat({ id: m.id, name }),
+				} satisfies ProviderModelConfig;
+			});
 	} catch (error) {
-		_logger.error(
-			"[crofai] Failed to fetch models:",
-			{ error: error instanceof Error ? error.message : String(error) },
-		);
+		_logger.error("[crofai] Failed to fetch models:", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return [];
 	}
 }

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -27,13 +27,13 @@ import {
 	PROVIDER_ZENMUX,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import {
+	getProxyModelCompat,
+	isLikelyReasoningModel,
+} from "../../lib/provider-compat.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
-import {
-	createReRegister,
-	enhanceWithCI,
-	setupProvider,
-} from "../../provider-helper.ts";
+import { createReRegister, setupProvider } from "../../provider-helper.ts";
 
 const _logger = createLogger("zenmux");
 
@@ -49,6 +49,11 @@ interface ZenMuxModel {
 		prompt?: number;
 		completion?: number;
 	};
+}
+
+function isZenmuxReasoningModel(model: Pick<ZenMuxModel, "id" | "name">) {
+	const haystack = `${model.id} ${model.name ?? ""}`.toLowerCase();
+	return isLikelyReasoningModel(model) || haystack.includes("claude");
 }
 
 async function fetchZenmuxModels(
@@ -83,7 +88,7 @@ async function fetchZenmuxModels(
 			(m): ProviderModelConfig => ({
 				id: m.id,
 				name: m.name || m.id,
-				reasoning: m.id.includes("claude") || m.id.includes("thinking"),
+				reasoning: isZenmuxReasoningModel(m),
 				input: ["text"],
 				cost: {
 					input: m.pricing?.prompt || 0,
@@ -93,13 +98,13 @@ async function fetchZenmuxModels(
 				},
 				contextWindow: m.context_length || 128000,
 				maxTokens: m.context_length ? Math.floor(m.context_length / 2) : 4096,
+				compat: getProxyModelCompat(m),
 			}),
 		);
 	} catch (error) {
-		_logger.error(
-			"[zenmux] Failed to fetch models:",
-			{ error: error instanceof Error ? error.message : String(error) },
-		);
+		_logger.error("[zenmux] Failed to fetch models:", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return [];
 	}
 }

--- a/tests/provider-compat.test.ts
+++ b/tests/provider-compat.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEEPSEEK_PROXY_COMPAT,
+	getProxyModelCompat,
+	isDeepSeekModel,
+	isLikelyReasoningModel,
+} from "../lib/provider-compat.ts";
+
+describe("provider-compat", () => {
+	describe("isDeepSeekModel", () => {
+		it("detects DeepSeek in model id", () => {
+			expect(isDeepSeekModel({ id: "deepseek/deepseek-v3.2" })).toBe(true);
+			expect(isDeepSeekModel({ id: "vendor/DeepSeek-R1" })).toBe(true);
+		});
+
+		it("detects DeepSeek in model name", () => {
+			expect(
+				isDeepSeekModel({ id: "vendor/model-1", name: "DeepSeek V4 Pro" }),
+			).toBe(true);
+		});
+
+		it("returns false for non-DeepSeek models", () => {
+			expect(isDeepSeekModel({ id: "openai/gpt-4.1" })).toBe(false);
+			expect(
+				isDeepSeekModel({ id: "anthropic/claude-sonnet", name: "Claude" }),
+			).toBe(false);
+		});
+	});
+
+	describe("isLikelyReasoningModel", () => {
+		it("detects common reasoning markers", () => {
+			expect(isLikelyReasoningModel({ id: "qwen/qwq-32b" })).toBe(true);
+			expect(isLikelyReasoningModel({ id: "foo/reasoner" })).toBe(true);
+			expect(
+				isLikelyReasoningModel({ id: "foo/bar", name: "Thinking Model" }),
+			).toBe(true);
+			expect(
+				isLikelyReasoningModel({ id: "foo/bar", name: "Reasoning Max" }),
+			).toBe(true);
+			expect(isLikelyReasoningModel({ id: "deepseek/deepseek-v3.2" })).toBe(
+				true,
+			);
+		});
+
+		it("returns false for normal non-reasoning models", () => {
+			expect(isLikelyReasoningModel({ id: "openai/gpt-4.1-mini" })).toBe(false);
+			expect(
+				isLikelyReasoningModel({ id: "meta/llama-3.3-70b-instruct" }),
+			).toBe(false);
+		});
+	});
+
+	describe("getProxyModelCompat", () => {
+		it("returns shared DeepSeek compat for proxied DeepSeek models", () => {
+			expect(getProxyModelCompat({ id: "deepseek/deepseek-r1" })).toEqual(
+				DEEPSEEK_PROXY_COMPAT,
+			);
+			expect(
+				getProxyModelCompat({ id: "vendor/model", name: "DeepSeek V4 Flash" }),
+			).toEqual(DEEPSEEK_PROXY_COMPAT);
+		});
+
+		it("returns undefined for non-DeepSeek models", () => {
+			expect(getProxyModelCompat({ id: "openai/gpt-4.1" })).toBeUndefined();
+			expect(
+				getProxyModelCompat({ id: "anthropic/claude-sonnet", name: "Claude" }),
+			).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary\n- add a shared helper for proxied DeepSeek model detection and compat\n- apply the helper to ZenMux and CrofAI model mapping\n- add unit tests for provider compat detection\n\n## Validation\n- npm run test:run\n- npx tsc --noEmit\n\nNo test regressions observed.