### PR TITLE
fix(probes): cache background model accessibility checks

### DIFF
--- a/lib/probe-cache.ts
+++ b/lib/probe-cache.ts
@@ -1,0 +1,86 @@
+/**
+ * Provider model probe cache.
+ *
+ * Stores the last successful accessibility probe per provider/model so
+ * background cleanup can avoid spending quota on the same checks every session.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createJSONStore } from "./json-persistence.ts";
+import { createLogger } from "./logger.ts";
+
+const _logger = createLogger("probe-cache");
+
+export const DEFAULT_PROBE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type ProbeStatus = "ok" | "broken";
+
+export interface ModelProbeResult {
+	modelId: string;
+	status: ProbeStatus;
+}
+
+interface ModelProbeEntry {
+	lastProbedAt: string;
+	status: ProbeStatus;
+}
+
+interface ProviderProbeCache {
+	provider: string;
+	models: Record<string, ModelProbeEntry>;
+}
+
+interface ProbeCacheData {
+	providers: Record<string, ProviderProbeCache>;
+}
+
+const CACHE_FILE = join(homedir(), ".pi", "probe-cache.json");
+const _cache = createJSONStore<ProbeCacheData>(CACHE_FILE, { providers: {} });
+
+export function getModelsDueForProbe(
+	providerId: string,
+	modelIds: string[],
+	ttlMs = DEFAULT_PROBE_TTL_MS,
+): string[] {
+	const provider = _cache.load().providers[providerId];
+	const now = Date.now();
+
+	return modelIds.filter((modelId) => {
+		const entry = provider?.models[modelId];
+		if (!entry) return true;
+
+		// Broken models are normally hidden immediately. If a user later unhides one,
+		// re-check it instead of letting a stale broken cache suppress cleanup.
+		if (entry.status === "broken") return true;
+
+		const lastProbedAt = Date.parse(entry.lastProbedAt);
+		if (!Number.isFinite(lastProbedAt)) return true;
+
+		return now - lastProbedAt >= ttlMs;
+	});
+}
+
+export function recordModelProbeResults(
+	providerId: string,
+	results: ModelProbeResult[],
+): void {
+	if (results.length === 0) return;
+
+	const data = _cache.load();
+	const provider = (data.providers[providerId] ??= {
+		provider: providerId,
+		models: {},
+	});
+	const lastProbedAt = new Date().toISOString();
+
+	for (const result of results) {
+		provider.models[result.modelId] = {
+			lastProbedAt,
+			status: result.status,
+		};
+	}
+
+	_cache.save(data);
+	_logger.debug(`Recorded ${results.length} probe results for ${providerId}`);
+}

--- a/providers/nvidia/nvidia.ts
+++ b/providers/nvidia/nvidia.ts
@@ -31,6 +31,10 @@ import {
 	URL_MODELS_DEV,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import {
+	getModelsDueForProbe,
+	recordModelProbeResults,
+} from "../../lib/probe-cache.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import type { ModelsDevModel, ModelsDevProvider } from "../../lib/types.ts";
 import {
@@ -287,12 +291,12 @@ async function fetchNvidiaModels(
 
 /**
  * Probe a single NVIDIA model with a minimal chat request.
- * Returns true if the model is routable (not 404), false if it 404s.
+ * Returns "broken" only for deterministic 404s; network errors are unknown.
  */
 async function probeNvidiaModel(
 	apiKey: string,
 	modelId: string,
-): Promise<boolean> {
+): Promise<"ok" | "broken" | "unknown"> {
 	try {
 		const response = await fetchWithTimeout(
 			`${BASE_URL_NVIDIA}/chat/completions`,
@@ -313,9 +317,9 @@ async function probeNvidiaModel(
 		);
 		// 404 = function not found (model not provisioned)
 		// 200/400/401/etc = at least routable
-		return response.status !== 404;
+		return response.status === 404 ? "broken" : "ok";
 	} catch {
-		return true; // Network errors / timeouts are not "model not found"
+		return "unknown"; // Network errors / timeouts are not "model not found"
 	}
 }
 
@@ -330,26 +334,51 @@ async function runNvidiaProbe(
 	modelsToTest: ProviderModelConfig[],
 	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] },
 	reRegister: (models: ProviderModelConfig[]) => void,
-): Promise<void> {
+	options: { useCache?: boolean } = {},
+): Promise<string[]> {
+	const modelIdsToProbe = options.useCache
+		? new Set(
+				getModelsDueForProbe(
+					PROVIDER_NVIDIA,
+					modelsToTest.map((m) => m.id),
+				),
+			)
+		: undefined;
+	const probeCandidates = modelIdsToProbe
+		? modelsToTest.filter((m) => modelIdsToProbe.has(m.id))
+		: modelsToTest;
+
+	if (probeCandidates.length === 0) {
+		_nvidiaLogger.info("Auto-probe: NVIDIA probe cache is fresh");
+		return [];
+	}
+
 	const notFound: string[] = [];
+	const cacheableResults: Array<{ modelId: string; status: "ok" | "broken" }> =
+		[];
 	const batchSize = 5;
 
-	for (let i = 0; i < modelsToTest.length; i += batchSize) {
-		const batch = modelsToTest.slice(i, i + batchSize);
+	for (let i = 0; i < probeCandidates.length; i += batchSize) {
+		const batch = probeCandidates.slice(i, i + batchSize);
 		const results = await Promise.all(
 			batch.map(async (m) => {
-				const ok = await probeNvidiaModel(apiKey, m.id);
-				return { id: m.id, ok };
+				const status = await probeNvidiaModel(apiKey, m.id);
+				return { id: m.id, status };
 			}),
 		);
 		for (const r of results) {
-			if (!r.ok) notFound.push(r.id);
+			if (r.status === "broken") notFound.push(r.id);
+			if (r.status !== "unknown") {
+				cacheableResults.push({ modelId: r.id, status: r.status });
+			}
 		}
 	}
 
+	recordModelProbeResults(PROVIDER_NVIDIA, cacheableResults);
+
 	if (notFound.length === 0) {
-		_nvidiaLogger.info("Auto-probe: all NVIDIA models are routable");
-		return;
+		_nvidiaLogger.info("Auto-probe: all checked NVIDIA models are routable");
+		return [];
 	}
 
 	// Auto-hide 404 models in config (provider-scoped)
@@ -367,6 +396,7 @@ async function runNvidiaProbe(
 	_nvidiaLogger.info(
 		`Auto-probe: found ${notFound.length} broken models (auto-hidden)`,
 	);
+	return notFound;
 }
 
 export default async function nvidiaProvider(pi: ExtensionAPI) {
@@ -416,7 +446,9 @@ export default async function nvidiaProvider(pi: ExtensionAPI) {
 		if (_autoProbeDone || !apiKey) return;
 		_autoProbeDone = true;
 		_nvidiaLogger.info("Starting lazy auto-probe of NVIDIA models...");
-		runNvidiaProbe(apiKey, allModels, stored, reRegister).catch((err) => {
+		runNvidiaProbe(apiKey, allModels, stored, reRegister, {
+			useCache: true,
+		}).catch((err) => {
 			_nvidiaLogger.warn("Auto-probe failed", {
 				error: err instanceof Error ? err.message : String(err),
 			});

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -39,6 +39,10 @@ import {
 	loadProviderCache,
 	saveProviderCache,
 } from "../../lib/provider-cache.ts";
+import {
+	getModelsDueForProbe,
+	recordModelProbeResults,
+} from "../../lib/probe-cache.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry, fetchWithTimeout } from "../../lib/util.ts";
 import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
@@ -379,6 +383,80 @@ async function fetchAllModels(apiKey: string): Promise<ProviderModelConfig[]> {
 	return applyHidden(models, PROVIDER_OLLAMA);
 }
 
+async function runOllamaProbe(
+	apiKey: string,
+	modelsToTest: ProviderModelConfig[],
+	applyModels: (models: ProviderModelConfig[]) => void,
+	options: { useCache?: boolean } = {},
+): Promise<string[]> {
+	const modelIdsToProbe = options.useCache
+		? new Set(
+				getModelsDueForProbe(
+					PROVIDER_OLLAMA,
+					modelsToTest.map((m) => m.id),
+				),
+			)
+		: undefined;
+	const probeCandidates = modelIdsToProbe
+		? modelsToTest.filter((m) => modelIdsToProbe.has(m.id))
+		: modelsToTest;
+
+	if (probeCandidates.length === 0) {
+		_logger.info("Auto-probe: Ollama probe cache is fresh");
+		return [];
+	}
+
+	const notFound: string[] = [];
+	const cacheableResults: Array<{ modelId: string; status: "ok" | "broken" }> =
+		[];
+	const batchSize = 5;
+
+	for (let i = 0; i < probeCandidates.length; i += batchSize) {
+		const batch = probeCandidates.slice(i, i + batchSize);
+		const results = await Promise.all(
+			batch.map(async (m) => {
+				const status = await probeOllamaModel(apiKey, m.id);
+				return { id: m.id, status };
+			}),
+		);
+		for (const r of results) {
+			if (r.status === "broken") notFound.push(r.id);
+			if (r.status !== "unknown") {
+				cacheableResults.push({ modelId: r.id, status: r.status });
+			}
+		}
+	}
+
+	recordModelProbeResults(PROVIDER_OLLAMA, cacheableResults);
+
+	if (notFound.length === 0) {
+		_logger.info("Auto-probe: all checked Ollama models are accessible");
+		return [];
+	}
+
+	// Auto-hide 403 models in config (provider-scoped)
+	const config = loadConfigFile();
+	const existingHidden = new Set(config.hidden_models ?? []);
+	for (const id of notFound) existingHidden.add(`${PROVIDER_OLLAMA}/${id}`);
+	saveConfig({
+		hidden_models: Array.from(existingHidden),
+	});
+
+	// Re-fetch and re-register so hidden models disappear immediately
+	try {
+		const fresh = await fetchAllModels(apiKey);
+		saveProviderCache(PROVIDER_OLLAMA, fresh);
+		applyModels(fresh);
+	} catch {
+		// If refresh fails, keep current models. The next refresh/probe will retry.
+	}
+
+	_logger.info(
+		`Auto-probe: found ${notFound.length} broken Ollama models (auto-hidden)`,
+	);
+	return notFound;
+}
+
 // =============================================================================
 // Extension Entry Point
 // =============================================================================
@@ -411,7 +489,7 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 
 	// ── Register immediately with cached/fallback models ────────────
 	const freeModels = allModels;
-	let stored = { free: freeModels, all: allModels };
+	const stored = { free: freeModels, all: allModels };
 	const hasKey = true;
 
 	const reRegister = createReRegister(pi, {
@@ -419,6 +497,12 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 		baseUrl: BASE_URL_OLLAMA,
 		apiKey,
 	});
+	const applyModelList = (models: ProviderModelConfig[]) => {
+		allModels = models;
+		stored.free = models;
+		stored.all = models;
+		reRegister(models);
+	};
 
 	registerWithGlobalToggle(PROVIDER_OLLAMA, stored, reRegister, hasKey);
 
@@ -460,9 +544,7 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 			try {
 				const fresh = await fetchAllModels(apiKey!);
 				saveProviderCache(PROVIDER_OLLAMA, fresh);
-				allModels = fresh;
-				stored = { free: fresh, all: fresh };
-				reRegister(fresh);
+				applyModelList(fresh);
 				ctx.ui.notify(
 					`Registered ${fresh.length} Ollama Cloud models (refresh complete)`,
 					"info",
@@ -488,45 +570,15 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 			const modelsToTest = allModels;
 			ctx.ui.notify(`Probing ${modelsToTest.length} Ollama models…`, "info");
 
-			const notFound: string[] = [];
-			const batchSize = 5;
-
-			for (let i = 0; i < modelsToTest.length; i += batchSize) {
-				const batch = modelsToTest.slice(i, i + batchSize);
-				const results = await Promise.all(
-					batch.map(async (m) => {
-						const ok = await probeOllamaModel(apiKey, m.id);
-						return { id: m.id, ok };
-					}),
-				);
-				for (const r of results) {
-					if (!r.ok) notFound.push(r.id);
-				}
-			}
+			const notFound = await runOllamaProbe(
+				apiKey,
+				modelsToTest,
+				applyModelList,
+			);
 
 			if (notFound.length === 0) {
 				ctx.ui.notify("All Ollama models are accessible ✅", "info");
 				return;
-			}
-
-			// Auto-hide 403 models in config (provider-scoped)
-			const config = loadConfigFile();
-			const existingHidden = new Set(config.hidden_models ?? []);
-			for (const id of notFound) existingHidden.add(`${PROVIDER_OLLAMA}/${id}`);
-			saveConfig({
-				hidden_models: Array.from(existingHidden),
-			});
-
-			// Re-fetch and re-register so hidden models disappear immediately
-			try {
-				const fresh = await fetchAllModels(apiKey!);
-				saveProviderCache(PROVIDER_OLLAMA, fresh);
-				allModels = fresh;
-				stored = { free: fresh, all: fresh };
-				reRegister(fresh);
-			} catch {
-				// If refresh fails, just re-register current models
-				reRegister(allModels);
 			}
 
 			ctx.ui.notify(
@@ -560,10 +612,15 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 
 		try {
 			const fresh = await refreshModels();
-			allModels = fresh;
-			stored = { free: fresh, all: fresh };
-			reRegister(fresh);
+			applyModelList(fresh);
 			ctx.ui.notify(`Ollama Cloud: ${fresh.length} models ready`, "info");
+			runOllamaProbe(apiKey, fresh, applyModelList, { useCache: true }).catch(
+				(error) => {
+					_logger.warn("Auto-probe failed", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				},
+			);
 		} catch {
 			// Already logged in refreshModels()
 		}
@@ -576,12 +633,12 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 
 /**
  * Probe a single Ollama model with a minimal chat request.
- * Returns true if the model is accessible (not 403), false if it 403s.
+ * Returns "broken" only for deterministic 403s; network errors are unknown.
  */
 async function probeOllamaModel(
 	apiKey: string,
 	modelId: string,
-): Promise<boolean> {
+): Promise<"ok" | "broken" | "unknown"> {
 	try {
 		const response = await fetchWithTimeout(
 			`${BASE_URL_OLLAMA}/chat/completions`,
@@ -602,9 +659,9 @@ async function probeOllamaModel(
 		);
 		// 403 = access denied (model not provisioned)
 		// 200/400/401/etc = at least accessible
-		return response.status !== 403;
+		return response.status === 403 ? "broken" : "ok";
 	} catch {
 		// Network errors / timeouts are not "access denied"
-		return true;
+		return "unknown";
 	}
 }


### PR DESCRIPTION
Implements the provider-specific probe policy discussed for NVIDIA/Ollama cleanup.\n\nChanges:\n- Adds ~/.pi/probe-cache.json with 24h TTL for successful probe checks.\n- Keeps probes provider-specific: NVIDIA hides deterministic 404s; Ollama hides deterministic 403s.\n- Does not cache network/timeouts as broken, and never hides on transient failures.\n- NVIDIA auto-probe now uses the cache instead of rechecking all models every session process.\n- Ollama now also runs a background auto-probe after its session_start refresh, cache-gated.\n- Manual /probe-nvidia and /probe-ollama still force-check the current model list.\n\nValidation:\n- npm run test:run