### PR TITLE
fix: use single-char-class regexes to fully resolve S5852

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -175,7 +175,7 @@ export function isUsableModel(modelId: string, minSizeB?: number): boolean {
 		if (KNOWN_SMALL_MODELS.has(baseId)) return false;
 
 		// Check Mixture-of-Experts models first (e.g., "8x22b" = 176b total)
-		const moeMatch = modelId.match(/(\d+)x(\d+\.?\d*)b/i);
+		const moeMatch = modelId.match(/(\d+)x([\d.]+)b/i);
 		if (moeMatch) {
 			const experts = Number.parseInt(moeMatch[1], 10);
 			const expertSize = Number.parseFloat(moeMatch[2]);
@@ -184,7 +184,7 @@ export function isUsableModel(modelId: string, minSizeB?: number): boolean {
 		}
 
 		// Standard model size (e.g., "70b", "8b")
-		const sizeMatch = modelId.match(/(\d+\.?\d*)b(?![.\d])/i);
+		const sizeMatch = modelId.match(/([\d.]+)b(?![.\d])/i);
 		if (sizeMatch) {
 			const modelSize = Number.parseFloat(sizeMatch[1]);
 			if (modelSize < minSizeB) return false;

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -271,7 +271,7 @@ function isVariantQualifier(segment: string): boolean {
  * AA uses instruct-70b order while providers often use 70b-instruct.
  */
 function normalizeSizeTokenOrder(id: string): string {
-	return id.replace(/(\d+\.?\d*b)-(instruct|chat)/gi, "$2-$1");
+	return id.replace(/([\d.]+b)-(instruct|chat)/gi, "$2-$1");
 }
 
 /**

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -87,11 +87,11 @@ async function fetchAIData(): Promise<AAModel[]> {
 }
 
 function normalizeModelName(name: string): string {
-	return name
-		.toLowerCase()
-		.replace(/[^-a-z0-9.]+/g, "-")
-		.replace(/^-+/, "")
-		.replace(/[-]{1,}$/, "");
+	name = name.toLowerCase().replace(/[^-a-z0-9.]+/g, "-");
+	// Strip leading/trailing dashes (no regex — avoids backtracking flags)
+	while (name.startsWith("-")) name = name.slice(1);
+	while (name.endsWith("-")) name = name.slice(0, -1);
+	return name;
 }
 
 function generateChunkFile(

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -45,7 +45,7 @@ vi.mock("../lib/util.ts", () => ({
 	isUsableModel: vi.fn((id: string, minSize?: number) => {
 		// Simple size check for testing
 		if (minSize !== undefined) {
-			const sizeMatch = id.match(/(\d+\.?\d*)b(?![.\d])/i);
+			const sizeMatch = id.match(/([\d.]+)b(?![.\d])/i);
 			if (sizeMatch) {
 				const size = Number.parseFloat(sizeMatch[1]);
 				if (size < minSize) return false;


### PR DESCRIPTION
## Problem

SonarCloud rescanned our first regex fix (switching from `(\d+(?:\.\d+)?)` to `(\d+\.?\d*)`) but still flags 5 S5852 hotspots. The `\d*` after `\d+` still creates a backtracking overlap.

## Fix

- **All size regexes**: changed from `\d+\.?\d*` → `[\d.]+` (one character class, one quantifier — guaranteed linear)
- **update-benchmarks.ts**: replaced regex dash stripping with `while (name.startsWith()/endsWith())` — zero regex

## Verification
- ✅ 208 tests pass
- ✅ TypeScript compiles clean