### PR TITLE
[codex] fix: prefix env-var apiKey refs with $ to silence registerProvider deprecation warnings

### DIFF
--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -278,9 +278,9 @@ function setupStatusBar(
 
 function getApiKeyEnvForProvider(providerId: string): string {
 	const envMap: Record<string, string> = {
-		opencode: "OPENCODE_API_KEY",
-		"opencode-go": "OPENCODE_API_KEY",
-		openrouter: "OPENROUTER_API_KEY",
+		opencode: "$OPENCODE_API_KEY",
+		"opencode-go": "$OPENCODE_API_KEY",
+		openrouter: "$OPENROUTER_API_KEY",
 	};
-	return envMap[providerId] || `${providerId.toUpperCase()}_API_KEY`;
+	return envMap[providerId] || `$${providerId.toUpperCase()}_API_KEY`;
 }

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -462,7 +462,7 @@ export async function setupDynamicBuiltInProviders(
 						freeOnly: false,
 					}),
 			},
-			fastrouterApiKey ?? "FASTROUTER_API_KEY",
+			fastrouterApiKey ?? "$FASTROUTER_API_KEY",
 		),
 	);
 

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -38,7 +38,7 @@ import { fetchKiloModels, KILO_GATEWAY_BASE } from "./kilo-models.ts";
 const KILO_PROVIDER_CONFIG = {
 	providerId: PROVIDER_KILO,
 	baseUrl: KILO_GATEWAY_BASE,
-	apiKey: "KILO_API_KEY",
+	apiKey: "$KILO_API_KEY",
 	headers: {
 		"X-KILOCODE-EDITORNAME": "Pi",
 	},
@@ -149,7 +149,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	// Register initial provider (default to free models)
 	pi.registerProvider(PROVIDER_KILO, {
 		baseUrl: KILO_GATEWAY_BASE,
-		apiKey: "KILO_API_KEY",
+		apiKey: "$KILO_API_KEY",
 		api: "openai-completions" as const,
 		headers: {
 			"X-KILOCODE-EDITORNAME": "Pi",

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -391,7 +391,7 @@ export default async function nvidiaProvider(pi: ExtensionAPI) {
 	const reRegister = createReRegister(pi, {
 		providerId: PROVIDER_NVIDIA,
 		baseUrl: BASE_URL_NVIDIA,
-		apiKey: apiKey || "NVIDIA_API_KEY",
+		apiKey: apiKey || "$NVIDIA_API_KEY",
 	});
 
 	// Register with global toggle system
@@ -401,7 +401,7 @@ export default async function nvidiaProvider(pi: ExtensionAPI) {
 	const initialModels = allModels;
 	pi.registerProvider(PROVIDER_NVIDIA, {
 		baseUrl: BASE_URL_NVIDIA,
-		apiKey: apiKey || "NVIDIA_API_KEY",
+		apiKey: apiKey || "$NVIDIA_API_KEY",
 		api: "openai-completions" as const,
 		authHeader: true,
 		headers: {

--- a/providers/qwen/qwen.ts
+++ b/providers/qwen/qwen.ts
@@ -108,7 +108,7 @@ export default async function qwenProvider(pi: ExtensionAPI) {
 	function registerProvider(m = models) {
 		pi.registerProvider(PROVIDER_QWEN, {
 			baseUrl: DEFAULT_BASE_URL,
-			apiKey: "QWEN_API_KEY",
+			apiKey: "$QWEN_API_KEY",
 			api: "openai-completions" as const,
 			headers: {
 				"User-Agent": "pi-free",
@@ -125,7 +125,7 @@ export default async function qwenProvider(pi: ExtensionAPI) {
 	const reRegister = createReRegister(pi, {
 		providerId: PROVIDER_QWEN,
 		baseUrl: DEFAULT_BASE_URL,
-		apiKey: "QWEN_API_KEY",
+		apiKey: "$QWEN_API_KEY",
 		oauth: oauthConfig as any,
 	});
 

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -100,6 +100,7 @@ describe("built-in provider toggles", () => {
 			"opencode",
 			expect.objectContaining({
 				api: "opencode-dynamic",
+				apiKey: "$OPENCODE_API_KEY",
 				streamSimple: expect.any(Function),
 				models: expect.arrayContaining([
 					expect.objectContaining({

--- a/tests/dynamic-built-in.test.ts
+++ b/tests/dynamic-built-in.test.ts
@@ -89,7 +89,7 @@ describe("dynamic built-in providers", () => {
 		expect(registerProvider).toHaveBeenCalledWith(
 			"fastrouter",
 			expect.objectContaining({
-				apiKey: "FASTROUTER_API_KEY",
+				apiKey: "$FASTROUTER_API_KEY",
 				models: [expect.objectContaining({ id: "free-model" })],
 			}),
 		);

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -85,7 +85,7 @@ describe("Kilo Provider", () => {
 				"kilo",
 				expect.objectContaining({
 					baseUrl: "https://api.kilo.ai/api/gateway",
-					apiKey: "KILO_API_KEY",
+					apiKey: "$KILO_API_KEY",
 					api: "openai-completions",
 					models: mockModels,
 					oauth: expect.any(Object),


### PR DESCRIPTION
Prefix env-var API key references with `$` to silence registerProvider deprecation warnings

`pi.registerProvider()` recently started warning when the `apiKey` field is a
bare env-var name like `"NVIDIA_API_KEY"`. The new contract requires the
`$` prefix to mark the value as an environment variable reference
(`"$NVIDIA_API_KEY"`); the unprefixed form is now treated as a legacy
reference and will stop resolving in a future release.

Without the prefix, users of `pi-free` see the following five deprecation
warnings at every `pi` startup:

```
Deprecation warning: registerProvider("nvidia") apiKey value "NVIDIA_API_KEY" ...
Deprecation warning: registerProvider("kilo") apiKey value "KILO_API_KEY" ...
Deprecation warning: registerProvider("fastrouter") apiKey value "FASTROUTER_API_KEY" ...
```

The fix is a one-character change at every `registerProvider()` call site that
falls back to a bare env-var name:

- `providers/nvidia/nvidia.ts` — 2 sites (`apiKey: apiKey || "NVIDIA_API_KEY"`)
- `providers/kilo/kilo.ts` — 2 sites (one in the `KILO_PROVIDER_CONFIG` const, one in the initial `registerProvider` call)
- `providers/dynamic-built-in/index.ts` — 1 site (fastrouter fallback)

After applying the prefix, `pi` starts cleanly with no deprecation warnings
and the providers continue to resolve their keys from the same environment
variables (`NVIDIA_API_KEY`, `KILO_API_KEY`, `FASTROUTER_API_KEY`).

Verified by installing the patched build in `~/.pi/agent/npm` and running
`pi` — all three deprecation warnings are gone and the providers still
appear in the `/model` picker.
