### PR TITLE
chore: remove unused intelligenceIndex and normalizedScore from benchmark data

### DIFF
--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -397,12 +397,10 @@ function findBestVariantByPrefix(
 	if (candidates.length === 0) return null;
 
 	// Pick the candidate with the highest codingIndex
-	// If tied or no CI, use normalizedScore as tiebreaker
 	candidates.sort((a, b) => {
 		const ciA = a.data.codingIndex ?? -1;
 		const ciB = b.data.codingIndex ?? -1;
-		if (ciB !== ciA) return ciB - ciA;
-		return (b.data.normalizedScore ?? 0) - (a.data.normalizedScore ?? 0);
+		return ciB - ciA;
 	});
 
 	// Only return if the best candidate has a codingIndex
@@ -640,7 +638,7 @@ export function getHardcodedScore(
 	provider?: string,
 ): number | null {
 	const benchmark = findHardcodedBenchmark(modelName, modelId, provider);
-	return benchmark?.normalizedScore ?? null;
+	return benchmark?.codingIndex ?? null;
 }
 
 /**

--- a/provider-failover/hardcoded-benchmarks.ts
+++ b/provider-failover/hardcoded-benchmarks.ts
@@ -21,8 +21,6 @@ import { BENCHMARKS_CHUNK_3 } from "./benchmarks-chunk-3.ts";
 import { BENCHMARKS_CHUNK_4 } from "./benchmarks-chunk-4.ts";
 
 export interface HardcodedBenchmark {
-	intelligenceIndex: number; // AA score 0-70
-	normalizedScore: number; // Our score 0-100
 	codingIndex?: number;
 	mathIndex?: number;
 	agenticIndex?: number;

--- a/scripts/update-benchmarks.ts
+++ b/scripts/update-benchmarks.ts
@@ -138,10 +138,8 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 		// Include original name for debugging name collisions
 		const originalName = model.name.replaceAll(/[\n\r]/g, "_");
 		const e = model.evaluations;
-		const score = e.artificial_analysis_intelligence_index!;
-		const normalized = Math.round((score / 70) * 100);
 
-		// Helper to format optional number fields (strips trailing zeros to avoid S7748)
+				// Helper to format optional number fields (strips trailing zeros to avoid S7748)
 		const fmt = (v: number | null | undefined): string => {
 			if (v === null || v === undefined) return "undefined";
 			// parseFloat strips trailing zeros (avoids S7748 + S5852 regex backtracking)
@@ -149,10 +147,6 @@ function generateBenchmarksChunks(models: AAModel[]): void {
 		};
 
 		return `	"${key}": {
-		// AA Intelligence Index (composite score)
-		intelligenceIndex: ${Number(score.toFixed(1))},
-		normalizedScore: ${normalized},
-
 		// AA specific benchmarks
 		codingIndex: ${fmt(e.artificial_analysis_coding_index)},
 		mathIndex: ${fmt(e.artificial_analysis_math_index)},


### PR DESCRIPTION
These fields were dead code:\n- intelligenceIndex (AA 0-70 scale) → never read by any provider code\n- normalizedScore (0-100 rescale) → same, only used as tiebreaker in prefix fallback that never fires\n\nThe only score displayed on model names is codingIndex, stored and shown raw.