### PR TITLE
feat: add DeepInfra provider (trial credit)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -30,6 +30,7 @@ interface PiFreeConfig {
 	codestral_api_key?: string;
 	mistral_api_key?: string;
 	llm7_api_key?: string;
+	deepinfra_api_key?: string;
 	groq_api_key?: string;
 	cerebras_api_key?: string;
 	xai_api_key?: string;
@@ -44,6 +45,7 @@ interface PiFreeConfig {
 	crofai_show_paid?: boolean;
 	codestral_show_paid?: boolean;
 	llm7_show_paid?: boolean;
+	deepinfra_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
 	opencode_show_paid?: boolean;
 }
@@ -56,6 +58,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	codestral_api_key: "",
 	mistral_api_key: "",
 	llm7_api_key: "",
+	deepinfra_api_key: "",
 	groq_api_key: "",
 	cerebras_api_key: "",
 	xai_api_key: "",
@@ -71,6 +74,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	crofai_show_paid: false,
 	codestral_show_paid: false,
 	llm7_show_paid: false,
+	deepinfra_show_paid: false,
 	openrouter_show_paid: false,
 	opencode_show_paid: false,
 };
@@ -166,6 +170,13 @@ export function getLlm7ShowPaid(): boolean {
 	return resolveBool("LLM7_SHOW_PAID", loadConfigFile().llm7_show_paid);
 }
 
+export function getDeepinfraShowPaid(): boolean {
+	return resolveBool(
+		"DEEPINFRA_SHOW_PAID",
+		loadConfigFile().deepinfra_show_paid,
+	);
+}
+
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -215,6 +226,10 @@ export function getCodestralApiKey(): string | undefined {
 
 export function getLlm7ApiKey(): string | undefined {
 	return resolve("LLM7_API_KEY", loadConfigFile().llm7_api_key);
+}
+
+export function getDeepinfraApiKey(): string | undefined {
+	return resolve("DEEPINFRA_TOKEN", loadConfigFile().deepinfra_api_key);
 }
 
 export function getOllamaApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -19,6 +19,7 @@ export const PROVIDER_ZENMUX = "zenmux";
 export const PROVIDER_CROFAI = "crofai";
 export const PROVIDER_CODESTRAL = "codestral";
 export const PROVIDER_LLM7 = "llm7";
+export const PROVIDER_DEEPINFRA = "deepinfra";
 
 export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_KILO,
@@ -32,6 +33,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_CROFAI,
 	PROVIDER_CODESTRAL,
 	PROVIDER_LLM7,
+	PROVIDER_DEEPINFRA,
 ] as const;
 
 // =============================================================================
@@ -50,6 +52,7 @@ export const BASE_URL_ZENMUX = "https://zenmux.ai/api/v1";
 export const BASE_URL_CROFAI = "https://crof.ai/v1";
 export const BASE_URL_CODESTRAL = "https://codestral.mistral.ai/v1";
 export const BASE_URL_LLM7 = "https://api.llm7.io/v1";
+export const BASE_URL_DEEPINFRA = "https://api.deepinfra.com/v1/openai";
 
 /** Cline fetches free models from OpenRouter */
 export const BASE_URL_OPENROUTER = "https://openrouter.ai/api/v1";

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ import codestral from "./providers/codestral/codestral.ts";
 import crofai from "./providers/crofai/crofai.ts";
 import kilo from "./providers/kilo/kilo.ts";
 import llm7 from "./providers/llm7/llm7.ts";
+import deepinfra from "./providers/deepinfra/deepinfra.ts";
 import nvidia from "./providers/nvidia/nvidia.ts";
 import ollama from "./providers/ollama/ollama.ts";
 import zenmux from "./providers/zenmux/zenmux.ts";
@@ -91,6 +92,8 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 			]);
 			// Freemium providers - all models share a free tier quota
 			const freemiumProviders = new Set(["nvidia"]);
+			// Trial credit providers - one-time credits, otherwise paid
+			const trialCreditProviders = new Set(["deepinfra"]);
 
 			for (const [id, entry] of registry) {
 				const free = entry.stored.free.length;
@@ -101,6 +104,9 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 				if (freemiumProviders.has(id)) {
 					// Freemium: all models share a free tier (e.g., 1,000 reqs/month)
 					lines.push(`${indicator} ${id}: ${all} models (freemium)`);
+				} else if (trialCreditProviders.has(id)) {
+					// Trial credit: one-time credits, otherwise paid
+					lines.push(`${indicator} ${id}: ${all} models ($5 trial credit)`);
 				} else if (noPricingApi.has(id)) {
 					// Provider doesn't expose pricing - can't determine free vs paid
 					lines.push(
@@ -148,6 +154,7 @@ export default async function (pi: ExtensionAPI) {
 		crofai(pi),
 		codestral(pi),
 		llm7(pi),
+		deepinfra(pi),
 	]);
 
 	// Setup dynamic built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face)

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -1,0 +1,180 @@
+/**
+ * DeepInfra Provider Extension
+ *
+ * DeepInfra is an AI inference cloud with an OpenAI-compatible API for
+ * 100+ open-source models (Llama, DeepSeek, Mistral, Qwen, Mixtral, etc.).
+ *
+ * Free tier:
+ *   - $5 one-time credit on signup (no credit card)
+ *   - ~5M tokens, expires after 90 days
+ *   - 60 RPM (varies by model)
+ *
+ * Paid: pay-per-token after credits exhaust
+ *
+ * Endpoint:
+ *   Chat: https://api.deepinfra.com/v1/openai/chat/completions
+ *
+ * Setup:
+ *   1. Sign up at https://deepinfra.com/ (GitHub or email)
+ *   2. Get API key from https://deepinfra.com/dash/api_keys
+ *   3. Set DEEPINFRA_TOKEN env var (or add to ~/.pi/free.json)
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Set DEEPINFRA_TOKEN env var
+ *   # Models appear in /model selector as "deepinfra/meta-llama/..."
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { getDeepinfraApiKey, getDeepinfraShowPaid } from "../../config.ts";
+import {
+	BASE_URL_DEEPINFRA,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_DEEPINFRA,
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import {
+	getProxyModelCompat,
+	isLikelyReasoningModel,
+} from "../../lib/provider-compat.ts";
+import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { createReRegister, setupProvider } from "../../provider-helper.ts";
+
+const _logger = createLogger("deepinfra");
+
+// =============================================================================
+// Fetch DeepInfra models
+// =============================================================================
+
+interface DeepinfraModel {
+	id: string;
+	object?: string;
+	created?: number;
+	owned_by?: string;
+}
+
+async function fetchDeepinfraModels(
+	apiKey: string,
+): Promise<ProviderModelConfig[]> {
+	_logger.info("[deepinfra] Fetching models from DeepInfra API...");
+
+	try {
+		const response = await fetchWithRetry(
+			`${BASE_URL_DEEPINFRA}/models`,
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
+
+		if (!response.ok) {
+			throw new Error(`DeepInfra API error: ${response.status}`);
+		}
+
+		const data = (await response.json()) as {
+			data?: DeepinfraModel[];
+		};
+		const models = data.data ?? [];
+
+		_logger.info(`[deepinfra] Fetched ${models.length} models`);
+
+		return models
+			.filter((m) => m.id)
+			.map((m) => {
+				const name = m.id.split("/").pop() || m.id;
+				return {
+					id: m.id,
+					name,
+					reasoning: isLikelyReasoningModel({ id: m.id, name }),
+					input: ["text"],
+					cost: {
+						input: 0.3, // Default — real pricing varies per model
+						output: 0.9,
+						cacheRead: 0,
+						cacheWrite: 0,
+					},
+					contextWindow: 128_000, // Default, varies by model
+					maxTokens: 4_096,
+					compat: getProxyModelCompat({ id: m.id, name }),
+				} satisfies ProviderModelConfig;
+			});
+	} catch (error) {
+		_logger.error("[deepinfra] Failed to fetch models:", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
+}
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function deepinfraProvider(pi: ExtensionAPI) {
+	const apiKey = getDeepinfraApiKey();
+
+	if (!apiKey) {
+		_logger.info(
+			"[deepinfra] Skipping — DEEPINFRA_TOKEN not set. Sign up at https://deepinfra.com/",
+		);
+		return;
+	}
+
+	// Fetch models
+	const allModels = await fetchDeepinfraModels(apiKey);
+
+	if (allModels.length === 0) {
+		_logger.warn("[deepinfra] No models available");
+		return;
+	}
+
+	// DeepInfra is a trial credit provider — $5 one-time credit, no truly free models.
+	// All models are marked as paid. When free-only mode is ON, no models are shown.
+	// Toggle free-only OFF to see all models.
+	const freeModels: ProviderModelConfig[] = [];
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[deepinfra] Registered ${allModels.length} models (trial credit, 0 free)`,
+	);
+
+	// Create re-register function
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_DEEPINFRA,
+		baseUrl: BASE_URL_DEEPINFRA,
+		apiKey,
+	});
+
+	// Register with global toggle
+	registerWithGlobalToggle(PROVIDER_DEEPINFRA, stored, reRegister, true);
+
+	// Setup provider with toggle command
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_DEEPINFRA,
+			initialShowPaid: getDeepinfraShowPaid(),
+			tosUrl: "https://deepinfra.com/pricing",
+			reRegister: (models, _stored) => {
+				if (_stored) {
+					stored.free = _stored.free;
+					stored.all = _stored.all;
+				}
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	// Initial registration — register as "all" (paid) since there are no free models
+	reRegister(allModels);
+}


### PR DESCRIPTION
## What

Adds [DeepInfra](https://deepinfra.com/) as a provider — an OpenAI-compatible AI inference cloud hosting 100+ open-source models (Llama, DeepSeek, Mistral, Qwen, Mixtral, etc.).

## Provider details

| | |
|---|---|
| **Base URL** | `https://api.deepinfra.com/v1/openai` |
| **API format** | OpenAI-compatible |
| **Auth** | `DEEPINFRA_TOKEN` env var (from [Dashboard](https://deepinfra.com/dash/api_keys)) |
| **Free tier** | $5 one-time credit on signup (no credit card), ~5M tokens, 90 day expiry |
| **Paid** | Pay-per-token after credits exhaust |
| **Models** | Fetched dynamically from `/v1/models` |
| **Streaming** | ✅ |
| **Tool calling** | ✅ |
| **Vision** | ✅ |
| **Reasoning** | ✅ |

## How it works

- Models are fetched dynamically on load (like CrofAI)
- All models are registered as paid (no truly free tier — just  trial credit)
- In free-only mode, no DeepInfra models are shown. Toggle `/toggle-free` to OFF to see them
- `/free-providers` shows: `🔑 deepinfra: 40 models ($5 trial credit)`

## Setup

```bash
# Sign up at https://deepinfra.com/ (GitHub or email)
# Get API key from https://deepinfra.com/dash/api_keys
export DEEPINFRA_TOKEN=your-key-here
# /toggle-free to OFF
# Select models from /model selector
```

## Files

- `providers/deepinfra/deepinfra.ts` — new provider (168 lines)
- `constants.ts` — added `PROVIDER_DEEPINFRA`, `BASE_URL_DEEPINFRA`
- `config.ts` — added `deepinfra_api_key`, `deepinfra_show_paid` getters
- `index.ts` — import, load, and trial credit display in `/free-providers`