### PR TITLE
feat: inject OpenCode required headers into built-in models (pi#4680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.12] - 2026-05-13
+
 ### Added
 
 - **Novita AI provider** — OpenAI-compatible API at `api.novita.ai/openai/v1` with 100+ open-source models. Non-standard but rich metadata: per-model pricing (`input_token_price_per_m`), context size, max output tokens, reasoning/vision features, and model descriptions. 3 free models, 99 paid.
 
 - **FastRouter provider** — OpenRouter-compatible API at `api.fastrouter.ai/api/v1` with 170+ models. Always discovered (no auth needed for model listing). Full pricing, context lengths, and feature metadata. 129 text models (6 free, 123 paid) after filtering image/video. Set `FASTROUTER_API_KEY` for chat completions.
-
-
 
 - **Dynamic model fetching for OpenCode and OpenRouter** — Pi's built-in providers now get their models fetched dynamically from the API (`opencode.ai/zen/v1/models` and `openrouter.ai/api/v1/models`), same as Mistral, Groq, Cerebras, and xAI. Overwrites Pi's defaults with the full model list. OpenCode uses name-based free detection (API returns no pricing); OpenRouter uses full cost-based detection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OpenCode static headers injection** — pi-free now injects required OpenCode headers (`x-opencode-client`, `x-opencode-session`, `x-opencode-request`, `x-opencode-project`, `User-Agent`) when capturing and re-registering pi's built-in OpenCode models. Prevents requests from hanging indefinitely when pi's model generation omits these headers ([pi#4680](https://github.com/earendil-works/pi/issues/4680)). Uses the existing (formerly unused) `createOpenCodeSessionTracker` for dynamic per-session UUIDs and per-model request IDs.
+
 ## [2.0.12] - 2026-05-13
 
 ### Added

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -24,8 +24,22 @@ import {
 	registerWithGlobalToggle,
 } from "./registry.ts";
 import { createToggleState } from "./toggle-state.ts";
+import { createOpenCodeSessionTracker } from "../providers/opencode-session.ts";
 
 const _logger = createLogger("built-in-toggle");
+
+// =============================================================================
+// OpenCode required headers (pi issue #4680)
+// Without these, requests to OpenCode models hang forever.
+// =============================================================================
+
+const OPENCODE_STATIC_HEADERS = {
+	"User-Agent": "opencode/1.15.3",
+	"x-opencode-client": "cli",
+	"x-opencode-project": "global",
+} as const;
+
+const _opencodeSession = createOpenCodeSessionTracker();
 
 // =============================================================================
 // Configuration
@@ -113,7 +127,9 @@ function tryCaptureProvider(
 	);
 	if (providerModels.length === 0) return undefined;
 
-	const allModels = providerModels.map(modelToProviderConfig);
+	const allModels = providerModels.map((m: Model<Api>) =>
+		modelToProviderConfig(m, config.id),
+	);
 	const freeModels = allModels.filter((m: ProviderModelConfig) =>
 		isFreeModel({ ...m, provider: config.id }, allModels),
 	);
@@ -196,8 +212,11 @@ function registerToggleCommand(
 // Helpers
 // =============================================================================
 
-function modelToProviderConfig(m: Model<Api>): ProviderModelConfig {
-	return {
+function modelToProviderConfig(
+	m: Model<Api>,
+	providerId?: string,
+): ProviderModelConfig {
+	const base: ProviderModelConfig = {
 		id: m.id,
 		name: m.name,
 		api: m.api,
@@ -209,6 +228,18 @@ function modelToProviderConfig(m: Model<Api>): ProviderModelConfig {
 		headers: m.headers,
 		compat: (m as any).compat,
 	};
+
+	// Inject OpenCode required headers for opencode / opencode-go models (pi #4680)
+	if (providerId === "opencode") {
+		base.headers = {
+			...m.headers,
+			...OPENCODE_STATIC_HEADERS,
+			"x-opencode-session": _opencodeSession.getSessionId(),
+			"x-opencode-request": _opencodeSession.nextRequestId(),
+		};
+	}
+
+	return base;
 }
 
 // =============================================================================

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "pi-free",
-	"version": "2.0.10",
+	"version": "2.0.12",
 	"type": "module",
-	"description": "AI model providers for Pi with free model filtering. Shows only $0 cost models by default. Supports Kilo (free OAuth), Cline (free), NVIDIA (freemium), ZenMux, CrofAI, Ollama Cloud, and more.",
+	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [
 		"pi-package",
 		"pi-extension",


### PR DESCRIPTION
## Summary

When pi-free registers OpenCode models, it now injects required headers that prevent requests from hanging indefinitely.

This now covers both code paths:

1. fallback capture/re-registration of pi's built-in OpenCode provider (`lib/built-in-toggle.ts`)
2. dynamic OpenCode discovery/registration from `opencode.ai/zen/v1` when `OPENCODE_API_KEY` / Pi auth.json is present (`providers/dynamic-built-in/index.ts`)

## Problem

[pi#4680](https://github.com/earendil-works/pi/issues/4680) / [pi-free#173](https://github.com/apmantza/pi-free/issues/173) — OpenCode models need specific headers (`x-opencode-client`, `x-opencode-session`, `x-opencode-request`, `x-opencode-project`, `User-Agent`) or requests can hang/freeze without a response.

The first version of this PR only fixed the fallback built-in capture path. Issue #173 exposed that users who log in / have an OpenCode key use pi-free's dynamic OpenCode provider path instead, which bypassed that fix.

## Solution

- Centralized OpenCode header construction in `providers/opencode-session.ts`
- Inject headers in `lib/built-in-toggle.ts`
- Inject headers in `providers/dynamic-built-in/index.ts`
- Reuse the existing `createOpenCodeSessionTracker` for per-session UUIDs and incrementing request IDs

## Testing

- All 274 tests pass (vitest)
