### PR TITLE
feat: _pricingKnown guard for accurate free model detection + dynamic…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,23 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npx vitest run
+
   install-test:
     name: Install test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Dynamic model fetching for OpenCode and OpenRouter** — Pi's built-in providers now get their models fetched dynamically from the API (`opencode.ai/zen/v1/models` and `openrouter.ai/api/v1/models`), same as Mistral, Groq, Cerebras, and xAI. Overwrites Pi's defaults with the full model list. OpenCode uses name-based free detection (API returns no pricing); OpenRouter uses full cost-based detection.
+
+- **API key reading from `~/.pi/agent/auth.json`** — `getOpencodeApiKey()` and `getOpenrouterApiKey()` now fall back to Pi's auth.json when the env var isn't set, matching how Pi's built-in providers read their keys.
+
+### Changed
+
+- **`_pricingKnown` guard in `isFreeModel`** — Providers can now signal whether pricing data is authoritative. When `_pricingKnown` is explicitly `false` (API returned no pricing), `isFreeModel` falls back to name-only detection (checks for "free" in the model name). This eliminates false positives where missing pricing data was treated as $0 cost. All 5 affected providers (ZenMux, Together, CrofAI, dynamic-built-in, fetchOpenAICompatibleModels) now set this flag correctly.
+
+- **DeepInfra and SambaNova now use `isFreeModel`** — DeepInfra previously hardcoded an empty free list; SambaNova previously treated all models as free. Both now use the standard `isFreeModel` detection with proper `_pricingKnown` metadata.
+
+- **Unified OpenRouter-based providers** — Kilo, OpenRouter, and Cline now share the same `fetchOpenRouterCompatibleModels` / OpenRouter API logic. DeepSeek proxy compat is auto-detected for all three.
+
+### Removed
+
+- **`DEFAULT_MIN_SIZE_B` (30B minimum model size filter)** — Removed from `model-fetcher.ts` and `cline-models.ts`. All models are now shown regardless of parameter count. NVIDIA still uses its own 70B threshold (`NVIDIA_MIN_SIZE_B`).
+
+### Fixed
+
+- **ZenMux false free classifications** — Models without `pricings` data (DeepSeek Chat V3.1, Kimi K2 0711, Claude 3.7 Sonnet) were incorrectly classified as free because missing pricing defaulted to $0. Fixed to 3 genuinely free models (down from 6 false positives).
+
+- **Together AI, CrofAI, dynamic-built-in missing-pricing false positives** — Same `?? 0` pattern across multiple providers could mark unpriced models as free. All now set `_pricingKnown: false` when pricing is absent from the API response.
+
 ## [2.0.10] - 2026-05-08
 
 ### Fixed

--- a/config.ts
+++ b/config.ts
@@ -303,11 +303,46 @@ export function getHfToken(): string | undefined {
 }
 
 /**
+ * Read an API key from ~/.pi/agent/auth.json.
+ * Pi stores built-in provider keys there (opencode, openrouter, etc.).
+ * Falls back to env var if auth.json is missing or key not found.
+ */
+function readAuthJsonKey(
+	providerId: string,
+	envVar: string,
+): string | undefined {
+	// Check env var first (fast path)
+	const envVal = process.env[envVar];
+	if (envVal) return envVal;
+
+	// Check auth.json
+	try {
+		const authPath = join(PI_DIR, "agent", "auth.json");
+		if (!existsSync(authPath)) return undefined;
+		const raw = readFileSync(authPath, "utf8");
+		const auth = JSON.parse(raw) as Record<
+			string,
+			{ type?: string; key?: string }
+		>;
+		const entry = auth[providerId];
+		if (entry?.key?.trim()) return entry.key;
+	} catch {
+		// auth.json missing or corrupt — silently skip
+	}
+	return undefined;
+}
+
+/**
  * OpenRouter key — pi's built-in provider reads from ~/.pi/agent/auth.json.
- * pi-free only checks the env var to avoid stale keys from free.json.
+ * pi-free checks env var first, then auth.json.
  */
 export function getOpenrouterApiKey(): string | undefined {
-	return process.env.OPENROUTER_API_KEY;
+	return readAuthJsonKey("openrouter", "OPENROUTER_API_KEY");
+}
+
+/** OpenCode key — pi's built-in provider. Read from env or auth.json. */
+export function getOpencodeApiKey(): string | undefined {
+	return readAuthJsonKey("opencode", "OPENCODE_API_KEY");
 }
 
 // =============================================================================

--- a/constants.ts
+++ b/constants.ts
@@ -84,7 +84,6 @@ export const CLINE_AUTH_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 // =============================================================================
 
 export const NVIDIA_MIN_SIZE_B = 70; // Minimum model size for NVIDIA NIM
-export const DEFAULT_MIN_SIZE_B = 30; // Default minimum model size for filtering
 
 // =============================================================================
 // Timeouts (milliseconds)

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -82,7 +82,7 @@ function detectPricingExposed(allModels: ProviderModelConfig[]): boolean {
  * @returns true if the model is definitively free per the provider's API
  */
 export function isFreeModel(
-	model: ProviderModelConfig & { provider?: string },
+	model: ProviderModelConfig & { provider?: string; _pricingKnown?: boolean },
 	allModels?: ProviderModelConfig[],
 ): boolean {
 	return isFreeModelInternal(model, allModels);
@@ -90,7 +90,7 @@ export function isFreeModel(
 
 // Internal implementation to work around TypeScript filter callback issues
 function isFreeModelInternal(
-	model: ProviderModelConfig & { provider?: string },
+	model: ProviderModelConfig & { provider?: string; _pricingKnown?: boolean },
 	allModels: ProviderModelConfig[] | undefined,
 ): boolean {
 	// Determine if pricing is exposed
@@ -106,12 +106,20 @@ function isFreeModelInternal(
 		pricingExposed = true;
 	}
 
-	// Route A: Pricing-exposed providers - use OR logic
-	// Model is free if EITHER cost is zero OR name contains "free"
+	// Route A: Pricing-exposed providers
+	// Model is free if EITHER cost is zero OR name contains "free".
+	// BUT: when _pricingKnown is explicitly false (API returned no pricing data),
+	// cost values are untrustworthy defaults — fall back to name-only detection.
 	if (pricingExposed) {
 		const isZeroCost =
 			(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0;
 		const hasFreeInName = model.name.toLowerCase().includes("free");
+
+		// Pricing missing for this specific model — only trust name-based signal
+		if (model._pricingKnown === false) {
+			return hasFreeInName;
+		}
+
 		return isZeroCost || hasFreeInName;
 	}
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -361,7 +361,8 @@ export function mapOpenRouterModel(m: {
 		contextWindow: m.context_length ?? 4096,
 		maxTokens:
 			m.max_completion_tokens ?? m.top_provider?.max_completion_tokens ?? 4096,
-	};
+		_pricingKnown: true,
+	} as ProviderModelConfig & { _pricingKnown?: boolean };
 }
 
 // =============================================================================
@@ -484,20 +485,19 @@ export async function fetchOpenAICompatibleModels(
 					(hasVision ? ["text", "image"] : ["text"]);
 
 				// Use per-model pricing if the API provides it, otherwise use defaults
-				const inputCost =
-					(typeof m.pricing?.prompt === "number" ||
+				const hasApiPricing = m.pricing !== undefined;
+				const apiInput =
+					typeof m.pricing?.prompt === "number" ||
 					typeof m.pricing?.prompt === "string"
 						? Number(m.pricing.prompt)
-						: undefined) ??
-					defaults.cost?.input ??
-					0;
-				const outputCost =
-					(typeof m.pricing?.completion === "number" ||
+						: undefined;
+				const apiOutput =
+					typeof m.pricing?.completion === "number" ||
 					typeof m.pricing?.completion === "string"
 						? Number(m.pricing.completion)
-						: undefined) ??
-					defaults.cost?.output ??
-					0;
+						: undefined;
+				const inputCost = apiInput ?? defaults.cost?.input ?? 0;
+				const outputCost = apiOutput ?? defaults.cost?.output ?? 0;
 
 				return {
 					id: m.id,
@@ -513,7 +513,8 @@ export async function fetchOpenAICompatibleModels(
 					contextWindow,
 					maxTokens,
 					compat: getProxyModelCompat({ id: m.id, name }),
-				};
+					_pricingKnown: hasApiPricing,
+				} as PiProviderModelConfig & { _pricingKnown?: boolean };
 			});
 	} catch (error) {
 		logger.error(`[${providerId}] Failed to fetch models:`, {

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -9,15 +9,10 @@ import { applyHidden } from "../../config.ts";
 import {
 	BASE_URL_OPENROUTER,
 	DEFAULT_FETCH_TIMEOUT_MS,
-	DEFAULT_MIN_SIZE_B,
 	PROVIDER_CLINE,
 } from "../../constants.ts";
 import type { ProviderModelConfig } from "../../lib/types.ts";
-import {
-	cleanModelName,
-	fetchWithRetry,
-	isUsableModel,
-} from "../../lib/util.ts";
+import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 
 interface OpenRouterRaw {
 	id: string;
@@ -74,10 +69,8 @@ export async function fetchClineModels(
 
 	const json = (await response.json()) as { data?: OpenRouterRaw[] };
 
-	// Filter to usable models (chat-capable, size threshold)
-	let usableModels = (json.data ?? []).filter((m) =>
-		isUsableModel(m.id, DEFAULT_MIN_SIZE_B),
-	);
+	// Filter to usable models (chat-capable)
+	let usableModels = json.data ?? [];
 
 	// If freeOnly, filter to free models
 	if (freeOnly) {

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -119,7 +119,11 @@ async function fetchCrofaiModels(
 				contextWindow: m.context_length ?? 128_000,
 				maxTokens: m.max_completion_tokens ?? 16_384,
 				compat: getProxyModelCompat({ id: m.id, name }),
-			};
+				_pricingKnown:
+					m.pricing?.prompt !== undefined ||
+					m.pricing?.completion !== undefined ||
+					m.pricing?.cache_prompt !== undefined,
+			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
 }
 

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -44,7 +44,7 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
 import { createReRegister, setupProvider } from "../../provider-helper.ts";
 
@@ -136,7 +136,8 @@ async function fetchDeepinfraModels(
 				contextWindow: meta?.context_length ?? 128_000,
 				maxTokens: meta?.max_tokens ?? 16_384,
 				compat: getProxyModelCompat({ id: m.id, name }),
-			};
+				_pricingKnown: meta?.pricing !== undefined,
+			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
 }
 
@@ -163,9 +164,10 @@ export default async function deepinfraProvider(pi: ExtensionAPI) {
 	}
 
 	// DeepInfra is a trial credit provider — $5 one-time credit, no truly free models.
-	// All models are marked as paid. When free-only mode is ON, no models are shown.
-	// Toggle free-only OFF to see all models.
-	const freeModels: ProviderModelConfig[] = [];
+	// Use isFreeModel for consistent detection across all providers.
+	const freeModels = allModels.filter((m) =>
+		isFreeModel({ ...m, provider: PROVIDER_DEEPINFRA }, allModels),
+	);
 	const stored = { free: freeModels, all: allModels };
 
 	_logger.info(

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -14,6 +14,8 @@
  * - groq (GROQ_API_KEY)
  * - cerebras (CEREBRAS_API_KEY)
  * - xai (XAI_API_KEY)
+ * - opencode (OPENCODE_API_KEY from auth.json)
+ * - openrouter (OPENROUTER_API_KEY from auth.json)
  * - huggingface (HF_TOKEN - optional, special-cased API shape)
  *
  * OpenAI is intentionally skipped per user request.
@@ -28,11 +30,14 @@ import {
 	getGroqApiKey,
 	getHfToken,
 	getMistralApiKey,
+	getOpencodeApiKey,
+	getOpenrouterApiKey,
 	getXaiApiKey,
 } from "../../config.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 import { createToggleState } from "../../lib/toggle-state.ts";
 import { enhanceWithCI } from "../../provider-helper.ts";
 
@@ -101,9 +106,10 @@ async function fetchModelsFromEndpoint(
 				((m.max_tokens ?? m.max_completion_tokens) as number) ??
 				opts.modelDefaults?.maxTokens ??
 				16_384,
+			_pricingKnown: false as boolean | undefined,
 			...opts.modelDefaults,
 			...(opts.compat ? { compat: opts.compat } : {}),
-		} satisfies ProviderModelConfig;
+		} satisfies ProviderModelConfig & { _pricingKnown?: boolean };
 	});
 }
 
@@ -164,6 +170,11 @@ interface DynamicProviderDef {
 	compat?: ProviderModelConfig["compat"];
 	/** Per-model field defaults when the API doesn't expose them. */
 	modelDefaults?: Partial<ProviderModelConfig>;
+	/**
+	 * Custom model fetcher (e.g., OpenRouter uses its own pricing-aware fetcher).
+	 * When not provided, fetchModelsFromEndpoint is used (no pricing, _pricingKnown=false).
+	 */
+	fetchModels?: (apiKey: string) => Promise<ProviderModelConfig[]>;
 }
 
 const DYNAMIC_PROVIDERS: DynamicProviderDef[] = [
@@ -196,6 +207,28 @@ const DYNAMIC_PROVIDERS: DynamicProviderDef[] = [
 		api: "openai-completions",
 		defaultShowPaid: false,
 	},
+	{
+		providerId: "opencode",
+		getApiKey: getOpencodeApiKey,
+		baseUrl: "https://opencode.ai/zen/v1",
+		api: "openai-completions",
+		defaultShowPaid: false,
+		// OpenCode API returns no pricing — _pricingKnown=false, name-based detection
+	},
+	{
+		providerId: "openrouter",
+		getApiKey: getOpenrouterApiKey,
+		baseUrl: "https://openrouter.ai/api/v1",
+		api: "openai-completions",
+		defaultShowPaid: false,
+		// OpenRouter returns full pricing — use its dedicated fetcher
+		fetchModels: (apiKey) =>
+			fetchOpenRouterCompatibleModels({
+				baseUrl: "https://openrouter.ai/api/v1",
+				apiKey,
+				freeOnly: false,
+			}),
+	},
 ];
 
 // =============================================================================
@@ -210,13 +243,17 @@ async function discoverAndRegister(
 	let allModels: ProviderModelConfig[];
 
 	try {
-		allModels = await fetchModelsFromEndpoint({
-			baseUrl: config.baseUrl,
-			apiKey,
-			compat: config.compat,
-			modelDefaults: config.modelDefaults,
-			timeoutMs: 1_000,
-		});
+		if (config.fetchModels) {
+			allModels = await config.fetchModels(apiKey);
+		} else {
+			allModels = await fetchModelsFromEndpoint({
+				baseUrl: config.baseUrl,
+				apiKey,
+				compat: config.compat,
+				modelDefaults: config.modelDefaults,
+				timeoutMs: 1_000,
+			});
+		}
 
 		// Apply DeepSeek proxy compat to matching models
 		allModels = allModels.map((m) => ({

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -3,17 +3,9 @@
  * Consolidates duplicate logic from openrouter.ts and kilo-models.ts
  */
 
-import {
-	DEFAULT_FETCH_TIMEOUT_MS,
-	DEFAULT_MIN_SIZE_B,
-	URL_MODELS_DEV,
-} from "../constants.ts";
+import { DEFAULT_FETCH_TIMEOUT_MS, URL_MODELS_DEV } from "../constants.ts";
 import type { ModelsDevModel, ProviderModelConfig } from "../lib/types.ts";
-import {
-	fetchWithRetry,
-	isUsableModel,
-	mapOpenRouterModel,
-} from "../lib/util.ts";
+import { fetchWithRetry, mapOpenRouterModel } from "../lib/util.ts";
 
 interface OpenRouterCompatibleModel {
 	id: string;
@@ -112,9 +104,6 @@ export async function fetchOpenRouterCompatibleModels(
 				const completion = Number.parseFloat(m.pricing?.completion ?? "1");
 				if (prompt !== 0 || completion !== 0) return false;
 			}
-
-			// Filter unusable and too-small models
-			if (!isUsableModel(m.id, DEFAULT_MIN_SIZE_B)) return false;
 
 			return true;
 		})

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -31,7 +31,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getSambanovaApiKey, getSambanovaShowPaid } from "../../config.ts";
 import { BASE_URL_SAMBANOVA, PROVIDER_SAMBANOVA } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
 import { createReRegister, setupProvider } from "../../provider-helper.ts";
 
@@ -66,7 +66,13 @@ export default async function sambanovaProvider(pi: ExtensionAPI) {
 
 	// All SambaNova models are free-tier (no payment method required).
 	// Rate limits are lower on free tier but all models are accessible.
-	const freeModels = allModels;
+	// Override _pricingKnown so isFreeModel trusts the zero costs.
+	for (const m of allModels) {
+		(m as unknown as { _pricingKnown?: boolean })._pricingKnown = true;
+	}
+	const freeModels = allModels.filter((m) =>
+		isFreeModel({ ...m, provider: PROVIDER_SAMBANOVA }, allModels),
+	);
 	const stored = { free: freeModels, all: allModels };
 
 	_logger.info(

--- a/providers/together/together.ts
+++ b/providers/together/together.ts
@@ -123,7 +123,8 @@ async function fetchTogetherModels(
 				contextWindow: m.context_length ?? 128_000,
 				maxTokens: 16_384,
 				compat: getProxyModelCompat({ id: m.id, name }),
-			};
+				_pricingKnown: m.pricing !== undefined,
+			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
 }
 

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -97,8 +97,9 @@ async function fetchZenmuxModels(
 
 		_logger.info(`[zenmux] Fetched ${models.length} models`);
 
-		return models.map(
-			(m): ProviderModelConfig => ({
+		return models.map((m) => {
+			const hasPricings = m.pricings !== undefined;
+			return {
 				id: m.id,
 				name: m.display_name || m.id,
 				reasoning: m.capabilities?.reasoning ?? false,
@@ -114,8 +115,9 @@ async function fetchZenmuxModels(
 				contextWindow: m.context_length || 128000,
 				maxTokens: m.context_length ? Math.floor(m.context_length / 2) : 4096,
 				compat: getProxyModelCompat(m),
-			}),
-		);
+				_pricingKnown: hasPricings,
+			} as ProviderModelConfig & { _pricingKnown?: boolean };
+		});
 	} catch (error) {
 		_logger.error("[zenmux] Failed to fetch models:", {
 			error: error instanceof Error ? error.message : String(error),

--- a/tests/isFreeModel.test.ts
+++ b/tests/isFreeModel.test.ts
@@ -252,3 +252,76 @@ describe("isFreeModel - edge cases", () => {
 		expect(isFreeModel({ ...model, provider: "nvidia" })).toBe(true);
 	});
 });
+
+describe("isFreeModel - _pricingKnown guard (Route A)", () => {
+	it("_pricingKnown=false + cost=0 + no 'free' in name = NOT free (missing pricing guarded)", () => {
+		const model = createModel("GPT-4", { input: 0, output: 0 });
+		// Simulate ZenMux models with missing pricing (e.g. deepseek-chat-v3.1)
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "zenmux", _pricingKnown: false }, allModels),
+		).toBe(false);
+	});
+
+	it("_pricingKnown=false + cost=0 + 'free' in name = free (name-based escape)", () => {
+		const model = createModel("Model Free Edition", { input: 0, output: 0 });
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "zenmux", _pricingKnown: false }, allModels),
+		).toBe(true);
+	});
+
+	it("_pricingKnown=false + cost>0 + 'free' in name = free (name beats unknown pricing)", () => {
+		const model = createModel("Free Tier Model", { input: 1, output: 1 });
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "opencode", _pricingKnown: false }, allModels),
+		).toBe(true);
+	});
+
+	it("_pricingKnown=true + cost=0 = free (same as old OR logic)", () => {
+		const model = createModel("Some Model", { input: 0, output: 0 });
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "openrouter", _pricingKnown: true }, allModels),
+		).toBe(true);
+	});
+
+	it("_pricingKnown=true + cost>0 = NOT free (pricing authoritative)", () => {
+		const model = createModel("Paid Model", { input: 1, output: 1 });
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "openrouter", _pricingKnown: true }, allModels),
+		).toBe(false);
+	});
+
+	it("_pricingKnown=undefined + cost=0 = free (backward compatible — defaults to old OR)", () => {
+		const model = createModel("GPT-4", { input: 0, output: 0 });
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "kilo", _pricingKnown: undefined }, allModels),
+		).toBe(true);
+	});
+
+	it("_pricingKnown=undefined + cost>0 + 'free' in name = free (backward compatible OR)", () => {
+		const model = createModel("Free Plan", { input: 5, output: 30 });
+		const allModels = [
+			{ ...createModel("GPT-4o-mini", { input: 0.15, output: 0.6 }) },
+		];
+		expect(
+			isFreeModel({ ...model, provider: "kilo", _pricingKnown: undefined }, allModels),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
… OpenCode/OpenRouter fetching

- Add _pricingKnown flag to isFreeModel: when API returns no pricing, fall back to name-based detection only (eliminates false positives where missing pricing defaulted to /usr/bin/bash)
- Fix ZenMux (6->3 correctly free), Together, CrofAI, dynamic-built-in
- Switch DeepInfra and SambaNova to standard isFreeModel detection
- Add dynamic model fetching for OpenCode and OpenRouter built-in providers
- Read OpenCode/OpenRouter API keys from ~/.pi/agent/auth.json
- Remove DEFAULT_MIN_SIZE_B size filter (all models now shown)
- Unify OpenRouter-based provider logic across Kilo/OpenRouter/Cline