### PR TITLE
chore: release 2.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.14] - 2026-06-02
+
+### Added
+
+- **Routeway provider** — OpenAI-compatible gateway (`api.routeway.ai/v1`) with 219 models, 16 free (`:free` suffix). Set `ROUTEWAY_API_KEY` or add `routeway_api_key` to `~/.pi/free.json`. Toggle with `/toggle-routeway` ([#209](https://github.com/apmantza/pi-free/pull/209)).
+
+### Fixed
+
+- **Cline free model merging** — Free-to-try models (e.g. `qwen3.7-plus`) from Cline's recommended list now appear in the free model picker even when absent from the main catalog ([#209](https://github.com/apmantza/pi-free/pull/209)).
+
+- **`_pricingKnown` / `_freeKnown` authoritatve flag** — Providers can now signal whether pricing data is authoritative via `_pricingKnown`. When `false`, `isFreeModel` falls back to name-based detection. Kilo's `isFree` API flag now flows through as `_freeKnown` ([#209](https://github.com/apmantza/pi-free/pull/209)).
+
 ## [2.0.13] - 2026-05-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.0.13",
+	"version": "2.0.14",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## Release 2.0.14

Bumps version from 2.0.13 → 2.0.14 (patch).

### Changes (from #209)

- **Routeway provider** — OpenAI-compatible gateway with 219 models, 16 free ( suffix)
- **Cline free model merging** —  and other free-to-try models now appear in the free picker
- ** /  flag** — Providers can signal authoritative pricing; Kilo's  flag now flows through

### After merge

- Already up to date.
- + pi-free@2.0.14 (manual — no GH token configured)