### PR TITLE
fix: correct spreadRegex to match just closing semicolon

### DIFF
--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -239,7 +239,7 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 
 		// Replace spread block (inside HARDCODED_BENCHMARKS object)
 		const spreadRegex =
-			/([\t ]+\.\.\.BENCHMARKS_CHUNK_\d+,)[\s\S]*?([\t ]+\};\n\})/;
+			/([\t ]+\.\.\.BENCHMARKS_CHUNK_\d+,)[\s\S]*?([\t ]+\};)/;
 		const finalContent = updatedContent.replace(
 			spreadRegex,
 			`${newSpreadSection}\n$2`,


### PR DESCRIPTION
The spreadRegex had a bad second capture group: it expected  (extra  after newline) but the file ends with just . This caused the regex to never match, so the spread section was never updated. Result: 6 imports but only 5 spreads in the benchmark data auto-update.