### PR TITLE
feat: add SambaNova provider (free tier, no credit card)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -31,6 +31,7 @@ interface PiFreeConfig {
 	mistral_api_key?: string;
 	llm7_api_key?: string;
 	deepinfra_api_key?: string;
+	sambanova_api_key?: string;
 	groq_api_key?: string;
 	cerebras_api_key?: string;
 	xai_api_key?: string;
@@ -46,6 +47,7 @@ interface PiFreeConfig {
 	codestral_show_paid?: boolean;
 	llm7_show_paid?: boolean;
 	deepinfra_show_paid?: boolean;
+	sambanova_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
 	opencode_show_paid?: boolean;
 }
@@ -59,6 +61,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	mistral_api_key: "",
 	llm7_api_key: "",
 	deepinfra_api_key: "",
+	sambanova_api_key: "",
 	groq_api_key: "",
 	cerebras_api_key: "",
 	xai_api_key: "",
@@ -75,6 +78,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	codestral_show_paid: false,
 	llm7_show_paid: false,
 	deepinfra_show_paid: false,
+	sambanova_show_paid: false,
 	openrouter_show_paid: false,
 	opencode_show_paid: false,
 };
@@ -177,6 +181,13 @@ export function getDeepinfraShowPaid(): boolean {
 	);
 }
 
+export function getSambanovaShowPaid(): boolean {
+	return resolveBool(
+		"SAMBANOVA_SHOW_PAID",
+		loadConfigFile().sambanova_show_paid,
+	);
+}
+
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -230,6 +241,10 @@ export function getLlm7ApiKey(): string | undefined {
 
 export function getDeepinfraApiKey(): string | undefined {
 	return resolve("DEEPINFRA_TOKEN", loadConfigFile().deepinfra_api_key);
+}
+
+export function getSambanovaApiKey(): string | undefined {
+	return resolve("SAMBANOVA_API_KEY", loadConfigFile().sambanova_api_key);
 }
 
 export function getOllamaApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -20,6 +20,7 @@ export const PROVIDER_CROFAI = "crofai";
 export const PROVIDER_CODESTRAL = "codestral";
 export const PROVIDER_LLM7 = "llm7";
 export const PROVIDER_DEEPINFRA = "deepinfra";
+export const PROVIDER_SAMBANOVA = "sambanova";
 
 export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_KILO,
@@ -34,6 +35,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_CODESTRAL,
 	PROVIDER_LLM7,
 	PROVIDER_DEEPINFRA,
+	PROVIDER_SAMBANOVA,
 ] as const;
 
 // =============================================================================
@@ -53,6 +55,7 @@ export const BASE_URL_CROFAI = "https://crof.ai/v1";
 export const BASE_URL_CODESTRAL = "https://codestral.mistral.ai/v1";
 export const BASE_URL_LLM7 = "https://api.llm7.io/v1";
 export const BASE_URL_DEEPINFRA = "https://api.deepinfra.com/v1/openai";
+export const BASE_URL_SAMBANOVA = "https://api.sambanova.ai/v1";
 
 /** Cline fetches free models from OpenRouter */
 export const BASE_URL_OPENROUTER = "https://openrouter.ai/api/v1";

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ import crofai from "./providers/crofai/crofai.ts";
 import kilo from "./providers/kilo/kilo.ts";
 import llm7 from "./providers/llm7/llm7.ts";
 import deepinfra from "./providers/deepinfra/deepinfra.ts";
+import sambanova from "./providers/sambanova/sambanova.ts";
 import nvidia from "./providers/nvidia/nvidia.ts";
 import ollama from "./providers/ollama/ollama.ts";
 import zenmux from "./providers/zenmux/zenmux.ts";
@@ -91,7 +92,7 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 				"cerebras",
 			]);
 			// Freemium providers - all models share a free tier quota
-			const freemiumProviders = new Set(["nvidia"]);
+			const freemiumProviders = new Set(["nvidia", "sambanova"]);
 			// Trial credit providers - one-time credits, otherwise paid
 			const trialCreditProviders = new Set(["deepinfra"]);
 
@@ -155,6 +156,7 @@ export default async function (pi: ExtensionAPI) {
 		codestral(pi),
 		llm7(pi),
 		deepinfra(pi),
+		sambanova(pi),
 	]);
 
 	// Setup dynamic built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face)

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -1,0 +1,181 @@
+/**
+ * SambaNova Provider Extension
+ *
+ * SambaNova Cloud offers fast inference on custom RDU hardware with an
+ * OpenAI-compatible API. Known for running Llama 3.3 70B faster than
+ * competitors.
+ *
+ * Free tier (no credit card, no payment method):
+ *   - Production models: 20-480 RPM, 400-9600 RPD
+ *   - Preview models: 10-150 RPM, 200-3000 RPD
+ *   - Forever free, no token pricing
+ *
+ * Developer tier (add payment method):
+ *   - Higher rate limits, same models
+ *
+ * Endpoint:
+ *   Chat: https://api.sambanova.ai/v1/chat/completions
+ *
+ * Setup:
+ *   1. Sign up at https://cloud.sambanova.ai/
+ *   2. Get API key from https://cloud.sambanova.ai/apis
+ *   3. Set SAMBANOVA_API_KEY env var (or add to ~/.pi/free.json)
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Set SAMBANOVA_API_KEY env var
+ *   # Models appear in /model selector as "sambanova/Meta-Llama-3.3-70B-Instruct"
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
+import { getSambanovaApiKey, getSambanovaShowPaid } from "../../config.ts";
+import {
+	BASE_URL_SAMBANOVA,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_SAMBANOVA,
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import {
+	getProxyModelCompat,
+	isLikelyReasoningModel,
+} from "../../lib/provider-compat.ts";
+import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { createReRegister, setupProvider } from "../../provider-helper.ts";
+
+const _logger = createLogger("sambanova");
+
+// =============================================================================
+// Fetch SambaNova models
+// =============================================================================
+
+interface SambanovaModel {
+	id: string;
+	object?: string;
+	created?: number;
+	owned_by?: string;
+}
+
+async function fetchSambanovaModels(
+	apiKey: string,
+): Promise<ProviderModelConfig[]> {
+	_logger.info("[sambanova] Fetching models from SambaNova API...");
+
+	try {
+		const response = await fetchWithRetry(
+			`${BASE_URL_SAMBANOVA}/models`,
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
+
+		if (!response.ok) {
+			throw new Error(`SambaNova API error: ${response.status}`);
+		}
+
+		const data = (await response.json()) as {
+			data?: SambanovaModel[];
+		};
+		const models = data.data ?? [];
+
+		_logger.info(`[sambanova] Fetched ${models.length} models`);
+
+		return models
+			.filter((m) => m.id)
+			.map((m) => {
+				const name = m.id.split("/").pop() || m.id;
+				return {
+					id: m.id,
+					name,
+					reasoning: isLikelyReasoningModel({ id: m.id, name }),
+					input: ["text"],
+					cost: {
+						input: 0, // Free tier — no per-token pricing
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+					},
+					contextWindow: 128_000, // Default, varies by model
+					maxTokens: 8_192,
+					compat: getProxyModelCompat({ id: m.id, name }),
+				} satisfies ProviderModelConfig;
+			});
+	} catch (error) {
+		_logger.error("[sambanova] Failed to fetch models:", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
+}
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function sambanovaProvider(pi: ExtensionAPI) {
+	const apiKey = getSambanovaApiKey();
+
+	if (!apiKey) {
+		_logger.info(
+			"[sambanova] Skipping — SAMBANOVA_API_KEY not set. Sign up at https://cloud.sambanova.ai/",
+		);
+		return;
+	}
+
+	// Fetch models
+	const allModels = await fetchSambanovaModels(apiKey);
+
+	if (allModels.length === 0) {
+		_logger.warn("[sambanova] No models available");
+		return;
+	}
+
+	// All SambaNova models are free-tier (no payment method required).
+	// Rate limits are lower on free tier but all models are accessible.
+	const freeModels = allModels;
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[sambanova] Registered ${allModels.length} models (all free tier)`,
+	);
+
+	// Create re-register function
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_SAMBANOVA,
+		baseUrl: BASE_URL_SAMBANOVA,
+		apiKey,
+	});
+
+	// Register with global toggle
+	registerWithGlobalToggle(PROVIDER_SAMBANOVA, stored, reRegister, true);
+
+	// Setup provider with toggle command
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_SAMBANOVA,
+			initialShowPaid: getSambanovaShowPaid(),
+			tosUrl: "https://sambanova.ai/terms",
+			reRegister: (models, _stored) => {
+				if (_stored) {
+					stored.free = _stored.free;
+					stored.all = _stored.all;
+				}
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	// Initial registration — all models are free
+	reRegister(freeModels);
+}


### PR DESCRIPTION
## What

Adds [SambaNova Cloud](https://cloud.sambanova.ai/) as a provider — OpenAI-compatible API with fast inference on custom RDU hardware. All models are accessible on the **free tier with no credit card required**.

## Provider details

| | |
|---|---|
| **Base URL** | `https://api.sambanova.ai/v1` |
| **API format** | OpenAI-compatible |
| **Auth** | `SAMBANOVA_API_KEY` env var (from [cloud.sambanova.ai/apis](https://cloud.sambanova.ai/apis)) |
| **Free tier** | All models, 20-480 RPM, 400-9600 RPD — **no credit card** |
| **Developer tier** | Add payment method for higher rate limits |
| **Models** | Fetched dynamically from `/v1/models` |
| **Streaming** | ✅ |
| **Notable models** | Llama 3.3 70B, DeepSeek-V3, DeepSeek-R1, Llama 4 Maverick, Qwen3-32B |

## How it works

- Models are fetched dynamically on load
- All models are marked as free (no per-token pricing, free tier covers everything)
- Shown in `/free-providers` as: `🔑 sambanova: 13 models (freemium)`
- Visible even in free-only mode

## Setup

```bash
# Sign up at https://cloud.sambanova.ai/
# Get API key from https://cloud.sambanova.ai/apis
export SAMBANOVA_API_KEY=your-key-here
# Models appear in /model selector as sambanova/Meta-Llama-3.3-70B-Instruct
```

## Files

- `providers/sambanova/sambanova.ts` — new provider (165 lines)
- `constants.ts` — added `PROVIDER_SAMBANOVA`, `BASE_URL_SAMBANOVA`
- `config.ts` — added `sambanova_api_key`, `sambanova_show_paid` getters
- `index.ts` — import, load, and freemium display in `/free-providers`