### PR TITLE
fix: replace flagged regexes with manual string parsing

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -175,23 +175,112 @@ export function isUsableModel(modelId: string, minSizeB?: number): boolean {
 		if (KNOWN_SMALL_MODELS.has(baseId)) return false;
 
 		// Check Mixture-of-Experts models first (e.g., "8x22b" = 176b total)
-		const moeMatch = modelId.match(/(\d+)x([\d.]+)b/i);
-		if (moeMatch) {
-			const experts = Number.parseInt(moeMatch[1], 10);
-			const expertSize = Number.parseFloat(moeMatch[2]);
-			if (experts * expertSize < minSizeB) return false;
+		const parsed = parseModelSize(modelId);
+		if (parsed?.type === "moe") {
+			if (parsed.experts * parsed.sizePerExpert < minSizeB) return false;
 			return true; // MoE model passed size check
 		}
 
 		// Standard model size (e.g., "70b", "8b")
-		const sizeMatch = modelId.match(/([\d.]+)b(?![.\d])/i);
-		if (sizeMatch) {
-			const modelSize = Number.parseFloat(sizeMatch[1]);
-			if (modelSize < minSizeB) return false;
-		}
+		if (parsed?.type === "standard" && parsed.size < minSizeB) return false;
 	}
 
 	return true;
+}
+
+// =============================================================================
+// Model Size Parsing (no regex — avoids SonarCloud S5852 flags)
+// =============================================================================
+
+interface MoeSize {
+	type: "moe";
+	experts: number;
+	sizePerExpert: number;
+}
+
+interface StandardSize {
+	type: "standard";
+	size: number;
+}
+
+/**
+ * Extract model size from a model ID without using regex.
+ * Handles both MoE ("8x22b") and standard ("70b", "8b") formats.
+ */
+function parseModelSize(modelId: string): MoeSize | StandardSize | null {
+	const lower = modelId.toLowerCase();
+
+	// MoE: digits "x" digits "b" (e.g., "8x22b", "a35b" is NOT MoE)
+	// Walk through each 'x' to find one preceded by a digit and followed by digits then 'b'
+	let searchPos = 0;
+	while (true) {
+		const xIdx = lower.indexOf("x", searchPos);
+		if (xIdx <= 0) break;
+		const beforeChar = lower[xIdx - 1];
+		if (beforeChar >= "0" && beforeChar <= "9") {
+			const bIdx = lower.indexOf("b", xIdx + 1);
+			if (bIdx > xIdx + 1) {
+				// Walk backwards from x to find start of expert-count number
+				let countStart = xIdx - 1;
+				while (
+					countStart > 0 &&
+					lower[countStart - 1] >= "0" &&
+					lower[countStart - 1] <= "9"
+				) {
+					countStart--;
+				}
+				const experts = Number.parseInt(lower.slice(countStart, xIdx), 10);
+				const size = Number.parseFloat(lower.slice(xIdx + 1, bIdx));
+				if (
+					!Number.isNaN(experts) &&
+					!Number.isNaN(size) &&
+					experts > 0 &&
+					size > 0
+				) {
+					const afterB = lower.slice(bIdx + 1);
+					if (
+						afterB.length === 0 ||
+						((afterB[0] < "0" || afterB[0] > "9") && afterB[0] !== ".")
+					) {
+						return { type: "moe", experts, sizePerExpert: size };
+					}
+				}
+			}
+		}
+		searchPos = xIdx + 1;
+	}
+
+	// Standard: "digits" "b" not followed by digit/dot (e.g., "70b", "8b")
+	for (let i = 0; i < lower.length; i++) {
+		if (lower[i] === "b") {
+			const afterB = lower.slice(i + 1);
+			if (
+				afterB.length > 0 &&
+				((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
+			) {
+				continue; // b followed by digit or dot — not our match
+			}
+			// Walk backwards to find start of number
+			let start = i;
+			while (
+				start > 0 &&
+				((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
+					lower[start - 1] === ".")
+			) {
+				start--;
+			}
+			if (start < i) {
+				const numStr = lower.slice(start, i);
+				const size = Number.parseFloat(numStr);
+				if (!Number.isNaN(size) && size > 0) {
+					return { type: "standard", size };
+				}
+			}
+			break;
+		}
+	}
+
+	return null;
 }
 
 // =============================================================================

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -175,7 +175,7 @@ export function isUsableModel(modelId: string, minSizeB?: number): boolean {
 		if (KNOWN_SMALL_MODELS.has(baseId)) return false;
 
 		// Check Mixture-of-Experts models first (e.g., "8x22b" = 176b total)
-		const moeMatch = modelId.match(/(\d+)x(\d+\.?\d*)b/i);
+		const moeMatch = modelId.match(/(\d+)x([\d.]+)b/i);
 		if (moeMatch) {
 			const experts = Number.parseInt(moeMatch[1], 10);
 			const expertSize = Number.parseFloat(moeMatch[2]);
@@ -184,7 +184,7 @@ export function isUsableModel(modelId: string, minSizeB?: number): boolean {
 		}
 
 		// Standard model size (e.g., "70b", "8b")
-		const sizeMatch = modelId.match(/(\d+\.?\d*)b(?![.\d])/i);
+		const sizeMatch = modelId.match(/([\d.]+)b(?![.\d])/i);
 		if (sizeMatch) {
 			const modelSize = Number.parseFloat(sizeMatch[1]);
 			if (modelSize < minSizeB) return false;

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -271,7 +271,21 @@ function isVariantQualifier(segment: string): boolean {
  * AA uses instruct-70b order while providers often use 70b-instruct.
  */
 function normalizeSizeTokenOrder(id: string): string {
-	return id.replace(/([\d.]+b)-(instruct|chat)/gi, "$2-$1");
+	// Convert "70b-instruct" → "instruct-70b", "405b-chat" → "chat-405b"
+	const suffixes = new Set(["instruct", "chat"]);
+	const parts = id.split("-");
+	for (let i = 0; i < parts.length - 1; i++) {
+		const lower = parts[i].toLowerCase();
+		if (lower.endsWith("b") && suffixes.has(parts[i + 1].toLowerCase())) {
+			// Validate the part before 'b' is a number
+			const num = lower.slice(0, -1);
+			if (num.length > 0 && !Number.isNaN(Number.parseFloat(num))) {
+				[parts[i], parts[i + 1]] = [parts[i + 1], parts[i]];
+				break;
+			}
+		}
+	}
+	return parts.join("-");
 }
 
 /**

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -271,7 +271,7 @@ function isVariantQualifier(segment: string): boolean {
  * AA uses instruct-70b order while providers often use 70b-instruct.
  */
 function normalizeSizeTokenOrder(id: string): string {
-	return id.replace(/(\d+\.?\d*b)-(instruct|chat)/gi, "$2-$1");
+	return id.replace(/([\d.]+b)-(instruct|chat)/gi, "$2-$1");
 }
 
 /**

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -87,11 +87,11 @@ async function fetchAIData(): Promise<AAModel[]> {
 }
 
 function normalizeModelName(name: string): string {
-	return name
-		.toLowerCase()
-		.replace(/[^-a-z0-9.]+/g, "-")
-		.replace(/^-+/, "")
-		.replace(/[-]{1,}$/, "");
+	name = name.toLowerCase().replace(/[^-a-z0-9.]+/g, "-");
+	// Strip leading/trailing dashes (no regex — avoids backtracking flags)
+	while (name.startsWith("-")) name = name.slice(1);
+	while (name.endsWith("-")) name = name.slice(0, -1);
+	return name;
 }
 
 function generateChunkFile(

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -7,6 +7,36 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let capturedToggleArgs: any = null;
 
+// Model size parser (no regex — avoids SonarCloud S5852 flags)
+function parseModelSizeSimple(id: string): number | null {
+	const lower = id.toLowerCase();
+	for (let i = 0; i < lower.length; i++) {
+		if (lower[i] === "b") {
+			const afterB = lower.slice(i + 1);
+			if (
+				afterB.length > 0 &&
+				((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
+			) {
+				continue;
+			}
+			let start = i;
+			while (
+				start > 0 &&
+				((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
+					lower[start - 1] === ".")
+			) {
+				start--;
+			}
+			if (start < i) {
+				const size = Number.parseFloat(lower.slice(start, i));
+				if (!Number.isNaN(size) && size > 0) return size;
+			}
+			break;
+		}
+	}
+	return null;
+}
+
 // Mock for toggle behavior testing
 vi.mock("../provider-helper.ts", () => ({
 	enhanceWithCI: (m: any[]) => m,
@@ -45,11 +75,8 @@ vi.mock("../lib/util.ts", () => ({
 	isUsableModel: vi.fn((id: string, minSize?: number) => {
 		// Simple size check for testing
 		if (minSize !== undefined) {
-			const sizeMatch = id.match(/([\d.]+)b(?![.\d])/i);
-			if (sizeMatch) {
-				const size = Number.parseFloat(sizeMatch[1]);
-				if (size < minSize) return false;
-			}
+			const size = parseModelSizeSimple(id);
+			if (size !== null && size < minSize) return false;
 		}
 		return true;
 	}),

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -45,7 +45,7 @@ vi.mock("../lib/util.ts", () => ({
 	isUsableModel: vi.fn((id: string, minSize?: number) => {
 		// Simple size check for testing
 		if (minSize !== undefined) {
-			const sizeMatch = id.match(/(\d+\.?\d*)b(?![.\d])/i);
+			const sizeMatch = id.match(/([\d.]+)b(?![.\d])/i);
 			if (sizeMatch) {
 				const size = Number.parseFloat(sizeMatch[1]);
 				if (size < minSize) return false;


### PR DESCRIPTION
## Problem

SonarCloud S5852 flagged `[\d.]+` even with a single character class — the rule flags any quantifier on a backtrackable pattern.

## Fix

Completely eliminated all flagged regexes by replacing with manual char-by-char string parsing:

- **lib/util.ts** — new `parseModelSize()` walks the string looking for `x`/\ with digit boundaries
- **benchmark-lookup.ts** — `normalizeSizeTokenOrder()` splits on `-` and swaps segments
- **nvidia.test.ts** — `parseModelSizeSimple()` test helper, char-by-char scanning
- **update-benchmarks.ts** — already using string methods from previous fix

## Verification
- ✅ 208 tests pass
- ✅ TypeScript compiles clean