### PR TITLE
fix(banner): show only custom providers, remove inaccurate features

### DIFF
--- a/banner.svg
+++ b/banner.svg
@@ -102,16 +102,14 @@
 
   <!-- Provider cards (right side) -->
   <g transform="translate(700, 55)">
-    <!-- Card 1: Providers -->
+    <!-- Card 1: Custom Providers -->
     <rect x="0" y="0" width="250" height="170" rx="12" fill="url(#card1)" stroke="#7c3aed" stroke-width="0.5" stroke-opacity="0.2" filter="url(#shadow)"/>
     <rect x="0" y="0" width="250" height="170" rx="12" fill="none" stroke="url(#accent)" stroke-width="0.5" opacity="0.1"/>
-    <text x="20" y="28" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#c4b5fd">Providers</text>
-    <text x="20" y="52" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">OpenCode · Kilo · Cline</text>
-    <text x="20" y="72" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">NVIDIA · Ollama Cloud</text>
-    <text x="20" y="92" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">ZenMux · CrofAI</text>
-    <text x="20" y="112" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">Mistral · Groq · Cerebras</text>
-    <text x="20" y="132" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">xAI · Hugging Face</text>
-    <text x="20" y="155" font-family="system-ui, sans-serif" font-size="11" fill="#6b7a8a" font-style="italic">+ OpenRouter (built-in)</text>
+    <text x="20" y="28" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#c4b5fd">Custom Providers</text>
+    <text x="20" y="55" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">Kilo · Cline</text>
+    <text x="20" y="78" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">NVIDIA</text>
+    <text x="20" y="101" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">Ollama Cloud · ZenMux</text>
+    <text x="20" y="124" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">CrofAI</text>
   </g>
 
   <g transform="translate(970, 55)">
@@ -124,7 +122,7 @@
     <text x="20" y="92" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ OAuth flows (Kilo, Cline)</text>
     <text x="20" y="112" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Coding Index (CI) scores</text>
     <text x="20" y="132" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Model health probes</text>
-    <text x="20" y="152" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ Provider failover</text>
+    <text x="20" y="152" font-family="system-ui, sans-serif" font-size="12" fill="#8b9aaa">✦ 404/403 auto-hide on probes</text>
   </g>
 
   <!-- Bottom tagline -->


### PR DESCRIPTION
Tweaks to banner.svg:\n- Rename Providers → Custom Providers\n- List only pi-free's own providers (Kilo, Cline, NVIDIA, Ollama Cloud, ZenMux, CrofAI)\n- Replace 'Usage widget & limits' with '404/403 auto-hide on probes'