### PR TITLE
chore: migrate package scope from @mariozechner to @earendil-works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Package scope migration** — Updated all peer dependency imports from `@mariozechner/*` to `@earendil-works/*` (`pi-ai`, `pi-coding-agent`, `pi-tui`) to match the upstream scope rename in `@earendil-works/pi` v0.74.0.
+
 ## [2.0.8] - 2026-05-07
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@
  * - LLM7: AI gateway (free default/fast selectors)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { setupBuiltInProviderToggles } from "./lib/built-in-toggle.ts";
 import { createLogger } from "./lib/logger.ts";
 import {

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -11,11 +11,11 @@
  * Usage: /toggle-opencode
  */
 
-import type { Api, Model } from "@mariozechner/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getOpencodeShowPaid, getOpenrouterShowPaid } from "../config.ts";
 import { createLogger } from "./logger.ts";
 import { isFreeModel, registerWithGlobalToggle } from "./registry.ts";

--- a/lib/model-detection.ts
+++ b/lib/model-detection.ts
@@ -4,7 +4,7 @@
  * Used for failover when providers hit rate limits.
  */
 
-import type { Model } from "@mariozechner/pi-ai";
+import type { Model } from "@earendil-works/pi-ai";
 import type { ProviderModelConfig } from "./types.ts";
 
 export interface ModelInfo {

--- a/lib/model-enhancer.ts
+++ b/lib/model-enhancer.ts
@@ -3,7 +3,7 @@
  * Adds Coding Index scores to model names for display in /model
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { enhanceModelNameWithCodingIndex } from "../provider-failover/benchmark-lookup.ts";
 
 /**

--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -1,4 +1,4 @@
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
 export interface ProviderModelIdentity {
 	id: string;

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -8,7 +8,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getFreeOnly, saveConfig } from "../config.ts";
 import { createLogger } from "./logger.ts";
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -3,7 +3,7 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "./provider-compat.ts";
-import type { ProviderModelConfig as PiProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig as PiProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type { ProviderModelConfig } from "./types.ts";
 
 const _logger = createLogger("util");

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
 		"test:run": "vitest run"
 	},
 	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"@mariozechner/pi-tui": "*"
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
 		"@vitest/ui": "^4.1.5",

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -10,7 +10,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { saveConfig } from "./config.ts";
 import { createLogger } from "./lib/logger.ts";
 import { enhanceModelNameWithCodingIndex } from "./provider-failover/benchmark-lookup.ts";

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -14,7 +14,7 @@ import { URL as NodeURL } from "node:url";
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import { BASE_URL_CLINE, CLINE_AUTH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -14,8 +14,8 @@
  *   # Models appear immediately; run /login cline to start chatting
  */
 
-import type { OAuthCredentials } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";

--- a/providers/codestral/codestral.ts
+++ b/providers/codestral/codestral.ts
@@ -33,7 +33,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
 	getCodestralApiKey,
 	getCodestralShowPaid,

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -15,7 +15,7 @@
  *   # Models appear in /model selector
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getCrofaiApiKey, getCrofaiShowPaid } from "../../config.ts";
 import { BASE_URL_CROFAI, PROVIDER_CROFAI } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -28,7 +28,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getDeepinfraApiKey } from "../../config.ts";
 import { BASE_URL_DEEPINFRA, PROVIDER_DEEPINFRA } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -22,7 +22,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
 	getCerebrasApiKey,
 	getGroqApiKey,

--- a/providers/kilo/kilo-auth.ts
+++ b/providers/kilo/kilo-auth.ts
@@ -5,7 +5,7 @@
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import {
 	KILO_POLL_INTERVAL_MS,
 	KILO_TOKEN_EXPIRATION_MS,

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -12,11 +12,11 @@
  *   # Free models visible immediately; /login kilo for paid access
  */
 
-import type { Api, Model, OAuthCredentials } from "@mariozechner/pi-ai";
+import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
 	getKiloFreeOnly,
 	getKiloShowPaid,

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -35,7 +35,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getLlm7ApiKey, getLlm7ShowPaid } from "../../config.ts";
 import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -16,7 +16,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
 	applyHidden,
 	getNvidiaApiKey,

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -23,7 +23,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
 	applyHidden,
 	getOllamaApiKey,

--- a/providers/qwen/qwen-auth.ts
+++ b/providers/qwen/qwen-auth.ts
@@ -16,7 +16,7 @@ import crypto from "node:crypto";
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import { createLogger } from "../../lib/logger.ts";
 import { openBrowser } from "../../lib/open-browser.ts";
 

--- a/providers/qwen/qwen-models.ts
+++ b/providers/qwen/qwen-models.ts
@@ -5,7 +5,7 @@
  * This provider remains for backward compatibility but should not be used.
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "../../lib/logger.ts";
 
 const _logger = createLogger("qwen-models");

--- a/providers/qwen/qwen.ts
+++ b/providers/qwen/qwen.ts
@@ -10,8 +10,8 @@
  * 1,000 free API calls/day — run /login qwen to authenticate.~~
  */
 
-import type { Api, Model, OAuthCredentials } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { PROVIDER_QWEN, URL_QWEN_TOS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { logWarning } from "../../lib/util.ts";

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -27,7 +27,7 @@
  *   # Models appear in /model selector as "sambanova/Meta-Llama-3.3-70B-Instruct"
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getSambanovaApiKey, getSambanovaShowPaid } from "../../config.ts";
 import { BASE_URL_SAMBANOVA, PROVIDER_SAMBANOVA } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -19,7 +19,7 @@
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
 import {
 	BASE_URL_ZENMUX,

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetGlobalFreeOnly = vi.fn();

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -2,7 +2,7 @@
  * Cline Provider Tests
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies

--- a/tests/isFreeModel.test.ts
+++ b/tests/isFreeModel.test.ts
@@ -6,7 +6,7 @@
  * - Route B (non-pricing-exposed): Name-based only, no cost fallback
  */
 
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { isFreeModel } from "../lib/registry.ts";
 

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -2,7 +2,7 @@
  * Kilo toggle behavior tests
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchKiloModels = vi.fn();

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -2,7 +2,7 @@
  * Kilo Provider Tests
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Create mock functions first

--- a/tests/nvidia.test.ts
+++ b/tests/nvidia.test.ts
@@ -2,7 +2,7 @@
  * NVIDIA Provider Tests
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let capturedToggleArgs: any = null;

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -5,7 +5,7 @@
  * global filter application, and pricing detection.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import {
 	applyGlobalFilter,


### PR DESCRIPTION
## Summary

Update all peer dependency imports from `@mariozechner/\*` to `@earendil-works/\*` to match the upstream scope rename in `@earendil-works/pi` v0.74.0.

## Changes

| Old scope | New scope |
|-----------|-----------|
| `@mariozechner/pi-ai` | `@earendil-works/pi-ai` |
| `@mariozechner/pi-coding-agent` | `@earendil-works/pi-coding-agent` |
| `@mariozechner/pi-tui` | `@earendil-works/pi-tui` |

**33 files changed** — all `*.ts` source files, test files, and `package.json` peer dependencies.

## Why

Pi v0.74.0 migrated the package scope from `mariozechner` → `earendil-works`. This extension needs to follow suit or imports will break when Pi ships with the new scope.

## References

- [pi v0.73.1–0.74.0 CHANGELOG](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/CHANGELOG.md) — scope rename announcement