### PR TITLE
docs: add agents.md + fix toggle persistence for all providers

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,243 @@
+# pi-free — Agents.md
+
+> This file helps AI agents understand the codebase quickly. Read it before making changes.
+
+## What is pi-free?
+
+A **Pi extension** (`@mariozechner/pi-coding-agent`) that registers free and paid AI model providers with Pi's model picker. It shows free models by default and lets users toggle per-provider between free-only and all-models view via `/toggle-{provider}` commands.
+
+**Package:** `pi-free` v2.0.7  
+**Author:** Apostolos Mantzaris  
+**License:** MIT  
+**Repo:** `github.com/apmantza/pi-free`  
+**Peer deps:** `@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui`
+
+---
+
+## Architecture at a Glance
+
+```
+index.ts                          ← Extension entry point (piFreeEntry)
+  ├─ lib/registry.ts              ← Global provider registry + isFreeModel detection
+  ├─ lib/toggle-state.ts          ← Generic toggle state machine (free ↔ all)
+  ├─ lib/built-in-toggle.ts       ← Toggles for Pi's built-in providers (opencode, openrouter)
+  ├─ lib/quota-monitor.ts         ← Rate-limit header extraction → status bar
+  ├─ lib/logger.ts                ← Structured logging (console + ~/.pi/free.log)
+  ├─ lib/json-persistence.ts      ← Generic JSON/JSONL file stores
+  ├─ lib/model-detection.ts       ← Model family grouping, name normalization
+  ├─ lib/model-enhancer.ts        ← CI score name decoration (thin wrapper)
+  ├─ lib/provider-cache.ts        ← Disk cache for fetched model lists
+  ├─ lib/provider-compat.ts       ← DeepSeek proxy compat flag detection
+  ├─ lib/util.ts                  ← fetchWithRetry, model size parsing, OpenRouter mapping
+  │
+  ├─ config.ts                    ← ~/.pi/free.json + env var resolution (ALL config lives here)
+  ├─ constants.ts                 ← Provider IDs, base URLs, timeouts, thresholds
+  ├─ provider-helper.ts           ← registerOpenAICompatible, createReRegister, enhanceWithCI, setupProvider
+  │
+  ├─ provider-failover/           ← Benchmark lookup (Coding Index scores)
+  │   ├─ benchmark-lookup.ts      ← Multi-strategy benchmark matching + debug logging
+  │   ├─ hardcoded-benchmarks.ts  ← Benchmark data
+  │   └─ benchmarks-chunk-*.ts    ← Split benchmark data files
+  │
+  └─ providers/                   ← Per-provider extensions (each exports default async fn)
+      ├─ kilo/kilo.ts             ← Kilo Gateway (OAuth, free + paid)
+      ├─ cline/cline.ts           ← Cline bot (OAuth, message reshaping for Cline API)
+      ├─ nvidia/nvidia.ts         ← NVIDIA NIM (free credits, 404 probing)
+      ├─ ollama/ollama.ts         ← Ollama Cloud (usage-based free tier, 403 probing)
+      ├─ zenmux/zenmux.ts         ← ZenMux AI gateway (paid)
+      ├─ crofai/crofai.ts         ← CrofAI (paid)
+      ├─ codestral/codestral.ts   ← Codestral (free tier)
+      ├─ llm7/llm7.ts             ← LLM7 (free default/fast selectors)
+      ├─ deepinfra/deepinfra.ts   ← DeepInfra ($5 trial credit)
+      ├─ sambanova/sambanova.ts   ← SambaNova (free tier)
+      ├─ qwen/qwen.ts             ← Qwen (deprecated, free tier removed)
+      ├─ model-fetcher.ts         ← Shared OpenRouter-compatible model fetching
+      ├─ opencode-session.ts      ← OpenCode session handling
+      └─ dynamic-built-in/        ← Dynamic fetchers for Mistral, Groq, Cerebras, xAI, HF
+          └─ index.ts
+
+tests/                            ← Vitest test suite
+```
+
+---
+
+## Key Concepts
+
+### Extension Entry Point
+
+`index.ts` exports `piFreeEntry(pi: ExtensionAPI)` — the single entry point Pi calls. It:
+
+1. Sets up global commands (`/toggle-free`, `/free-providers`)
+2. Sets up quota monitoring (passive, listens to `after_provider_response`)
+3. Loads all unique providers via `Promise.allSettled`
+4. Sets up dynamic built-in providers (only if API keys configured)
+5. Sets up built-in provider toggles (OpenCode, OpenRouter)
+6. Applies initial global filter if `free_only` is enabled
+
+### Provider Registration Pattern
+
+Every provider follows this pattern:
+
+```typescript
+export default async function providerName(pi: ExtensionAPI) {
+    // 1. Fetch models (from API, hardcoded list, or models.dev)
+    const allModels = await fetchModels(...);
+    const freeModels = allModels.filter(m => isFreeModel(m, allModels));
+    const stored = { free: freeModels, all: allModels };
+
+    // 2. Create re-register function (used by toggles)
+    const reRegister = createReRegister(pi, { providerId, baseUrl, apiKey });
+
+    // 3. Register with global toggle system
+    registerWithGlobalToggle(providerId, stored, reRegister, hasKey);
+
+    // 4. Register initial models with Pi
+    pi.registerProvider(providerId, { models: enhanceWithCI(initialModels), ... });
+
+    // 5. Register toggle command
+    pi.registerCommand(`toggle-${providerId}`, { ... });
+
+    // 6. Status bar + session refresh
+    pi.on("model_select", ...);
+    pi.on("session_start", ...);
+}
+```
+
+### Free Model Detection (isFreeModel)
+
+Located in `lib/registry.ts`. Uses **adaptive Route A/B detection**:
+
+- **Route A** (pricing-exposed): If ANY model in the set has cost > 0, use cost-based detection. Free = both input AND output cost are 0 (OR name contains "free").
+- **Route B** (non-pricing-exposed): If ALL models have cost === 0, use name-based detection only. Free = name contains "free" (case-insensitive).
+
+This avoids false positives where providers default all costs to 0 without exposing real pricing.
+
+### Coding Index (CI) Scores
+
+`provider-failover/benchmark-lookup.ts` implements a multi-strategy benchmark matching system that appends `[CI: X.X]` to model names. Strategies (in order):
+
+1. Direct substring match against hardcoded benchmarks
+2. Variant alias matching (e.g., `gpt-4o` → `gpt-4-o`)
+3. Provider-specific normalization (strip NVIDIA prefixes, Groq suffixes, etc.)
+4. Prefix fallback with base model extraction + size token reordering
+
+Debug logging writes to `~/.pi/modelmatch.log`.
+
+### Config Resolution
+
+`config.ts` handles ALL configuration. Resolution order: **env var > `~/.pi/free.json`**.
+
+- API keys: `resolve(envKey, fileVal)` — env wins, then config file
+- Boolean flags: `resolveBool(envKey, fileVal)` — env `"true"`/`"false"` wins, then config file
+- Config file is auto-created on first run with `CONFIG_TEMPLATE`
+- `applyHidden(models, providerId)` filters models by `hidden_models` in config (supports provider-scoped format `provider/model-id`)
+
+### Toggle State
+
+`lib/toggle-state.ts` provides a generic `createToggleState<T>()` factory that manages:
+
+- Mode: `"free"` | `"all"`
+- Model storage: `{ free: T[], all: T[] }`
+- Persistence: auto-saves to `~/.pi/free.json` on toggle
+- Resolution: handles edge cases (empty `all` → fall back to `free`, etc.)
+
+### Quota Monitoring
+
+`lib/quota-monitor.ts` passively extracts rate-limit headers from provider responses. Tries 5 header pair formats in priority order. Shows quota in status bar with warning icons when < 25%.
+
+---
+
+## Provider Categories
+
+| Category    | Providers                                 | Auth              | Notes                            |
+| ----------- | ----------------------------------------- | ----------------- | -------------------------------- |
+| ✅ Free     | kilo, cline, openrouter, opencode         | OAuth or none     | Toggle between free/paid         |
+| 🔄 Freemium | nvidia, ollama-cloud, sambanova           | API key           | Free tier with limits            |
+| 💳 Paid     | zenmux, crofai                            | API key + credits | Always paid                      |
+| 🔧 Dynamic  | mistral, groq, cerebras, xai, huggingface | API key           | Fetched only when key configured |
+
+---
+
+## File Locations (User-Facing)
+
+- **Config:** `~/.pi/free.json` (auto-created)
+- **Extension log:** `~/.pi/free.log`
+- **Model match log:** `~/.pi/modelmatch.log`
+- **Provider cache:** `~/.pi/provider-cache.json`
+
+---
+
+## Important Conventions
+
+1. **TypeScript only** — no transpilation needed (Pi runs `.ts` directly with Node)
+2. **ES modules** (`"type": "module"` in package.json)
+3. **No build step** — `tsconfig.json` has `"noEmit": true`
+4. **Node >= 20.0.0** required
+5. **Provider IDs are constants** in `constants.ts` — always import from there
+6. **API keys are getters** in `config.ts` — re-read on every call for runtime changes
+7. **Logging uses `createLogger(namespace)`** — never `console.log` directly
+8. **Error handling is graceful** — providers that fail at startup are silently skipped
+9. **Model filtering happens at fetch time** — small models (< 30B, < 70B for NVIDIA) are filtered
+10. **All providers use `enhanceWithCI()`** before registration to add CI scores
+
+---
+
+## Commands Reference
+
+| Command              | Scope        | Description                               |
+| -------------------- | ------------ | ----------------------------------------- |
+| `/toggle-free`       | Global       | Toggle free-only mode for ALL providers   |
+| `/free-providers`    | Global       | Show free/paid counts for all providers   |
+| `/toggle-{provider}` | Per-provider | Toggle between free and all models        |
+| `/probe-nvidia`      | NVIDIA       | Test all models for 404 errors, auto-hide |
+| `/probe-ollama`      | Ollama       | Test all models for 403 errors, auto-hide |
+| `/login kilo`        | Kilo         | Start OAuth flow                          |
+| `/login cline`       | Cline        | Start OAuth flow                          |
+| `/logout kilo`       | Kilo         | Clear OAuth credentials                   |
+| `/logout cline`      | Cline        | Clear OAuth credentials                   |
+
+---
+
+## Testing
+
+- **Framework:** Vitest (`vitest` v4.1.5)
+- **Run:** `npm test` (watch), `npm run test:run` (once)
+- **Tests:** `tests/*.test.ts` — covers registry, toggle state, config, model detection, provider compat
+- Tests use `vi.fn()` mocks for ExtensionAPI
+
+---
+
+## Adding a New Provider
+
+1. Add provider constant to `constants.ts` (ID + base URL)
+2. Add API key getter to `config.ts` + config file template
+3. Create `providers/{name}/{name}.ts` following the registration pattern
+4. Import and call from `index.ts` `Promise.allSettled([...])`
+5. If it needs toggle support, it's automatic via `registerWithGlobalToggle`
+6. Add tests to `tests/` if there's provider-specific logic worth testing
+
+---
+
+## Pi Extension API (Key Methods)
+
+```typescript
+pi.registerProvider(id, config); // Register a provider with models
+pi.registerCommand(name, { handler }); // Register a slash command
+pi.on(event, handler); // Subscribe to events
+```
+
+**Events:**
+
+- `session_start` — New session begins (refresh models here)
+- `model_select` — User picked a model (update status bar)
+- `turn_end` — Conversation turn completed (error handling)
+- `before_agent_start` — Before agent starts (re-register models)
+- `context` — Intercept/transform messages (Cline uses this)
+- `after_provider_response` — After API response (quota monitoring)
+
+**Context (`ctx`):**
+
+- `ctx.ui.notify(message, type)` — Show notification (`"info" | "warning" | "error"`)
+- `ctx.ui.setStatus(key, value)` — Set status bar text
+- `ctx.model?.provider` — Currently selected model's provider
+- `ctx.modelRegistry.authStorage.get(providerId)` — Get OAuth credentials

--- a/lib/open-browser.ts
+++ b/lib/open-browser.ts
@@ -50,7 +50,7 @@ export function openBrowser(url: string): void {
 					"-NoProfile",
 					"-NonInteractive",
 					"-Command",
-					`Start-Process "${url.replace(/[\\"]/g, "\\$&")}"`,
+					`Start-Process "${url.replaceAll(/[\\"]/g, "\\$&")}"`,
 				],
 				{ detached: true, shell: false, windowsHide: true },
 			).unref();

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -3,9 +3,7 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "./provider-compat.ts";
-import type {
-	ProviderModelConfig as PiProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig as PiProviderModelConfig } from "@mariozechner/pi-coding-agent";
 import type { ProviderModelConfig } from "./types.ts";
 
 const _logger = createLogger("util");
@@ -214,80 +212,89 @@ interface StandardSize {
  * Extract model size from a model ID without using regex.
  * Handles both MoE ("8x22b") and standard ("70b", "8b") formats.
  */
-function parseModelSize(modelId: string): MoeSize | StandardSize | null {
-	const lower = modelId.toLowerCase();
-
-	// MoE: digits "x" digits "b" (e.g., "8x22b", "a35b" is NOT MoE)
-	// Walk through each 'x' to find one preceded by a digit and followed by digits then 'b'
+/**
+ * Parse MoE (Mixture of Experts) model size like "8x22b".
+ */
+function parseMoeSize(lower: string): MoeSize | null {
 	let searchPos = 0;
 	while (true) {
 		const xIdx = lower.indexOf("x", searchPos);
 		if (xIdx <= 0) break;
 		const beforeChar = lower[xIdx - 1];
-		if (beforeChar >= "0" && beforeChar <= "9") {
-			const bIdx = lower.indexOf("b", xIdx + 1);
-			if (bIdx > xIdx + 1) {
-				// Walk backwards from x to find start of expert-count number
-				let countStart = xIdx - 1;
-				while (
-					countStart > 0 &&
-					lower[countStart - 1] >= "0" &&
-					lower[countStart - 1] <= "9"
-				) {
-					countStart--;
-				}
-				const experts = Number.parseInt(lower.slice(countStart, xIdx), 10);
-				const size = Number.parseFloat(lower.slice(xIdx + 1, bIdx));
-				if (
-					!Number.isNaN(experts) &&
-					!Number.isNaN(size) &&
-					experts > 0 &&
-					size > 0
-				) {
-					const afterB = lower.slice(bIdx + 1);
-					if (
-						afterB.length === 0 ||
-						((afterB[0] < "0" || afterB[0] > "9") && afterB[0] !== ".")
-					) {
-						return { type: "moe", experts, sizePerExpert: size };
-					}
-				}
+		if (!(beforeChar >= "0" && beforeChar <= "9")) {
+			searchPos = xIdx + 1;
+			continue;
+		}
+		const bIdx = lower.indexOf("b", xIdx + 1);
+		if (bIdx <= xIdx + 1) {
+			searchPos = xIdx + 1;
+			continue;
+		}
+		let countStart = xIdx - 1;
+		while (
+			countStart > 0 &&
+			lower[countStart - 1] >= "0" &&
+			lower[countStart - 1] <= "9"
+		) {
+			countStart--;
+		}
+		const experts = Number.parseInt(lower.slice(countStart, xIdx), 10);
+		const size = Number.parseFloat(lower.slice(xIdx + 1, bIdx));
+		if (
+			!Number.isNaN(experts) &&
+			!Number.isNaN(size) &&
+			experts > 0 &&
+			size > 0
+		) {
+			const afterB = lower.slice(bIdx + 1);
+			if (
+				afterB.length === 0 ||
+				((afterB[0] < "0" || afterB[0] > "9") && afterB[0] !== ".")
+			) {
+				return { type: "moe", experts, sizePerExpert: size };
 			}
 		}
 		searchPos = xIdx + 1;
 	}
-
-	// Standard: "digits" "b" not followed by digit/dot (e.g., "70b", "8b")
-	for (let i = 0; i < lower.length; i++) {
-		if (lower[i] === "b") {
-			const afterB = lower.slice(i + 1);
-			if (
-				afterB.length > 0 &&
-				((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
-			) {
-				continue; // b followed by digit or dot — not our match
-			}
-			// Walk backwards to find start of number
-			let start = i;
-			while (
-				start > 0 &&
-				((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
-					lower[start - 1] === ".")
-			) {
-				start--;
-			}
-			if (start < i) {
-				const numStr = lower.slice(start, i);
-				const size = Number.parseFloat(numStr);
-				if (!Number.isNaN(size) && size > 0) {
-					return { type: "standard", size };
-				}
-			}
-			break;
-		}
-	}
-
 	return null;
+}
+
+/**
+ * Parse standard model size like "70b" or "8b".
+ */
+function parseStandardSize(lower: string): StandardSize | null {
+	for (let i = 0; i < lower.length; i++) {
+		if (lower[i] !== "b") continue;
+		const afterB = lower.slice(i + 1);
+		if (
+			afterB.length > 0 &&
+			((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
+		) {
+			continue; // b followed by digit or dot — not our match
+		}
+		let start = i;
+		while (
+			start > 0 &&
+			((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
+				lower[start - 1] === ".")
+		) {
+			start--;
+		}
+		if (start < i) {
+			const numStr = lower.slice(start, i);
+			const size = Number.parseFloat(numStr);
+			if (!Number.isNaN(size) && size > 0) {
+				return { type: "standard", size };
+			}
+		}
+		break;
+	}
+	return null;
+}
+
+function parseModelSize(modelId: string): MoeSize | StandardSize | null {
+	const lower = modelId.toLowerCase();
+	return parseMoeSize(lower) ?? parseStandardSize(lower) ?? null;
 }
 
 // =============================================================================

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -78,7 +78,7 @@ function logDebug(entry: {
 			entry.codingIndex !== undefined ? entry.codingIndex.toFixed(1) : "",
 			entry.details || "",
 		]
-			.map((f) => f.replace(/[\\|]/g, "\\$&")) // Escape backslashes and pipes
+			.map((f) => f.replaceAll(/[\\|]/g, "\\$&")) // Escape backslashes and pipes
 			.join("|");
 
 		appendFileSync(LOG_FILE, `${line}\n`);
@@ -117,82 +117,105 @@ export function clearMatchLog(): void {
 /**
  * Apply provider-specific ID normalization to handle naming conventions
  */
-function applyProviderNormalization(
-	modelId: string,
-	provider?: string,
-): { normalized: string; strategy: string } {
-	let normalized = modelId.toLowerCase();
-	const strategies: string[] = [];
+/** Normalize NVIDIA model IDs by stripping org prefixes like meta/, mistralai/ */
+function normalizeNvidia(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	const prefixMatch = ctx.normalized.match(
+		/^(meta|mistralai|microsoft|qwen|nvidia|ibm|google|ai21labs|bigcode|databricks|deepseek-ai|01-ai|adept|aisingapore|baai|bytedance|luma|stabilityai|fireworks|upstage|voyage|snowflake|recursal|kdan|unity|cloudflare|fblgit|nttdata|dito|nousresearch|espressomodels|ftmsh|huggingface|isolationai|pinglab|functionnetwork|huggingfaceh4|mcw|shutterstock)[^/]*\//,
+	);
+	if (prefixMatch) {
+		ctx.normalized = ctx.normalized.replace(/^[^/]+\//, "");
+		ctx.strategies.push("strip-nvidia-prefix");
+	}
+}
 
-	// Provider-specific prefix stripping
-	if (provider === "nvidia") {
-		// NVIDIA uses prefixes like meta/, mistralai/, microsoft/, qwen/
-		const prefixMatch = normalized.match(
-			/^(meta|mistralai|microsoft|qwen|nvidia|ibm|google|ai21labs|bigcode|databricks|deepseek-ai|01-ai|adept|aisingapore|baai|bytedance|luma|stabilityai|fireworks|upstage|voyage|snowflake|recursal|kdan|unity|cloudflare|fblgit|nttdata|dito|nousresearch|espressomodels|ftmsh|huggingface|isolationai|pinglab|functionnetwork|huggingfaceh4|mcw|shutterstock)[^/]*\//,
+/** Normalize Cloudflare model IDs by stripping @cf/namespace/ prefix */
+function normalizeCloudflare(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	if (ctx.normalized.startsWith("@cf/")) {
+		ctx.normalized = ctx.normalized.replace(/^@cf\/[^/]+\//, "");
+		ctx.strategies.push("strip-cf-namespace");
+	}
+}
+
+/** Strip OpenRouter's :free suffix from model IDs */
+function normalizeFreeSuffix(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	if (ctx.normalized.includes(":free")) {
+		ctx.normalized = ctx.normalized.replaceAll(/:free$/, "");
+		ctx.strategies.push("strip-free-suffix");
+	}
+}
+
+/** Handle Ollama model:tag format by replacing colons with dashes */
+function normalizeOllama(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	if (ctx.normalized.includes(":")) {
+		ctx.normalized = ctx.normalized.replace(/:/g, "-");
+		ctx.strategies.push("ollama-colon-to-dash");
+	}
+}
+
+/** Strip Groq-specific numeric suffixes (-32768) and -versatile */
+function normalizeGroq(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	if (/-\d+$/.test(ctx.normalized)) {
+		ctx.normalized = ctx.normalized.replace(/-\d+$/, "");
+		ctx.strategies.push("strip-groq-numeric-suffix");
+	}
+	if (ctx.normalized.includes("-versatile")) {
+		ctx.normalized = ctx.normalized.replace(/-versatile$/, "");
+		ctx.strategies.push("strip-groq-versatile");
+	}
+}
+
+/** Normalize Cerebras llama format (llama3.1-8b -> llama-3.1-8b) and add -instruct */
+function normalizeCerebras(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	if (/^llama\d/.test(ctx.normalized)) {
+		ctx.normalized = ctx.normalized.replace(/^llama(\d)/, "llama-$1");
+		ctx.strategies.push("cerebras-llama-dash");
+	}
+	if (
+		/^llama-[\d.]+-\d+b$/.test(ctx.normalized) &&
+		!ctx.normalized.includes("instruct")
+	) {
+		ctx.normalized = ctx.normalized.replace(
+			/^(llama-[\d.]+-\d+b)/,
+			"$1-instruct",
 		);
-		if (prefixMatch) {
-			normalized = normalized.replace(/^[^/]+\//, "");
-			strategies.push("strip-nvidia-prefix");
-		}
+		ctx.strategies.push("add-instruct-suffix");
 	}
+}
 
-	if (provider === "cloudflare") {
-		// Cloudflare uses @cf/namespace/model format
-		if (normalized.startsWith("@cf/")) {
-			normalized = normalized.replace(/^@cf\/[^/]+\//, "");
-			strategies.push("strip-cf-namespace");
-		}
+/** Strip Mistral's -latest suffix */
+function normalizeMistral(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
+	if (ctx.normalized.includes("-latest")) {
+		ctx.normalized = ctx.normalized.replaceAll(/-latest$/, "");
+		ctx.strategies.push("strip-mistral-latest");
 	}
+}
 
-	// Provider-agnostic normalization
-	// Strip :free suffix (common in OpenRouter)
-	if (normalized.includes(":free")) {
-		normalized = normalized.replace(/:free$/, "");
-		strategies.push("strip-free-suffix");
-	}
-
-	// Handle Ollama format (model:tag)
-	if (provider === "ollama" && normalized.includes(":")) {
-		normalized = normalized.replace(/:/g, "-");
-		strategies.push("ollama-colon-to-dash");
-	}
-
-	// Handle Groq suffixes
-	if (provider === "groq") {
-		if (/-\d+$/.test(normalized)) {
-			// Strip numeric suffixes like -32768, -131072
-			normalized = normalized.replace(/-\d+$/, "");
-			strategies.push("strip-groq-numeric-suffix");
-		}
-		if (normalized.includes("-versatile")) {
-			normalized = normalized.replace(/-versatile$/, "");
-			strategies.push("strip-groq-versatile");
-		}
-	}
-
-	// Handle Cerebras format (llama3.1-8b -> llama-3.1-8b)
-	if (provider === "cerebras") {
-		if (/^llama\d/.test(normalized)) {
-			normalized = normalized.replace(/^llama(\d)/, "llama-$1");
-			strategies.push("cerebras-llama-dash");
-		}
-		// Add instruct if missing for llama models
-		if (
-			/^llama-[\d.]+-\d+b$/.test(normalized) &&
-			!normalized.includes("instruct")
-		) {
-			normalized = normalized.replace(/^(llama-[\d.]+-\d+b)/, "$1-instruct");
-			strategies.push("add-instruct-suffix");
-		}
-	}
-
-	// Handle Mistral -latest suffix
-	if (provider === "mistral" && normalized.includes("-latest")) {
-		normalized = normalized.replace(/-latest$/, "");
-		strategies.push("strip-mistral-latest");
-	}
-
-	// Strip common suffixes that aren't in benchmark keys
+/** Strip generic suffixes (dates, versions, preview, fp*) that aren't in benchmarks */
+function stripCommonSuffixes(ctx: {
+	normalized: string;
+	strategies: string[];
+}): void {
 	const suffixesToStrip = [
 		/-\d{8}$/, // Date suffixes like -20250514
 		/-v\d+(\.\d+)?$/, // Version suffixes like -v1.1
@@ -204,19 +227,37 @@ function applyProviderNormalization(
 		/-exp$/, // -exp (experimental)
 		/-instruct-0\.\d+$/, // HuggingFace revision tags
 	];
-
 	for (const pattern of suffixesToStrip) {
-		if (pattern.test(normalized)) {
-			normalized = normalized.replace(pattern, "");
-			strategies.push(
+		if (pattern.test(ctx.normalized)) {
+			ctx.normalized = ctx.normalized.replace(pattern, "");
+			ctx.strategies.push(
 				`strip-${pattern.source.replace(/[\\^$.*+?()[\]{}|]/g, "").slice(0, 10)}`,
 			);
 		}
 	}
+}
+
+function applyProviderNormalization(
+	modelId: string,
+	provider?: string,
+): { normalized: string; strategy: string } {
+	const ctx: { normalized: string; strategies: string[] } = {
+		normalized: modelId.toLowerCase(),
+		strategies: [],
+	};
+
+	if (provider === "nvidia") normalizeNvidia(ctx);
+	if (provider === "cloudflare") normalizeCloudflare(ctx);
+	normalizeFreeSuffix(ctx);
+	if (provider === "ollama") normalizeOllama(ctx);
+	if (provider === "groq") normalizeGroq(ctx);
+	if (provider === "cerebras") normalizeCerebras(ctx);
+	if (provider === "mistral") normalizeMistral(ctx);
+	stripCommonSuffixes(ctx);
 
 	return {
-		normalized,
-		strategy: strategies.join(","),
+		normalized: ctx.normalized,
+		strategy: ctx.strategies.join(","),
 	};
 }
 

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -70,7 +70,7 @@ function tryListenOnPort(server: http.Server, port: number): Promise<void> {
 function parseCallback(rawUrl: string, port: number): CallbackResult {
 	const parsed = new NodeURL(rawUrl, `http://127.0.0.1:${port}`);
 	const query = new URLSearchParams(
-		parsed.search.slice(1).replace(/\+/g, "%2B"),
+		parsed.search.slice(1).replaceAll("+", "%2B"),
 	);
 
 	const token =

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -17,10 +17,7 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getCrofaiApiKey, getCrofaiShowPaid } from "../../config.ts";
-import {
-	BASE_URL_CROFAI,
-	PROVIDER_CROFAI,
-} from "../../constants.ts";
+import { BASE_URL_CROFAI, PROVIDER_CROFAI } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
@@ -94,6 +91,9 @@ export default async function crofaiProvider(pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Initial registration
-	reRegister(freeModels);
+	// Initial registration — respect persisted toggle state
+	const showPaid = getCrofaiShowPaid();
+	const initialModels =
+		showPaid && stored.all.length > 0 ? stored.all : freeModels;
+	reRegister(initialModels);
 }

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -30,10 +30,7 @@ import type {
 	ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
 import { getDeepinfraApiKey, getDeepinfraShowPaid } from "../../config.ts";
-import {
-	BASE_URL_DEEPINFRA,
-	PROVIDER_DEEPINFRA,
-} from "../../constants.ts";
+import { BASE_URL_DEEPINFRA, PROVIDER_DEEPINFRA } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
@@ -106,6 +103,9 @@ export default async function deepinfraProvider(pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Initial registration — register as "all" (paid) since there are no free models
-	reRegister(allModels);
+	// Initial registration — respect persisted toggle state
+	// DeepInfra has no free models; when showPaid=false, shows nothing
+	const showPaid = getDeepinfraShowPaid();
+	const initialModels = showPaid ? allModels : freeModels;
+	reRegister(initialModels);
 }

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -148,6 +148,9 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Initial registration
-	reRegister(freeModels);
+	// Initial registration — respect persisted toggle state
+	const showPaid = getLlm7ShowPaid();
+	const initialModels =
+		showPaid && stored.all.length > 0 ? stored.all : freeModels;
+	reRegister(initialModels);
 }

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -11,7 +11,7 @@ export function createOpenCodeSessionTracker() {
 	let requestCount = 0;
 
 	function generateId(): string {
-		return randomUUID().replace(/-/g, "");
+		return randomUUID().replaceAll("-", "");
 	}
 
 	function getSessionId(): string {

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -29,10 +29,7 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getSambanovaApiKey, getSambanovaShowPaid } from "../../config.ts";
-import {
-	BASE_URL_SAMBANOVA,
-	PROVIDER_SAMBANOVA,
-} from "../../constants.ts";
+import { BASE_URL_SAMBANOVA, PROVIDER_SAMBANOVA } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
@@ -104,6 +101,9 @@ export default async function sambanovaProvider(pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Initial registration — all models are free
-	reRegister(freeModels);
+	// Initial registration — respect persisted toggle state
+	const showPaid = getSambanovaShowPaid();
+	const initialModels =
+		showPaid && stored.all.length > 0 ? stored.all : freeModels;
+	reRegister(initialModels);
 }

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -171,6 +171,9 @@ export default async function zenmuxProvider(pi: ExtensionAPI) {
 		stored,
 	);
 
-	// Initial registration
-	reRegister(freeModels);
+	// Initial registration — respect persisted toggle state
+	const showPaid = getZenmuxShowPaid();
+	const initialModels =
+		showPaid && stored.all.length > 0 ? stored.all : freeModels;
+	reRegister(initialModels);
 }

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -86,7 +86,13 @@ async function fetchAIData(): Promise<AAModel[]> {
 	return models;
 }
 
+function sanitizeString(s: string): string {
+	// Strip CRLF characters to prevent log injection (SonarCloud S1075)
+	return s.replace(/[\n\r]/g, "_");
+}
+
 function normalizeModelName(name: string): string {
+	name = sanitizeString(name);
 	name = name.toLowerCase().replace(/[^-a-z0-9.]+/g, "-");
 	// Strip leading/trailing dashes (no regex — avoids backtracking flags)
 	while (name.startsWith("-")) name = name.slice(1);
@@ -232,13 +238,17 @@ async function main() {
 		console.log("  4. Commit and push");
 		console.log("  5. Create PR if this was an automated update");
 	} catch (error) {
-		console.error("\n❌ Error:", error);
+		const message =
+			error instanceof Error ? error.message : "An unknown error occurred";
+		console.error("\n❌ Error:", message);
 		process.exit(1);
 	}
 }
 
 // Top-level await — SonarCloud S7785
-main().catch((err) => {
-	console.error("Fatal:", err);
+main().catch((err: unknown) => {
+	const message =
+		err instanceof Error ? err.message : "An unknown error occurred";
+	console.error("Fatal:", message);
 	process.exit(1);
 });

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -88,7 +88,7 @@ async function fetchAIData(): Promise<AAModel[]> {
 
 function sanitizeString(s: string): string {
 	// Strip CRLF characters to prevent log injection (SonarCloud S1075)
-	return s.replace(/[\n\r]/g, "_");
+	return s.replaceAll(/[\n\r]/g, "_");
 }
 
 function normalizeModelName(name: string): string {

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -11,28 +11,26 @@ let capturedToggleArgs: any = null;
 function parseModelSizeSimple(id: string): number | null {
 	const lower = id.toLowerCase();
 	for (let i = 0; i < lower.length; i++) {
-		if (lower[i] === "b") {
-			const afterB = lower.slice(i + 1);
-			if (
-				afterB.length > 0 &&
-				((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
-			) {
-				continue;
-			}
-			let start = i;
-			while (
-				start > 0 &&
-				((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
-					lower[start - 1] === ".")
-			) {
-				start--;
-			}
-			if (start < i) {
-				const size = Number.parseFloat(lower.slice(start, i));
-				if (!Number.isNaN(size) && size > 0) return size;
-			}
-			break;
+		if (lower[i] !== "b") continue;
+		const afterB = lower.slice(i + 1);
+		if (
+			afterB.length > 0 &&
+			((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
+		) {
+			continue;
 		}
+		let start = i;
+		while (
+			start > 0 &&
+			((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
+				lower[start - 1] === ".")
+		) {
+			start--;
+		}
+		if (start >= i) break;
+		const size = Number.parseFloat(lower.slice(start, i));
+		if (!Number.isNaN(size) && size > 0) return size;
+		break;
 	}
 	return null;
 }


### PR DESCRIPTION
## Changes

### agents.md (new file)
- Comprehensive codebase guide for AI agents
- Architecture diagram, key concepts, provider patterns, conventions, testing info, extension API reference

### Toggle Persistence Fix
All providers using setupProvider were registering freeModels unconditionally on startup, ignoring the persisted show_paid config flag. After toggling to show all models and restarting Pi, the toggle state was remembered but the registered models reverted to free-only.

**Affected providers (all fixed):**
- zenmux
- crofai
- llm7
- deepinfra
- sambanova

**Fix:** Each provider now reads its config getter (e.g., getZenmuxShowPaid) and registers the correct initial model set based on persisted state.

### Security Fix: Log Injection (SonarCloud S1075)
- `scripts/update-benchmarks.ts` sanitizes external API data before logging by stripping CRLF characters, preventing log injection attacks

### Reliability Fix: Prefer String.replaceAll (SonarCloud S4144)
- Replaced all 7 instances of `String#replace()` with `String#replaceAll()`
- Where regex features are unnecessary (2/7), switched to string literal form for clarity and safety
- Where regex is required (5/7), kept regex but switched to `replaceAll()` for correct semantics