### PR TITLE
fix(cline): switch from PLAN MODE to ACT MODE

### DIFF
--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -73,9 +73,9 @@ function toApiKey(credentials: OAuthCredentials): string {
 // =============================================================================
 
 const TASK_PROGRESS_BLOCK = `
-# task_progress List (Optional - Plan Mode)
+# task_progress List (Optional)
 
-While in PLAN MODE, if you've outlined concrete steps or requirements for the user, you may include a preliminary todo list using the task_progress parameter.
+You may include a todo list using the task_progress parameter to track progress on multi-step tasks.
 
 1. To create or update a todo list, include the task_progress parameter in the next tool call
 2. Review each item and update its status:
@@ -100,7 +100,7 @@ function buildEnvironmentDetails(): string {
 0 / 204.8K tokens used (0%)
 
 # Current Mode
-PLAN MODE
+ACT MODE
 </environmentDetails>`;
 }
 


### PR DESCRIPTION
## Problem

Cline models were stuck in plan mode because  hardcoded b in the message envelope sent to Cline's API. This caused models to only outline steps without ever executing tools.

## Changes

- b → b in the environment details block
- Made  mode-neutral (task_progress is useful in act mode too for tracking multi-step tasks)

## Verification

-  → clean
- 
> pi-free@2.0.14 test:run
> vitest run


 RUN  v4.1.5 C:/Users/R3LiC/Desktop/pi-free


 Test Files  19 passed (19)
      Tests  282 passed (282)
   Start at  20:40:54
   Duration  3.67s (transform 2.11s, setup 0ms, import 2.71s, tests 4.65s, environment 3ms) → all 282 tests pass

Fixes the issue where Cline models appeared to be stuck in plan mode.