### PR TITLE
feat: Routeway provider + Cline free model fix + isFreeModel flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Free models are shown by default — look for the provider prefixes:
 - `codestral/` — Codestral via Mistral (free Experiment plan: 2 req/min, 1B tokens/month)
 - `deepinfra/` — DeepInfra inference cloud ($5 one-time trial credit, no credit card)
 - `novita/` — Novita AI (100+ open-source models, OpenAI-compatible, 3 free models)
+- `routeway/` — Routeway AI gateway (OpenAI-compatible, `:free` models)
 
 > **Note:** Paid providers may occasionally offer free models or promotional credits. The `isFreeModel` helper automatically detects free models based on provider pricing data or model names containing "free". For providers that don't expose pricing (like CrofAI), only models with "free" in their names are marked as free.
 
@@ -102,6 +103,7 @@ Want to see paid models too? Run the toggle command for your provider:
 /toggle-sambanova # Toggle SambaNova (🔄 freemium)
 /toggle-llm7      # Toggle LLM7 (✅ free gateway)
 /toggle-novita    # Toggle Novita AI (💳 paid — 3 free models)
+/toggle-routeway  # Toggle Routeway AI (💳 paid — has :free models)
 /toggle-fastrouter # Toggle FastRouter (🔧 dynamic — always discovered)
 ```
 
@@ -132,7 +134,8 @@ Add your API keys to this file:
   "sambanova_api_key": "...",
   "llm7_api_key": "...",
   "zenmux_api_key": "...",
-  "crofai_api_key": "..."
+  "crofai_api_key": "...",
+  "routeway_api_key": "sk-..."
 }
 ```
 

--- a/config.ts
+++ b/config.ts
@@ -17,6 +17,7 @@ export {
 	PROVIDER_MODAL,
 	PROVIDER_NVIDIA,
 	PROVIDER_QWEN,
+	PROVIDER_ROUTEWAY,
 } from "./constants.ts";
 import { createLogger } from "./lib/logger.ts";
 
@@ -33,6 +34,7 @@ interface PiFreeConfig {
 	sambanova_api_key?: string;
 	together_api_key?: string;
 	novita_api_key?: string;
+	routeway_api_key?: string;
 	fastrouter_api_key?: string;
 	kilo_free_only?: boolean;
 	hidden_models?: string[];
@@ -48,6 +50,7 @@ interface PiFreeConfig {
 	sambanova_show_paid?: boolean;
 	together_show_paid?: boolean;
 	novita_show_paid?: boolean;
+	routeway_show_paid?: boolean;
 	fastrouter_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
 	opencode_show_paid?: boolean;
@@ -64,6 +67,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	sambanova_api_key: "",
 	together_api_key: "",
 	novita_api_key: "",
+	routeway_api_key: "",
 	fastrouter_api_key: "",
 
 	kilo_free_only: false,
@@ -80,6 +84,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	sambanova_show_paid: false,
 	together_show_paid: false,
 	novita_show_paid: false,
+	routeway_show_paid: false,
 	fastrouter_show_paid: false,
 	openrouter_show_paid: false,
 	opencode_show_paid: false,
@@ -222,6 +227,10 @@ export function getNovitaShowPaid(): boolean {
 	return resolveBool("NOVITA_SHOW_PAID", loadConfigFile().novita_show_paid);
 }
 
+export function getRoutewayShowPaid(): boolean {
+	return resolveBool("ROUTEWAY_SHOW_PAID", loadConfigFile().routeway_show_paid);
+}
+
 export function getFastrouterShowPaid(): boolean {
 	return resolveBool(
 		"FASTROUTER_SHOW_PAID",
@@ -266,6 +275,8 @@ export function getProviderShowPaid(providerId: string): boolean {
 			return getTogetherShowPaid();
 		case "novita":
 			return getNovitaShowPaid();
+		case "routeway":
+			return getRoutewayShowPaid();
 		case "fastrouter":
 			return getFastrouterShowPaid();
 		case "ollama-cloud":
@@ -329,6 +340,10 @@ export function getTogetherApiKey(): string | undefined {
 
 export function getNovitaApiKey(): string | undefined {
 	return resolve("NOVITA_API_KEY", loadConfigFile().novita_api_key);
+}
+
+export function getRoutewayApiKey(): string | undefined {
+	return resolve("ROUTEWAY_API_KEY", loadConfigFile().routeway_api_key);
 }
 
 export function getFastrouterApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -23,6 +23,7 @@ export const PROVIDER_DEEPINFRA = "deepinfra";
 export const PROVIDER_SAMBANOVA = "sambanova";
 export const PROVIDER_TOGETHER = "together";
 export const PROVIDER_NOVITA = "novita";
+export const PROVIDER_ROUTEWAY = "routeway";
 
 export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_KILO,
@@ -40,6 +41,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_SAMBANOVA,
 	PROVIDER_TOGETHER,
 	PROVIDER_NOVITA,
+	PROVIDER_ROUTEWAY,
 ] as const;
 
 // =============================================================================
@@ -62,6 +64,7 @@ export const BASE_URL_DEEPINFRA = "https://api.deepinfra.com/v1/openai";
 export const BASE_URL_SAMBANOVA = "https://api.sambanova.ai/v1";
 export const BASE_URL_TOGETHER = "https://api.together.xyz/v1";
 export const BASE_URL_NOVITA = "https://api.novita.ai/openai/v1";
+export const BASE_URL_ROUTEWAY = "https://api.routeway.ai/v1";
 
 /** Cline fetches free models from OpenRouter */
 export const BASE_URL_OPENROUTER = "https://openrouter.ai/api/v1";

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@
  * - DeepInfra: AI inference cloud ($5 trial credit)
  * - SambaNova: Fast inference on RDU hardware (free tier, no credit card)
  * - Together: Fast inference on 200+ open-source models ($1 trial credit)
+ * - Routeway: OpenAI-compatible gateway with free `:free` models
  * - LLM7: AI gateway (free default/fast selectors)
  */
 
@@ -48,6 +49,7 @@ import deepinfra from "./providers/deepinfra/deepinfra.ts";
 import sambanova from "./providers/sambanova/sambanova.ts";
 import together from "./providers/together/together.ts";
 import novita from "./providers/novita/novita.ts";
+import routeway from "./providers/routeway/routeway.ts";
 import nvidia from "./providers/nvidia/nvidia.ts";
 import ollama from "./providers/ollama/ollama.ts";
 import zenmux from "./providers/zenmux/zenmux.ts";
@@ -344,6 +346,7 @@ export default async function piFreeEntry(pi: ExtensionAPI) {
 		sambanova(pi),
 		together(pi),
 		novita(pi),
+		routeway(pi),
 	]);
 
 	// Setup dynamic built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face,

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -82,7 +82,12 @@ function detectPricingExposed(allModels: ProviderModelConfig[]): boolean {
  * @returns true if the model is definitively free per the provider's API
  */
 export function isFreeModel(
-	model: ProviderModelConfig & { provider?: string; _pricingKnown?: boolean },
+	model: ProviderModelConfig & {
+		provider?: string;
+		_pricingKnown?: boolean;
+		_freeKnown?: boolean;
+		_isFree?: boolean;
+	},
 	allModels?: ProviderModelConfig[],
 ): boolean {
 	return isFreeModelInternal(model, allModels);
@@ -90,9 +95,21 @@ export function isFreeModel(
 
 // Internal implementation to work around TypeScript filter callback issues
 function isFreeModelInternal(
-	model: ProviderModelConfig & { provider?: string; _pricingKnown?: boolean },
+	model: ProviderModelConfig & {
+		provider?: string;
+		_pricingKnown?: boolean;
+		_freeKnown?: boolean;
+		_isFree?: boolean;
+	},
 	allModels: ProviderModelConfig[] | undefined,
 ): boolean {
+	// Some gateways expose an authoritative free/paid flag. Prefer it over
+	// pricing because a few non-chat or preview models can report zero token
+	// prices while still not being offered as free chat models.
+	if (model._freeKnown === true) {
+		return model._isFree === true;
+	}
+
 	// Determine if pricing is exposed
 	let pricingExposed: boolean;
 
@@ -213,7 +230,12 @@ export function applyGlobalFilter(
 
 	for (const [providerId, entry] of providerRegistry) {
 		try {
-			applyFilterToProvider(providerId, entry, freeOnly, options.force === true);
+			applyFilterToProvider(
+				providerId,
+				entry,
+				freeOnly,
+				options.force === true,
+			);
 		} catch (err) {
 			_logger.error(
 				`[pi-free] Failed to apply filter to ${providerId}`,

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -341,6 +341,7 @@ export function mapOpenRouterModel(m: {
 		input_modalities?: string[] | null;
 		output_modalities?: string[] | null;
 	};
+	isFree?: boolean;
 }): ProviderModelConfig {
 	const promptPrice = Number.parseFloat(m.pricing?.prompt ?? "0");
 	const completionPrice = Number.parseFloat(m.pricing?.completion ?? "0");
@@ -362,7 +363,15 @@ export function mapOpenRouterModel(m: {
 		maxTokens:
 			m.max_completion_tokens ?? m.top_provider?.max_completion_tokens ?? 4096,
 		_pricingKnown: true,
-	} as ProviderModelConfig & { _pricingKnown?: boolean };
+		...(typeof m.isFree === "boolean" && {
+			_freeKnown: true,
+			_isFree: m.isFree,
+		}),
+	} as ProviderModelConfig & {
+		_pricingKnown?: boolean;
+		_freeKnown?: boolean;
+		_isFree?: boolean;
+	};
 }
 
 // =============================================================================

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -1,27 +1,70 @@
 /**
  * Cline model fetching.
  *
- * Fetches ALL models from OpenRouter (Cline's gateway).
- * Free/paid filtering is handled by the global free-only filter.
+ * Fetches Cline's own model catalog from api.cline.bot instead of OpenRouter.
+ * Cline also exposes a recommended/free-to-try list; those models may have
+ * non-zero list pricing in the catalog, so we mark exact recommended-free IDs
+ * as zero-cost for pi-free's free-model filter.
  */
 
 import { applyHidden } from "../../config.ts";
 import {
-	BASE_URL_OPENROUTER,
+	BASE_URL_CLINE,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	PROVIDER_CLINE,
 } from "../../constants.ts";
 import type { ProviderModelConfig } from "../../lib/types.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 
-interface OpenRouterRaw {
+interface ClineRaw {
 	id: string;
-	name: string;
-	context_length?: number;
-	supported_parameters?: string[];
-	architecture?: { input_modalities?: string[]; output_modalities?: string[] };
-	top_provider?: { max_completion_tokens?: number | null };
-	pricing?: { prompt?: string; completion?: string };
+	name?: string;
+	description?: string | null;
+	context_length?: number | null;
+	supported_parameters?: string[] | null;
+	architecture?: {
+		modality?: string | string[] | null;
+		input_modalities?: string[] | null;
+		output_modalities?: string[] | null;
+	} | null;
+	top_provider?: {
+		max_completion_tokens?: number | null;
+		context_length?: number | null;
+	} | null;
+	pricing?: {
+		prompt?: string | null;
+		completion?: string | null;
+		input_cache_read?: string | null;
+		input_cache_write?: string | null;
+	} | null;
+}
+
+interface ClineRecommendedModel {
+	id: string;
+	name?: string;
+	description?: string;
+	tags?: string[];
+}
+
+interface ClineRecommendedModelsResponse {
+	recommended?: ClineRecommendedModel[];
+	free?: ClineRecommendedModel[];
+}
+
+const VS_CODE_VERSION = "1.109.3";
+const CLINE_EXTENSION_VERSION = "3.76.0";
+
+function buildClineFetchHeaders(): Record<string, string> {
+	return {
+		Accept: "application/json",
+		"Content-Type": "application/json",
+		"User-Agent": `Cline/${CLINE_EXTENSION_VERSION}`,
+		"X-PLATFORM": "Visual Studio Code",
+		"X-PLATFORM-VERSION": VS_CODE_VERSION,
+		"X-CLIENT-TYPE": "VSCode Extension",
+		"X-CLIENT-VERSION": CLINE_EXTENSION_VERSION,
+		"X-CORE-VERSION": CLINE_EXTENSION_VERSION,
+	};
 }
 
 function extractNameFromId(id: string): string {
@@ -34,84 +77,169 @@ function extractNameFromId(id: string): string {
 
 /**
  * Parse pricing string to cost per million tokens.
- * OpenRouter returns pricing as string (e.g., "0.0001" or "0").
+ * Cline returns pricing as string per token (e.g. "0.0001" or "0").
  */
-function parsePricing(pricingStr: string | undefined): number {
+function parsePricing(pricingStr: string | null | undefined): number {
 	if (!pricingStr || pricingStr === "0") return 0;
 	const parsed = Number.parseFloat(pricingStr);
-	return Number.isNaN(parsed) ? 0 : parsed * 1_000_000; // Convert to per-million
+	return Number.isNaN(parsed) ? 0 : parsed * 1_000_000;
 }
 
-/**
- * Check if a model is free (both prompt and completion pricing is 0).
- */
-function isFreeModel(info: OpenRouterRaw): boolean {
-	return info.pricing?.prompt === "0" && info.pricing?.completion === "0";
+function modalityIncludes(
+	modality: string | string[] | null | undefined,
+	needle: string,
+): boolean {
+	if (Array.isArray(modality)) return modality.includes(needle);
+	return typeof modality === "string" && modality.includes(needle);
 }
 
-/**
- * Fetch ALL models from OpenRouter.
- * @param freeOnly - If true, return only free models
- */
-export async function fetchClineModels(
-	freeOnly = false,
-): Promise<ProviderModelConfig[]> {
+function hasTextOutput(info: ClineRaw): boolean {
+	const outputMods = info.architecture?.output_modalities;
+	if (Array.isArray(outputMods) && outputMods.length > 0) {
+		return outputMods.includes("text");
+	}
+	return modalityIncludes(info.architecture?.modality, "text");
+}
+
+function supportsImages(info: ClineRaw): boolean {
+	const inputMods = info.architecture?.input_modalities;
+	if (Array.isArray(inputMods) && inputMods.includes("image")) return true;
+	return modalityIncludes(info.architecture?.modality, "image");
+}
+
+function modelFromRecommended(
+	model: ClineRecommendedModel,
+): ProviderModelConfig & { _pricingKnown?: boolean } {
+	const name = model.name?.trim() || extractNameFromId(model.id);
+	return {
+		id: model.id,
+		name: `${cleanModelName(name)} (Cline)`,
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+		_pricingKnown: true,
+	};
+}
+
+function modelFromCatalog(
+	info: ClineRaw,
+	freeToTryIds: ReadonlySet<string>,
+): ProviderModelConfig & { _pricingKnown?: boolean } {
+	const isReasoning = !!(
+		info.supported_parameters?.includes("include_reasoning") ||
+		info.supported_parameters?.includes("reasoning")
+	);
+	const isFreeToTry = freeToTryIds.has(info.id);
+	const inputCost = isFreeToTry ? 0 : parsePricing(info.pricing?.prompt);
+	const outputCost = isFreeToTry ? 0 : parsePricing(info.pricing?.completion);
+	const cacheRead = isFreeToTry
+		? 0
+		: parsePricing(info.pricing?.input_cache_read);
+	const cacheWrite = isFreeToTry
+		? 0
+		: parsePricing(info.pricing?.input_cache_write);
+	const isFree = inputCost === 0 && outputCost === 0;
+	const cleanName = info.name
+		? cleanModelName(info.name)
+		: extractNameFromId(info.id);
+
+	return {
+		id: info.id,
+		name: `${cleanName} (Cline)${isFree ? "" : " 💰"}`,
+		reasoning: isReasoning,
+		input: supportsImages(info) ? ["text", "image"] : ["text"],
+		cost: {
+			input: inputCost,
+			output: outputCost,
+			cacheRead,
+			cacheWrite,
+		},
+		contextWindow:
+			info.context_length ?? info.top_provider?.context_length ?? 128_000,
+		maxTokens: info.top_provider?.max_completion_tokens ?? 8_192,
+		_pricingKnown: info.pricing !== null && info.pricing !== undefined,
+	};
+}
+
+async function fetchClineRecommendedFreeModels(): Promise<
+	ClineRecommendedModel[]
+> {
 	const response = await fetchWithRetry(
-		`${BASE_URL_OPENROUTER}/models`,
-		{},
+		`${BASE_URL_CLINE}/ai/cline/recommended-models`,
+		{ headers: buildClineFetchHeaders() },
+		3,
+		1000,
+		DEFAULT_FETCH_TIMEOUT_MS,
+	);
+
+	if (!response.ok) return [];
+
+	const json = (await response.json()) as ClineRecommendedModelsResponse;
+	return Array.isArray(json.free) ? json.free.filter((m) => m?.id) : [];
+}
+
+async function fetchClineCatalogModels(): Promise<ClineRaw[]> {
+	const response = await fetchWithRetry(
+		`${BASE_URL_CLINE}/ai/cline/models`,
+		{ headers: buildClineFetchHeaders() },
 		3,
 		1000,
 		DEFAULT_FETCH_TIMEOUT_MS,
 	);
 
 	if (!response.ok)
-		throw new Error(`Failed to fetch OpenRouter models: ${response.status}`);
+		throw new Error(`Failed to fetch Cline models: ${response.status}`);
 
-	const json = (await response.json()) as { data?: OpenRouterRaw[] };
+	const json = (await response.json()) as { data?: ClineRaw[] };
+	if (!Array.isArray(json.data)) {
+		throw new Error("Invalid Cline models response: missing data array");
+	}
+	return json.data;
+}
 
-	// Filter to usable models (chat-capable)
-	let usableModels = json.data ?? [];
+/**
+ * Fetch models from Cline.
+ * @param freeOnly - If true, return only zero-cost/free-to-try models
+ */
+export async function fetchClineModels(
+	freeOnly = false,
+): Promise<ProviderModelConfig[]> {
+	const [catalogModels, recommendedFreeModels] = await Promise.all([
+		fetchClineCatalogModels(),
+		fetchClineRecommendedFreeModels().catch(() => []),
+	]);
+	const recommendedFreeIds = new Set(recommendedFreeModels.map((m) => m.id));
 
-	// If freeOnly, filter to free models
-	if (freeOnly) {
-		usableModels = usableModels.filter(isFreeModel);
+	const models: Array<ProviderModelConfig & { _pricingKnown?: boolean }> = [];
+	const seen = new Set<string>();
+
+	for (const info of catalogModels) {
+		if (!hasTextOutput(info)) continue;
+		const model = modelFromCatalog(info, recommendedFreeIds);
+		models.push(model);
+		seen.add(model.id);
 	}
 
-	const models: ProviderModelConfig[] = [];
-	for (const info of usableModels) {
-		const isReasoning = !!(
-			info.supported_parameters?.includes("include_reasoning") ||
-			info.supported_parameters?.includes("reasoning")
-		);
-		const hasImage =
-			info.architecture?.input_modalities?.includes("image") ?? false;
-
-		// Calculate cost per million tokens
-		const inputCost = parsePricing(info.pricing?.prompt);
-		const outputCost = parsePricing(info.pricing?.completion);
-		const isFree = inputCost === 0 && outputCost === 0;
-
-		const cleanName = info.name
-			? cleanModelName(info.name)
-			: extractNameFromId(info.id);
-
-		models.push({
-			id: info.id,
-			name: `${cleanName} (Cline)${isFree ? "" : " 💰"}`,
-			reasoning: isReasoning,
-			input: hasImage ? ["text", "image"] : ["text"],
-			cost: {
-				input: inputCost,
-				output: outputCost,
-				cacheRead: 0,
-				cacheWrite: 0,
-			},
-			contextWindow: info.context_length ?? 128_000,
-			maxTokens: info.top_provider?.max_completion_tokens ?? 8_192,
-		});
+	// The recommended/free-to-try endpoint can lead the full catalog. Include
+	// those exact IDs so newly promoted models (e.g. alibaba/qwen3.7-plus) show up.
+	for (const model of recommendedFreeModels) {
+		if (seen.has(model.id)) continue;
+		models.push(modelFromRecommended(model));
+		seen.add(model.id);
 	}
 
-	return applyHidden(models, PROVIDER_CLINE);
+	const filtered = freeOnly
+		? models.filter((m) => m.cost.input === 0 && m.cost.output === 0)
+		: models;
+
+	return applyHidden(filtered, PROVIDER_CLINE);
 }
 
 /**

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -24,6 +24,7 @@ interface OpenRouterCompatibleModel {
 	};
 	top_provider?: { max_completion_tokens?: number | null };
 	supported_parameters?: string[];
+	isFree?: boolean;
 }
 
 interface FetchModelsOptions {
@@ -98,8 +99,9 @@ export async function fetchOpenRouterCompatibleModels(
 			const outputMods = m.architecture?.output_modalities ?? [];
 			if (outputMods.includes("image")) return false;
 
-			// Filter by pricing if freeOnly
+			// Filter by provider flag when available, otherwise pricing.
 			if (freeOnly) {
+				if (typeof m.isFree === "boolean") return m.isFree;
 				const prompt = Number.parseFloat(m.pricing?.prompt ?? "1");
 				const completion = Number.parseFloat(m.pricing?.completion ?? "1");
 				if (prompt !== 0 || completion !== 0) return false;

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -1,0 +1,213 @@
+/**
+ * Routeway AI Provider Extension
+ *
+ * Routeway exposes an OpenAI-compatible chat completions API with a model
+ * catalog that includes free models marked by a `:free` suffix and zero token
+ * pricing.
+ *
+ * API: https://api.routeway.ai/v1
+ * Models: /v1/models
+ * Docs: https://docs.routeway.ai
+ *
+ * Setup:
+ *   ROUTEWAY_API_KEY=sk-...
+ *   # or add routeway_api_key to ~/.pi/free.json
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import { getRoutewayApiKey, getRoutewayShowPaid } from "../../config.ts";
+import {
+	BASE_URL_ROUTEWAY,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_ROUTEWAY,
+} from "../../constants.ts";
+import { applyHidden } from "../../config.ts";
+import { createLogger } from "../../lib/logger.ts";
+import {
+	getProxyModelCompat,
+	isLikelyReasoningModel,
+} from "../../lib/provider-compat.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
+import { createReRegister, setupProvider } from "../../provider-helper.ts";
+
+const _logger = createLogger("routeway");
+
+interface RoutewayPrice {
+	unit?: string;
+	price_per_million_t?: number;
+	price_per_token_usd?: string;
+}
+
+interface RoutewayModel {
+	id: string;
+	name?: string;
+	short_name?: string;
+	description?: string;
+	context_length?: number;
+	available?: boolean;
+	type?: string;
+	endpoints?: string[];
+	pricing?: {
+		input?: RoutewayPrice;
+		output?: RoutewayPrice;
+		caching?: { read?: RoutewayPrice; write?: RoutewayPrice };
+	};
+	supported_parameters?: string[];
+	capabilities?: {
+		vision?: boolean;
+		function_call?: boolean;
+		reasoning?: boolean;
+	};
+}
+
+function parsePricePerToken(price: RoutewayPrice | undefined): number {
+	if (!price) return 0;
+	if (typeof price.price_per_token_usd === "string") {
+		const parsed = Number.parseFloat(price.price_per_token_usd);
+		if (!Number.isNaN(parsed)) return parsed;
+	}
+	if (typeof price.price_per_million_t === "number") {
+		return price.price_per_million_t / 1_000_000;
+	}
+	return 0;
+}
+
+function isChatModel(model: RoutewayModel): boolean {
+	return (
+		model.available !== false &&
+		(model.type === "chat.completions" ||
+			(model.endpoints ?? []).includes("/v1/chat/completions"))
+	);
+}
+
+function mapRoutewayModel(
+	model: RoutewayModel,
+): ProviderModelConfig & { _pricingKnown?: boolean } {
+	const rawName = model.short_name || model.name || model.id;
+	const name = cleanModelName(rawName);
+	const inputCost = parsePricePerToken(model.pricing?.input);
+	const outputCost = parsePricePerToken(model.pricing?.output);
+	const cacheRead = parsePricePerToken(model.pricing?.caching?.read);
+	const cacheWrite = parsePricePerToken(model.pricing?.caching?.write);
+	const hasPricing = !!(model.pricing?.input || model.pricing?.output);
+	const reasoning =
+		model.capabilities?.reasoning === true ||
+		(model.supported_parameters ?? []).includes("reasoning_effort") ||
+		isLikelyReasoningModel({ id: model.id, name });
+	const free = inputCost === 0 && outputCost === 0;
+
+	return {
+		id: model.id,
+		name: `${name} (Routeway)${free ? "" : " 💰"}`,
+		reasoning,
+		input: model.capabilities?.vision ? ["text", "image"] : ["text"],
+		cost: {
+			input: inputCost,
+			output: outputCost,
+			cacheRead,
+			cacheWrite,
+		},
+		contextWindow: model.context_length ?? 128_000,
+		maxTokens: 16_384,
+		compat: getProxyModelCompat({ id: model.id, name }),
+		_pricingKnown: hasPricing,
+	} as ProviderModelConfig & { _pricingKnown?: boolean };
+}
+
+async function fetchRoutewayModels(
+	apiKey: string,
+): Promise<ProviderModelConfig[]> {
+	_logger.info("[routeway] Fetching models from Routeway API...");
+
+	try {
+		const response = await fetchWithRetry(
+			`${BASE_URL_ROUTEWAY}/models`,
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+					"Content-Type": "application/json",
+				},
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
+
+		if (!response.ok) {
+			throw new Error(`Routeway API error: ${response.status}`);
+		}
+
+		const json = (await response.json()) as { data?: RoutewayModel[] };
+		const models = (json.data ?? []).filter(isChatModel);
+
+		_logger.info(`[routeway] Fetched ${models.length} chat models`);
+		return applyHidden(models.map(mapRoutewayModel), PROVIDER_ROUTEWAY);
+	} catch (error) {
+		_logger.error("[routeway] Failed to fetch models", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
+}
+
+export default async function routewayProvider(pi: ExtensionAPI) {
+	const apiKey = getRoutewayApiKey();
+
+	if (!apiKey) {
+		_logger.info(
+			"[routeway] Skipping — ROUTEWAY_API_KEY not set. Sign up at https://routeway.ai/",
+		);
+		return;
+	}
+
+	const allModels = await fetchRoutewayModels(apiKey);
+
+	if (allModels.length === 0) {
+		_logger.warn("[routeway] No chat models available");
+		return;
+	}
+
+	const freeModels = allModels.filter((m) =>
+		isFreeModel({ ...m, provider: PROVIDER_ROUTEWAY }, allModels),
+	);
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[routeway] Registered ${allModels.length} models (${freeModels.length} free)`,
+	);
+
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_ROUTEWAY,
+		baseUrl: BASE_URL_ROUTEWAY,
+		apiKey,
+	});
+
+	registerWithGlobalToggle(PROVIDER_ROUTEWAY, stored, reRegister, true);
+
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_ROUTEWAY,
+			initialShowPaid: getRoutewayShowPaid(),
+			tosUrl: "https://routeway.ai/terms",
+			reRegister: (models, _stored) => {
+				if (_stored) {
+					stored.free = _stored.free;
+					stored.all = _stored.all;
+				}
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	const showPaid = getRoutewayShowPaid();
+	const initialModels =
+		showPaid && stored.all.length > 0 ? stored.all : freeModels;
+	reRegister(initialModels);
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -179,6 +179,19 @@ describe("show-paid getters", () => {
 		expect(getProviderShowPaid("zenmux")).toBe(true);
 		expect(getProviderShowPaid("unknown-provider")).toBe(false);
 	});
+
+	it("getRoutewayShowPaid reads from file", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		const fs = await import("node:fs");
+		const { __mockData } = fs as any;
+		__mockData.set(configPath(), JSON.stringify({ routeway_show_paid: true }));
+
+		const { getProviderShowPaid, getRoutewayShowPaid } = await import(
+			"../config.ts"
+		);
+		expect(getRoutewayShowPaid()).toBe(true);
+		expect(getProviderShowPaid("routeway")).toBe(true);
+	});
 });
 
 // =============================================================================

--- a/tests/isFreeModel.test.ts
+++ b/tests/isFreeModel.test.ts
@@ -346,3 +346,32 @@ describe("isFreeModel - _pricingKnown guard (Route A)", () => {
 		).toBe(true);
 	});
 });
+
+describe("isFreeModel - authoritative free flag", () => {
+	it("uses _isFree=true when a provider exposes an explicit flag", () => {
+		const model = createModel("Paid-list-price free trial", {
+			input: 5,
+			output: 30,
+		});
+		expect(
+			isFreeModel({
+				...model,
+				provider: "kilo",
+				_freeKnown: true,
+				_isFree: true,
+			}),
+		).toBe(true);
+	});
+
+	it("uses _isFree=false over zero pricing and free-looking names", () => {
+		const model = createModel("Free-looking Preview", { input: 0, output: 0 });
+		expect(
+			isFreeModel({
+				...model,
+				provider: "kilo",
+				_freeKnown: true,
+				_isFree: false,
+			}),
+		).toBe(false);
+	});
+});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -197,6 +197,22 @@ describe("Utility Functions", () => {
 			expect(result.cost.output).toBe(0);
 		});
 
+		it("should preserve provider free flags when present", () => {
+			const result = mapOpenRouterModel({
+				id: "kilo-auto/free",
+				name: "Auto Free",
+				pricing: { prompt: "0", completion: "0" },
+				isFree: true,
+			});
+
+			expect(
+				(result as typeof result & { _freeKnown?: boolean })._freeKnown,
+			).toBe(true);
+			expect((result as typeof result & { _isFree?: boolean })._isFree).toBe(
+				true,
+			);
+		});
+
 		it("should use default values when fields are missing", () => {
 			const input = {
 				id: "unknown/model",


### PR DESCRIPTION
## Changes

### 1. New provider: Routeway AI
- Adds **Routeway** (`api.routeway.ai/v1`) — OpenAI-compatible gateway with 16 free models
- Free models identified by `:free` suffix in model ID and zero token pricing
- Models include: DeepSeek V4 Flash, Gemma 4 31B, Llama 3.3 70B, GPT OSS 120B, and more
- Set `ROUTEWAY_API_KEY` or add `routeway_api_key` to `~/.pi/free.json`
- Config keys: `routeway_api_key`, `routeway_show_paid`

### 2. Cline: Fix free model discovery
- Merges **catalog** (`/api/v1/ai/cline/models`) + **recommended free-to-try list** (`/api/v1/ai/cline/recommended-models`)
- Previously: models like `qwen3.7-plus` only appeared in the recommended list, not the catalog, so they were missed
- Now: free-to-try models get forced zero cost and appear in free-only mode
- Result: 30 free Cline models (up from 28), including `qwen3.7-plus` and `qwen3.7-max`

### 3. isFreeModel: Authoritative free flag
- Adds `_freeKnown` / `_isFree` flag support — preferred over zero-cost heuristic
- Kilo's `isFree` API flag now flows through: fixes edge cases like Lyria (Google audio model, $0 cost but not a chat model)
- `model-fetcher.ts` respects the flag when filtering free models
- Zero-priced models without the flag still work via existing cost logic

### 4. Tests
- 282 tests pass (was 280)
- Added: `isFreeModel` authoritative flag tests, config getter test, util isFree preservation test