### PR TITLE
chore: release v2.0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .pisessionsummaries/
 .pi-lens/
 *.log
+.pi/greedysearch-sources/
 .DS_Store
 dist/
 *.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.13] - 2026-05-21
+
 ### Added
 
-- **OpenCode static headers injection** — pi-free now injects required OpenCode headers (`x-opencode-client`, `x-opencode-session`, `x-opencode-request`, `x-opencode-project`, `User-Agent`) when capturing/re-registering pi's built-in OpenCode models **and** when dynamically fetching/registering OpenCode models from `opencode.ai/zen/v1`. Prevents requests from hanging indefinitely when pi's model generation omits these headers ([pi#4680](https://github.com/earendil-works/pi/issues/4680), [#173](https://github.com/apmantza/pi-free/issues/173)). Uses the existing (formerly unused) `createOpenCodeSessionTracker` for dynamic per-session UUIDs and per-model request IDs.
+- **OpenCode static headers injection** — pi-free now injects required OpenCode headers (`x-opencode-client`, `x-opencode-session`, `x-opencode-request`, `x-opencode-project`, `User-Agent`) when capturing/re-registering pi's built-in OpenCode models **and** when dynamically fetching/registering OpenCode models from `opencode.ai/zen/v1`. Prevents requests from hanging indefinitely when pi's model generation omits these headers ([pi#4680](https://github.com/earendil-works/pi/issues/4680), [#171](https://github.com/apmantza/pi-free/issues/171), [#173](https://github.com/apmantza/pi-free/issues/173), [#174](https://github.com/apmantza/pi-free/issues/174)). Headers are now regenerated per-call with fresh session and request IDs. Uses native `ses_`/`msg_` prefixed ULID identifiers matching OpenCode's `Identifier.descending()` format to avoid daily rate-limit throttling ([#175](https://github.com/apmantza/pi-free/issues/175)).
+
+- **OpenCode endpoint detection** — Replaced regex-based OpenCode endpoint check with a simple string comparison, reducing overhead on every streaming request.
+
+### Fixed
+
+- **Lazy-load Pi AI stream providers** — Pi-ai's OpenAI completions and Anthropic stream modules are now imported lazily on first use rather than at extension load time. Eliminates start-up failures when pi-ai exports are not yet resolvable ([#177](https://github.com/apmantza/pi-free/issues/177)).
+
+- **Subpath resolution for isolated extension context** — Pi loads pi-free from a directory tree that does not contain `@earendil-works/pi-ai` in its `node_modules`. `createRequire().resolve()` only understands CJS resolution, but pi-ai is ESM-only with strict exports. The new fallback resolves a pi-ai dependency from Pi's entry point, walks up to `node_modules`, reads `pi-ai/package.json`, and maps the `exports` field to the actual file path. Fixes module resolution for both `anthropic` and `openai-completions` subpaths. Includes integration test.
+
+- **Security: shell injection in test** — Replaced `execSync` with `execFileSync` in the OpenCode session integration test to avoid shell injection risk.
+
+### Security
+
+- **Bump `brace-expansion` 5.0.5 → 5.0.6** — Patches minor dependency vulnerability. Fixes `npm audit`. ([#172](https://github.com/apmantza/pi-free/issues/172))
 
 ## [2.0.12] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When you install pi-free, it:
 
 3. **Filters to show only free models by default** for providers that expose pricing — You see only the models that cost $0 to use. Paid models are hidden until you explicitly toggle them on.
 
-4. **Provides per-provider toggle commands** — Run `/toggle-{provider}` (e.g., `/toggle-kilo`, `/toggle-opencode`) to switch between free-only mode and showing all models including paid ones. Changes apply immediately and your preference is saved for the next Pi restart.
+4. **Provides per-provider toggle commands** — Run `/toggle-{provider}` (e.g., `/toggle-kilo`) to switch between free-only mode and showing all models including paid ones. Changes apply immediately and your preference is saved for the next Pi restart.
 
 5. **Handles authentication for you** — OAuth flows (Kilo, Cline) open your browser automatically; API keys are read from `~/.pi/free.json` or environment variables
 
@@ -46,7 +46,6 @@ Free models are shown by default — look for the provider prefixes:
 
 **✅ Free Models (no payment required):**
 
-- `opencode/` — OpenCode models (no setup required; toggle with `/toggle-opencode`)
 - `kilo/` — Kilo models (free models available immediately, more after `/login kilo`)
 - `openrouter/` — OpenRouter models (free account required)
 - `cline/` — Cline models (run `/login cline` to use)
@@ -75,7 +74,6 @@ Free models are shown by default — look for the provider prefixes:
 - `cerebras/` — Cerebras models (when `CEREBRAS_API_KEY` set)
 - `xai/` — xAI models (when `XAI_API_KEY` set)
 - `huggingface/` — Hugging Face models (when `HF_TOKEN` set)
-- `opencode/` — OpenCode models (fetched from opencode.ai/zen/v1, when `OPENCODE_API_KEY` set)
 - `openrouter/` — OpenRouter models (fetched from openrouter.ai, when `OPENROUTER_API_KEY` set)
 - `fastrouter/` — FastRouter models (always discovered, 170+ models, no auth for listing)
 
@@ -86,7 +84,6 @@ Free models are shown by default — look for the provider prefixes:
 Want to see paid models too? Run the toggle command for your provider:
 
 ```
-/toggle-opencode   # Toggle OpenCode (✅ offers free models)
 /toggle-kilo       # Toggle Kilo (✅ offers free models)
 /toggle-openrouter # Toggle OpenRouter (✅ offers free models)
 /toggle-cline      # Toggle Cline (✅ offers free models)
@@ -113,10 +110,6 @@ Want to see paid models too? Run the toggle command for your provider:
 - **Toggle commands are mainly for ✅ and 🔄 providers** — to switch between "free models only" vs "show paid models too"
 - **🔧 Dynamic providers** show all fetched models by default — the toggle filters the list when you have an API key configured
 - **Freemium providers** show all models by default; you manage your usage limits via their dashboards
-
-You'll see a notification like: `opencode: showing free models` or `opencode: showing all models`
-
-**Note:** Built-in provider toggles such as OpenCode and OpenRouter update in the current session — no restart needed.
 
 ### 4. Add API keys for more providers (optional)
 
@@ -204,7 +197,7 @@ Providers have different pricing models. pi-free handles them all:
 
 **Provider types:**
 
-- ✅ **Free providers** (OpenCode, Kilo, Cline) — Toggle between free-only vs paid models
+- ✅ **Free providers** (Kilo, Cline) — Toggle between free-only vs paid models
 - 🔄 **Freemium** (NVIDIA, Ollama) — Free tier with limits, toggle shows all
 - 🔧 **Dynamic API** (Mistral, Groq, Cerebras, xAI) — Fetched when API key configured, toggle filters the list
 
@@ -218,17 +211,6 @@ Authentication is handled automatically:
 ---
 
 ## Using Free Models (No Setup Required)
-
-### OpenCode
-
-Works immediately with zero setup:
-
-1. Press `Ctrl+L`
-2. Search for `opencode/`
-3. Pick any model (e.g., `opencode/big-pickle`)
-4. Start chatting
-
-No account, no API key, no OAuth. Run `/toggle-opencode` to switch between free and paid OpenCode models.
 
 ### Kilo (free models, more after login)
 
@@ -450,7 +432,6 @@ Each provider has toggle commands to switch between free and all models:
 
 | Command                 | Action                                                   |
 | ----------------------- | -------------------------------------------------------- |
-| `/toggle-opencode`      | Toggle between free/all OpenCode models                  |
 | `/toggle-kilo`          | Toggle between free/all Kilo models                      |
 | `/toggle-openrouter`    | Toggle between free/all OpenRouter models                |
 | `/toggle-cline`         | Toggle between free/all Cline models                     |
@@ -477,7 +458,7 @@ Each provider has toggle commands to switch between free and all models:
 - **For 🔄 freemium providers**: Shows all models by default; toggle switches between filtered and full list
 - **For 🔧 dynamic API providers**: Filters the model list when you have an API key configured
 - **Persists your preference** to `~/.pi/free.json` for next startup
-- Shows a notification: "opencode: showing free models" or "opencode: showing all models"
+
 
 ### Probe Commands (Health Check)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.0.12",
+			"version": "2.0.13",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^4.1.5",
@@ -5549,9 +5549,9 @@
 			"peer": true
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## Changes

- **Bump version** 2.0.12 → 2.0.13
- **Remove OpenCode references from README** — Clean up docs (OpenCode provider no longer promoted in user-facing docs)
- **Add `.pi/greedysearch-sources/` to .gitignore** — Prevents garbage cache dir from being tracked
- **Bump ws 8.20.0 → 8.20.1** — npm audit fix

## Checklist

- [x] ALL 277 tests pass
- [x] npm audit — 0 vulnerabilities
- [x] npm publish --dry-run — clean