### PR TITLE
fix: switch Codestral from openai-completions to mistral-conversations API

### DIFF
--- a/providers/codestral/codestral.ts
+++ b/providers/codestral/codestral.ts
@@ -3,8 +3,13 @@
  *
  * Codestral is Mistral AI's code-focused model. This provider registers it
  * through the Codestral-specific endpoint (codestral.mistral.ai) using
- * OpenAI-compatible chat completions — separate from the built-in "mistral"
- * provider which uses api.mistral.ai with the Mistral SDK.
+ * the Mistral SDK (api: "mistral-conversations") — separate from the built-in
+ * "mistral" provider which uses api.mistral.ai.
+ *
+ * NOTE: Do NOT use api: "openai-completions" here. Codestral's API is
+ * Mistral-format (camelCase fields, maxTokens, no stream_options/store).
+ * The OpenAI completions adapter sends OpenAI-specific fields that Mistral
+ * rejects with HTTP 422 "Extra inputs are not permitted".
  *
  * Free tier (Experiment plan):
  *   - 2 req/min, 500K tokens/min, 1B tokens/month
@@ -33,11 +38,7 @@ import { getCodestralApiKey, getMistralApiKey } from "../../config.ts";
 import { BASE_URL_CODESTRAL, PROVIDER_CODESTRAL } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import {
-	createReRegister,
-	enhanceWithCI,
-	setupProvider,
-} from "../../provider-helper.ts";
+import { enhanceWithCI, setupProvider } from "../../provider-helper.ts";
 
 const _logger = createLogger("codestral");
 
@@ -84,12 +85,17 @@ export default async function codestralProvider(pi: ExtensionAPI) {
 	const freeModels = allModels; // All $0.30/$0.90 — still accessible via Experiment free tier
 	const stored = { free: freeModels, all: allModels };
 
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_CODESTRAL,
-		baseUrl: BASE_URL_CODESTRAL,
-		apiKey,
-	});
+	// Re-register function — uses mistral-conversations API (Mistral SDK)
+	// NOT openai-completions: Codestral uses the same API format as Mistral
+	// and rejects OpenAI-specific fields (stream_options, store, max_completion_tokens) with 422.
+	const reRegister = (models: typeof freeModels) => {
+		pi.registerProvider(PROVIDER_CODESTRAL, {
+			baseUrl: BASE_URL_CODESTRAL,
+			apiKey,
+			api: "mistral-conversations" as const,
+			models: enhanceWithCI(models, PROVIDER_CODESTRAL),
+		});
+	};
 
 	// Register with global toggle
 	registerWithGlobalToggle(PROVIDER_CODESTRAL, stored, reRegister, true);
@@ -110,13 +116,8 @@ export default async function codestralProvider(pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Initial registration
-	pi.registerProvider(PROVIDER_CODESTRAL, {
-		baseUrl: BASE_URL_CODESTRAL,
-		apiKey,
-		api: "openai-completions" as const,
-		models: enhanceWithCI(freeModels, PROVIDER_CODESTRAL),
-	});
+	// Initial registration — uses mistral-conversations API (Mistral SDK)
+	reRegister(freeModels);
 
 	_logger.info(`[codestral] Registered codestral-latest via ${keySource}`);
 


### PR DESCRIPTION
## Problem

The Codestral provider was using `api: \openai-completions\`, which routes through pi's OpenAI completions adapter. This adapter sends OpenAI-specific fields that Mistral's API rejects with **HTTP 422 "Extra inputs are not permitted"**:

| Field | Status |
|---|---|
| `stream_options: { include_usage: true }` | ❌ OpenAI-only |
| `store: false` | ❌ OpenAI-only |
| `max_completion_tokens` | ❌ Mistral uses `maxTokens` |
| `prompt_cache_key` / `prompt_cache_retention` | ❌ OpenAI-only |

This is a well-known issue — Mistral's API is notoriously strict about unrecognized fields (see langchain-ai/langchainjs#5144, open-webui/open-webui#10167, microsoft/autogen#2748).

## Fix

Switched the API type from `\openai-completions\` → `\mistral-conversations\`, which uses pi's built-in Mistral SDK. Since `codestral.mistral.ai` uses the exact same API format as `api.mistral.ai`, the Mistral SDK sends properly formatted requests with only recognized fields in the correct camelCase format (`maxTokens`, `toolCalls`, `toolCallId`).

Also removed the `createReRegister` dependency (which hardcoded `api: \openai-completions\`) and wrote a direct re-registration function.

## Files changed

- `providers/codestral/codestral.ts` — switched API type and rewrote re-registration