### PR TITLE
fix: allow zero whitespace before closing brace in spread replacement

### DIFF
--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -242,7 +242,7 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 
 		// Replace spread block (inside HARDCODED_BENCHMARKS object)
 		const spreadRegex =
-			/([\t ]+\.\.\.BENCHMARKS_CHUNK_\d+,)[\s\S]*?([\t ]+\};)/;
+			/([\t ]+\.\.\.BENCHMARKS_CHUNK_\d+,)[\s\S]*?([\t ]*\};)/;
 		const finalContent = updatedContent.replace(
 			spreadRegex,
 			`${newSpreadSection}\n$2`,


### PR DESCRIPTION
The spreadRegex required one or more whitespace chars before the closing `;` but the file has `;` at column 0 with no indent. Changed `+\}` to `*`} to allow zero whitespace.