### PR TITLE
fix: inject OpenCode headers for dynamic provider path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.12] - 2026-05-13
-
 ### Added
 
-- **OpenCode static headers injection** — pi-free now injects required OpenCode headers (`x-opencode-client`, `x-opencode-session`, `x-opencode-request`, `x-opencode-project`, `User-Agent`) when capturing and re-registering pi's built-in OpenCode models. Prevents requests from hanging indefinitely when pi's model generation omits these headers ([pi#4680](https://github.com/earendil-works/pi/issues/4680)). Uses the existing (formerly unused) `createOpenCodeSessionTracker` for dynamic per-session UUIDs and per-model request IDs.
+- **OpenCode static headers injection** — pi-free now injects required OpenCode headers (`x-opencode-client`, `x-opencode-session`, `x-opencode-request`, `x-opencode-project`, `User-Agent`) when capturing/re-registering pi's built-in OpenCode models **and** when dynamically fetching/registering OpenCode models from `opencode.ai/zen/v1`. Prevents requests from hanging indefinitely when pi's model generation omits these headers ([pi#4680](https://github.com/earendil-works/pi/issues/4680), [#173](https://github.com/apmantza/pi-free/issues/173)). Uses the existing (formerly unused) `createOpenCodeSessionTracker` for dynamic per-session UUIDs and per-model request IDs.
 
 ## [2.0.12] - 2026-05-13
 

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -24,21 +24,14 @@ import {
 	registerWithGlobalToggle,
 } from "./registry.ts";
 import { createToggleState } from "./toggle-state.ts";
-import { createOpenCodeSessionTracker } from "../providers/opencode-session.ts";
+import {
+	createOpenCodeHeaders,
+	createOpenCodeSessionTracker,
+} from "../providers/opencode-session.ts";
 
 const _logger = createLogger("built-in-toggle");
 
-// =============================================================================
-// OpenCode required headers (pi issue #4680)
-// Without these, requests to OpenCode models hang forever.
-// =============================================================================
-
-const OPENCODE_STATIC_HEADERS = {
-	"User-Agent": "opencode/1.15.3",
-	"x-opencode-client": "cli",
-	"x-opencode-project": "global",
-} as const;
-
+// OpenCode required headers (pi issue #4680). Without these, requests hang.
 const _opencodeSession = createOpenCodeSessionTracker();
 
 // =============================================================================
@@ -231,12 +224,7 @@ function modelToProviderConfig(
 
 	// Inject OpenCode required headers for opencode / opencode-go models (pi #4680)
 	if (providerId === "opencode") {
-		base.headers = {
-			...m.headers,
-			...OPENCODE_STATIC_HEADERS,
-			"x-opencode-session": _opencodeSession.getSessionId(),
-			"x-opencode-request": _opencodeSession.nextRequestId(),
-		};
+		base.headers = createOpenCodeHeaders(_opencodeSession, m.headers);
 	}
 
 	return base;

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -46,8 +46,16 @@ import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 import { createToggleState } from "../../lib/toggle-state.ts";
 import { enhanceWithCI } from "../../provider-helper.ts";
+import {
+	createOpenCodeHeaders,
+	createOpenCodeSessionTracker,
+} from "../opencode-session.ts";
 
 const _logger = createLogger("dynamic-built-in");
+
+// OpenCode required headers (pi issue #4680). Dynamic OpenCode registration
+// bypasses built-in-toggle.ts, so inject them here as well.
+const _opencodeSession = createOpenCodeSessionTracker();
 
 // =============================================================================
 // Generic Model Fetcher
@@ -261,10 +269,15 @@ async function discoverAndRegister(
 			});
 		}
 
-		// Apply DeepSeek proxy compat to matching models
+		// Apply DeepSeek proxy compat to matching models and OpenCode headers when
+		// dynamically replacing Pi's built-in OpenCode provider.
 		allModels = allModels.map((m) => ({
 			...m,
 			compat: getProxyModelCompat(m) ?? m.compat,
+			headers:
+				config.providerId === "opencode"
+					? createOpenCodeHeaders(_opencodeSession, m.headers)
+					: m.headers,
 		}));
 	} catch (error) {
 		_logger.info(

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
 
+export const OPENCODE_STATIC_HEADERS = {
+	"User-Agent": "opencode/1.15.3",
+	"x-opencode-client": "cli",
+	"x-opencode-project": "global",
+} as const;
+
 /**
  * Shared OpenCode session/request tracking.
  *
@@ -29,5 +35,19 @@ export function createOpenCodeSessionTracker() {
 	return {
 		getSessionId,
 		nextRequestId,
+	};
+}
+
+export type OpenCodeSessionTracker = ReturnType<typeof createOpenCodeSessionTracker>;
+
+export function createOpenCodeHeaders(
+	tracker: OpenCodeSessionTracker,
+	existingHeaders?: Record<string, string>,
+): Record<string, string> {
+	return {
+		...existingHeaders,
+		...OPENCODE_STATIC_HEADERS,
+		"x-opencode-session": tracker.getSessionId(),
+		"x-opencode-request": tracker.nextRequestId(),
 	};
 }


### PR DESCRIPTION
## Summary

Follow-up to #171. That PR fixed the fallback built-in OpenCode capture path, but users with an OpenCode API key / Pi auth.json use pi-free's dynamic OpenCode registration path instead.

This PR injects the required OpenCode headers in the dynamic provider path too.

## Problem

Reported in #173: after logging in / configuring OpenCode, OpenCode models still freeze. That happens because dynamic registration from `opencode.ai/zen/v1` bypasses `lib/built-in-toggle.ts`, so the headers from #171 were not applied.

## Solution

- Move OpenCode header construction into `providers/opencode-session.ts`
- Keep fallback built-in capture using the shared helper
- Apply the same helper in `providers/dynamic-built-in/index.ts` when `providerId === "opencode"`
- Update changelog to mention both paths and #173

## Testing

- `npm run test:run` — 274 tests passed
