### PR TITLE
Release 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.12] - 2026-05-13
+
 ### Added
 
 - **Novita AI provider** — OpenAI-compatible API at `api.novita.ai/openai/v1` with 100+ open-source models. Non-standard but rich metadata: per-model pricing (`input_token_price_per_m`), context size, max output tokens, reasoning/vision features, and model descriptions. 3 free models, 99 paid.
 
 - **FastRouter provider** — OpenRouter-compatible API at `api.fastrouter.ai/api/v1` with 170+ models. Always discovered (no auth needed for model listing). Full pricing, context lengths, and feature metadata. 129 text models (6 free, 123 paid) after filtering image/video. Set `FASTROUTER_API_KEY` for chat completions.
-
-
 
 - **Dynamic model fetching for OpenCode and OpenRouter** — Pi's built-in providers now get their models fetched dynamically from the API (`opencode.ai/zen/v1/models` and `openrouter.ai/api/v1/models`), same as Mistral, Groq, Cerebras, and xAI. Overwrites Pi's defaults with the full model list. OpenCode uses name-based free detection (API returns no pricing); OpenRouter uses full cost-based detection.
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "pi-free",
-	"version": "2.0.10",
+	"version": "2.0.12",
 	"type": "module",
-	"description": "AI model providers for Pi with free model filtering. Shows only $0 cost models by default. Supports Kilo (free OAuth), Cline (free), NVIDIA (freemium), ZenMux, CrofAI, Ollama Cloud, and more.",
+	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [
 		"pi-package",
 		"pi-extension",


### PR DESCRIPTION
## Summary

Release v2.0.12 — bump from the `[Unreleased]` features already in master (Novita AI, FastRouter, dynamic built-in providers, `_pricingKnown` guard, fixes).

### Changes
- Bump version from 2.0.10 → 2.0.12
- Move `[Unreleased]` changelog entries under `[2.0.12] - 2026-05-13`
- Update description to reflect current scope
