### PR TITLE
release: 2.0.8 — fix replaceAll regexps + bump basic-ftp

### DIFF
--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -126,7 +126,7 @@ function normalizeNvidia(ctx: {
 		/^(meta|mistralai|microsoft|qwen|nvidia|ibm|google|ai21labs|bigcode|databricks|deepseek-ai|01-ai|adept|aisingapore|baai|bytedance|luma|stabilityai|fireworks|upstage|voyage|snowflake|recursal|kdan|unity|cloudflare|fblgit|nttdata|dito|nousresearch|espressomodels|ftmsh|huggingface|isolationai|pinglab|functionnetwork|huggingfaceh4|mcw|shutterstock)[^/]*\//,
 	);
 	if (prefixMatch) {
-		ctx.normalized = ctx.normalized.replaceAll(/^[^/]+\//, "");
+		ctx.normalized = ctx.normalized.replaceAll(/^[^/]+\//g, "");
 		ctx.strategies.push("strip-nvidia-prefix");
 	}
 }
@@ -137,7 +137,7 @@ function normalizeCloudflare(ctx: {
 	strategies: string[];
 }): void {
 	if (ctx.normalized.startsWith("@cf/")) {
-		ctx.normalized = ctx.normalized.replaceAll(/^@cf\/[^/]+\//, "");
+		ctx.normalized = ctx.normalized.replaceAll(/^@cf\/[^/]+\//g, "");
 		ctx.strategies.push("strip-cf-namespace");
 	}
 }
@@ -148,7 +148,7 @@ function normalizeFreeSuffix(ctx: {
 	strategies: string[];
 }): void {
 	if (ctx.normalized.includes(":free")) {
-		ctx.normalized = ctx.normalized.replaceAll(/:free$/, "");
+		ctx.normalized = ctx.normalized.replaceAll(/:free$/g, "");
 		ctx.strategies.push("strip-free-suffix");
 	}
 }
@@ -170,11 +170,11 @@ function normalizeGroq(ctx: {
 	strategies: string[];
 }): void {
 	if (/-\d+$/.test(ctx.normalized)) {
-		ctx.normalized = ctx.normalized.replaceAll(/-\d+$/, "");
+		ctx.normalized = ctx.normalized.replaceAll(/-\d+$/g, "");
 		ctx.strategies.push("strip-groq-numeric-suffix");
 	}
 	if (ctx.normalized.includes("-versatile")) {
-		ctx.normalized = ctx.normalized.replaceAll(/-versatile$/, "");
+		ctx.normalized = ctx.normalized.replaceAll(/-versatile$/g, "");
 		ctx.strategies.push("strip-groq-versatile");
 	}
 }
@@ -185,7 +185,7 @@ function normalizeCerebras(ctx: {
 	strategies: string[];
 }): void {
 	if (/^llama\d/.test(ctx.normalized)) {
-		ctx.normalized = ctx.normalized.replaceAll(/^llama(\d)/, "llama-$1");
+		ctx.normalized = ctx.normalized.replaceAll(/^llama(\d)/g, "llama-$1");
 		ctx.strategies.push("cerebras-llama-dash");
 	}
 	if (
@@ -193,7 +193,7 @@ function normalizeCerebras(ctx: {
 		!ctx.normalized.includes("instruct")
 	) {
 		ctx.normalized = ctx.normalized.replaceAll(
-			/^(llama-[\d.]+-\d+b)/,
+			/^(llama-[\d.]+-\d+b)/g,
 			"$1-instruct",
 		);
 		ctx.strategies.push("add-instruct-suffix");
@@ -206,7 +206,7 @@ function normalizeMistral(ctx: {
 	strategies: string[];
 }): void {
 	if (ctx.normalized.includes("-latest")) {
-		ctx.normalized = ctx.normalized.replaceAll(/-latest$/, "");
+		ctx.normalized = ctx.normalized.replaceAll(/-latest$/g, "");
 		ctx.strategies.push("strip-mistral-latest");
 	}
 }
@@ -217,15 +217,15 @@ function stripCommonSuffixes(ctx: {
 	strategies: string[];
 }): void {
 	const suffixesToStrip = [
-		/-\d{8}$/, // Date suffixes like -20250514
-		/-v\d+(\.\d+)?$/, // Version suffixes like -v1.1
-		/-\d{3,}$/, // Numeric suffixes like -001, -2603
-		/-it$/, // -it (Gemma convention)
-		/-fp\d+$/, // -fp8, -fp16
-		/-bf\d+$/, // -bf16
-		/-preview$/, // -preview
-		/-exp$/, // -exp (experimental)
-		/-instruct-0\.\d+$/, // HuggingFace revision tags
+		/-\d{8}$/g, // Date suffixes like -20250514
+		/-v\d+(\.\d+)?$/g, // Version suffixes like -v1.1
+		/-\d{3,}$/g, // Numeric suffixes like -001, -2603
+		/-it$/g, // -it (Gemma convention)
+		/-fp\d+$/g, // -fp8, -fp16
+		/-bf\d+$/g, // -bf16
+		/-preview$/g, // -preview
+		/-exp$/g, // -exp (experimental)
+		/-instruct-0\.\d+$/g, // HuggingFace revision tags
 	];
 	for (const pattern of suffixesToStrip) {
 		if (pattern.test(ctx.normalized)) {
@@ -336,14 +336,14 @@ function normalizeSizeTokenOrder(id: string): string {
 function extractBaseModelId(modelId: string): string {
 	return modelId
 		.toLowerCase()
-		.replaceAll(/^.*\//, "") // Strip ALL path prefixes - keep only last segment
-		.replaceAll(/:free$/, "") // Strip :free suffix
-		.replaceAll(/-\d{8}$/, "") // Strip date suffixes like -20250514
-		.replaceAll(/-v\d+(\.\d+)?$/, "") // Strip version suffixes like -v1.1
-		.replaceAll(/-\d{3,}$/, "") // Strip numeric suffixes like -001, -2603
-		.replaceAll(/-it$/, "") // Strip -it suffix (Gemma convention for "instruct")
-		.replaceAll(/-fp\d+$/, "") // Strip -fp8, -fp16 suffixes
-		.replaceAll(/-bf\d+$/, "") // Strip -bf16 suffixes
+		.replaceAll(/^.*\//g, "") // Strip ALL path prefixes - keep only last segment
+		.replaceAll(/:free$/g, "") // Strip :free suffix
+		.replaceAll(/-\d{8}$/g, "") // Strip date suffixes like -20250514
+		.replaceAll(/-v\d+(\.\d+)?$/g, "") // Strip version suffixes like -v1.1
+		.replaceAll(/-\d{3,}$/g, "") // Strip numeric suffixes like -001, -2603
+		.replaceAll(/-it$/g, "") // Strip -it suffix (Gemma convention for "instruct")
+		.replaceAll(/-fp\d+$/g, "") // Strip -fp8, -fp16 suffixes
+		.replaceAll(/-bf\d+$/g, "") // Strip -bf16 suffixes
 		.trim();
 }
 

--- a/tests/benchmark-lookup.test.ts
+++ b/tests/benchmark-lookup.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+	enhanceModelNameWithCodingIndex,
+	findHardcodedBenchmark,
+	getHardcodedScore,
+} from "../provider-failover/benchmark-lookup.ts";
+
+describe("Benchmark Lookup", () => {
+	describe("enhanceModelNameWithCodingIndex", () => {
+		it("should not throw for models with NVIDIA prefixes", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Meta Llama 3 70B",
+					"meta/llama-3-70b",
+					"nvidia",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for models with Cloudflare @cf prefix", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Llama 3 8B",
+					"@cf/meta/llama-3-8b",
+					"cloudflare",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for OpenRouter :free suffix", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"GPT-4o",
+					"openai/gpt-4o:free",
+					"openrouter",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for Ollama colon format", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Llama 3",
+					"llama3:latest",
+					"ollama",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for Groq numeric suffix", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Mixtral 8x7B",
+					"mixtral-8x7b-32768",
+					"groq",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for Groq -versatile suffix", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Llama 3.1 70B",
+					"llama-3.1-70b-versatile",
+					"groq",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for Cerebras llama format", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Llama 3.1 8B",
+					"llama3.1-8b",
+					"cerebras",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for Mistral -latest suffix", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Mistral Large",
+					"mistral-large-latest",
+					"mistral",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for models with date suffixes", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"GPT-4o",
+					"gpt-4o-20250514",
+					"openai",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for models with version suffixes", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Claude 3.5",
+					"claude-3-5-sonnet-v1.1",
+					"anthropic",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for models with fp/bf suffixes", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Llama 3 70B",
+					"llama-3-70b-fp16",
+					"nvidia",
+				),
+			).not.toThrow();
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Llama 3 70B",
+					"llama-3-70b-bf16",
+					"nvidia",
+				),
+			).not.toThrow();
+		});
+
+		it("should not throw for models with -it suffix", () => {
+			expect(() =>
+				enhanceModelNameWithCodingIndex(
+					"Gemma 2 9B",
+					"gemma-2-9b-it",
+					"google",
+				),
+			).not.toThrow();
+		});
+
+		it("should return enhanced name with CI score when matched", () => {
+			const result = enhanceModelNameWithCodingIndex(
+				"GPT-4o",
+				"gpt-4o",
+				"openai",
+			);
+			expect(result).toContain("[CI:");
+		});
+
+		it("should return original name when no match", () => {
+			const result = enhanceModelNameWithCodingIndex(
+				"Some Unknown Model",
+				"unknown-model-xyz",
+				"test",
+			);
+			expect(result).toBe("Some Unknown Model");
+		});
+	});
+
+	describe("findHardcodedBenchmark", () => {
+		it("should find benchmark for exact model name", () => {
+			const result = findHardcodedBenchmark("GPT-4o", "gpt-4o", "openai");
+			expect(result).not.toBeNull();
+			expect(result?.codingIndex).toBeDefined();
+		});
+
+		it("should find benchmark via variant alias", () => {
+			const result = findHardcodedBenchmark(
+				"Claude 3.5 Sonnet",
+				"claude-3-5-sonnet",
+				"anthropic",
+			);
+			expect(result).not.toBeNull();
+		});
+
+		it("should return null for unknown models", () => {
+			const result = findHardcodedBenchmark(
+				"Unknown Model",
+				"unknown-model",
+				"test",
+			);
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("getHardcodedScore", () => {
+		it("should return a score for known models", () => {
+			const score = getHardcodedScore("GPT-4o", "gpt-4o", "openai");
+			expect(score).not.toBeNull();
+			expect(typeof score).toBe("number");
+		});
+
+		it("should return null for unknown models", () => {
+			const score = getHardcodedScore("Unknown", "unknown", "test");
+			expect(score).toBeNull();
+		});
+	});
+
+	describe("replaceAll regex global flag", () => {
+		it("should not use replaceAll with non-global RegExp in benchmark-lookup.ts", () => {
+			// This test prevents regression of the TypeError:
+			// "String.prototype.replaceAll called with a non-global RegExp argument"
+			const fs = require("node:fs");
+			const path = require("node:path");
+			const filePath = path.join(
+				__dirname,
+				"..",
+				"provider-failover",
+				"benchmark-lookup.ts",
+			);
+			const content = fs.readFileSync(filePath, "utf-8");
+
+			// Find all replaceAll calls with regex literals
+			const replaceAllRegex = /\.replaceAll\(\/[^/]+\/[^g,]*,/g;
+			const matches = content.match(replaceAllRegex) || [];
+
+			// Filter out false positives where 'g' might be present but not captured
+			const nonGlobalMatches = matches.filter((m: string) => !m.includes("/g,"));
+
+			if (nonGlobalMatches.length > 0) {
+				throw new Error(
+					`Found replaceAll calls with non-global RegExp in benchmark-lookup.ts:\n${nonGlobalMatches.join("\n")}`,
+				);
+			}
+
+			expect(nonGlobalMatches).toHaveLength(0);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #151

## Release 2.0.8

### Fixed
- **Missing `g` flag on `replaceAll` regexps broke model filtering** — `String.prototype.replaceAll()` requires a global RegExp. 20+ patterns in `benchmark-lookup.ts` were missing it, causing a `TypeError` that prevented models from appearing for providers like cline and kilo. Fixes #151.

### Security
- **Bump `basic-ftp` 5.3.0 → 5.3.1** — Patches GHSA-rpmf-866q-6p89 (high severity): malicious FTP server could cause client-side DoS via unbounded multiline control response buffering.

### Added (since 2.0.7)
- **Passive quota monitoring** — Extracts rate-limit headers from every provider response via `after_provider_response`. Shows remaining quota in the status bar with warnings at ≤25% / ≤10%. Fixes #147.
- **`agents.md`** — Codebase guide for AI agents.

### Changed (since 2.0.7)
- **Resolved ~280 SonarCloud issues across 21 files** — S7748, S7764, S7773, S7726, S7780, S7785, S7763, S7755, S7772, S5145. Fixes #148.

### Refactored (since 2.0.7)
- **Extracted shared model-fetch helper** — `fetchOpenAICompatibleModels()` eliminates ~120 lines of duplicated boilerplate. Fixes #146.

---

**Test**
- Added `tests/benchmark-lookup.test.ts` with regression test that scans the source file for non-global `replaceAll` regexps
- All 228 tests pass