### PR TITLE
fix: speed up session start and Cline reasoning compat

### DIFF
--- a/lib/provider-cache.ts
+++ b/lib/provider-cache.ts
@@ -44,6 +44,24 @@ const CACHE_FILE = resolveSafeDataFile(
 
 const _cache = createJSONStore<CacheData>(CACHE_FILE, { providers: {} });
 
+export const DEFAULT_PROVIDER_CACHE_TTL_MS = 60 * 60 * 1000;
+
+function getProviderCacheEntry(
+	providerId: string,
+): CachedProviderModels | undefined {
+	try {
+		const data = _cache.load();
+		const cached = data?.providers?.[providerId];
+		if (!cached || !Array.isArray(cached.models)) return undefined;
+		return cached;
+	} catch (error) {
+		_logger.warn(`Failed to load provider cache for ${providerId}`, {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
+}
+
 /**
  * Load cached models for a provider.
  * Returns undefined if no cache exists.
@@ -51,8 +69,7 @@ const _cache = createJSONStore<CacheData>(CACHE_FILE, { providers: {} });
 export function loadProviderCache(
 	providerId: string,
 ): ProviderModelConfig[] | undefined {
-	const data = _cache.load();
-	const cached = data.providers[providerId];
+	const cached = getProviderCacheEntry(providerId);
 
 	if (!cached) {
 		return undefined;
@@ -64,6 +81,32 @@ export function loadProviderCache(
 	});
 
 	return structuredClone(cached.models);
+}
+
+/**
+ * Return the age of a provider cache entry in milliseconds.
+ * Returns undefined if no cache exists or the timestamp is invalid.
+ */
+function getProviderCacheAgeMs(providerId: string): number | undefined {
+	const cached = getProviderCacheEntry(providerId);
+	if (!cached) return undefined;
+
+	const fetchedAt = new Date(cached.fetchedAt).getTime();
+	if (Number.isNaN(fetchedAt)) return undefined;
+	const age = Date.now() - fetchedAt;
+	if (age < -5000) return undefined;
+	return Math.max(0, age);
+}
+
+/**
+ * Check whether a provider cache entry is fresh enough to skip network refresh.
+ */
+export function isProviderCacheFresh(
+	providerId: string,
+	maxAgeMs: number,
+): boolean {
+	const age = getProviderCacheAgeMs(providerId);
+	return age !== undefined && age <= maxAgeMs;
 }
 
 /**

--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -28,11 +28,23 @@ export function isDeepSeekModel(model: ProviderModelIdentity): boolean {
 	return haystack.includes("deepseek");
 }
 
+function getModelHaystack(model: ProviderModelIdentity): string {
+	return `${model.id} ${model.name ?? ""}`.toLowerCase();
+}
+
+/** MiMo/Xiaomi reasoning models expose OpenAI-compatible reasoning controls
+ * through gateways such as Cline/OpenRouter, but they are not DeepSeek-format. */
+function isMimoModel(model: ProviderModelIdentity): boolean {
+	const haystack = getModelHaystack(model);
+	return haystack.includes("mimo") || haystack.includes("xiaomi");
+}
+
 export function isLikelyReasoningModel(model: ProviderModelIdentity): boolean {
-	const haystack = `${model.id} ${model.name ?? ""}`.toLowerCase();
+	const haystack = getModelHaystack(model);
 	return (
 		isDeepSeekModel(model) ||
 		haystack.includes("minimax") ||
+		isMimoModel(model) ||
 		haystack.includes("kimi") ||
 		haystack.includes("qwen3.7") ||
 		haystack.includes("qwen3-7") ||
@@ -77,7 +89,7 @@ export function getProxyModelCompat(
 	if (isDeepSeekStyleModel(model)) {
 		return DEEPSEEK_PROXY_COMPAT;
 	}
-	if (isKimiModel(model)) {
+	if (isKimiModel(model) || isMimoModel(model)) {
 		return KIMI_PROXY_COMPAT;
 	}
 	return undefined;

--- a/lib/provider-probe.ts
+++ b/lib/provider-probe.ts
@@ -75,12 +75,12 @@ export interface ProviderProbe {
 
 	/**
 	 * Convenience: wire lazy async auto-probe into session_start.
-	 * Returns a session_start handler that probes once on first session.
+	 * Returns a fire-and-forget session_start handler that schedules one probe.
 	 */
 	autoProbeHandler: (
 		apiKey: string,
 		models: ProviderModelConfig[],
-	) => () => Promise<void>;
+	) => () => void;
 }
 
 // =============================================================================
@@ -172,17 +172,15 @@ export function createProviderProbe(
 		models,
 	) => {
 		let done = false;
-		return async () => {
+		return () => {
 			if (done) return;
 			done = true;
 			_logger.info(`[probe] Starting lazy auto-probe for ${providerId}...`);
-			try {
-				await run(apiKey, models, { useCache: true });
-			} catch (err) {
+			run(apiKey, models, { useCache: true }).catch((err) => {
 				_logger.warn(`[probe] ${providerId}: auto-probe failed`, {
 					error: err instanceof Error ? err.message : String(err),
 				});
-			}
+			});
 		};
 	};
 

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -15,9 +15,18 @@
  */
 
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
 import { getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
+import {
+	DEFAULT_PROVIDER_CACHE_TTL_MS,
+	isProviderCacheFresh,
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
 import { createToggleState } from "../../lib/toggle-state.ts";
@@ -176,10 +185,21 @@ function shapeMessagesForCline(messages: any[]): any[] {
 // =============================================================================
 
 export default async function clineProvider(pi: ExtensionAPI) {
-	let allModels = await fetchClineModels(false).catch((err) => {
-		logWarning("cline", "Failed to fetch models at startup", err);
-		return [];
-	});
+	let allModels: ProviderModelConfig[];
+	const cachedModels = loadProviderCache(PROVIDER_CLINE);
+	if (cachedModels && cachedModels.length > 0) {
+		allModels = cachedModels;
+	} else {
+		allModels = await fetchClineModels(false).catch((err) => {
+			logWarning("cline", "Failed to fetch models at startup", err);
+			return [];
+		});
+		if (allModels.length > 0) {
+			saveProviderCache(PROVIDER_CLINE, allModels).catch((err) => {
+				logWarning("cline", "Failed to save model cache", err);
+			});
+		}
+	}
 	let freeModels = allModels.filter((m) =>
 		isFreeModel({ ...m, provider: PROVIDER_CLINE }, allModels),
 	);
@@ -206,12 +226,23 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		});
 	};
 
+	const applyModelList = (models: ProviderModelConfig[]) => {
+		allModels = models;
+		freeModels = allModels.filter((m) =>
+			isFreeModel({ ...m, provider: PROVIDER_CLINE }, allModels),
+		);
+		stored.all = allModels;
+		stored.free = freeModels;
+		toggleState.setModels(stored);
+		toggleState.applyCurrent(reRegister);
+	};
+
 	registerWithGlobalToggle(PROVIDER_CLINE, stored, (m) => reRegister(m), false);
 	toggleState.applyCurrent(reRegister);
 
 	pi.registerCommand("toggle-cline", {
 		description: "Toggle between free and all Cline models",
-		handler: async (_args, ctx) => {
+		handler: (_args, ctx) => {
 			const applied = toggleState.toggle(reRegister);
 			const freeCount = stored.free.length;
 			const paidCount = stored.all.length - freeCount;
@@ -227,6 +258,7 @@ export default async function clineProvider(pi: ExtensionAPI) {
 					"info",
 				);
 			}
+			return Promise.resolve();
 		},
 	});
 
@@ -253,44 +285,40 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		ctx.ui.setStatus(`${PROVIDER_CLINE}-status`, status);
 	});
 
-	pi.on("before_agent_start", async (_event, ctx) => {
+	pi.on("before_agent_start", (_event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		_currentTaskId = generateUlid();
 		toggleState.applyCurrent(reRegister);
 	});
 
-	pi.on("context", async (event, ctx) => {
+	pi.on("context", (event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		const sourceMessages = Array.isArray(event.messages) ? event.messages : [];
 		return { messages: shapeMessagesForCline(sourceMessages) };
 	});
 
+	let refreshInFlight: Promise<void> | undefined;
 	pi.on(
 		"session_start",
-		wrapSessionStartHandler("cline", async (_event, ctx) => {
-			try {
-				const fresh = await fetchClineModels(false);
-				if (fresh.length > 0) {
-					allModels = fresh;
-					freeModels = allModels.filter((m) =>
-						isFreeModel({ ...m, provider: PROVIDER_CLINE }, allModels),
-					);
-					stored.all = allModels;
-					stored.free = freeModels;
-					toggleState.setModels(stored);
-					toggleState.applyCurrent(reRegister);
-					if (ctx.model?.provider === PROVIDER_CLINE) {
-						const freeCount = stored.free.length;
-						const paidCount = stored.all.length - freeCount;
-						ctx.ui.notify(
-							`Cline: ${freeCount} free, ${paidCount} paid models available`,
-							"info",
-						);
-					}
-				}
-			} catch (err) {
-				logWarning("cline", "Failed to refresh models at session start", err);
+		wrapSessionStartHandler("cline", () => {
+			if (refreshInFlight) return Promise.resolve();
+			if (isProviderCacheFresh(PROVIDER_CLINE, DEFAULT_PROVIDER_CACHE_TTL_MS)) {
+				return Promise.resolve();
 			}
+
+			refreshInFlight = fetchClineModels(false)
+				.then(async (fresh) => {
+					if (fresh.length === 0) return;
+					await saveProviderCache(PROVIDER_CLINE, fresh);
+					applyModelList(fresh);
+				})
+				.catch((err) => {
+					logWarning("cline", "Failed to refresh models at session start", err);
+				})
+				.finally(() => {
+					refreshInFlight = undefined;
+				});
+			return Promise.resolve();
 		}),
 	);
 }

--- a/providers/kilo/kilo-models.ts
+++ b/providers/kilo/kilo-models.ts
@@ -4,6 +4,7 @@
 
 import { applyHidden } from "../../config.ts";
 import { PROVIDER_KILO } from "../../constants.ts";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 
 const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
@@ -16,7 +17,7 @@ export const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
 export async function fetchKiloModels(options?: {
 	token?: string;
 	freeOnly?: boolean;
-}): Promise<ReturnType<typeof fetchOpenRouterCompatibleModels>> {
+}): Promise<ProviderModelConfig[]> {
 	const models = await fetchOpenRouterCompatibleModels({
 		baseUrl: KILO_GATEWAY_BASE,
 		apiKey: options?.token,

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -230,17 +230,15 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	});
 
 	// Refresh models on session start if authenticated
+	let refreshInFlight: Promise<void> | undefined;
 	pi.on(
 		"session_start",
-		wrapSessionStartHandler("kilo", async (_event, ctx) => {
+		wrapSessionStartHandler("kilo", (_event, ctx) => {
 			const cred = ctx.modelRegistry.authStorage.get(PROVIDER_KILO);
+			if (cred?.type !== "oauth" || refreshInFlight) return Promise.resolve();
 
-			if (cred?.type === "oauth") {
-				try {
-					const newModels = await fetchKiloModels({
-						token: cred.access,
-						freeOnly: false,
-					});
+			refreshInFlight = fetchKiloModels({ token: cred.access, freeOnly: false })
+				.then((newModels) => {
 					allModels = newModels;
 					stored.all = allModels;
 					freeModels = allModels.filter((m) =>
@@ -258,14 +256,18 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 					if (showPaidModels && !getKiloFreeOnly()) {
 						ctxReRegister(allModels);
 					}
-				} catch (error) {
+				})
+				.catch((error) => {
 					logWarning(
 						"kilo",
 						"Failed to refresh models at session start",
-						error,
+						error instanceof Error ? error.message : String(error),
 					);
-				}
-			}
+				})
+				.finally(() => {
+					refreshInFlight = undefined;
+				});
+			return Promise.resolve();
 		}),
 	);
 }

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -36,6 +36,8 @@ import {
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import {
+	DEFAULT_PROVIDER_CACHE_TTL_MS,
+	isProviderCacheFresh,
 	loadProviderCache,
 	saveProviderCache,
 } from "../../lib/provider-cache.ts";
@@ -518,7 +520,7 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 	_logger.info(
 		`[ollama-cloud] Registered ${initialModels.length} models` +
 			(fromCache ? " (from cache)" : " (fallback)") +
-			", fetching fresh in background...",
+			", refresh scheduled on session start...",
 	);
 
 	// ── Background refresh ─────────────────────────────────────────
@@ -602,31 +604,49 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 		ctx.ui.setStatus(`${PROVIDER_OLLAMA}-status`, `ollama: ${count} models`);
 	});
 
+	const runProbeInBackground = (models: ProviderModelConfig[]) => {
+		runOllamaProbe(apiKey, models, applyModelList, { useCache: true }).catch(
+			(error) => {
+				_logger.warn("Auto-probe failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			},
+		);
+	};
+
 	// ── Background refresh on session_start ─────────────────────────
-	let bgRefreshed = false;
+	let refreshInFlight: Promise<void> | undefined;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	pi.on(
 		"session_start" as any,
-		wrapSessionStartHandler("ollama-cloud", async (_event: any, ctx: any) => {
-			if (bgRefreshed) {
-				return;
-			}
-			bgRefreshed = true;
+		wrapSessionStartHandler("ollama-cloud", (_event: any, ctx: any) => {
+			if (refreshInFlight) return Promise.resolve();
 
-			try {
-				const fresh = await refreshModels();
-				applyModelList(fresh);
-				ctx.ui.notify(`Ollama Cloud: ${fresh.length} models ready`, "info");
-				runOllamaProbe(apiKey, fresh, applyModelList, { useCache: true }).catch(
-					(error) => {
-						_logger.warn("Auto-probe failed", {
-							error: error instanceof Error ? error.message : String(error),
-						});
-					},
+			if (
+				isProviderCacheFresh(PROVIDER_OLLAMA, DEFAULT_PROVIDER_CACHE_TTL_MS)
+			) {
+				_logger.info(
+					"session_start: Ollama Cloud cache is fresh; skipping refresh",
 				);
-			} catch {
-				// Already logged in refreshModels()
+				runProbeInBackground(allModels);
+				return Promise.resolve();
 			}
+
+			refreshInFlight = refreshModels()
+				.then((fresh) => {
+					applyModelList(fresh);
+					ctx.ui.notify(`Ollama Cloud: ${fresh.length} models ready`, "info");
+					runProbeInBackground(fresh);
+				})
+				.catch((error) => {
+					_logger.warn("Background refresh failed", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				})
+				.finally(() => {
+					refreshInFlight = undefined;
+				});
+			return Promise.resolve();
 		}),
 	);
 }

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -19,6 +19,9 @@ vi.mock("../lib/registry.ts", () => ({
 
 const mockGetClineShowPaid = vi.fn();
 const mockSaveConfig = vi.fn();
+const mockLoadProviderCache = vi.fn();
+const mockSaveProviderCache = vi.fn();
+const mockIsProviderCacheFresh = vi.fn();
 
 vi.mock("../lib/util.ts", () => ({
 	logWarning: vi.fn(),
@@ -27,6 +30,14 @@ vi.mock("../lib/util.ts", () => ({
 vi.mock("../config.ts", () => ({
 	getClineShowPaid: () => mockGetClineShowPaid(),
 	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+}));
+
+vi.mock("../lib/provider-cache.ts", () => ({
+	DEFAULT_PROVIDER_CACHE_TTL_MS: 60 * 60 * 1000,
+	loadProviderCache: (...args: unknown[]) => mockLoadProviderCache(...args),
+	saveProviderCache: (...args: unknown[]) => mockSaveProviderCache(...args),
+	isProviderCacheFresh: (...args: unknown[]) =>
+		mockIsProviderCacheFresh(...args),
 }));
 
 vi.mock("../providers/cline/cline-auth.ts", () => ({
@@ -58,6 +69,9 @@ describe("Cline Provider", () => {
 		mockOn = vi.fn();
 		commandHandlers = {};
 		mockGetClineShowPaid.mockReturnValue(false);
+		mockLoadProviderCache.mockReturnValue(undefined);
+		mockSaveProviderCache.mockResolvedValue(undefined);
+		mockIsProviderCacheFresh.mockReturnValue(false);
 
 		mockPi = {
 			registerProvider: mockRegisterProvider,
@@ -109,6 +123,33 @@ describe("Cline Provider", () => {
 			expect(mockOn).toHaveBeenCalledWith(
 				"session_start",
 				expect.any(Function),
+			);
+		});
+
+		it("should use cached models at startup without fetching", async () => {
+			const cachedModels = [
+				{
+					id: "cached-free-model",
+					name: "Cached Free Model",
+					reasoning: false,
+					input: ["text" as const],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+			];
+			mockLoadProviderCache.mockReturnValue(cachedModels);
+
+			await clineProvider(mockPi);
+
+			expect(fetchClineModels).not.toHaveBeenCalled();
+			expect(mockRegisterProvider).toHaveBeenCalledWith(
+				"cline",
+				expect.objectContaining({
+					models: expect.arrayContaining([
+						expect.objectContaining({ id: "cached-free-model" }),
+					]),
+				}),
 			);
 		});
 	});
@@ -212,15 +253,83 @@ describe("Cline Provider", () => {
 				{ model: { provider: "cline" }, ui: { notify } },
 			);
 
-			expect(mockRegisterProvider).toHaveBeenCalledWith(
-				"cline",
-				expect.objectContaining({
-					models: expect.arrayContaining([
-						expect.objectContaining({ id: "free-model" }),
-						expect.objectContaining({ id: "paid-model" }),
-					]),
-				}),
-			);
+			await vi.waitFor(() => {
+				expect(mockRegisterProvider).toHaveBeenCalledWith(
+					"cline",
+					expect.objectContaining({
+						models: expect.arrayContaining([
+							expect.objectContaining({ id: "free-model" }),
+							expect.objectContaining({ id: "paid-model" }),
+						]),
+					}),
+				);
+			});
+		});
+
+		it("should skip session_start refresh when cache is fresh", async () => {
+			vi.mocked(fetchClineModels).mockResolvedValue([]);
+			mockIsProviderCacheFresh.mockReturnValue(true);
+
+			await clineProvider(mockPi);
+
+			vi.mocked(fetchClineModels).mockClear();
+			const sessionStartHandler = mockOn.mock.calls.find(
+				(call) => call[0] === "session_start",
+			)?.[1];
+			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+
+			expect(fetchClineModels).not.toHaveBeenCalled();
+			expect(mockSaveProviderCache).not.toHaveBeenCalled();
+		});
+
+		it("should save cache after stale session_start refresh", async () => {
+			const initialModels = [
+				{
+					id: "free-model",
+					name: "Free Model",
+					reasoning: false,
+					input: ["text" as const],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 8192,
+				},
+			];
+			vi.mocked(fetchClineModels).mockResolvedValue(initialModels);
+
+			await clineProvider(mockPi);
+			mockSaveProviderCache.mockClear();
+
+			const sessionStartHandler = mockOn.mock.calls.find(
+				(call) => call[0] === "session_start",
+			)?.[1];
+			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+
+			await vi.waitFor(() => {
+				expect(mockSaveProviderCache).toHaveBeenCalledWith("cline", initialModels);
+			});
+		});
+
+		it("should not start duplicate session_start refresh while one is in flight", async () => {
+			vi.mocked(fetchClineModels).mockResolvedValueOnce([]);
+			let resolveRefresh!: (models: any[]) => void;
+			const refreshPromise = new Promise<any[]>((resolve) => {
+				resolveRefresh = resolve;
+			});
+			vi.mocked(fetchClineModels).mockReturnValueOnce(refreshPromise as any);
+
+			await clineProvider(mockPi);
+			vi.mocked(fetchClineModels).mockClear();
+			vi.mocked(fetchClineModels).mockReturnValue(refreshPromise as any);
+
+			const sessionStartHandler = mockOn.mock.calls.find(
+				(call) => call[0] === "session_start",
+			)?.[1];
+			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+
+			expect(fetchClineModels).toHaveBeenCalledTimes(1);
+			resolveRefresh([]);
+			await refreshPromise;
 		});
 
 		it("should re-register provider with fresh headers on before_agent_start", async () => {

--- a/tests/provider-cache.test.ts
+++ b/tests/provider-cache.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, unlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,6 +18,7 @@ describe("provider cache", () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		delete process.env.HOME;
 		delete process.env.USERPROFILE;
 	});
@@ -40,5 +41,54 @@ describe("provider cache", () => {
 		models.pop();
 		const models2 = loadProviderCache("test")!;
 		expect(models2).toHaveLength(1);
+	});
+
+	it("reports whether a provider cache entry is fresh", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+		const { isProviderCacheFresh, saveProviderCache } = await import(
+			"../lib/provider-cache.ts"
+		);
+		const model = {
+			id: "m1",
+			name: "Model 1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 2048,
+		};
+
+		await saveProviderCache("test", [model as any]);
+		expect(isProviderCacheFresh("test", 60_000)).toBe(true);
+
+		vi.setSystemTime(new Date("2026-01-01T00:02:00.000Z"));
+		expect(isProviderCacheFresh("test", 60_000)).toBe(false);
+		expect(isProviderCacheFresh("missing", 60_000)).toBe(false);
+	});
+
+	it("treats invalid or future cache timestamps as stale", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+		writeFileSync(
+			join(tempDir, "provider-cache.json"),
+			JSON.stringify({
+				providers: {
+					invalid: {
+						provider: "invalid",
+						models: [],
+						fetchedAt: "invalid-date",
+					},
+					future: {
+						provider: "future",
+						models: [],
+						fetchedAt: "2026-01-01T00:01:00.000Z",
+					},
+				},
+			}),
+		);
+		const { isProviderCacheFresh } = await import("../lib/provider-cache.ts");
+		expect(isProviderCacheFresh("invalid", 60_000)).toBe(false);
+		expect(isProviderCacheFresh("future", 60_000)).toBe(false);
 	});
 });

--- a/tests/provider-compat.test.ts
+++ b/tests/provider-compat.test.ts
@@ -40,6 +40,10 @@ describe("provider-compat", () => {
 			expect(isLikelyReasoningModel({ id: "deepseek/deepseek-v3.2" })).toBe(
 				true,
 			);
+			expect(isLikelyReasoningModel({ id: "xiaomi/mimo-v2.5" })).toBe(true);
+			expect(
+				isLikelyReasoningModel({ id: "vendor/model", name: "Xiaomi MiMo" }),
+			).toBe(true);
 		});
 
 		it("returns false for normal non-reasoning models", () => {
@@ -58,6 +62,23 @@ describe("provider-compat", () => {
 			expect(
 				getProxyModelCompat({ id: "vendor/model", name: "DeepSeek V4 Flash" }),
 			).toEqual(DEEPSEEK_PROXY_COMPAT);
+		});
+
+		it("returns OpenAI-compatible reasoning compat for proxied MiMo/Xiaomi models", () => {
+			expect(getProxyModelCompat({ id: "xiaomi/mimo-v2.5" })).toEqual({
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: true,
+				requiresReasoningContentOnAssistantMessages: true,
+			});
+			expect(
+				getProxyModelCompat({ id: "vendor/model", name: "Xiaomi MiMo" }),
+			).toEqual({
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: true,
+				requiresReasoningContentOnAssistantMessages: true,
+			});
 		});
 
 		it("returns undefined for non-DeepSeek models", () => {


### PR DESCRIPTION
## Summary
- add provider-cache freshness helpers and TTL checks
- cache Cline model catalogs and refresh stale Cline/Ollama/Kilo model lists in the background
- make generic provider auto-probes fire-and-forget on session_start
- add MiMo/Xiaomi reasoning compat for Cline/gateway models

## Tests
- npm run test:run

## Notes
- npm run check currently fails locally with spawnSync npm.cmd EINVAL, unrelated to these changes
- agents.md has local uncommitted changes and is intentionally not included