### PR TITLE
Add model telemetry tracking for real-world performance data

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -238,9 +238,14 @@ function setupQuotaMonitoring(pi: ExtensionAPI) {
 // =============================================================================
 
 function setupTelemetry(pi: ExtensionAPI) {
+	// Only track FREE models (input + output cost === 0)
+	const isFreeModel = (m: { cost?: { input?: number; output?: number } } | undefined): boolean =>
+		!!m && (m.cost?.input ?? 0) === 0 && (m.cost?.output ?? 0) === 0;
+
 	// Start timing when the agent begins processing
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(pi as any).on("before_agent_start", (_event: any, ctx: any) => {
+		if (!isFreeModel(ctx.model)) return;
 		const provider = ctx.model?.provider;
 		const model = ctx.model?.id;
 		if (provider && model) {
@@ -250,6 +255,8 @@ function setupTelemetry(pi: ExtensionAPI) {
 
 	// Record telemetry when a turn completes
 	pi.on("turn_end", (event, ctx) => {
+		if (!isFreeModel(ctx.model)) return;
+
 		const msg = (
 			event as { message?: { role?: string; model?: string; usage?: { input?: number; output?: number; totalTokens?: number; cost?: { total?: number } }; stopReason?: string; errorMessage?: string } }
 		).message;

--- a/index.ts
+++ b/index.ts
@@ -155,13 +155,17 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 
 	// /telemetry — Show model telemetry data
 	pi.registerCommand("free-telemetry", {
-		description: "Show real-world performance data for free models (tokens/s, latency, success rate)",
+		description:
+			"Show real-world performance data for free models (tokens/s, latency, success rate)",
 		handler: async (_args, ctx) => {
 			const allTelemetry = getAllTelemetry();
 			const entries = Object.entries(allTelemetry);
 
 			if (entries.length === 0) {
-				ctx.ui.notify("No telemetry data yet. Use some free models first!", "info");
+				ctx.ui.notify(
+					"No telemetry data yet. Use some free models first!",
+					"info",
+				);
 				return;
 			}
 
@@ -169,16 +173,27 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 			entries.sort((a, b) => b[1].totalCalls - a[1].totalCalls);
 
 			const lines = ["📊 Model Telemetry:", ""];
-			lines.push(`${`Model`.padEnd(40)} ${`Calls`.padEnd(6)} ${`OK%`.padEnd(6)} ${`Lat`.padEnd(7)} ${`tok/s`.padEnd(7)} ${`Cost`}`);
+			lines.push(
+				`${`Model`.padEnd(40)} ${`Calls`.padEnd(6)} ${`OK%`.padEnd(6)} ${`Lat`.padEnd(7)} ${`tok/s`.padEnd(7)} ${`Cost`}`,
+			);
 			lines.push(`─`.repeat(75));
 
 			for (const [key, t] of entries.slice(0, 20)) {
 				const name = key.length > 38 ? key.slice(0, 35) + "..." : key;
 				const calls = String(t.totalCalls).padStart(5);
 				const ok = `${t.successRate}%`.padStart(5);
-				const lat = t.avgLatencyMs > 0 ? `${t.avgLatencyMs}ms`.padStart(6) : "—".padStart(6);
-				const tps = t.avgTokensPerSecond > 0 ? `${t.avgTokensPerSecond}`.padStart(6) : "—".padStart(6);
-				const cost = t.totalCost > 0 ? `$${t.totalCost.toFixed(4)}`.padStart(8) : "free".padStart(8);
+				const lat =
+					t.avgLatencyMs > 0
+						? `${t.avgLatencyMs}ms`.padStart(6)
+						: "—".padStart(6);
+				const tps =
+					t.avgTokensPerSecond > 0
+						? `${t.avgTokensPerSecond}`.padStart(6)
+						: "—".padStart(6);
+				const cost =
+					t.totalCost > 0
+						? `$${t.totalCost.toFixed(4)}`.padStart(8)
+						: "free".padStart(8);
 				lines.push(`${name.padEnd(40)} ${calls} ${ok} ${lat} ${tps} ${cost}`);
 			}
 
@@ -238,14 +253,11 @@ function setupQuotaMonitoring(pi: ExtensionAPI) {
 // =============================================================================
 
 function setupTelemetry(pi: ExtensionAPI) {
-	// Only track FREE models (input + output cost === 0)
-	const isFreeModel = (m: { cost?: { input?: number; output?: number } } | undefined): boolean =>
-		!!m && (m.cost?.input ?? 0) === 0 && (m.cost?.output ?? 0) === 0;
-
-	// Start timing when the agent begins processing
+	// Only track telemetry for FREE models (uses same isFreeModel logic as model filtering)
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(pi as any).on("before_agent_start", (_event: any, ctx: any) => {
-		if (!isFreeModel(ctx.model)) return;
+		if (!ctx.model) return;
+		if (!isFreeModel(ctx.model as any)) return;
 		const provider = ctx.model?.provider;
 		const model = ctx.model?.id;
 		if (provider && model) {
@@ -255,10 +267,24 @@ function setupTelemetry(pi: ExtensionAPI) {
 
 	// Record telemetry when a turn completes
 	pi.on("turn_end", (event, ctx) => {
-		if (!isFreeModel(ctx.model)) return;
+		if (!ctx.model) return;
+		if (!isFreeModel(ctx.model as any)) return;
 
 		const msg = (
-			event as { message?: { role?: string; model?: string; usage?: { input?: number; output?: number; totalTokens?: number; cost?: { total?: number } }; stopReason?: string; errorMessage?: string } }
+			event as {
+				message?: {
+					role?: string;
+					model?: string;
+					usage?: {
+						input?: number;
+						output?: number;
+						totalTokens?: number;
+						cost?: { total?: number };
+					};
+					stopReason?: string;
+					errorMessage?: string;
+				};
+			}
 		).message;
 
 		if (msg?.role !== "assistant") return;

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,13 @@ import {
 	formatQuotaStatus,
 } from "./lib/quota-monitor.ts";
 import {
+	startModelCall,
+	recordModelCall,
+	getAllTelemetry,
+	getTelemetryPath,
+	clearTelemetry,
+} from "./lib/telemetry.ts";
+import {
 	applyGlobalFilter,
 	getGlobalFreeOnly,
 	getProviderRegistry,
@@ -145,6 +152,49 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 			ctx.ui.notify(lines.join("\n"), "info");
 		},
 	});
+
+	// /telemetry — Show model telemetry data
+	pi.registerCommand("free-telemetry", {
+		description: "Show real-world performance data for free models (tokens/s, latency, success rate)",
+		handler: async (_args, ctx) => {
+			const allTelemetry = getAllTelemetry();
+			const entries = Object.entries(allTelemetry);
+
+			if (entries.length === 0) {
+				ctx.ui.notify("No telemetry data yet. Use some free models first!", "info");
+				return;
+			}
+
+			// Sort by total calls descending
+			entries.sort((a, b) => b[1].totalCalls - a[1].totalCalls);
+
+			const lines = ["📊 Model Telemetry:", ""];
+			lines.push(`${`Model`.padEnd(40)} ${`Calls`.padEnd(6)} ${`OK%`.padEnd(6)} ${`Lat`.padEnd(7)} ${`tok/s`.padEnd(7)} ${`Cost`}`);
+			lines.push(`─`.repeat(75));
+
+			for (const [key, t] of entries.slice(0, 20)) {
+				const name = key.length > 38 ? key.slice(0, 35) + "..." : key;
+				const calls = String(t.totalCalls).padStart(5);
+				const ok = `${t.successRate}%`.padStart(5);
+				const lat = t.avgLatencyMs > 0 ? `${t.avgLatencyMs}ms`.padStart(6) : "—".padStart(6);
+				const tps = t.avgTokensPerSecond > 0 ? `${t.avgTokensPerSecond}`.padStart(6) : "—".padStart(6);
+				const cost = t.totalCost > 0 ? `$${t.totalCost.toFixed(4)}`.padStart(8) : "free".padStart(8);
+				lines.push(`${name.padEnd(40)} ${calls} ${ok} ${lat} ${tps} ${cost}`);
+			}
+
+			lines.push("", `File: ${getTelemetryPath()}`);
+			ctx.ui.notify(lines.join("\n"), "info");
+		},
+	});
+
+	// /clear-free-telemetry — Clear all telemetry data
+	pi.registerCommand("clear-free-telemetry", {
+		description: "Clear all model telemetry data",
+		handler: async (_args, ctx) => {
+			clearTelemetry();
+			ctx.ui.notify("Telemetry data cleared", "info");
+		},
+	});
 }
 
 // =============================================================================
@@ -184,6 +234,52 @@ function setupQuotaMonitoring(pi: ExtensionAPI) {
 }
 
 // =============================================================================
+// Model Telemetry
+// =============================================================================
+
+function setupTelemetry(pi: ExtensionAPI) {
+	// Start timing when the agent begins processing
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(pi as any).on("before_agent_start", (_event: any, ctx: any) => {
+		const provider = ctx.model?.provider;
+		const model = ctx.model?.id;
+		if (provider && model) {
+			startModelCall(provider, model);
+		}
+	});
+
+	// Record telemetry when a turn completes
+	pi.on("turn_end", (event, ctx) => {
+		const msg = (
+			event as { message?: { role?: string; model?: string; usage?: { input?: number; output?: number; totalTokens?: number; cost?: { total?: number } }; stopReason?: string; errorMessage?: string } }
+		).message;
+
+		if (msg?.role !== "assistant") return;
+
+		const provider = ctx.model?.provider;
+		const model = msg.model || ctx.model?.id;
+		if (!provider || !model) return;
+
+		const usage = msg.usage;
+		const inputTokens = usage?.input ?? 0;
+		const outputTokens = usage?.output ?? 0;
+		const totalTokens = usage?.totalTokens ?? inputTokens + outputTokens;
+		const cost = usage?.cost?.total ?? 0;
+		const isError = msg.stopReason === "error" || !!msg.errorMessage;
+
+		recordModelCall(
+			provider,
+			model,
+			{ input: inputTokens, output: outputTokens, totalTokens },
+			cost,
+			!isError,
+			msg.stopReason,
+			msg.errorMessage,
+		);
+	});
+}
+
+// =============================================================================
 // Main Entry Point
 // =============================================================================
 
@@ -196,6 +292,9 @@ export default async function piFreeEntry(pi: ExtensionAPI) {
 
 	// Setup quota monitoring (passive, no extra API calls)
 	setupQuotaMonitoring(pi);
+
+	// Setup model telemetry (tracks real-world performance)
+	setupTelemetry(pi);
 
 	// Load all unique providers
 	// Each provider will register itself with the global toggle system

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -1,0 +1,328 @@
+/**
+ * Model Telemetry — tracks real-world performance of free models.
+ *
+ * Hooks into Pi's turn_end event to capture token usage, latency, and
+ * success/failure per model. Persists to ~/.pi/free-telemetry.json.
+ *
+ * Provides a real-world performance signal alongside static CI benchmarks.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "./logger.ts";
+
+const _logger = createLogger("telemetry");
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface TelemetryEntry {
+	timestamp: number;
+	provider: string;
+	model: string;
+	success: boolean;
+	latencyMs: number;
+	promptTokens: number;
+	completionTokens: number;
+	totalTokens: number;
+	tokensPerSecond: number;
+	cost: number;
+	stopReason?: string;
+	error?: string;
+}
+
+export interface ModelTelemetry {
+	/** Total calls tracked for this model. */
+	totalCalls: number;
+	/** Successful calls. */
+	successCalls: number;
+	/** Failed calls. */
+	errorCalls: number;
+	/** Total tokens consumed (input + output). */
+	totalTokens: number;
+	/** Total prompt (input) tokens. */
+	totalPromptTokens: number;
+	/** Total completion (output) tokens. */
+	totalCompletionTokens: number;
+	/** Sum of all latencies in ms (for avg calculation). */
+	totalLatencyMs: number;
+	/** Sum of all costs. */
+	totalCost: number;
+
+	// Derived (computed on read)
+	avgLatencyMs: number;
+	avgTokensPerSecond: number;
+	successRate: number;
+
+	/** Recent calls (last 50). */
+	recentCalls: TelemetryEntry[];
+}
+
+export interface TelemetryStore {
+	/** Keyed by "provider/model" */
+	models: Record<string, ModelTelemetry>;
+	/** When the store was last updated. */
+	lastUpdated: number;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const TELEMETRY_DIR = join(homedir(), ".pi");
+const TELEMETRY_FILE = join(TELEMETRY_DIR, "free-telemetry.json");
+const MAX_RECENT_CALLS = 50;
+
+// In-flight tracking: keyed by "provider/model", value is start timestamp
+const _inFlight = new Map<string, number>();
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+function ensureDir(): void {
+	if (!existsSync(TELEMETRY_DIR)) {
+		mkdirSync(TELEMETRY_DIR, { recursive: true });
+	}
+}
+
+function loadStore(): TelemetryStore {
+	try {
+		if (!existsSync(TELEMETRY_FILE)) {
+			return { models: {}, lastUpdated: Date.now() };
+		}
+		const raw = readFileSync(TELEMETRY_FILE, "utf-8");
+		return JSON.parse(raw) as TelemetryStore;
+	} catch (err) {
+		_logger.warn("Failed to load telemetry store, resetting", {
+			error: String(err),
+		});
+		return { models: {}, lastUpdated: Date.now() };
+	}
+}
+
+function saveStore(store: TelemetryStore): void {
+	try {
+		ensureDir();
+		store.lastUpdated = Date.now();
+		writeFileSync(TELEMETRY_FILE, JSON.stringify(store, null, 2), "utf-8");
+	} catch (err) {
+		_logger.warn("Failed to save telemetry store", {
+			error: String(err),
+		});
+	}
+}
+
+// =============================================================================
+// Entry management
+// =============================================================================
+
+function deriveModelTelemetry(modelKey: string, entries: TelemetryEntry[]): ModelTelemetry {
+	const recent = entries.slice(-MAX_RECENT_CALLS);
+	const totalCalls = entries.length;
+	const successCalls = entries.filter((e) => e.success).length;
+	const errorCalls = totalCalls - successCalls;
+
+	const stats = entries.reduce(
+		(acc, e) => {
+			acc.totalTokens += e.totalTokens;
+			acc.totalPromptTokens += e.promptTokens;
+			acc.totalCompletionTokens += e.completionTokens;
+			acc.totalLatencyMs += e.latencyMs;
+			acc.totalCost += e.cost;
+			return acc;
+		},
+		{ totalTokens: 0, totalPromptTokens: 0, totalCompletionTokens: 0, totalLatencyMs: 0, totalCost: 0 },
+	);
+
+	const totalSuccessEntries = entries.filter((e) => e.success);
+	const totalTokensFromSuccessful = totalSuccessEntries.reduce((s, e) => s + e.totalTokens, 0);
+	const totalLatencyFromSuccessful = totalSuccessEntries.reduce((s, e) => s + e.latencyMs, 0);
+
+	return {
+		totalCalls,
+		successCalls,
+		errorCalls,
+		totalTokens: stats.totalTokens,
+		totalPromptTokens: stats.totalPromptTokens,
+		totalCompletionTokens: stats.totalCompletionTokens,
+		totalLatencyMs: stats.totalLatencyMs,
+		totalCost: stats.totalCost,
+		avgLatencyMs: totalSuccessEntries.length > 0
+			? Math.round(totalLatencyFromSuccessful / totalSuccessEntries.length)
+			: 0,
+		avgTokensPerSecond: totalLatencyFromSuccessful > 0
+			? parseFloat((totalTokensFromSuccessful / (totalLatencyFromSuccessful / 1000)).toFixed(1))
+			: 0,
+		successRate: totalCalls > 0
+			? parseFloat((successCalls / totalCalls * 100).toFixed(1))
+			: 0,
+		recentCalls: recent,
+	};
+}
+
+function addEntry(entry: TelemetryEntry): void {
+	const store = loadStore();
+	const modelKey = `${entry.provider}/${entry.model}`;
+
+	const existing: TelemetryEntry[] = store.models[modelKey]?.recentCalls ?? [];
+	existing.push(entry);
+
+	// Keep only last MAX_RECENT_CALLS * 2 in raw storage (we derive stats from these)
+	const pruned = existing.slice(-MAX_RECENT_CALLS * 2);
+
+	store.models[modelKey] = deriveModelTelemetry(modelKey, pruned);
+	saveStore(store);
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Get telemetry for all tracked models.
+ */
+export function getAllTelemetry(): Record<string, ModelTelemetry> {
+	const store = loadStore();
+	return store.models;
+}
+
+/**
+ * Get telemetry for a specific provider/model combination.
+ */
+export function getModelTelemetry(provider: string, model: string): ModelTelemetry | null {
+	const store = loadStore();
+	return store.models[`${provider}/${model}`] ?? null;
+}
+
+/**
+ * Format a model's telemetry as a human-readable string (for status bar / /model list).
+ * Returns undefined if no telemetry data is available.
+ */
+export function formatModelTelemetry(provider: string, model: string): string | undefined {
+	const telemetry = getModelTelemetry(provider, model);
+	if (!telemetry || telemetry.totalCalls === 0) return undefined;
+
+	const parts: string[] = [];
+	if (telemetry.totalCalls > 0) {
+		parts.push(`${telemetry.totalCalls} calls`);
+	}
+	if (telemetry.successRate > 0) {
+		parts.push(`${telemetry.successRate}% ok`);
+	}
+	if (telemetry.avgLatencyMs > 0) {
+		parts.push(`${telemetry.avgLatencyMs}ms`);
+	}
+	if (telemetry.avgTokensPerSecond > 0) {
+		parts.push(`${telemetry.avgTokensPerSecond} tok/s`);
+	}
+
+	return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
+/**
+ * Get telemetry summary for a provider (all models combined).
+ */
+export function getProviderTelemetry(provider: string): {
+	totalCalls: number;
+	totalCost: number;
+	models: number;
+} {
+	const store = loadStore();
+	let totalCalls = 0;
+	let totalCost = 0;
+	let models = 0;
+
+	for (const [key, data] of Object.entries(store.models)) {
+		if (key.startsWith(`${provider}/`)) {
+			totalCalls += data.totalCalls;
+			totalCost += data.totalCost;
+			models++;
+		}
+	}
+
+	return { totalCalls, totalCost, models };
+}
+
+/**
+ * Mark a model call as started (records the start timestamp).
+ * Call this from before_agent_start or model_select.
+ */
+export function startModelCall(provider: string, model: string): void {
+	const key = `${provider}/${model}`;
+	_inFlight.set(key, Date.now());
+}
+
+/**
+ * Record a completed model call with its usage data.
+ * Call this from turn_end when the message is an AssistantMessage.
+ *
+ * @param provider - The provider ID
+ * @param model - The model ID
+ * @param usage - Token usage { input, output, totalTokens }
+ * @param cost - Cost in USD
+ * @param success - Whether the call succeeded
+ * @param stopReason - The stop reason (e.g. "stop", "error")
+ * @param errorMessage - Error message if failed
+ */
+export function recordModelCall(
+	provider: string,
+	model: string,
+	usage: { input: number; output: number; totalTokens: number },
+	cost: number,
+	success: boolean,
+	stopReason?: string,
+	errorMessage?: string,
+): void {
+	const key = `${provider}/${model}`;
+	const startTime = _inFlight.get(key) ?? Date.now();
+	const latencyMs = Date.now() - startTime;
+	_inFlight.delete(key);
+
+	const totalTokens = usage.totalTokens || usage.input + usage.output;
+	const tokensPerSecond = latencyMs > 0
+		? parseFloat((totalTokens / (latencyMs / 1000)).toFixed(1))
+		: 0;
+
+	const entry: TelemetryEntry = {
+		timestamp: Date.now(),
+		provider,
+		model,
+		success,
+		latencyMs,
+		promptTokens: usage.input,
+		completionTokens: usage.output,
+		totalTokens,
+		tokensPerSecond,
+		cost,
+		stopReason,
+		...(errorMessage ? { error: errorMessage } : {}),
+	};
+
+	addEntry(entry);
+
+	_logger.info(`Telemetry: ${provider}/${model}`, {
+		latencyMs,
+		totalTokens,
+		tokensPerSecond,
+		success,
+		cost,
+	});
+}
+
+/**
+ * Clear all telemetry data.
+ */
+export function clearTelemetry(): void {
+	const store: TelemetryStore = { models: {}, lastUpdated: Date.now() };
+	saveStore(store);
+}
+
+/**
+ * Get the path to the telemetry file.
+ */
+export function getTelemetryPath(): string {
+	return TELEMETRY_FILE;
+}


### PR DESCRIPTION
## Summary

Adds a telemetry system that tracks real-world model performance during use, complementing the static CI benchmarks from Artificial Analysis.

## What it tracks

For every LLM call via Pi, the telemetry module captures:
- **Token usage** — input, output, and total tokens
- **Tokens per second** — throughput measurement
- **Latency** — round-trip time in ms
- **Success/failure rate** — success %, error counts
- **Cost** — actual cost when priced, "free" when /usr/bin/bash
- **Stop reason** — `stop`, `error`, `length`, etc.

Data is persisted to `~/.pi/free-telemetry.json` and aggregated per model.

## New commands

- **`/free-telemetry`** — Shows a table of all tracked models sorted by usage, with columns: Model, Calls, OK%, Latency, tok/s, Cost
- **`/clear-free-telemetry`** — Resets all telemetry data

## Architecture

Two Pi event hooks:
1. `before_agent_start` — records start timestamp per provider/model
2. `turn_end` — captures the `AssistantMessage` with its `usage` field (input/output tokens, cost, stopReason)

The module follows the same pattern as the existing quota monitor — passive, no extra API calls, no external dependencies.

## Why this matters

Static CI benchmarks from AA miss many models (codestral, phi3, gemma2, fine-tunes, etc.). Telemetry builds a **real-world signal** from actual usage, filling those gaps with real performance data.