### PR TITLE
feat: add Codestral provider via codestral.mistral.ai endpoint

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -27,6 +27,7 @@ interface PiFreeConfig {
 	ollama_api_key?: string;
 	zenmux_api_key?: string;
 	crofai_api_key?: string;
+	codestral_api_key?: string;
 	mistral_api_key?: string;
 	groq_api_key?: string;
 	cerebras_api_key?: string;
@@ -40,6 +41,7 @@ interface PiFreeConfig {
 	cline_show_paid?: boolean;
 	zenmux_show_paid?: boolean;
 	crofai_show_paid?: boolean;
+	codestral_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
 	opencode_show_paid?: boolean;
 }
@@ -49,6 +51,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	ollama_api_key: "",
 	zenmux_api_key: "",
 	crofai_api_key: "",
+	codestral_api_key: "",
 	mistral_api_key: "",
 	groq_api_key: "",
 	cerebras_api_key: "",
@@ -63,6 +66,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	cline_show_paid: false,
 	zenmux_show_paid: false,
 	crofai_show_paid: false,
+	codestral_show_paid: false,
 	openrouter_show_paid: false,
 	opencode_show_paid: false,
 };
@@ -147,6 +151,13 @@ export function getCrofaiShowPaid(): boolean {
 	return resolveBool("CROFAI_SHOW_PAID", loadConfigFile().crofai_show_paid);
 }
 
+export function getCodestralShowPaid(): boolean {
+	return resolveBool(
+		"CODESTRAL_SHOW_PAID",
+		loadConfigFile().codestral_show_paid,
+	);
+}
+
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -188,6 +199,10 @@ export function getZenmuxApiKey(): string | undefined {
 
 export function getCrofaiApiKey(): string | undefined {
 	return resolve("CROFAI_API_KEY", loadConfigFile().crofai_api_key);
+}
+
+export function getCodestralApiKey(): string | undefined {
+	return resolve("CODESTRAL_API_KEY", loadConfigFile().codestral_api_key);
 }
 
 export function getOllamaApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -17,6 +17,7 @@ export const PROVIDER_QWEN = "qwen";
 export const PROVIDER_MODAL = "modal";
 export const PROVIDER_ZENMUX = "zenmux";
 export const PROVIDER_CROFAI = "crofai";
+export const PROVIDER_CODESTRAL = "codestral";
 
 export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_KILO,
@@ -28,6 +29,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_OLLAMA,
 	PROVIDER_ZENMUX,
 	PROVIDER_CROFAI,
+	PROVIDER_CODESTRAL,
 ] as const;
 
 // =============================================================================
@@ -44,6 +46,7 @@ export const BASE_URL_QWEN =
 	"https://dashscope.aliyuncs.com/compatible-mode/v1";
 export const BASE_URL_ZENMUX = "https://zenmux.ai/api/v1";
 export const BASE_URL_CROFAI = "https://crof.ai/v1";
+export const BASE_URL_CODESTRAL = "https://codestral.mistral.ai/v1";
 
 /** Cline fetches free models from OpenRouter */
 export const BASE_URL_OPENROUTER = "https://openrouter.ai/api/v1";

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@
  * - NVIDIA: NVIDIA NIM hosting (free tier available)
  * - Ollama Cloud: Ollama's cloud-hosted models with usage-based free tier
  * - ZenMux: Unified AI API gateway with 200+ models
+ * - Codestral: Mistral's code-focused model via codestral.mistral.ai (free tier)
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -24,6 +25,7 @@ import {
 } from "./lib/registry.ts";
 // Import unique provider extensions (only providers NOT built into pi)
 import cline from "./providers/cline/cline.ts";
+import codestral from "./providers/codestral/codestral.ts";
 import crofai from "./providers/crofai/crofai.ts";
 import kilo from "./providers/kilo/kilo.ts";
 import nvidia from "./providers/nvidia/nvidia.ts";
@@ -143,6 +145,7 @@ export default async function (pi: ExtensionAPI) {
 		cline(pi),
 		zenmux(pi),
 		crofai(pi),
+		codestral(pi),
 	]);
 
 	// Setup dynamic built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face)

--- a/providers/codestral/codestral.ts
+++ b/providers/codestral/codestral.ts
@@ -1,0 +1,134 @@
+/**
+ * Codestral Provider Extension
+ *
+ * Codestral is Mistral AI's code-focused model. This provider registers it
+ * through the Codestral-specific endpoint (codestral.mistral.ai) using
+ * OpenAI-compatible chat completions — separate from the built-in "mistral"
+ * provider which uses api.mistral.ai with the Mistral SDK.
+ *
+ * Free tier (Experiment plan):
+ *   - 2 req/min, 500K tokens/min, 1B tokens/month
+ *   - No credit card — phone verification only
+ *   - Sign up at https://console.mistral.ai/codestral
+ *
+ * Endpoints:
+ *   Chat:  https://codestral.mistral.ai/v1/chat/completions
+ *   FIM:   https://codestral.mistral.ai/v1/fim/completions (not used by pi)
+ *
+ * Setup:
+ *   1. Get API key from https://console.mistral.ai/codestral
+ *   2. Set CODESTRAL_API_KEY env var (or MISTRAL_API_KEY as fallback)
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Set CODESTRAL_API_KEY env var
+ *   # Models appear in /model selector as "codestral/codestral-latest"
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { getCodestralApiKey, getMistralApiKey } from "../../config.ts";
+import { BASE_URL_CODESTRAL, PROVIDER_CODESTRAL } from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import {
+	createReRegister,
+	enhanceWithCI,
+	setupProvider,
+} from "../../provider-helper.ts";
+
+const _logger = createLogger("codestral");
+
+// =============================================================================
+// Model Definition
+// =============================================================================
+
+const CODESTRAL_MODEL: ProviderModelConfig = {
+	id: "codestral-latest",
+	name: "Codestral",
+	reasoning: false,
+	input: ["text"],
+	cost: {
+		input: 0.3,
+		output: 0.9,
+		cacheRead: 0,
+		cacheWrite: 0,
+	},
+	contextWindow: 256_000,
+	maxTokens: 4_096,
+};
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function codestralProvider(pi: ExtensionAPI) {
+	// Try CODESTRAL_API_KEY first, fall back to MISTRAL_API_KEY
+	const apiKey = getCodestralApiKey() || getMistralApiKey();
+
+	if (!apiKey) {
+		_logger.info(
+			"[codestral] Skipping — neither CODESTRAL_API_KEY nor MISTRAL_API_KEY set",
+		);
+		return;
+	}
+
+	const keySource = getCodestralApiKey()
+		? "CODESTRAL_API_KEY"
+		: "MISTRAL_API_KEY";
+	_logger.info(`[codestral] Using key from ${keySource}`);
+
+	const allModels = [CODESTRAL_MODEL];
+	const freeModels = allModels; // All $0.30/$0.90 — still accessible via Experiment free tier
+	const stored = { free: freeModels, all: allModels };
+
+	// Create re-register function
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_CODESTRAL,
+		baseUrl: BASE_URL_CODESTRAL,
+		apiKey,
+	});
+
+	// Register with global toggle
+	registerWithGlobalToggle(PROVIDER_CODESTRAL, stored, reRegister, true);
+
+	// Setup provider (toggle command, status bar, error handling)
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_CODESTRAL,
+			initialShowPaid: false,
+			skipToggle: true, // Only one model, no toggle needed
+			reRegister: (models) => {
+				stored.free = models;
+				stored.all = models;
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	// Initial registration
+	pi.registerProvider(PROVIDER_CODESTRAL, {
+		baseUrl: BASE_URL_CODESTRAL,
+		apiKey,
+		api: "openai-completions" as const,
+		models: enhanceWithCI(freeModels, PROVIDER_CODESTRAL),
+	});
+
+	_logger.info(`[codestral] Registered codestral-latest via ${keySource}`);
+
+	// Status bar
+	pi.on("model_select", (_event, ctx) => {
+		if (_event.model?.provider !== PROVIDER_CODESTRAL) {
+			ctx.ui.setStatus(`${PROVIDER_CODESTRAL}-status`, undefined);
+			return;
+		}
+		ctx.ui.setStatus(
+			`${PROVIDER_CODESTRAL}-status`,
+			`codestral: 1 model (free tier) 🔑`,
+		);
+	});
+}


### PR DESCRIPTION
Registers Codestral as a separate 'codestral' provider using OpenAI-compatible chat completions at codestral.mistral.ai/v1.

- Uses CODESTRAL_API_KEY, falls back to MISTRAL_API_KEY
- Free Experiment tier: 2 RPM, 500K tokens/min, 1B tokens/month
- Single model: codestral-latest (256K context, 4K max output)
- Separate from built-in 'mistral' provider (which uses api.mistral.ai + Mistral SDK)