### PR TITLE
chore: bump version to 2.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.8] - 2026-05-07
+
 ### Added
 
 - **Codestral provider** — Mistral's code-focused model via codestral.mistral.ai.
@@ -56,6 +58,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`agents.md`** — Codebase guide for AI agents covering architecture, patterns,
   conventions, testing, and the Pi extension API.
+
+### Added
+
+- **Passive quota monitoring** — Extracts rate-limit headers from every
+  provider response via `after_provider_response` event (no extra API calls).
+  Tries 6 header format variants (`x-ratelimit-remaining`,
+  `ratelimit-remaining-requests-day`, etc.). Shows remaining quota in the
+  status bar with warning icons when ≤25% or ≤10%. Fixes #147.
+
+### Fixed
+
+- **Missing `g` flag on `replaceAll` regexps broke model filtering** —
+  `String.prototype.replaceAll()` requires a global RegExp; 20+ patterns in
+  `benchmark-lookup.ts` were missing it, causing a `TypeError` that prevented
+  models from appearing for providers like cline and kilo. Added `/g` flag to
+  all affected patterns. Fixes #151.
+
+### Changed
+
+- **Resolved ~280 SonarCloud issues across 21 files** — Bulk code-quality
+  cleanup including: stripping trailing zeros from `toFixed()` (S7748),
+  `global` → `globalThis` (S7764), `parseFloat` → `Number.parseFloat` (S7773),
+  naming unnamed async exports (S7726), `String.raw` for path strings (S7780),
+  top-level await over promise chains (S7785), re-export from source (S7763),
+  `.at(-1)` over `[length-1]` (S7755), `node:fs` protocol imports (S7772),
+  and logging user-controlled data sanitization (S5145). Fixes #148.
+
+### Security
+
+- **Bump `basic-ftp` 5.3.0 → 5.3.1** — Patches GHSA-rpmf-866q-6p89 (high
+  severity): malicious FTP server could cause client-side DoS via unbounded
+  multiline control response buffering. Fixes `npm audit` finding.
 
 ### Refactored
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3086,9 +3086,9 @@
 			"peer": true
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering. Shows only $0 cost models by default. Supports Kilo (free OAuth), Cline (free), NVIDIA (freemium), ZenMux, CrofAI, Ollama Cloud, and more.",
 	"keywords": [


### PR DESCRIPTION
## What's in 2.0.8

Since 2.0.7 was published, the following changes have landed on master but were not yet released:

### Added
- **Passive quota monitoring** -- Extracts rate-limit headers from every provider response. Shows remaining quota in the status bar with warnings at ≤25% / ≤10%. Fixes #147.
- **agents.md** -- Codebase guide for AI agents.
- **Codestral, LLM7, DeepInfra, SambaNova providers**

### Fixed
- **Missing `g` flag on `replaceAll` regexps** -- Fixes #151 (already merged in #153)
- **Toggle persistence for all providers** -- Fixes #149

### Changed
- **Resolved ~280 SonarCloud issues** across 21 files. Fixes #148.

### Security
- **Bump `basic-ftp` 5.3.0 → 5.3.1** -- Patches GHSA-rpmf-866q-6p89 (high severity DoS). Fixes `npm audit` finding.

### Refactored
- **Extracted shared model-fetch helper** -- `fetchOpenAICompatibleModels()`. Fixes #146.

---

**Release checklist**
- [x] Version bumped in `package.json`
- [x] `package-lock.json` updated
- [x] `CHANGELOG.md` updated with release date
- [x] `npm audit` passes (0 vulnerabilities)
- [x] All tests pass
