### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.3] - 2026-05-02
 
 ### Added
 
@@ -23,21 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Comprehensive `isFreeModel` test suite** — Added 30+ unit tests covering Route A, Route B, freemium behavior, and edge cases. Tests verify correct classification on actual OpenRouter API data (371 models, 30 free).
 
+- **Toggle commands for dynamic built-in providers** — Added `/toggle-mistral`, `/toggle-groq`,
+  `/toggle-cerebras`, `/toggle-xai`, and `/toggle-huggingface` commands. These providers were
+  registered with the global toggle system but lacked per-provider toggle commands, making
+  free/paid switching inaccessible without editing config files.
+
+- **Lazy auto-probe for NVIDIA models** — Extracted `runNvidiaProbe()` into a shared function
+  called automatically on first `session_start` (once per session). Previously, users had to
+  manually run `/probe-nvidia` to discover 404 models. Now broken models are detected and
+  auto-hidden on first use.
+
 ### Changed
 
 - **Cline provider now uses `isFreeModel`** — Fixed Cline to use the consistent `isFreeModel` helper instead of `m.cost.input === 0`. Previously used cost-only filtering, now uses proper OR logic for pricing-exposed providers.
 
 - **NVIDIA test expectations updated** — Updated tests to reflect strict Route B behavior (name-only detection for non-pricing-exposed providers). Added test for models with `"free"` in name being marked as free.
-
-### Removed
-
-- **Qwen provider (deprecated)** — Removed Qwen OAuth provider as the 1,000 req/day free tier is no longer available. Provider remains functional for existing authenticated users but new free tier registrations are not supported.
-
-- **Modal provider** — Removed single-model Modal provider (only had GLM-5.1 FP8). Users should use other providers for GLM models.
-
-- **Cloudflare provider** — Removed Cloudflare Workers AI provider as it's now built into pi core. Users can use pi's built-in Cloudflare provider instead.
-
-- **Qwen test file** — Removed `tests/qwen.test.ts` along with the deprecated provider.
 
 ### Fixed
 
@@ -57,17 +57,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`index.ts` — Removed redundant `.catch()` on deprecated Qwen provider** — The `.catch()`
   was unnecessary since `Promise.allSettled` already handles rejections.
 
-### Added
+### Removed
 
-- **Toggle commands for dynamic built-in providers** — Added `/toggle-mistral`, `/toggle-groq`,
-  `/toggle-cerebras`, `/toggle-xai`, and `/toggle-huggingface` commands. These providers were
-  registered with the global toggle system but lacked per-provider toggle commands, making
-  free/paid switching inaccessible without editing config files.
+- **Qwen provider (deprecated)** — Removed Qwen OAuth provider as the 1,000 req/day free tier is no longer available. Provider remains functional for existing authenticated users but new free tier registrations are not supported.
 
-- **Lazy auto-probe for NVIDIA models** — Extracted `runNvidiaProbe()` into a shared function
-  called automatically on first `session_start` (once per session). Previously, users had to
-  manually run `/probe-nvidia` to discover 404 models. Now broken models are detected and
-  auto-hidden on first use.
+- **Modal provider** — Removed single-model Modal provider (only had GLM-5.1 FP8). Users should use other providers for GLM models.
+
+- **Cloudflare provider** — Removed Cloudflare Workers AI provider as it's now built into pi core. Users can use pi's built-in Cloudflare provider instead.
+
+- **Qwen test file** — Removed `tests/qwen.test.ts` along with the deprecated provider.
 
 ## [2.0.2] - 2026-04-26
 
@@ -138,17 +136,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added regex-based non-chat model filtering for unknown models (embeddings, whisper, reward models, safety guards, parsers, detectors, etc.)
   - Graceful fallback to `models.dev` if NVIDIA API is unreachable
   - Removed paid/free toggle filtering — NVIDIA is freemium (all models use free credits)
-
-## [2.0.2] - 2026-04-24
-
-### Fixed
-
-- **Provider toggle state now persists reliably** — Follow-up fixes to the new `toggle-{provider}` flow ensure saved free-vs-all preferences are restored consistently across sessions for built-in and extension-managed providers.
-- **Config parse errors are now logged** — Invalid `~/.pi/free.json` content is no longer ignored silently; startup parse failures are written to `~/.pi/free.log` to make misconfiguration easier to diagnose.
-
-### Changed
-
-- **README refreshed** — Clarified that provider toggle changes apply immediately, persist across restarts, and that malformed config is surfaced in the extension log.
 
 ## [2.0.1] - 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Want to see paid models too? Run the toggle command for your provider:
 /toggle-mistral    # Toggle Mistral (🔧 dynamic - needs API key)
 /toggle-groq       # Toggle Groq (🔧 dynamic - needs API key)
 /toggle-cerebras   # Toggle Cerebras (🔧 dynamic - needs API key)
+/toggle-xai        # Toggle xAI (🔧 dynamic - needs API key)
+/toggle-huggingface # Toggle Hugging Face (🔧 dynamic - needs HF_TOKEN)
 /toggle-zenmux    # Toggle ZenMux (💳 paid - needs API key with credits)
 /toggle-crofai    # Toggle CrofAI (💳 paid - needs API key with credits)
 ```
@@ -111,8 +113,6 @@ Add your API keys to this file:
 {
   "openrouter_api_key": "sk-or-v1-...",
   "nvidia_api_key": "nvapi-...",
-  "cloudflare_api_token": "...",
-  "cloudflare_account_id": "...",
   "ollama_api_key": "...",
   "mistral_api_key": "...",
   "modal_api_key": "sk-modal-..."
@@ -148,7 +148,6 @@ NVIDIA's API lists 130+ models, but 57+ return 404 "Function not found" when you
 - **Auto-discovery from NVIDIA's API** — Queries `integrate.api.nvidia.com/v1/models` directly for the ground-truth list
 - **`/probe-nvidia` command** — On-demand health check: tests every model with a minimal request, auto-hides new 404s, and re-registers immediately
 
-
 ### 🎯 Coding Index (CI) Scores
 
 Every model shows a **Coding Index score** (e.g., `CI: 52.3`) in the model picker:
@@ -159,13 +158,13 @@ Every model shows a **Coding Index score** (e.g., `CI: 52.3`) in the model picke
 
 **Missing CI scores?** Provider model IDs often don't match benchmark database keys exactly. pi-free applies provider-specific normalization to improve matching:
 
-| Provider       | Normalization Applied                                              |
-| -------------- | ------------------------------------------------------------------ |
-| **NVIDIA**     | Strips vendor prefixes (`meta/`, `mistralai/`, `microsoft/`, etc.) |
-| **Groq**       | Removes `-versatile` and numeric suffixes (`-32768`)               |
-| **Cerebras**   | Normalizes `llama3.1` → `llama-3.1`, adds `instruct` suffix        |
-| **Mistral**    | Strips `-latest` suffix                                            |
-| **Ollama**     | Converts `model:tag` → `model-tag`                                 |
+| Provider     | Normalization Applied                                              |
+| ------------ | ------------------------------------------------------------------ |
+| **NVIDIA**   | Strips vendor prefixes (`meta/`, `mistralai/`, `microsoft/`, etc.) |
+| **Groq**     | Removes `-versatile` and numeric suffixes (`-32768`)               |
+| **Cerebras** | Normalizes `llama3.1` → `llama-3.1`, adds `instruct` suffix        |
+| **Mistral**  | Strips `-latest` suffix                                            |
+| **Ollama**   | Converts `model:tag` → `model-tag`                                 |
 
 **Debug missing scores:** Check `~/.pi/modelmatch.log` to see which models matched/didn't match and what normalization was applied.
 
@@ -310,37 +309,7 @@ Or in `~/.pi/free.json`:
 
 Toggle anytime with `/toggle-nvidia`
 
-
-# Legacy env vars also work
-export CLOUDFLARE_API_TOKEN="your_token_here"
-export CLOUDFLARE_ACCOUNT_ID="your_account_id"
-```
-
 **Models available:** Llama 4/3.x, Mistral Small 3.1, DeepSeek R1, Gemma 4, Kimi K2.5/2.6, Qwen 3/2.5, OpenAI GPT-OSS, and more.
-
-### Modal (GLM-5.1 FP8 — free promotional period until April 30, 2026)
-
-Modal hosts GLM-5.1 FP8 with a free promotional period. Get an API key at [modal.com](https://modal.com), then:
-
-**Option A: Environment variable**
-
-```bash
-export MODAL_API_KEY="sk-modal-..."
-```
-
-**Option B: Config file** (`~/.pi/free.json`)
-
-```json
-{
-  "modal_api_key": "sk-modal-..."
-}
-```
-
-**Details:**
-
-- Free promotional period until April 30, 2026
-- Model: GLM-5.1 FP8 (128k context, 16k max output)
-- No credit card required during the promotional period
 
 ### Ollama Cloud
 
@@ -380,17 +349,19 @@ export MISTRAL_API_KEY="..."
 
 Each provider has toggle commands to switch between free and all models:
 
-| Command              | Action                                               |
-| -------------------- | ---------------------------------------------------- |
-| `/toggle-opencode`   | Toggle between free/all OpenCode models              |
-| `/toggle-kilo`       | Toggle between free/all Kilo models                  |
-| `/toggle-openrouter` | Toggle between free/all OpenRouter models            |
-| `/toggle-cline`      | Toggle between free/all Cline models                 |
-| `/toggle-nvidia`     | Toggle between free/all NVIDIA models                |
-| `/toggle-ollama`     | Toggle between free/all Ollama Cloud models          |
-| `/toggle-mistral`    | Toggle between free/all Mistral models (🔧 dynamic)  |
-| `/toggle-groq`       | Toggle between free/all Groq models (🔧 dynamic)     |
-| `/toggle-cerebras`   | Toggle between free/all Cerebras models (🔧 dynamic) |
+| Command               | Action                                                   |
+| --------------------- | -------------------------------------------------------- |
+| `/toggle-opencode`    | Toggle between free/all OpenCode models                  |
+| `/toggle-kilo`        | Toggle between free/all Kilo models                      |
+| `/toggle-openrouter`  | Toggle between free/all OpenRouter models                |
+| `/toggle-cline`       | Toggle between free/all Cline models                     |
+| `/toggle-nvidia`      | Toggle between free/all NVIDIA models                    |
+| `/toggle-ollama`      | Toggle between free/all Ollama Cloud models              |
+| `/toggle-mistral`     | Toggle between free/all Mistral models (🔧 dynamic)      |
+| `/toggle-groq`        | Toggle between free/all Groq models (🔧 dynamic)         |
+| `/toggle-cerebras`    | Toggle between free/all Cerebras models (🔧 dynamic)     |
+| `/toggle-xai`         | Toggle between free/all xAI models (🔧 dynamic)          |
+| `/toggle-huggingface` | Toggle between free/all Hugging Face models (🔧 dynamic) |
 
 /toggle-zenmux # Toggle ZenMux (💳 paid - needs API key with credits)
 /toggle-crofai # Toggle CrofAI (💳 paid - needs API key with credits)
@@ -432,13 +403,10 @@ Create `~/.pi/free.json` in your home directory:
 {
   "openrouter_api_key": "YOUR_OPENROUTER_KEY",
   "nvidia_api_key": "YOUR_NVIDIA_KEY",
-  "cloudflare_api_token": "YOUR_CLOUDFLARE_TOKEN",
-  "cloudflare_account_id": "YOUR_ACCOUNT_ID",
   "mistral_api_key": "YOUR_MISTRAL_KEY",
   "opencode_api_key": "YOUR_OPENCODE_KEY",
   "ollama_api_key": "YOUR_OLLAMA_KEY",
   "ollama_show_paid": true,
-  "modal_api_key": "YOUR_MODAL_KEY",
   "hidden_models": ["model-id-to-hide"]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering. Shows only $0 cost models by default. Supports Kilo (free OAuth), Cline (free), NVIDIA (freemium), ZenMux, CrofAI, Ollama Cloud, and more.",
 	"keywords": [


### PR DESCRIPTION
## Summary

Bump patch version from 2.0.2 → 2.0.3 with changelog and README updates.

### Changes

- **Version**: 2.0.2 → 2.0.3
- **Changelog**: Move Unreleased entries to [2.0.3] - 2026-05-02 (isFreeModel helper, CrofAI/ZenMux providers, toggle commands for dynamic built-in providers, lazy NVIDIA auto-probe, provider removals)
- **Changelog**: Merge duplicate [2.0.2] entries (2026-04-24 and 2026-04-26)
- **README**: Remove Modal section (promotional period ended Apr 30, 2026)
- **README**: Remove Cloudflare provider references (now built into pi core)
- **README**: Add /toggle-xai and /toggle-huggingface to toggle command lists