### PR TITLE
debug: add originalModel field to benchmark entries

### DIFF
--- a/provider-failover/hardcoded-benchmarks.ts
+++ b/provider-failover/hardcoded-benchmarks.ts
@@ -34,6 +34,12 @@ export interface HardcodedBenchmark {
 	supportsReasoning: boolean;
 	supportsVision: boolean;
 	lastUpdated: string;
+
+	/**
+	 * Original model name from the source API (for debugging name collisions).
+	 * Only present when regenerated; absent in shipped data.
+	 */
+	originalModel?: string;
 }
 
 /**

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -135,6 +135,8 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 	// Generate entries
 	const allEntries = scoredModels.map((model) => {
 		const key = normalizeModelName(model.name);
+		// Include original name for debugging name collisions
+		const originalName = model.name.replaceAll(/[\n\r]/g, "_");
 		const e = model.evaluations;
 		const score = e.artificial_analysis_intelligence_index!;
 		const normalized = Math.round((score / 70) * 100);
@@ -167,6 +169,7 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 
 		// Metadata
 		lastUpdated: "${today}",
+		originalModel: "${originalName}",
 	},`;
 	});
 


### PR DESCRIPTION
Adds originalModel field to generated benchmark entries to trace which AA models produce duplicate normalized keys. Temporary debug field.