### PR TITLE
feat: passive quota monitoring via after_provider_response

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,11 +11,18 @@
  * - Ollama Cloud: Ollama's cloud-hosted models with usage-based free tier
  * - ZenMux: Unified AI API gateway with 200+ models
  * - Codestral: Mistral's code-focused model via codestral.mistral.ai (free tier)
+ * - DeepInfra: AI inference cloud ($5 trial credit)
+ * - SambaNova: Fast inference on RDU hardware (free tier, no credit card)
+ * - LLM7: AI gateway (free default/fast selectors)
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { setupBuiltInProviderToggles } from "./lib/built-in-toggle.ts";
 import { createLogger } from "./lib/logger.ts";
+import {
+	processQuotaResponse,
+	formatQuotaStatus,
+} from "./lib/quota-monitor.ts";
 import {
 	applyGlobalFilter,
 	getGlobalFreeOnly,
@@ -134,6 +141,39 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 }
 
 // =============================================================================
+// Quota Monitoring
+// =============================================================================
+
+function setupQuotaMonitoring(pi: ExtensionAPI) {
+	// Capture rate-limit headers from every provider response
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(pi as any).on("after_provider_response", (event: { status: number; headers: Record<string, string> }, ctx: any) => {
+		const providerId = ctx.model?.provider;
+		if (!providerId) return;
+
+		processQuotaResponse(providerId, event.headers);
+
+		// Update status bar with quota for the active provider
+		const status = formatQuotaStatus(providerId);
+		if (status) {
+			ctx.ui.setStatus("quota", status);
+		}
+	});
+
+	// Clear quota status when switching away from a provider
+	pi.on("model_select", (_event, ctx) => {
+		const providerId = ctx.model?.provider;
+		if (!providerId) {
+			ctx.ui.setStatus("quota", undefined);
+			return;
+		}
+		// Show cached quota on provider switch (if still fresh)
+		const status = formatQuotaStatus(providerId);
+		ctx.ui.setStatus("quota", status);
+	});
+}
+
+// =============================================================================
 // Main Entry Point
 // =============================================================================
 
@@ -143,6 +183,9 @@ export default async function (pi: ExtensionAPI) {
 
 	// Setup global commands first
 	setupGlobalCommands(pi);
+
+	// Setup quota monitoring (passive, no extra API calls)
+	setupQuotaMonitoring(pi);
 
 	// Load all unique providers
 	// Each provider will register itself with the global toggle system

--- a/index.ts
+++ b/index.ts
@@ -99,7 +99,7 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 				"cerebras",
 			]);
 			// Freemium providers - all models share a free tier quota
-			const freemiumProviders = new Set(["nvidia", "sambanova"]);
+			const freemiumProviders = new Set(["nvidia", "sambanova", "ollama-cloud"]);
 			// Trial credit providers - one-time credits, otherwise paid
 			const trialCreditProviders = new Set(["deepinfra"]);
 
@@ -147,18 +147,21 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 function setupQuotaMonitoring(pi: ExtensionAPI) {
 	// Capture rate-limit headers from every provider response
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	(pi as any).on("after_provider_response", (event: { status: number; headers: Record<string, string> }, ctx: any) => {
-		const providerId = ctx.model?.provider;
-		if (!providerId) return;
+	(pi as any).on(
+		"after_provider_response",
+		(event: { status: number; headers: Record<string, string> }, ctx: any) => {
+			const providerId = ctx.model?.provider;
+			if (!providerId) return;
 
-		processQuotaResponse(providerId, event.headers);
+			processQuotaResponse(providerId, event.headers);
 
-		// Update status bar with quota for the active provider
-		const status = formatQuotaStatus(providerId);
-		if (status) {
-			ctx.ui.setStatus("quota", status);
-		}
-	});
+			// Update status bar with quota for the active provider
+			const status = formatQuotaStatus(providerId);
+			if (status) {
+				ctx.ui.setStatus("quota", status);
+			}
+		},
+	);
 
 	// Clear quota status when switching away from a provider
 	pi.on("model_select", (_event, ctx) => {

--- a/lib/quota-monitor.ts
+++ b/lib/quota-monitor.ts
@@ -58,8 +58,8 @@ export function extractQuota(
 	}
 
 	for (const [remainingKey, limitKey] of HEADER_PAIRS) {
-		const remaining = parseFloat(normalized[remainingKey]);
-		const limit = parseFloat(normalized[limitKey]);
+		const remaining = Number.parseFloat(normalized[remainingKey]);
+		const limit = Number.parseFloat(normalized[limitKey]);
 		if (Number.isFinite(remaining) && Number.isFinite(limit) && limit > 0) {
 			return { remaining, limit, source: remainingKey };
 		}

--- a/lib/quota-monitor.ts
+++ b/lib/quota-monitor.ts
@@ -1,0 +1,123 @@
+/**
+ * Quota Monitoring for pi-free providers.
+ *
+ * Subscribes to pi's `after_provider_response` event to extract rate-limit
+ * headers from provider responses and track remaining quota per provider.
+ *
+ * Inspired by free-coding-models' extractQuotaPercent and provider-quota-fetchers.
+ *
+ * Supported header formats (tried in order):
+ *   1. x-ratelimit-remaining-requests / x-ratelimit-limit-requests (SambaNova)
+ *   2. x-ratelimit-remaining / x-ratelimit-limit (Mistral, others)
+ *   3. ratelimit-remaining-requests / ratelimit-limit-requests
+ *   4. ratelimit-remaining / ratelimit-limit
+ *   5. x-ratelimit-remaining-requests-day / x-ratelimit-limit-requests-day (SambaNova daily)
+ */
+
+const _quotaState = new Map<string, QuotaSnapshot>();
+
+/** Snapshot of quota state for a single provider. */
+export interface QuotaSnapshot {
+	/** Requests remaining in the current window. */
+	remaining: number;
+	/** Total requests allowed in the current window. */
+	limit: number;
+	/** Remaining as percentage 0–100. */
+	percent: number;
+	/** Timestamp (Date.now()) when this snapshot was captured. */
+	lastUpdated: number;
+	/** Which header variant was matched (for debugging). */
+	source: string;
+}
+
+// Header key pairs to try, in priority order.
+// Each pair is [remaining, limit].
+const HEADER_PAIRS: [string, string][] = [
+	// Per-minute (most common)
+	["x-ratelimit-remaining-requests", "x-ratelimit-limit-requests"],
+	["x-ratelimit-remaining", "x-ratelimit-limit"],
+	["ratelimit-remaining-requests", "ratelimit-limit-requests"],
+	["ratelimit-remaining", "ratelimit-limit"],
+	// Per-day
+	["x-ratelimit-remaining-requests-day", "x-ratelimit-limit-requests-day"],
+	["x-ratelimit-remaining-day", "x-ratelimit-limit-day"],
+];
+
+/**
+ * Attempt to extract quota from response headers.
+ * Returns { remaining, limit, source } or null if no quota headers found.
+ */
+export function extractQuota(
+	headers: Record<string, string>,
+): { remaining: number; limit: number; source: string } | null {
+	// Normalize keys to lowercase for case-insensitive matching.
+	// Some proxies/servers vary header casing.
+	const normalized: Record<string, string> = {};
+	for (const [key, value] of Object.entries(headers)) {
+		normalized[key.toLowerCase()] = value;
+	}
+
+	for (const [remainingKey, limitKey] of HEADER_PAIRS) {
+		const remaining = parseFloat(normalized[remainingKey]);
+		const limit = parseFloat(normalized[limitKey]);
+		if (Number.isFinite(remaining) && Number.isFinite(limit) && limit > 0) {
+			return { remaining, limit, source: remainingKey };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Process an after_provider_response event, updating quota state.
+ * Call from the event handler in index.ts.
+ */
+export function processQuotaResponse(
+	providerId: string,
+	headers: Record<string, string>,
+): void {
+	const extracted = extractQuota(headers);
+	if (!extracted) return;
+
+	const percent = Math.round((extracted.remaining / extracted.limit) * 100);
+
+	_quotaState.set(providerId, {
+		remaining: extracted.remaining,
+		limit: extracted.limit,
+		percent: Math.max(0, Math.min(100, percent)),
+		lastUpdated: Date.now(),
+		source: extracted.source,
+	});
+}
+
+/**
+ * Get the latest quota snapshot for a provider, or null if unknown.
+ */
+export function getQuota(providerId: string): QuotaSnapshot | null {
+	return _quotaState.get(providerId) ?? null;
+}
+
+/**
+ * Get all tracked quotas.
+ */
+export function getAllQuotas(): ReadonlyMap<string, QuotaSnapshot> {
+	return _quotaState;
+}
+
+/**
+ * Build a human-readable status bar line for a provider's quota.
+ * Returns undefined if no quota data is available.
+ */
+export function formatQuotaStatus(providerId: string): string | undefined {
+	const q = _quotaState.get(providerId);
+	if (!q) return undefined;
+
+	// Stale after 5 minutes
+	if (Date.now() - q.lastUpdated > 5 * 60 * 1000) return undefined;
+
+	if (q.percent <= 10)
+		return `⚠️ ${providerId}: ${q.remaining}/${q.limit} (${q.percent}%)`;
+	if (q.percent <= 25)
+		return `⚡ ${providerId}: ${q.remaining}/${q.limit} (${q.percent}%)`;
+	return `${providerId}: ${q.remaining}/${q.limit} (${q.percent}%)`;
+}


### PR DESCRIPTION
## What

Adds passive quota monitoring that extracts rate-limit headers from every provider response — **no extra API calls needed**.

## How it works

1. Subscribes to pi's `after_provider_response` event (fires after every provider request)
2. Parses `x-ratelimit-remaining` / `x-ratelimit-limit` headers from the response
3. Updates the status bar with remaining quota for the active provider

**Status bar indicators:**
- Normal: `nvidia: 847/1000 (84%)`
- Low (≤25%): `⚡ nvidia: 200/1000 (20%)`
- Critical (≤10%): `⚠️ nvidia: 50/1000 (5%)`
- Stale (>5 min): hidden

## Supported header formats (6 variants)

| Priority | Remaining Key | Limit Key | Used By |
|---|---|---|---|
| 1 | `x-ratelimit-remaining-requests` | `x-ratelimit-limit-requests` | SambaNova |
| 2 | `x-ratelimit-remaining` | `x-ratelimit-limit` | Mistral, others |
| 3 | `ratelimit-remaining-requests` | `ratelimit-limit-requests` | — |
| 4 | `ratelimit-remaining` | `ratelimit-limit` | Groq, Cerebras |
| 5 | `x-ratelimit-remaining-requests-day` | `x-ratelimit-limit-requests-day` | SambaNova daily |
| 6 | `x-ratelimit-remaining-day` | `x-ratelimit-limit-day` | — |

All keys are matched case-insensitively.

## Files

- `lib/quota-monitor.ts` — new: quota extraction, state, formatting (123 lines)
- `index.ts` — event subscription + status bar integration