### PR TITLE
fix(ci): auto-update hardcoded-benchmarks.ts on chunk count change

### DIFF
--- a/.github/workflows/update-benchmarks.yml
+++ b/.github/workflows/update-benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Update benchmark data
         env:
           ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
-        run: npx tsx scripts/update-benchmarks.ts
+        run: node --import tsx scripts/update-benchmarks.ts
 
       - name: Check for changes
         id: check-changes

--- a/provider-failover/hardcoded-benchmarks.ts
+++ b/provider-failover/hardcoded-benchmarks.ts
@@ -11,6 +11,7 @@
  * under the 3000-line limit. This file re-exports the merged result.
  *
  * To update: Run scripts/update-benchmarks.ts with ARTIFICIAL_ANALYSIS_API_KEY
+ * The script auto-updates this file's imports and spread when chunk count changes.
  */
 
 import { BENCHMARKS_CHUNK_0 } from "./benchmarks-chunk-0.ts";

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -1,12 +1,12 @@
 /**
  * Script to update hardcoded benchmark data
- * Run: ARTIFICIAL_ANALYSIS_API_KEY=xxx npx tsx scripts/update-benchmarks.ts
+ * Run: ARTIFICIAL_ANALYSIS_API_KEY=xxx node --import tsx scripts/update-benchmarks.ts
  *
  * This fetches fresh data from Artificial Analysis API and updates
  * provider-failover/benchmarks-chunk-*.ts files.
  *
- * The main hardcoded-benchmarks.ts is a hand-maintained aggregator that
- * imports and merges all chunks — this script does NOT overwrite it.
+ * Also auto-updates provider-failover/hardcoded-benchmarks.ts to import
+ * the correct number of chunk files.
  */
 
 import { readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
@@ -205,18 +205,48 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 		chunkIndex++;
 	}
 
-	// Check if hardcoded-benchmarks.ts needs updating (new chunk count)
+	// Auto-update hardcoded-benchmarks.ts to match the new chunk count
 	const mainFile = join(OUTPUT_DIR, "hardcoded-benchmarks.ts");
 	const mainContent = readFileSync(mainFile, "utf-8");
 	const currentChunks = (mainContent.match(/BENCHMARKS_CHUNK_\d+/g) || [])
 		.length;
 	if (currentChunks !== chunkIndex) {
 		console.log(
-			`\n⚠️  hardcoded-benchmarks.ts references ${currentChunks} chunks but ${chunkIndex} were generated.`,
+			`\n🔄 Updating hardcoded-benchmarks.ts: ${currentChunks} chunks → ${chunkIndex} chunks`,
 		);
-		console.log(
-			"   Update the imports and spread in hardcoded-benchmarks.ts to match.",
+
+		// Generate new import lines
+		const chunkImports: string[] = [];
+		for (let i = 0; i < chunkIndex; i++) {
+			chunkImports.push(
+				`import { BENCHMARKS_CHUNK_${i} } from "./benchmarks-chunk-${i}.ts";`,
+			);
+		}
+		const newImportSection = chunkImports.join("\n");
+
+		// Generate new spread lines for the export
+		const chunkSpreads: string[] = [];
+		for (let i = 0; i < chunkIndex; i++) {
+			chunkSpreads.push(`\t...BENCHMARKS_CHUNK_${i},`);
+		}
+		const newSpreadSection = chunkSpreads.join("\n");
+
+		// Replace import block (everything between first import and the blank line before export interface)
+		const importRegex = /import\s+\{[^}]+\}\s+from\s+"[^"]+";[\s\S]*?(?=\nexport interface)/;
+		const updatedContent = mainContent.replace(
+			importRegex,
+			newImportSection,
 		);
+
+		// Replace spread block (inside HARDCODED_BENCHMARKS object)
+		const spreadRegex = /([\t ]+\.\.\.BENCHMARKS_CHUNK_\d+,)[\s\S]*?([\t ]+\};\n\})/;
+		const finalContent = updatedContent.replace(
+			spreadRegex,
+			`${newSpreadSection}\n$2`,
+		);
+
+		writeFileSync(mainFile, finalContent, "utf-8");
+		console.log(`  ✅ Updated hardcoded-benchmarks.ts with ${chunkIndex} chunk imports`);
 	}
 
 	console.log(`\n✅ Generated ${chunkIndex} chunk files in ${OUTPUT_DIR}/`);
@@ -232,7 +262,7 @@ async function main() {
 		console.log("\n📝 Next steps:");
 		console.log("  1. Review the chunk file changes");
 		console.log(
-			"  2. If chunk count changed, update hardcoded-benchmarks.ts imports",
+			"  2. Verify hardcoded-benchmarks.ts imports — auto-updated if chunk count changed",
 		);
 		console.log("  3. Run tests: npm run test:run");
 		console.log("  4. Commit and push");


### PR DESCRIPTION
## Problem

The May 1st scheduled benchmark update run failed with `ReferenceError: require is not defined` because `npx tsx` had ESM resolution issues in the CI runner. The data **was actually fetched** and **6 chunk files were written** (up from 5), but:

1. The script crashed before the `git diff` step, so no PR was ever created
2. Even if it hadn't crashed, `hardcoded-benchmarks.ts` only imported 5 chunks — the script only logged a warning, didn't auto-fix

## Fixes

- **`update-benchmarks.yml`**: Changed `npx tsx` → `node --import tsx` to avoid ESM loader issues
- **`update-benchmarks.ts`**: Now auto-updates `hardcoded-benchmarks.ts` imports and spread when chunk count changes (was just a warning before)
- **`hardcoded-benchmarks.ts`**: Doc comment updated

## Testing

After merge, I'll trigger a `workflow_dispatch` run to pull fresh AI data.