### PR TITLE
Release 2.0.12: Novita AI, FastRouter, dynamic built-in providers, pricingKnown guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.12] - 2026-05-13
+
 ### Added
 
 - **Novita AI provider** — OpenAI-compatible API at `api.novita.ai/openai/v1` with 100+ open-source models. Non-standard but rich metadata: per-model pricing (`input_token_price_per_m`), context size, max output tokens, reasoning/vision features, and model descriptions. 3 free models, 99 paid.
 
 - **FastRouter provider** — OpenRouter-compatible API at `api.fastrouter.ai/api/v1` with 170+ models. Always discovered (no auth needed for model listing). Full pricing, context lengths, and feature metadata. 129 text models (6 free, 123 paid) after filtering image/video. Set `FASTROUTER_API_KEY` for chat completions.
-
-
 
 - **Dynamic model fetching for OpenCode and OpenRouter** — Pi's built-in providers now get their models fetched dynamically from the API (`opencode.ai/zen/v1/models` and `openrouter.ai/api/v1/models`), same as Mistral, Groq, Cerebras, and xAI. Overwrites Pi's defaults with the full model list. OpenCode uses name-based free detection (API returns no pricing); OpenRouter uses full cost-based detection.
 
@@ -33,11 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FastRouter startup auth validation** — Pi requires a non-empty `apiKey` when replacing a provider's models during registration. FastRouter now passes the configured API key (or `FASTROUTER_API_KEY` env var name as a placeholder) instead of an empty string, preventing startup auth validation errors.
+
 - **ZenMux false free classifications** — Models without `pricings` data (DeepSeek Chat V3.1, Kimi K2 0711, Claude 3.7 Sonnet) were incorrectly classified as free because missing pricing defaulted to $0. Fixed to 3 genuinely free models (down from 6 false positives).
 
 - **Together AI, CrofAI, dynamic-built-in missing-pricing false positives** — Same `?? 0` pattern across multiple providers could mark unpriced models as free. All now set `_pricingKnown: false` when pricing is absent from the API response.
 
-## [2.0.10] - 2026-05-08
+## [2.0.11] - 2026-05-08
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ Add your API keys to this file:
 {
   "nvidia_api_key": "nvapi-...",
   "ollama_api_key": "...",
-  "mistral_api_key": "...",
+  "together_ai_api_key": "...",
+  "novita_api_key": "...",
+  "fastrouter_api_key": "...",
   "codestral_api_key": "...",
-  "deepinfra_api_key": "...",
+  "deepinfra_token": "...",
   "sambanova_api_key": "...",
   "llm7_api_key": "...",
   "zenmux_api_key": "...",
@@ -143,7 +145,7 @@ Add your API keys to this file:
 }
 ```
 
-Or set environment variables instead (same names, uppercase: `OPENROUTER_API_KEY`, `NVIDIA_API_KEY`, etc.)
+Or set environment variables instead (same names, uppercase: `NVIDIA_API_KEY`, `TOGETHER_AI_API_KEY`, `FASTROUTER_API_KEY`, etc.)
 
 If `~/.pi/free.json` contains invalid JSON, pi-free now logs the parse error to `~/.pi/free.log` so you can fix the file quickly.
 
@@ -507,9 +509,17 @@ Create `~/.pi/free.json` in your home directory:
 ```json
 {
   "nvidia_api_key": "YOUR_NVIDIA_KEY",
-  "mistral_api_key": "YOUR_MISTRAL_KEY",
   "ollama_api_key": "YOUR_OLLAMA_KEY",
   "ollama_show_paid": true,
+  "together_ai_api_key": "YOUR_TOGETHER_KEY",
+  "novita_api_key": "YOUR_NOVITA_KEY",
+  "fastrouter_api_key": "YOUR_FASTROUTER_KEY",
+  "deepinfra_token": "YOUR_DEEPINFRA_TOKEN",
+  "sambanova_api_key": "YOUR_SAMBANOVA_KEY",
+  "codestral_api_key": "YOUR_CODESTRAL_KEY",
+  "llm7_api_key": "YOUR_LLM7_KEY",
+  "zenmux_api_key": "YOUR_ZENMUX_KEY",
+  "crofai_api_key": "YOUR_CROFAI_KEY",
   "hidden_models": ["model-id-to-hide"]
 }
 ```

--- a/agents.md
+++ b/agents.md
@@ -149,12 +149,12 @@ Debug logging writes to `~/.pi/modelmatch.log`.
 
 ## Provider Categories
 
-| Category    | Providers                                          | Auth              | Notes                            |
-| ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
-| ✅ Free     | kilo, cline, openrouter, opencode, llm7            | OAuth or none     | Toggle between free/paid         |
-| 🔄 Freemium | nvidia, ollama-cloud, sambanova, codestral         | API key           | Free tier with limits            |
-| 💳 Paid     | zenmux, crofai, deepinfra, together, novita        | API key + credits | Trial credits or pay-per-token   |
-| 🔧 Dynamic  | mistral, groq, cerebras, xai, huggingface, fastrouter | API key        | Fetched when key configured      |
+| Category    | Providers                                             | Auth              | Notes                          |
+| ----------- | ----------------------------------------------------- | ----------------- | ------------------------------ |
+| ✅ Free     | kilo, cline, openrouter, opencode, llm7               | OAuth or none     | Toggle between free/paid       |
+| 🔄 Freemium | nvidia, ollama-cloud, sambanova, codestral            | API key           | Free tier with limits          |
+| 💳 Paid     | zenmux, crofai, deepinfra, together, novita           | API key + credits | Trial credits or pay-per-token |
+| 🔧 Dynamic  | mistral, groq, cerebras, xai, huggingface, fastrouter | API key           | Fetched when key configured    |
 
 ---
 

--- a/config.ts
+++ b/config.ts
@@ -229,6 +229,7 @@ export function getFastrouterShowPaid(): boolean {
 	);
 }
 
+
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -334,6 +335,7 @@ export function getNovitaApiKey(): string | undefined {
 export function getFastrouterApiKey(): string | undefined {
 	return resolve("FASTROUTER_API_KEY", loadConfigFile().fastrouter_api_key);
 }
+
 
 export function getOllamaApiKey(): string | undefined {
 	return resolve("OLLAMA_API_KEY", loadConfigFile().ollama_api_key);

--- a/config.ts
+++ b/config.ts
@@ -337,6 +337,7 @@ export function getFastrouterApiKey(): string | undefined {
 }
 
 
+
 export function getOllamaApiKey(): string | undefined {
 	return resolve("OLLAMA_API_KEY", loadConfigFile().ollama_api_key);
 }

--- a/config.ts
+++ b/config.ts
@@ -229,7 +229,6 @@ export function getFastrouterShowPaid(): boolean {
 	);
 }
 
-
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -335,8 +334,6 @@ export function getNovitaApiKey(): string | undefined {
 export function getFastrouterApiKey(): string | undefined {
 	return resolve("FASTROUTER_API_KEY", loadConfigFile().fastrouter_api_key);
 }
-
-
 
 export function getOllamaApiKey(): string | undefined {
 	return resolve("OLLAMA_API_KEY", loadConfigFile().ollama_api_key);

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "pi-free",
-	"version": "2.0.10",
+	"version": "2.0.12",
 	"type": "module",
-	"description": "AI model providers for Pi with free model filtering. Shows only $0 cost models by default. Supports Kilo (free OAuth), Cline (free), NVIDIA (freemium), ZenMux, CrofAI, Ollama Cloud, and more.",
+	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [
 		"pi-package",
 		"pi-extension",


### PR DESCRIPTION
## Summary

Release v2.0.12 — consolidates the last round of feature work:

### Added
- **Novita AI provider** — OpenAI-compatible, 100+ models with rich metadata
- **FastRouter provider** — OpenRouter-compatible, 170+ models, always discovered
- **Dynamic model fetching** for OpenCode & OpenRouter built-in providers
- **API key fallback** from `~/.pi/agent/auth.json`

### Changed
- **`_pricingKnown` guard** — eliminates false free-model classifications when APIs don't return pricing
- **All providers use `isFreeModel` consistently** (Together, DeepInfra, SambaNova migrated)
- **Unified OpenRouter-based providers** (Kilo, OpenRouter, Cline share logic)

### Fixed
- **FastRouter startup auth validation** — passes configured key instead of empty string
- **Provider model toggles preserved on startup** — no more post-session_start toggle corruption
- **ZenMux/Together/CrofAI false free classifications** — proper `_pricingKnown` handling
