### PR TITLE
chore: release 2.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.15] - 2026-06-02
+
+### Fixed
+
+- **Qwen 3.7 reasoning compat** — `qwen/qwen3.7-max` on Cline/OpenRouter uses DeepSeek-style `reasoning_content` format. Added `DEEPSEEK_PROXY_COMPAT` so Pi preserves and replays reasoning tokens correctly, preventing plan-mode hangs ([#213](https://github.com/apmantza/pi-free/pull/213)).
+
+- **Kimi K2.6 reasoning compat** — Kimi models on NVIDIA/OpenRouter need `requiresReasoningContentOnAssistantMessages: true` to correctly replay reasoning tokens in assistant messages. Without it, the model gets stuck when trying to call tools or produce output after thinking. Refs [earendil-works/pi#5309](https://github.com/earendil-works/pi/issues/5309) ([#213](https://github.com/apmantza/pi-free/pull/213)).
+
+- **MiniMax reasoning compat** — MiniMax M3 and other MiniMax models now have full DeepSeek-style compat (`thinkingFormat: "deepseek"`, `requiresReasoningContentOnAssistantMessages: true`). Previously, models marked `reasoning: true` without `thinkingFormat` caused Pi to enter plan mode but couldn't parse the reasoning tokens, resulting in hangs ([#212](https://github.com/apmantza/pi-free/pull/212), [#213](https://github.com/apmantza/pi-free/pull/213)).
+
+### Added
+
+- **`/probe-routeway` command** — Tests each Routeway model with a minimal chat request and auto-hides models that return 5xx or 404 errors. Runs lazily on first `session_start` with 24h probe cache TTL. Follows the same pattern as `/probe-nvidia` ([#213](https://github.com/apmantza/pi-free/pull/213)).
+
 ## [2.0.14] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -467,10 +467,11 @@ Each provider has toggle commands to switch between free and all models:
 
 Test models for 404/403 errors and auto-hide broken ones:
 
-| Command         | What it does                                                |
-| --------------- | ----------------------------------------------------------- |
-| `/probe-nvidia` | Test all NVIDIA models, auto-hide 404s in `~/.pi/free.json` |
-| `/probe-ollama` | Test all Ollama models, auto-hide 403s in `~/.pi/free.json` |
+| Command           | What it does                                                |
+| ----------------- | ----------------------------------------------------------- |
+| `/probe-nvidia`   | Test all NVIDIA models, auto-hide 404s in `~/.pi/free.json` |
+| `/probe-ollama`   | Test all Ollama models, auto-hide 403s in `~/.pi/free.json` |
+| `/probe-routeway` | Test all Routeway models, auto-hide 5xx/404s               |
 
 **How it works:**
 

--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -46,12 +46,14 @@ export function getProxyModelCompat(
 		return DEEPSEEK_PROXY_COMPAT;
 	}
 
-	// MiniMax uses OpenAI-compatible reasoning_effort param
+	// MiniMax on OpenRouter/Cline uses reasoning_content (DeepSeek format)
 	if (model.id.toLowerCase().includes("minimax")) {
 		return {
 			supportsStore: false,
 			supportsDeveloperRole: false,
 			supportsReasoningEffort: true,
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
 		};
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## [2.0.15] - 2026-06-02

### Fixed
- **MiniMax reasoning compat** — Full DeepSeek-style compat (, ). Matches built-in DeepSeek model pattern. Prevents plan-mode hangs.
- **Qwen 3.7 reasoning compat** — DeepSeek  format on Cline/OpenRouter.
- **Kimi K2.6 reasoning compat** —  for tool calls after thinking. Refs earendil-works/pi#5309.

### Added
-  command — Tests models for 5xx/404, auto-hides broken ones. Lazy auto-probe on first session start.

### Changed
-  — Added  to probe commands table