### PR TITLE
fix: regenerate OpenCode request headers per call

### DIFF
--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -25,13 +25,15 @@ import {
 } from "./registry.ts";
 import { createToggleState } from "./toggle-state.ts";
 import {
-	createOpenCodeHeaders,
+	OPENCODE_DYNAMIC_API,
 	createOpenCodeSessionTracker,
+	createOpenCodeStreamSimple,
+	isOpenCodeProvider,
 } from "../providers/opencode-session.ts";
 
 const _logger = createLogger("built-in-toggle");
 
-// OpenCode required headers (pi issue #4680). Without these, requests hang.
+// OpenCode requires per-request ids; see createOpenCodeStreamSimple().
 const _opencodeSession = createOpenCodeSessionTracker();
 
 // =============================================================================
@@ -45,6 +47,7 @@ interface BuiltInToggleConfig {
 
 const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
 	{ id: "opencode", getShowPaid: getOpencodeShowPaid },
+	{ id: "opencode-go", getShowPaid: getOpencodeShowPaid },
 	{ id: "openrouter", getShowPaid: getOpenrouterShowPaid },
 ];
 
@@ -135,7 +138,10 @@ function tryCaptureProvider(
 		pi.registerProvider(config.id, {
 			baseUrl,
 			apiKey: apiKeyEnv,
-			api,
+			api: isOpenCodeProvider(config.id) ? OPENCODE_DYNAMIC_API : api,
+			...(isOpenCodeProvider(config.id)
+				? { streamSimple: createOpenCodeStreamSimple(_opencodeSession) }
+				: {}),
 			models,
 		});
 	};
@@ -222,9 +228,10 @@ function modelToProviderConfig(
 		compat: (m as any).compat,
 	};
 
-	// Inject OpenCode required headers for opencode / opencode-go models (pi #4680)
-	if (providerId === "opencode") {
-		base.headers = createOpenCodeHeaders(_opencodeSession, m.headers);
+	// Use a custom OpenCode API wrapper so per-request headers are regenerated
+	// for every LLM call instead of being frozen at registration time.
+	if (providerId && isOpenCodeProvider(providerId)) {
+		base.api = OPENCODE_DYNAMIC_API;
 	}
 
 	return base;
@@ -272,6 +279,7 @@ function setupStatusBar(
 function getApiKeyEnvForProvider(providerId: string): string {
 	const envMap: Record<string, string> = {
 		opencode: "OPENCODE_API_KEY",
+		"opencode-go": "OPENCODE_API_KEY",
 		openrouter: "OPENROUTER_API_KEY",
 	};
 	return envMap[providerId] || `${providerId.toUpperCase()}_API_KEY`;

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -22,6 +22,7 @@
  * OpenAI is intentionally skipped per user request.
  */
 
+import type { Api } from "@earendil-works/pi-ai";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
@@ -47,14 +48,15 @@ import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 import { createToggleState } from "../../lib/toggle-state.ts";
 import { enhanceWithCI } from "../../provider-helper.ts";
 import {
-	createOpenCodeHeaders,
+	OPENCODE_DYNAMIC_API,
 	createOpenCodeSessionTracker,
+	createOpenCodeStreamSimple,
+	isOpenCodeProvider,
 } from "../opencode-session.ts";
 
 const _logger = createLogger("dynamic-built-in");
 
-// OpenCode required headers (pi issue #4680). Dynamic OpenCode registration
-// bypasses built-in-toggle.ts, so inject them here as well.
+// OpenCode headers must be regenerated for every LLM request.
 const _opencodeSession = createOpenCodeSessionTracker();
 
 // =============================================================================
@@ -178,7 +180,7 @@ interface DynamicProviderDef {
 	providerId: string;
 	getApiKey: () => string | undefined;
 	baseUrl: string;
-	api: "openai-completions" | "mistral-conversations" | "anthropic-messages";
+	api: Api;
 	defaultShowPaid: boolean | (() => boolean);
 	/** Optional per-provider compat overrides (e.g., DeepSeek proxy). */
 	compat?: ProviderModelConfig["compat"];
@@ -225,9 +227,17 @@ const DYNAMIC_PROVIDERS: DynamicProviderDef[] = [
 		providerId: "opencode",
 		getApiKey: getOpencodeApiKey,
 		baseUrl: "https://opencode.ai/zen/v1",
-		api: "openai-completions",
+		api: OPENCODE_DYNAMIC_API,
 		defaultShowPaid: getOpencodeShowPaid,
 		// OpenCode API returns no pricing — _pricingKnown=false, name-based detection
+	},
+	{
+		providerId: "opencode-go",
+		getApiKey: getOpencodeApiKey,
+		baseUrl: "https://opencode.ai/zen/go/v1",
+		api: OPENCODE_DYNAMIC_API,
+		defaultShowPaid: getOpencodeShowPaid,
+		// OpenCode Go uses the same OPENCODE_API_KEY and per-request headers
 	},
 	{
 		providerId: "openrouter",
@@ -269,15 +279,12 @@ async function discoverAndRegister(
 			});
 		}
 
-		// Apply DeepSeek proxy compat to matching models and OpenCode headers when
-		// dynamically replacing Pi's built-in OpenCode provider.
+		// Apply DeepSeek proxy compat to matching models. OpenCode headers are
+		// injected per request by createOpenCodeStreamSimple(), not stored here.
 		allModels = allModels.map((m) => ({
 			...m,
+			api: isOpenCodeProvider(config.providerId) ? OPENCODE_DYNAMIC_API : m.api,
 			compat: getProxyModelCompat(m) ?? m.compat,
-			headers:
-				config.providerId === "opencode"
-					? createOpenCodeHeaders(_opencodeSession, m.headers)
-					: m.headers,
 		}));
 	} catch (error) {
 		_logger.info(
@@ -340,6 +347,9 @@ async function registerProvider(
 			baseUrl: config.baseUrl,
 			apiKey,
 			api: config.api,
+			...(isOpenCodeProvider(config.providerId)
+				? { streamSimple: createOpenCodeStreamSimple(_opencodeSession) }
+				: {}),
 			models: enhanceWithCI(models, config.providerId),
 		});
 	};

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -1,9 +1,14 @@
 import { randomUUID } from "node:crypto";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { streamSimpleAnthropic } from "@earendil-works/pi-ai/anthropic";
+import { streamSimpleOpenAICompletions } from "@earendil-works/pi-ai/openai-completions";
+import type { ProviderConfig } from "@earendil-works/pi-coding-agent";
+
+export const OPENCODE_DYNAMIC_API = "opencode-dynamic" as const;
 
 export const OPENCODE_STATIC_HEADERS = {
-	"User-Agent": "opencode/1.15.3",
+	"User-Agent": "opencode/1.15.5",
 	"x-opencode-client": "cli",
-	"x-opencode-project": "global",
 } as const;
 
 /**
@@ -38,7 +43,9 @@ export function createOpenCodeSessionTracker() {
 	};
 }
 
-export type OpenCodeSessionTracker = ReturnType<typeof createOpenCodeSessionTracker>;
+export type OpenCodeSessionTracker = ReturnType<
+	typeof createOpenCodeSessionTracker
+>;
 
 export function createOpenCodeHeaders(
 	tracker: OpenCodeSessionTracker,
@@ -49,5 +56,42 @@ export function createOpenCodeHeaders(
 		...OPENCODE_STATIC_HEADERS,
 		"x-opencode-session": tracker.getSessionId(),
 		"x-opencode-request": tracker.nextRequestId(),
+	};
+}
+
+export function isOpenCodeProvider(providerId: string): boolean {
+	return providerId === "opencode" || providerId === "opencode-go";
+}
+
+function isAnthropicOpenCodeEndpoint(model: Model<Api>): boolean {
+	return !model.baseUrl.replace(/\/+$/, "").endsWith("/v1");
+}
+
+/**
+ * Pi's static model headers are evaluated at registration time. OpenCode treats
+ * x-opencode-request like a per-request id, so reusing one value across turns can
+ * leave later requests attached to an old/in-flight generation. Registering a
+ * provider-specific stream keeps the normal Pi parsers but refreshes headers for
+ * every LLM call.
+ */
+export function createOpenCodeStreamSimple(
+	tracker: OpenCodeSessionTracker,
+): NonNullable<ProviderConfig["streamSimple"]> {
+	return (model, context, options) => {
+		const headers = createOpenCodeHeaders(tracker, options?.headers);
+
+		if (isAnthropicOpenCodeEndpoint(model)) {
+			return streamSimpleAnthropic(
+				{ ...model, api: "anthropic-messages" } as Model<"anthropic-messages">,
+				context,
+				{ ...options, headers },
+			);
+		}
+
+		return streamSimpleOpenAICompletions(
+			{ ...model, api: "openai-completions" } as Model<"openai-completions">,
+			context,
+			{ ...options, headers },
+		);
 	};
 }

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -99,9 +99,17 @@ describe("built-in provider toggles", () => {
 		expect(mockRegisterProvider).toHaveBeenCalledWith(
 			"opencode",
 			expect.objectContaining({
+				api: "opencode-dynamic",
+				streamSimple: expect.any(Function),
 				models: expect.arrayContaining([
-					expect.objectContaining({ id: "free-model" }),
-					expect.objectContaining({ id: "paid-model" }),
+					expect.objectContaining({
+						id: "free-model",
+						api: "opencode-dynamic",
+					}),
+					expect.objectContaining({
+						id: "paid-model",
+						api: "opencode-dynamic",
+					}),
 				]),
 			}),
 		);
@@ -109,6 +117,7 @@ describe("built-in provider toggles", () => {
 
 	it("skips fallback capture for providers already registered dynamically", () => {
 		mockProviderRegistry.set("opencode", {});
+		mockProviderRegistry.set("opencode-go", {});
 		mockProviderRegistry.set("openrouter", {});
 
 		setupBuiltInProviderToggles(mockPi);


### PR DESCRIPTION
## Summary
- register OpenCode/OpenCode Go with a custom Pi API wrapper that regenerates x-opencode-session/request headers on every LLM call
- keep Pi's OpenAI/Anthropic stream parsers while routing OpenCode requests through the per-request header wrapper
- include opencode-go in built-in fallback toggle handling

## Tests
- npm run test:run
- npx tsc -p tsconfig.json --noEmit