### PR TITLE
fix: stop reading OpenRouter key from free.json for built-in providers

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -32,7 +32,6 @@ interface PiFreeConfig {
 	cerebras_api_key?: string;
 	xai_api_key?: string;
 	hf_token?: string;
-	openrouter_api_key?: string;
 	kilo_free_only?: boolean;
 	hidden_models?: string[];
 	free_only?: boolean;
@@ -55,7 +54,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	cerebras_api_key: "",
 	xai_api_key: "",
 	hf_token: "",
-	openrouter_api_key: "",
+
 	kilo_free_only: false,
 	hidden_models: [],
 	free_only: true,
@@ -215,8 +214,12 @@ export function getHfToken(): string | undefined {
 	return resolve("HF_TOKEN", loadConfigFile().hf_token);
 }
 
+/**
+ * OpenRouter key — pi's built-in provider reads from ~/.pi/agent/auth.json.
+ * pi-free only checks the env var to avoid stale keys from free.json.
+ */
 export function getOpenrouterApiKey(): string | undefined {
-	return resolve("OPENROUTER_API_KEY", loadConfigFile().openrouter_api_key);
+	return process.env.OPENROUTER_API_KEY;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Problem

OpenRouter API key in `free.json` was stale/revoked, causing `401 User not found` errors.
pi's built-in OpenRouter provider uses `~/.pi/agent/auth.json` for its key, but pi-free's
`getOpenrouterApiKey()` was falling back to `free.json` when no env var was set.

## Changes

- **config.ts**: Removed `openrouter_api_key` from `PiFreeConfig` interface and `CONFIG_TEMPLATE`
- **getOpenrouterApiKey()**: Now only checks `OPENROUTER_API_KEY` env var, no `free.json` fallback
- **free.json**: Cleaned up stale `openrouter_api_key` and empty `opencode_api_key` fields

## Testing

```
✓ 10 test files - 129 tests passed
```