### PR TITLE
fix: preserve DeepSeek reasoning replay for proxy providers

### DIFF
--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -10,7 +10,8 @@ export const DEEPSEEK_PROXY_COMPAT: NonNullable<ProviderModelConfig["compat"]> =
 		supportsStore: false,
 		supportsDeveloperRole: false,
 		supportsReasoningEffort: true,
-		thinkingFormat: "openai",
+		requiresReasoningContentOnAssistantMessages: true,
+		thinkingFormat: "deepseek",
 	};
 
 export function isDeepSeekModel(model: ProviderModelIdentity): boolean {


### PR DESCRIPTION
## Summary
- set proxied DeepSeek compat to `thinkingFormat: "deepseek"`
- require replayed assistant `reasoning_content` for DeepSeek proxy/gateway models
- fixes ZenMux/CrofAI style proxy routing for DeepSeek thinking mode

## Why
DeepSeek V4 via gateway providers can return:

> 400 The `reasoning_content` in the thinking mode must be passed back to the API

pi-ai supports this for native DeepSeek, but proxy providers need explicit compat because URL-based auto-detection does not apply.

## Validation
- `npx vitest run` ✅
- `npm run check` ✅
