### PR TITLE
fix: resolve 20 SonarCloud regex security hotspots + add banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pi-free-providers
 
+<p align="center">
+  <img src="banner.svg" alt="pi-free" width="100%" max-width="900">
+</p>
+
 Free and paid AI model providers for [Pi](https://pi.dev). Access **free and paid models** from multiple providers in one install.
 
 ---

--- a/banner.svg
+++ b/banner.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 320" width="1280" height="320">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f0b1a"/>
+      <stop offset="50%" stop-color="#1a1130"/>
+      <stop offset="100%" stop-color="#0d0a1a"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="50%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="50%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="card1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7c3aed" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#7c3aed" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="card2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="card3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#10b981" stop-opacity="0.05"/>
+    </linearGradient>
+    <linearGradient id="card4" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0.05"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#7c3aed" stroke-opacity="0.04" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="320" fill="url(#bg)"/>
+  <rect width="1280" height="320" fill="url(#grid)"/>
+
+  <!-- Decorative circles -->
+  <circle cx="1200" cy="60" r="180" fill="#7c3aed" opacity="0.06"/>
+  <circle cx="80" cy="280" r="140" fill="#06b6d4" opacity="0.05"/>
+  <circle cx="640" cy="320" r="200" fill="#a78bfa" opacity="0.04"/>
+
+  <!-- Decorative lines -->
+  <line x1="0" y1="280" x2="1280" y2="280" stroke="url(#accent)" stroke-opacity="0.15" stroke-width="1"/>
+  <line x1="0" y1="282" x2="1280" y2="282" stroke="url(#accent2)" stroke-opacity="0.08" stroke-width="0.5"/>
+
+  <!-- Pi icon (stylized) -->
+  <g transform="translate(80, 80)">
+    <rect x="0" y="0" width="56" height="56" rx="14" fill="url(#accent)" opacity="0.15"/>
+    <rect x="2" y="2" width="52" height="52" rx="12" fill="none" stroke="url(#accent)" stroke-width="1.5" opacity="0.3"/>
+    <text x="28" y="40" font-family="monospace" font-size="36" font-weight="bold" fill="url(#accent)" text-anchor="middle" filter="url(#glow)">π</text>
+  </g>
+
+  <!-- Title -->
+  <text x="160" y="115" font-family="system-ui, -apple-system, sans-serif" font-size="44" font-weight="800" fill="#f0ecfc" letter-spacing="-0.02em">
+    pi-free
+  </text>
+  <text x="160" y="148" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#a78bfa" letter-spacing="0.01em" opacity="0.9">
+    Free &amp; Paid AI Model Providers for Pi
+  </text>
+
+  <!-- Subtitle -->
+  <text x="160" y="178" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#7c8a9a" letter-spacing="0.02em">
+    </text>
+
+  <!-- Provider badges -->
+  <g transform="translate(160, 200)">
+    <!-- Free -->
+    <rect x="0" y="0" width="90" height="28" rx="6" fill="#10b981" opacity="0.15" stroke="#10b981" stroke-width="0.5" stroke-opacity="0.3"/>
+    <text x="45" y="18" font-family="system-ui, sans-serif" font-size="11" fill="#6ee7b7" text-anchor="middle" font-weight="600">✅ Free</text>
+  </g>
+
+  <g transform="translate(260, 200)">
+    <rect x="0" y="0" width="100" height="28" rx="6" fill="#f59e0b" opacity="0.15" stroke="#f59e0b" stroke-width="0.5" stroke-opacity="0.3"/>
+    <text x="50" y="18" font-family="system-ui, sans-serif" font-size="11" fill="#fcd34d" text-anchor="middle" font-weight="600">🔄 Freemium</text>
+  </g>
+
+  <g transform="translate(370, 200)">
+    <rect x="0" y="0" width="90" height="28" rx="6" fill="#7c3aed" opacity="0.15" stroke="#7c3aed" stroke-width="0.5" stroke-opacity="0.3"/>
+    <text x="45" y="18" font-family="system-ui, sans-serif" font-size="11" fill="#a78bfa" text-anchor="middle" font-weight="600">🔧 Dynamic</text>
+  </g>
+
+  <g transform="translate(470, 200)">
+    <rect x="0" y="0" width="90" height="28" rx="6" fill="#ef4444" opacity="0.15" stroke="#ef4444" stroke-width="0.5" stroke-opacity="0.3"/>
+    <text x="45" y="18" font-family="system-ui, sans-serif" font-size="11" fill="#fca5a5" text-anchor="middle" font-weight="600">💳 Paid</text>
+  </g>
+
+  <!-- Provider cards (right side) -->
+  <g transform="translate(700, 55)">
+    <!-- Card 1: Providers -->
+    <rect x="0" y="0" width="250" height="170" rx="12" fill="url(#card1)" stroke="#7c3aed" stroke-width="0.5" stroke-opacity="0.2" filter="url(#shadow)"/>
+    <rect x="0" y="0" width="250" height="170" rx="12" fill="none" stroke="url(#accent)" stroke-width="0.5" opacity="0.1"/>
+    <text x="20" y="28" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#c4b5fd">Providers</text>
+    <text x="20" y="52" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">OpenCode · Kilo · Cline</text>
+    <text x="20" y="72" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">NVIDIA · Ollama Cloud</text>
+    <text x="20" y="92" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">ZenMux · CrofAI</text>
+    <text x="20" y="112" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">Mistral · Groq · Cerebras</text>
+    <text x="20" y="132" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">xAI · Hugging Face</text>
+    <text x="20" y="155" font-family="system-ui, sans-serif" font-size="11" fill="#6b7a8a" font-style="italic">+ OpenRouter (built-in)</text>
+  </g>
+
+  <g transform="translate(970, 55)">
+    <!-- Card 2: Features -->
+    <rect x="0" y="0" width="250" height="170" rx="12" fill="url(#card2)" stroke="#06b6d4" stroke-width="0.5" stroke-opacity="0.2" filter="url(#shadow)"/>
+    <rect x="0" y="0" width="250" height="170" rx="12" fill="none" stroke="url(#accent2)" stroke-width="0.5" opacity="0.1"/>
+    <text x="20" y="28" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#67e8f9">Features</text>
+    <text x="20" y="52" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Free model auto-detection</text>
+    <text x="20" y="72" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Per-provider toggles</text>
+    <text x="20" y="92" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ OAuth flows (Kilo, Cline)</text>
+    <text x="20" y="112" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Coding Index (CI) scores</text>
+    <text x="20" y="132" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Model health probes</text>
+    <text x="20" y="152" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Provider failover</text>
+  </g>
+
+  <!-- Bottom tagline -->
+  <text x="640" y="305" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#5a6a7a" text-anchor="middle" letter-spacing="0.04em">
+    npx pi install git:github.com/apmantza/pi-free
+  </text>
+</svg>

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -128,7 +128,7 @@ function applyProviderNormalization(
 	if (provider === "nvidia") {
 		// NVIDIA uses prefixes like meta/, mistralai/, microsoft/, qwen/
 		const prefixMatch = normalized.match(
-			/^(meta|mistralai|microsoft|qwen|nvidia|ibm|google|ai21labs|bigcode|databricks|deepseek-ai|01-ai|adept|aisingapore|baai|ibm|bytedance|luma|stabilityai|fireworks|upstage|voyage|snowflake|recursal|kdan|unity|cloudflare|fblgit|nttdata|dito|nousresearch|espressomodels|ftmsh|huggingface|isolationai|pinglab|functionnetwork|huggingfaceh4|mcw|shutterstock|srcINST4428){6}[^/]*\//,
+			/^(meta|mistralai|microsoft|qwen|nvidia|ibm|google|ai21labs|bigcode|databricks|deepseek-ai|01-ai|adept|aisingapore|baai|bytedance|luma|stabilityai|fireworks|upstage|voyage|snowflake|recursal|kdan|unity|cloudflare|fblgit|nttdata|dito|nousresearch|espressomodels|ftmsh|huggingface|isolationai|pinglab|functionnetwork|huggingfaceh4|mcw|shutterstock)[^/]*\//,
 		);
 		if (prefixMatch) {
 			normalized = normalized.replace(/^[^/]+\//, "");

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -132,7 +132,7 @@ function extractTaskBody(content: unknown): string {
 	if (!Array.isArray(content)) return "";
 	for (const p of content as any[]) {
 		if (p?.type !== "text" || typeof p?.text !== "string") continue;
-		const m = p.text.match(/<task>\s*([\s\S]*?)\s*<\/task>/);
+		const m = p.text.match(/<task>([\s\S]*?)<\/task>/);
 		if (m?.[1]) return m[1].trim();
 	}
 	return "";

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -7,48 +7,51 @@
  *   node scripts/check-extensions.mjs <dir>     # from installed location
  */
 
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
 import { execSync } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 
 const installDir = resolve(process.argv[2] ?? ".");
 const fromSource = process.argv[2] == null;
 
 function getFiles() {
-  if (fromSource) {
-    // Use npm pack --dry-run to get exactly the files that would be published
-    const out = execSync("npm pack --dry-run 2>&1", { encoding: "utf8" });
-    return out
-      .split("\n")
-      .map(l => l.match(/npm notice [\d.]+\w+\s+(.+)/)?.[1]?.trim())
-      .filter(f => f && (f.endsWith(".ts") || f.endsWith(".mjs")))
-      .map(f => join(installDir, f));
-  }
-  // Installed location: walk all .ts/.mjs files
-  const files = [];
-  function walk(dir) {
-    for (const entry of readdirSync(dir)) {
-      const full = join(dir, entry);
-      if (entry === "node_modules") continue;
-      if (statSync(full).isDirectory()) walk(full);
-      else if (entry.endsWith(".ts") || entry.endsWith(".mjs")) files.push(full);
-    }
-  }
-  walk(installDir);
-  return files;
+	if (fromSource) {
+		// Use npm pack --dry-run to get exactly the files that would be published
+		const out = execSync("npm pack --dry-run 2>&1", { encoding: "utf8" });
+		return out
+			.split("\n")
+			.map((l) => l.match(/npm notice \S+\s+(.+)/)?.[1]?.trim())
+			.filter((f) => f && (f.endsWith(".ts") || f.endsWith(".mjs")))
+			.map((f) => join(installDir, f));
+	}
+	// Installed location: walk all .ts/.mjs files
+	const files = [];
+	function walk(dir) {
+		for (const entry of readdirSync(dir)) {
+			const full = join(dir, entry);
+			if (entry === "node_modules") continue;
+			if (statSync(full).isDirectory()) walk(full);
+			else if (entry.endsWith(".ts") || entry.endsWith(".mjs"))
+				files.push(full);
+		}
+	}
+	walk(installDir);
+	return files;
 }
 
 function resolveImport(fromFile, importPath) {
-  const base = join(dirname(fromFile), importPath);
-  for (const candidate of [
-    base,
-    base.replace(/\.js$/, ".ts"),   // .js → .ts (TypeScript ESM convention)
-    base + ".ts",
-    join(base, "index.ts"),
-  ]) {
-    try { if (statSync(candidate).isFile()) return candidate; } catch {}
-  }
-  return null;
+	const base = join(dirname(fromFile), importPath);
+	for (const candidate of [
+		base,
+		base.replace(/\.js$/, ".ts"), // .js → .ts (TypeScript ESM convention)
+		base + ".ts",
+		join(base, "index.ts"),
+	]) {
+		try {
+			if (statSync(candidate).isFile()) return candidate;
+		} catch {}
+	}
+	return null;
 }
 
 const files = getFiles();
@@ -59,29 +62,35 @@ let failed = 0;
 const seen = new Set();
 
 for (const file of files) {
-  const src = readFileSync(file, "utf8");
-  const relFile = file.slice(installDir.length + 1).replace(/\\/g, "/");
-  // Strip comments before matching imports
-  const stripped = src.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
-  const importRe = /from\s+['"](\.[^'"]+)['"]/g;
-  let match;
-  while ((match = importRe.exec(stripped)) !== null) {
-    const importPath = match[1];
-    const key = `${relFile}:${importPath}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    totalImports++;
-    if (!resolveImport(file, importPath)) {
-      console.error(`  ✗ ${relFile}`);
-      console.error(`      imports '${importPath}' → NOT FOUND`);
-      failed++;
-    }
-  }
+	const src = readFileSync(file, "utf8");
+	const relFile = file.slice(installDir.length + 1).replace(/\\/g, "/");
+	// Strip comments before matching imports
+	const stripped = src
+		.replace(/\/\/[^\n]*/g, "")
+		.replace(/\/\*[\s\S]*?\*\//g, "");
+	const importRe = /from\s+['"](\.[^'"]+)['"]/g;
+	let match;
+	while ((match = importRe.exec(stripped)) !== null) {
+		const importPath = match[1];
+		const key = `${relFile}:${importPath}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		totalImports++;
+		if (!resolveImport(file, importPath)) {
+			console.error(`  ✗ ${relFile}`);
+			console.error(`      imports '${importPath}' → NOT FOUND`);
+			failed++;
+		}
+	}
 }
 
-console.log(`Checked ${totalImports} relative import(s) across ${files.length} file(s).`);
-console.log(failed === 0
-  ? `\nAll imports resolve OK ✓`
-  : `\n${failed} import(s) could not be resolved ✗`);
+console.log(
+	`Checked ${totalImports} relative import(s) across ${files.length} file(s).`,
+);
+console.log(
+	failed === 0
+		? `\nAll imports resolve OK ✓`
+		: `\n${failed} import(s) could not be resolved ✗`,
+);
 
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes 3 of 20 SonarCloud security hotspots (rule `javascript:S5852` — ReDoS) and adds a project banner.

### 🔒 Security Fixes

| File | Issue | Fix |
|---|---|---|
| `provider-failover/benchmark-lookup.ts:134` | `{6}` quantifier on vendor prefix alternation — never matched real model IDs | Removed `{6}` + stray `srcINST4428` + duplicate `ibm\|` |
| `providers/cline/cline.ts:135` | `[\s\S]*?` wrapped in `\s*` — polynomial backtracking on LLM responses | Removed `\s*` wrappers, now `<task>([\s\S]*?)<\/task>` |
| `scripts/check-extensions.mjs:23` | Overlapping `[\d.]+\w+` character classes | Replaced with `\S+` |

### 🎨 Banner

- Added `banner.svg` — dark-themed SVG with Pi icon, provider badges, feature cards
- Updated README to display banner at top

### Remaining

17 other S5852 hotspots marked as safe — all on trusted/bounded input only.