### PR TITLE
feat: add LLM7.io provider

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -29,6 +29,7 @@ interface PiFreeConfig {
 	crofai_api_key?: string;
 	codestral_api_key?: string;
 	mistral_api_key?: string;
+	llm7_api_key?: string;
 	groq_api_key?: string;
 	cerebras_api_key?: string;
 	xai_api_key?: string;
@@ -42,6 +43,7 @@ interface PiFreeConfig {
 	zenmux_show_paid?: boolean;
 	crofai_show_paid?: boolean;
 	codestral_show_paid?: boolean;
+	llm7_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
 	opencode_show_paid?: boolean;
 }
@@ -53,6 +55,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	crofai_api_key: "",
 	codestral_api_key: "",
 	mistral_api_key: "",
+	llm7_api_key: "",
 	groq_api_key: "",
 	cerebras_api_key: "",
 	xai_api_key: "",
@@ -67,6 +70,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	zenmux_show_paid: false,
 	crofai_show_paid: false,
 	codestral_show_paid: false,
+	llm7_show_paid: false,
 	openrouter_show_paid: false,
 	opencode_show_paid: false,
 };
@@ -158,6 +162,10 @@ export function getCodestralShowPaid(): boolean {
 	);
 }
 
+export function getLlm7ShowPaid(): boolean {
+	return resolveBool("LLM7_SHOW_PAID", loadConfigFile().llm7_show_paid);
+}
+
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -203,6 +211,10 @@ export function getCrofaiApiKey(): string | undefined {
 
 export function getCodestralApiKey(): string | undefined {
 	return resolve("CODESTRAL_API_KEY", loadConfigFile().codestral_api_key);
+}
+
+export function getLlm7ApiKey(): string | undefined {
+	return resolve("LLM7_API_KEY", loadConfigFile().llm7_api_key);
 }
 
 export function getOllamaApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -18,6 +18,7 @@ export const PROVIDER_MODAL = "modal";
 export const PROVIDER_ZENMUX = "zenmux";
 export const PROVIDER_CROFAI = "crofai";
 export const PROVIDER_CODESTRAL = "codestral";
+export const PROVIDER_LLM7 = "llm7";
 
 export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_KILO,
@@ -30,6 +31,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_ZENMUX,
 	PROVIDER_CROFAI,
 	PROVIDER_CODESTRAL,
+	PROVIDER_LLM7,
 ] as const;
 
 // =============================================================================
@@ -47,6 +49,7 @@ export const BASE_URL_QWEN =
 export const BASE_URL_ZENMUX = "https://zenmux.ai/api/v1";
 export const BASE_URL_CROFAI = "https://crof.ai/v1";
 export const BASE_URL_CODESTRAL = "https://codestral.mistral.ai/v1";
+export const BASE_URL_LLM7 = "https://api.llm7.io/v1";
 
 /** Cline fetches free models from OpenRouter */
 export const BASE_URL_OPENROUTER = "https://openrouter.ai/api/v1";

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ import cline from "./providers/cline/cline.ts";
 import codestral from "./providers/codestral/codestral.ts";
 import crofai from "./providers/crofai/crofai.ts";
 import kilo from "./providers/kilo/kilo.ts";
+import llm7 from "./providers/llm7/llm7.ts";
 import nvidia from "./providers/nvidia/nvidia.ts";
 import ollama from "./providers/ollama/ollama.ts";
 import zenmux from "./providers/zenmux/zenmux.ts";
@@ -146,6 +147,7 @@ export default async function (pi: ExtensionAPI) {
 		zenmux(pi),
 		crofai(pi),
 		codestral(pi),
+		llm7(pi),
 	]);
 
 	// Setup dynamic built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face)

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -1,0 +1,157 @@
+/**
+ * LLM7.io Provider Extension
+ *
+ * LLM7.io is an LLM API gateway that routes requests across multiple
+ * providers (OpenAI, Mistral, Google, DeepSeek, Cloudflare, etc.) through
+ * a single OpenAI-compatible endpoint.
+ *
+ * Free tier:
+ *   - Free token from https://token.llm7.io/
+ *   - 100 req/hr, 20 req/min, 2 req/s
+ *   - No credit card required
+ *
+ * Pro tier ($12/mo):
+ *   - Higher rate limits, JSON mode, function calling
+ *   - Access to "pro" routing selector
+ *
+ * Model selectors (not specific model IDs — LLM7 routes randomly):
+ *   - "default" — first available free model (free)
+ *   - "fast" — lowest latency option (free)
+ *   - "pro" — highest quality, longer reasoning (paid)
+ *
+ * Endpoint:
+ *   Chat: https://api.llm7.io/v1/chat/completions
+ *
+ * Setup:
+ *   1. Get free token from https://token.llm7.io/
+ *   2. Set LLM7_API_KEY env var (or add to ~/.pi/free.json)
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Set LLM7_API_KEY env var
+ *   # Models appear in /model selector as "llm7/default", "llm7/fast", "llm7/pro"
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { getLlm7ApiKey, getLlm7ShowPaid } from "../../config.ts";
+import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import {
+	createReRegister,
+	enhanceWithCI,
+	setupProvider,
+} from "../../provider-helper.ts";
+
+const _logger = createLogger("llm7");
+
+// =============================================================================
+// Model Definitions
+// =============================================================================
+
+const LLM7_MODELS: ProviderModelConfig[] = [
+	{
+		id: "default",
+		name: "LLM7 Default",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	},
+	{
+		id: "fast",
+		name: "LLM7 Fast",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	},
+	{
+		id: "pro",
+		name: "LLM7 Pro",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0.3, // Requires $12/mo LLM7 Pro subscription
+			output: 0.9,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	},
+];
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function llm7Provider(pi: ExtensionAPI) {
+	const apiKey = getLlm7ApiKey();
+
+	if (!apiKey) {
+		_logger.info(
+			"[llm7] Skipping — LLM7_API_KEY not set. Get a free token at https://token.llm7.io/",
+		);
+		return;
+	}
+
+	_logger.info("[llm7] Using LLM7_API_KEY");
+
+	const allModels = LLM7_MODELS;
+	const freeModels = allModels.filter((m) =>
+		isFreeModel({ ...m, provider: PROVIDER_LLM7 }, allModels),
+	);
+
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[llm7] Registered ${allModels.length} models (${freeModels.length} free)`,
+	);
+
+	// Create re-register function
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_LLM7,
+		baseUrl: BASE_URL_LLM7,
+		apiKey,
+	});
+
+	// Register with global toggle
+	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, true);
+
+	// Setup provider with toggle command
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_LLM7,
+			initialShowPaid: getLlm7ShowPaid(),
+			tosUrl: "https://llm7.io/",
+			reRegister: (models, _stored) => {
+				if (_stored) {
+					stored.free = _stored.free;
+					stored.all = _stored.all;
+				}
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	// Initial registration
+	reRegister(freeModels);
+}


### PR DESCRIPTION
## What

Adds [LLM7.io](https://llm7.io/) as a new provider — an OpenAI-compatible API gateway that routes requests across multiple providers (OpenAI, Mistral, Google, DeepSeek, Cloudflare, etc.) through a single endpoint.

## Provider details

| | |
|---|---|
| **Base URL** | `https://api.llm7.io/v1` |
| **API format** | OpenAI-compatible |
| **Auth** | `LLM7_API_KEY` env var (free token from [token.llm7.io](https://token.llm7.io/)) |
| **Free models** | `default`, `fast` (random routing across providers) |
| **Paid model** | `pro` (requires $12/mo LLM7 Pro subscription) |
| **Rate limits (free)** | 100 req/hr, 20 req/min, 2 req/s |
| **Streaming** | ✅ Supported |

## Setup

```bash
# Get a free token at https://token.llm7.io/
export LLM7_API_KEY=your-token-here
```

Then select `llm7/default` or `llm7/fast` from the /model selector. Toggle paid models with `/toggle-llm7`.

## Files

- `providers/llm7/llm7.ts` — new provider (138 lines)
- `constants.ts` — added `PROVIDER_LLM7`, `BASE_URL_LLM7`
- `config.ts` — added `llm7_api_key`, `llm7_show_paid` getters
- `index.ts` — import + load `llm7(pi)`