### PR TITLE
fix(compat): MiniMax reasoning compat to prevent plan-mode hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`_pricingKnown` / `_freeKnown` authoritatve flag** — Providers can now signal whether pricing data is authoritative via `_pricingKnown`. When `false`, `isFreeModel` falls back to name-based detection. Kilo's `isFree` API flag now flows through as `_freeKnown` ([#209](https://github.com/apmantza/pi-free/pull/209)).
 
+- **MiniMax reasoning compat** — MiniMax M3 and other MiniMax models now have `supportsReasoningEffort: true` compat settings. Previously, models marked `reasoning: true` without compat caused Pi to enter plan mode without knowing the thinking format, resulting in hangs.
+
 ## [2.0.13] - 2026-05-21
 
 ### Added

--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -23,6 +23,7 @@ export function isLikelyReasoningModel(model: ProviderModelIdentity): boolean {
 	const haystack = `${model.id} ${model.name ?? ""}`.toLowerCase();
 	return (
 		isDeepSeekModel(model) ||
+		haystack.includes("minimax") ||
 		haystack.includes("thinking") ||
 		haystack.includes("reasoning") ||
 		haystack.includes("reasoner") ||
@@ -40,6 +41,15 @@ export function getProxyModelCompat(
 ): ProviderModelConfig["compat"] | undefined {
 	if (isDeepSeekModel(model)) {
 		return DEEPSEEK_PROXY_COMPAT;
+	}
+
+	// MiniMax uses OpenAI-compatible reasoning_effort param
+	if (model.id.toLowerCase().includes("minimax")) {
+		return {
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: true,
+		};
 	}
 
 	return undefined;

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -14,6 +14,7 @@ import {
 	PROVIDER_CLINE,
 } from "../../constants.ts";
 import type { ProviderModelConfig } from "../../lib/types.ts";
+import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 
 interface ClineRaw {
@@ -164,8 +165,11 @@ function modelFromCatalog(
 		contextWindow:
 			info.context_length ?? info.top_provider?.context_length ?? 128_000,
 		maxTokens: info.top_provider?.max_completion_tokens ?? 8_192,
+		...(getProxyModelCompat({ id: info.id, name: info.name })
+			? { compat: getProxyModelCompat({ id: info.id, name: info.name }) }
+			: {}),
 		_pricingKnown: info.pricing !== null && info.pricing !== undefined,
-	};
+	} as ProviderModelConfig & { _pricingKnown?: boolean; compat?: any };
 }
 
 async function fetchClineRecommendedFreeModels(): Promise<


### PR DESCRIPTION
MiniMax M3 and other MiniMax models are marked reasoning:true by Cline/Routeway but had no compat settings. Pi enters plan mode without knowing the thinking format → hangs.

- Add minimax to isLikelyReasoningModel()
- Add supportsReasoningEffort:true compat for MiniMax models
- Apply compat in Cline model mapper