### PR TITLE
chore: bump to v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2026-05-02
+
+### Fixed
+
+- **OpenRouter key resolution no longer falls back to `free.json`** —
+  `getOpenrouterApiKey()` now only checks the `OPENROUTER_API_KEY` environment variable.
+  Previously it fell back to `~/.pi/free.json`, which could contain stale/revoked keys
+  that conflict with pi's built-in OpenRouter provider (which reads from
+  `~/.pi/agent/auth.json`).
+
+- **Removed `openrouter_api_key` from `PiFreeConfig` interface and config template** —
+  Prevents future persistence of OpenRouter keys in `free.json`, eliminating the
+  source of stale key conflicts for built-in providers.
+
 ## [2.0.3] - 2026-05-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering. Shows only $0 cost models by default. Supports Kilo (free OAuth), Cline (free), NVIDIA (freemium), ZenMux, CrofAI, Ollama Cloud, and more.",
 	"keywords": [


### PR DESCRIPTION
## Changes

- **v2.0.4 patch release**: OpenRouter key resolution fix — only checks `OPENROUTER_API_KEY` env var, no more `free.json` fallback.
- Updated `CHANGELOG.md` with 2.0.4 entry.
- Bumped `package.json` version.

## Testing

```
✓ 10 test files - 129 tests passed
```

## Next steps after merge

- Wait for CI to go green
- `npm publish` the new patch version