### PR TITLE
feat: enrich model capabilities from models.dev

### DIFF
--- a/lib/model-enhancer.ts
+++ b/lib/model-enhancer.ts
@@ -6,15 +6,24 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { enhanceModelNameWithCodingIndex } from "../provider-failover/benchmark-lookup.ts";
 
+interface ModelsDevEnrichedMetadata {
+	modelsDev?: Parameters<typeof enhanceModelNameWithCodingIndex>[3];
+}
+
 /**
  * Enhance model names with Coding Index scores
  * Use this before registering providers to show CI in /model list
  */
 export function enhanceModelsWithCodingIndex(
-	models: ProviderModelConfig[],
+	models: Array<ProviderModelConfig & ModelsDevEnrichedMetadata>,
 ): ProviderModelConfig[] {
 	return models.map((m) => ({
 		...m,
-		name: enhanceModelNameWithCodingIndex(m.name, m.id),
+		name: enhanceModelNameWithCodingIndex(
+			m.name,
+			m.id,
+			undefined,
+			m.modelsDev,
+		),
 	}));
 }

--- a/lib/model-metadata.ts
+++ b/lib/model-metadata.ts
@@ -1,0 +1,269 @@
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_FETCH_TIMEOUT_MS, URL_MODELS_DEV } from "../constants.ts";
+import { getProxyModelCompat } from "./provider-compat.ts";
+import type {
+	CostConfig,
+	ModelIdentity,
+	ModelMatchHints,
+	ModelsDevEnrichedMetadata,
+	ModelsDevModel,
+	ModelsDevProvider,
+} from "./types.ts";
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 16_384;
+const MODELS_DEV_PROVIDER_ALIASES: Record<string, string> = {
+	together: "togetherai",
+	novita: "novita-ai",
+};
+
+type ThinkingLevelMap = NonNullable<ProviderModelConfig["thinkingLevelMap"]>;
+type ModelCompat = NonNullable<ProviderModelConfig["compat"]>;
+
+function collectAllModels(
+	catalog: Record<string, ModelsDevProvider>,
+): Record<string, ModelsDevModel> {
+	const allModels: Record<string, ModelsDevModel> = {};
+	for (const [providerKey, provider] of Object.entries(catalog)) {
+		for (const [modelId, model] of Object.entries(provider.models ?? {})) {
+			allModels[`${provider.id ?? providerKey}/${modelId}`] = model;
+		}
+	}
+	return allModels;
+}
+
+export async function fetchModelsDevMeta(
+	providerId?: string,
+): Promise<Record<string, ModelsDevModel>> {
+	const response = await fetch(URL_MODELS_DEV, {
+		headers: { "User-Agent": "pi-free-providers" },
+		signal: AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS),
+	});
+	if (!response.ok) return {};
+
+	const catalog = (await response.json()) as Record<string, ModelsDevProvider>;
+	if (providerId) {
+		const catalogProviderId =
+			MODELS_DEV_PROVIDER_ALIASES[providerId] ?? providerId;
+		const scopedModels = catalog[catalogProviderId]?.models;
+		if (scopedModels && Object.keys(scopedModels).length > 0) {
+			return scopedModels;
+		}
+	}
+
+	return collectAllModels(catalog);
+}
+
+function normalizeModelKey(id: string): string {
+	return id
+		.toLowerCase()
+		.replace(/^~/, "")
+		.replace(/:free$/, "")
+		.replace(/-free$/, "");
+}
+
+function buildModelMetaIndex(
+	meta: Record<string, ModelsDevModel>,
+): Map<string, ModelsDevModel> {
+	const index = new Map<string, ModelsDevModel>();
+	for (const [key, model] of Object.entries(meta)) {
+		for (const value of [key, model.id, key.split("/").pop()]) {
+			if (value) index.set(normalizeModelKey(value), model);
+		}
+	}
+	return index;
+}
+
+function findModelDevMeta(
+	index: Map<string, ModelsDevModel>,
+	modelId: string,
+): ModelsDevModel | undefined {
+	const id = normalizeModelKey(modelId);
+	return index.get(id) ?? index.get(id.split("/").pop() ?? id);
+}
+
+function isTextOnly(input: ProviderModelConfig["input"]): boolean {
+	return input.length === 1 && input[0] === "text";
+}
+
+function costLooksLikeFallback(cost: CostConfig): boolean {
+	return (
+		cost.input === 0 &&
+		cost.output === 0 &&
+		cost.cacheRead === 0 &&
+		cost.cacheWrite === 0
+	);
+}
+
+function costFromModelsDev(
+	cost: ModelsDevModel["cost"],
+): CostConfig | undefined {
+	if (!cost) return undefined;
+	return {
+		input: cost.input / 1_000_000,
+		output: cost.output / 1_000_000,
+		cacheRead: (cost.cache_read ?? 0) / 1_000_000,
+		cacheWrite: (cost.cache_write ?? 0) / 1_000_000,
+	};
+}
+
+function thinkingMapFromReasoningOptions(
+	options: ModelsDevModel["reasoning_options"],
+): ThinkingLevelMap | undefined {
+	const effort = options?.find((option) => option.type === "effort");
+	if (!effort?.values?.length) return undefined;
+
+	const values = new Set(effort.values);
+	return {
+		off: values.has("none") ? "none" : null,
+		minimal: values.has("minimal") ? "minimal" : null,
+		low: values.has("low") ? "low" : null,
+		medium: values.has("medium") ? "medium" : null,
+		high: values.has("high") ? "high" : null,
+		xhigh: values.has("xhigh") ? "xhigh" : values.has("max") ? "max" : null,
+	};
+}
+
+function identityFromMeta(
+	model: ProviderModelConfig,
+	meta: ModelsDevModel,
+): ModelIdentity {
+	return {
+		id: [model.id, meta.id, meta.family, meta.provider]
+			.filter(Boolean)
+			.join(" "),
+		name: [model.name, meta.name].filter(Boolean).join(" "),
+		family: meta.family,
+		provider: meta.provider,
+	};
+}
+
+function mergeCompat(
+	existing: ProviderModelConfig["compat"],
+	derived: ProviderModelConfig["compat"],
+): ProviderModelConfig["compat"] | undefined {
+	if (!existing) return derived;
+	if (!derived) return existing;
+	return { ...(derived as ModelCompat), ...(existing as ModelCompat) };
+}
+
+export interface ModelsDevEnrichmentOptions {
+	/** Provider id to scope models.dev lookup. Omit to search all providers. */
+	providerId?: string;
+	/** Values treated as provider defaults and safe to replace from models.dev. */
+	fallbackContextWindows?: number[];
+	fallbackMaxTokens?: number[];
+	/** Fill image modality when the provider exposed text-only fallback. */
+	enrichInput?: boolean;
+	/** Fill reasoning flag and effort map from models.dev. */
+	enrichReasoning?: boolean;
+	/** Fill cost only when explicitly enabled and current cost is all-zero fallback. */
+	enrichCost?: "never" | "fallback-only";
+	/** Add model/family compat without overwriting existing compat keys. */
+	enrichCompat?: boolean;
+}
+
+/**
+ * Fill Pi-usable model fields from models.dev when provider APIs only expose
+ * generic defaults. Fail-open: network/API failures leave models unchanged.
+ */
+export async function enrichModelsWithModelsDev<T extends ProviderModelConfig>(
+	models: T[],
+	options: ModelsDevEnrichmentOptions = {},
+): Promise<Array<T & ModelsDevEnrichedMetadata>> {
+	if (models.length === 0) return models;
+
+	let meta: Record<string, ModelsDevModel>;
+	try {
+		meta = await fetchModelsDevMeta(options.providerId);
+	} catch {
+		return models;
+	}
+	if (Object.keys(meta).length === 0) return models;
+
+	const index = buildModelMetaIndex(meta);
+	const fallbackContextWindows = new Set(
+		options.fallbackContextWindows ?? [DEFAULT_CONTEXT_WINDOW, 4096],
+	);
+	const fallbackMaxTokens = new Set(
+		options.fallbackMaxTokens ?? [DEFAULT_MAX_TOKENS, 4096],
+	);
+	const enrichInput = options.enrichInput ?? true;
+	const enrichReasoning = options.enrichReasoning ?? true;
+	const enrichCost = options.enrichCost ?? "never";
+	const enrichCompat = options.enrichCompat ?? true;
+
+	try {
+		return models.map((model) => {
+			const modelMeta = findModelDevMeta(index, model.id);
+			if (!modelMeta) return model;
+
+			const contextWindow =
+				modelMeta.limit && fallbackContextWindows.has(model.contextWindow)
+					? modelMeta.limit.context
+					: model.contextWindow;
+			const maxTokens =
+				modelMeta.limit && fallbackMaxTokens.has(model.maxTokens)
+					? modelMeta.limit.output
+					: model.maxTokens;
+			const input =
+				enrichInput &&
+				isTextOnly(model.input) &&
+				modelMeta.modalities?.input?.includes("image")
+					? (["text", "image"] as const)
+					: model.input;
+			const reasoning =
+				enrichReasoning && modelMeta.reasoning === true
+					? true
+					: model.reasoning;
+			const thinkingLevelMap =
+				enrichReasoning && model.thinkingLevelMap === undefined
+					? thinkingMapFromReasoningOptions(modelMeta.reasoning_options)
+					: model.thinkingLevelMap;
+			const cost =
+				enrichCost === "fallback-only" && costLooksLikeFallback(model.cost)
+					? (costFromModelsDev(modelMeta.cost) ?? model.cost)
+					: model.cost;
+			const compat = enrichCompat
+				? mergeCompat(
+						model.compat,
+						getProxyModelCompat(identityFromMeta(model, modelMeta)),
+					)
+				: model.compat;
+
+			const modelsDevMetadata: ModelMatchHints = {
+				id: modelMeta.id,
+				name: modelMeta.name,
+				...(modelMeta.family ? { family: modelMeta.family } : {}),
+				...(modelMeta.provider ? { provider: modelMeta.provider } : {}),
+			};
+
+			return {
+				...model,
+				contextWindow,
+				maxTokens,
+				input,
+				reasoning,
+				...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+				cost,
+				...(compat ? { compat } : {}),
+				modelsDev: modelsDevMetadata,
+			};
+		});
+	} catch {
+		return models;
+	}
+}
+
+export async function safeEnrichModelsWithModelsDev<
+	T extends ProviderModelConfig,
+>(
+	models: T[],
+	options: ModelsDevEnrichmentOptions = {},
+): Promise<Array<T & ModelsDevEnrichedMetadata>> {
+	try {
+		return await enrichModelsWithModelsDev(models, options);
+	} catch {
+		return models;
+	}
+}

--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -1,9 +1,7 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ModelIdentity } from "./types.ts";
 
-export interface ProviderModelIdentity {
-	id: string;
-	name?: string;
-}
+export type ProviderModelIdentity = ModelIdentity;
 
 export const DEEPSEEK_PROXY_COMPAT: NonNullable<ProviderModelConfig["compat"]> =
 	{
@@ -23,13 +21,15 @@ const KIMI_PROXY_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
 	requiresReasoningContentOnAssistantMessages: true,
 };
 
-export function isDeepSeekModel(model: ProviderModelIdentity): boolean {
-	const haystack = `${model.id} ${model.name ?? ""}`.toLowerCase();
-	return haystack.includes("deepseek");
+function getModelHaystack(model: ProviderModelIdentity): string {
+	return [model.id, model.name, model.family, model.provider]
+		.filter(Boolean)
+		.join(" ")
+		.toLowerCase();
 }
 
-function getModelHaystack(model: ProviderModelIdentity): string {
-	return `${model.id} ${model.name ?? ""}`.toLowerCase();
+export function isDeepSeekModel(model: ProviderModelIdentity): boolean {
+	return getModelHaystack(model).includes("deepseek");
 }
 
 /** MiMo/Xiaomi reasoning models expose OpenAI-compatible reasoning controls

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,6 +14,19 @@ export interface CostConfig {
 	cacheWrite: number;
 }
 
+export interface ModelIdentity {
+	id: string;
+	name?: string;
+	family?: string;
+	provider?: string;
+}
+
+export type ModelMatchHints = Partial<ModelIdentity>;
+
+export interface ModelsDevEnrichedMetadata {
+	modelsDev?: ModelMatchHints;
+}
+
 export interface ProviderModelConfig {
 	id: string;
 	name: string;
@@ -35,6 +48,13 @@ export interface ModelsDevCost {
 	cache_write?: number;
 }
 
+export interface ModelsDevReasoningOption {
+	type: "effort" | "toggle" | "budget_tokens";
+	values?: string[];
+	min?: number;
+	max?: number;
+}
+
 export interface ModelsDevLimit {
 	context: number;
 	output: number;
@@ -45,10 +65,10 @@ export interface ModelsDevModalities {
 	output?: string[];
 }
 
-export interface ModelsDevModel {
-	id: string;
+export interface ModelsDevModel extends ModelIdentity {
 	name: string;
 	reasoning: boolean;
+	reasoning_options?: ModelsDevReasoningOption[];
 	cost?: ModelsDevCost;
 	limit: ModelsDevLimit;
 	modalities?: ModelsDevModalities;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "./logger.ts";
+import { safeEnrichModelsWithModelsDev } from "./model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -470,8 +471,7 @@ export async function fetchOpenAICompatibleModels(
 	callbacks: OpenAIModelCallbacks = {},
 ): Promise<PiProviderModelConfig[]> {
 	const logger = createLogger(providerId);
-	const detectReasoning =
-		callbacks.detectReasoning ?? isLikelyReasoningModel;
+	const detectReasoning = callbacks.detectReasoning ?? isLikelyReasoningModel;
 	const getCompat = callbacks.getProxyCompat ?? getProxyModelCompat;
 
 	logger.info(`[${providerId}] Fetching models...`);
@@ -501,7 +501,7 @@ export async function fetchOpenAICompatibleModels(
 
 		logger.info(`[${providerId}] Fetched ${models.length} models`);
 
-		return models
+		const mapped = models
 			.filter((m) => m.id)
 			.map((m): PiProviderModelConfig => {
 				const name = m.id.split("/").pop() || m.id;
@@ -522,8 +522,7 @@ export async function fetchOpenAICompatibleModels(
 					4_096;
 
 				// Use per-model reasoning flag if the API provides it
-				const reasoning =
-					m.reasoning ?? detectReasoning({ id: m.id, name });
+				const reasoning = m.reasoning ?? detectReasoning({ id: m.id, name });
 
 				// Use per-model input_modalities if the API provides it
 				const hasVision = m.input_modalities?.includes("image") ?? false;
@@ -563,6 +562,8 @@ export async function fetchOpenAICompatibleModels(
 					_pricingKnown: hasApiPricing,
 				} as PiProviderModelConfig & { _pricingKnown?: boolean };
 			});
+
+		return await safeEnrichModelsWithModelsDev(mapped, { providerId });
 	} catch (error) {
 		logger.error(`[${providerId}] Failed to fetch models:`, {
 			error: error instanceof Error ? error.message : String(error),

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -12,6 +12,7 @@
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { ModelMatchHints } from "../lib/types.ts";
 import {
 	HARDCODED_BENCHMARKS,
 	type HardcodedBenchmark,
@@ -677,6 +678,7 @@ export function findHardcodedBenchmark(
 	modelName: string,
 	modelId: string,
 	provider?: string,
+	hints?: ModelMatchHints,
 ): HardcodedBenchmark | null {
 	// Normalize: convert colons to dashes (Ollama model:tag format)
 	const search = `${modelName} ${modelId}`.toLowerCase().replaceAll(":", "-");
@@ -699,9 +701,17 @@ export function findHardcodedBenchmark(
 	);
 	if (normalizedResult) return normalizedResult;
 
-	// 4. Prefix fallback with base model extraction
-	const prefix = tryPrefixFallback(normalized, provider, modelId, modelName);
-	if (prefix) return prefix;
+	// 4. Prefix fallback with base model extraction. Also try models.dev
+	// canonical IDs/names when available for opaque gateway model IDs.
+	const prefixCandidates = [normalized, hints?.id, hints?.name]
+		.map((candidate) =>
+			(candidate?.trim() ?? "").toLowerCase().replaceAll(/[\s_:]+/g, "-"),
+		)
+		.filter(Boolean);
+	for (const candidate of prefixCandidates) {
+		const prefix = tryPrefixFallback(candidate, provider, modelId, modelName);
+		if (prefix) return prefix;
+	}
 
 	// No match found
 	logDebug({
@@ -724,8 +734,9 @@ export function getHardcodedScore(
 	modelName: string,
 	modelId: string,
 	provider?: string,
+	hints?: ModelMatchHints,
 ): number | null {
-	const benchmark = findHardcodedBenchmark(modelName, modelId, provider);
+	const benchmark = findHardcodedBenchmark(modelName, modelId, provider, hints);
 	return benchmark?.codingIndex ?? null;
 }
 
@@ -737,8 +748,9 @@ export function enhanceModelNameWithCodingIndex(
 	modelName: string,
 	modelId: string,
 	provider?: string,
+	hints?: ModelMatchHints,
 ): string {
-	const benchmark = findHardcodedBenchmark(modelName, modelId, provider);
+	const benchmark = findHardcodedBenchmark(modelName, modelId, provider, hints);
 	if (benchmark?.codingIndex !== undefined) {
 		return `${modelName} [CI: ${benchmark.codingIndex.toFixed(1)}]`;
 	}

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -17,6 +17,10 @@ import { enhanceModelNameWithCodingIndex } from "./provider-failover/benchmark-l
 
 const _logger = createLogger("provider-helper");
 
+type ModelsDevEnrichedMetadata = {
+	modelsDev?: Parameters<typeof enhanceModelNameWithCodingIndex>[3];
+};
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -78,12 +82,17 @@ export interface OpenAICompatibleConfig {
  * Use this for direct provider registration (not through setupProvider)
  */
 export function enhanceWithCI(
-	models: ProviderModelConfig[],
+	models: Array<ProviderModelConfig & ModelsDevEnrichedMetadata>,
 	providerId?: string,
 ): ProviderModelConfig[] {
 	return models.map((m) => ({
 		...m,
-		name: enhanceModelNameWithCodingIndex(m.name, m.id, providerId),
+		name: enhanceModelNameWithCodingIndex(
+			m.name,
+			m.id,
+			providerId,
+			m.modelsDev,
+		),
 	}));
 }
 

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -14,6 +14,7 @@ import {
 	PROVIDER_CLINE,
 } from "../../constants.ts";
 import type { ProviderModelConfig } from "../../lib/types.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 
@@ -243,7 +244,12 @@ export async function fetchClineModels(
 		? models.filter((m) => m.cost.input === 0 && m.cost.output === 0)
 		: models;
 
-	return applyHidden(filtered, PROVIDER_CLINE);
+	return applyHidden(
+		await safeEnrichModelsWithModelsDev(filtered, {
+			providerId: PROVIDER_CLINE,
+		}),
+		PROVIDER_CLINE,
+	);
 }
 
 /**

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -28,6 +28,7 @@ import {
 	PROVIDER_CROFAI,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -98,7 +99,7 @@ async function fetchCrofaiModels(
 
 	_logger.info(`[crofai] Fetched ${models.length} models`);
 
-	return models
+	const mapped = models
 		.filter((m) => m.id)
 		.map((m): ProviderModelConfig => {
 			const name = m.name || m.id;
@@ -125,6 +126,10 @@ async function fetchCrofaiModels(
 					m.pricing?.cache_prompt !== undefined,
 			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
+
+	return await safeEnrichModelsWithModelsDev(mapped, {
+		providerId: PROVIDER_CROFAI,
+	});
 }
 
 // =============================================================================

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -40,6 +40,7 @@ import {
 	PROVIDER_DEEPINFRA,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -101,7 +102,7 @@ async function fetchDeepinfraModels(
 
 	_logger.info(`[deepinfra] Fetched ${models.length} models`);
 
-	return models
+	const mapped = models
 		.filter((m) => {
 			const id = m.id.toLowerCase();
 			// Filter out non-chat models
@@ -141,6 +142,10 @@ async function fetchDeepinfraModels(
 				_pricingKnown: meta?.pricing !== undefined,
 			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
+
+	return await safeEnrichModelsWithModelsDev(mapped, {
+		providerId: PROVIDER_DEEPINFRA,
+	});
 }
 
 // =============================================================================

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -42,6 +42,7 @@ import {
 } from "../../config.ts";
 import { DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import {
 	getModelsDueForProbe,
@@ -72,6 +73,7 @@ const _opencodeSession = createOpenCodeSessionTracker();
 // =============================================================================
 
 interface FetchModelsOptions {
+	providerId: string;
 	baseUrl: string;
 	apiKey: string;
 	compat?: ProviderModelConfig["compat"];
@@ -111,7 +113,7 @@ async function fetchModelsFromEndpoint(
 		? body
 		: (body.data ?? []);
 
-	return rawModels.map((m) => {
+	const models = rawModels.map((m) => {
 		const id = String(m.id ?? "");
 		const inputModalities = m.input_modalities as string[] | undefined;
 		return {
@@ -123,7 +125,9 @@ async function fetchModelsFromEndpoint(
 				: (["text"] as const),
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow:
-				((m.max_context_length ?? m.context_window) as number) ??
+				((m.context_length ??
+					m.max_context_length ??
+					m.context_window) as number) ??
 				opts.modelDefaults?.contextWindow ??
 				128_000,
 			maxTokens:
@@ -134,6 +138,10 @@ async function fetchModelsFromEndpoint(
 			...opts.modelDefaults,
 			...(opts.compat ? { compat: opts.compat } : {}),
 		} satisfies ProviderModelConfig & { _pricingKnown?: boolean };
+	});
+
+	return await safeEnrichModelsWithModelsDev(models, {
+		providerId: opts.providerId,
 	});
 }
 
@@ -284,6 +292,7 @@ const DYNAMIC_PROVIDERS: DynamicProviderDef[] = [
 		// OpenRouter returns full pricing — use its dedicated fetcher
 		fetchModels: (apiKey) =>
 			fetchOpenRouterCompatibleModels({
+				providerId: "openrouter",
 				baseUrl: "https://openrouter.ai/api/v1",
 				apiKey,
 				freeOnly: false,
@@ -307,6 +316,7 @@ async function discoverAndRegister(
 			allModels = await config.fetchModels(apiKey);
 		} else {
 			allModels = await fetchModelsFromEndpoint({
+				providerId: config.providerId,
 				baseUrl: config.baseUrl,
 				apiKey,
 				compat: config.compat,
@@ -652,6 +662,7 @@ export async function setupDynamicBuiltInProviders(
 				defaultShowPaid: getFastrouterShowPaid,
 				fetchModels: () =>
 					fetchOpenRouterCompatibleModels({
+						providerId: "fastrouter",
 						baseUrl: "https://api.fastrouter.ai/api/v1",
 						apiKey: fastrouterApiKey,
 						freeOnly: false,

--- a/providers/kilo/kilo-models.ts
+++ b/providers/kilo/kilo-models.ts
@@ -19,6 +19,7 @@ export async function fetchKiloModels(options?: {
 	freeOnly?: boolean;
 }): Promise<ProviderModelConfig[]> {
 	const models = await fetchOpenRouterCompatibleModels({
+		providerId: PROVIDER_KILO,
 		baseUrl: KILO_GATEWAY_BASE,
 		apiKey: options?.token,
 		freeOnly: options?.freeOnly,

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -3,8 +3,9 @@
  * Consolidates duplicate logic from openrouter.ts and kilo-models.ts
  */
 
-import { DEFAULT_FETCH_TIMEOUT_MS, URL_MODELS_DEV } from "../constants.ts";
-import type { ModelsDevModel, ProviderModelConfig } from "../lib/types.ts";
+import { DEFAULT_FETCH_TIMEOUT_MS } from "../constants.ts";
+import { safeEnrichModelsWithModelsDev } from "../lib/model-metadata.ts";
+import type { ProviderModelConfig } from "../lib/types.ts";
 import { fetchWithRetry, mapOpenRouterModel } from "../lib/util.ts";
 
 interface OpenRouterCompatibleModel {
@@ -28,6 +29,8 @@ interface OpenRouterCompatibleModel {
 }
 
 interface FetchModelsOptions {
+	/** Provider id for scoped models.dev enrichment (e.g., openrouter, kilo). */
+	providerId?: string;
 	/** Base URL for the API (e.g., https://api.openrouter.ai/api/v1) */
 	baseUrl: string;
 	/** API key for authentication (optional) */
@@ -93,7 +96,7 @@ export async function fetchOpenRouterCompatibleModels(
 		throw new Error("Invalid models response: missing data array");
 	}
 
-	return json.data
+	const models = json.data
 		.filter((m) => {
 			// Filter out image generation models
 			const outputMods = m.architecture?.output_modalities ?? [];
@@ -110,6 +113,10 @@ export async function fetchOpenRouterCompatibleModels(
 			return true;
 		})
 		.map(mapOpenRouterModel);
+
+	return await safeEnrichModelsWithModelsDev(models, {
+		providerId: options.providerId,
+	});
 }
 
 /**
@@ -130,53 +137,4 @@ export async function fetchOpenRouterModelsWithFree(
 	});
 
 	return { free, all };
-}
-
-// =============================================================================
-// Models.dev metadata fetching
-// =============================================================================
-
-interface ModelsDevResponse {
-	[id: string]: {
-		id?: string;
-		models?: Record<string, ModelsDevModel>;
-	};
-}
-
-/**
- * Fetch model metadata from models.dev.
- * @param providerId - If specified, only return models for that provider
- * @returns Map of model ID to model metadata
- */
-export async function fetchModelsDevMeta(
-	providerId?: string,
-): Promise<Record<string, ModelsDevModel>> {
-	const response = await fetchWithRetry(
-		URL_MODELS_DEV,
-		{
-			headers: { "User-Agent": "pi-free-providers" },
-		},
-		3,
-		1000,
-		DEFAULT_FETCH_TIMEOUT_MS,
-	);
-
-	if (!response.ok) return {};
-
-	const json = (await response.json()) as ModelsDevResponse;
-
-	// If providerId specified, return only that provider's models
-	if (providerId) {
-		const provider = Object.values(json).find((p) => p?.id === providerId);
-		return provider?.models ?? {};
-	}
-
-	// Otherwise, return all models from all providers
-	const allModels: Record<string, ModelsDevModel> = {};
-	for (const provider of Object.values(json)) {
-		if (provider?.models) {
-			Object.assign(allModels, provider.models);
-		}
-	}
-	return allModels;
 }

--- a/providers/novita/novita.ts
+++ b/providers/novita/novita.ts
@@ -32,6 +32,7 @@ import {
 	PROVIDER_NOVITA,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -98,7 +99,7 @@ async function fetchNovitaModels(
 
 		_logger.info(`[novita] Fetched ${models.length} models`);
 
-		return models.map((m): ProviderModelConfig => {
+		const mapped = models.map((m): ProviderModelConfig => {
 			const name = m.display_name || m.id.split("/").pop() || m.id;
 			const reasoning =
 				(m.features ?? []).includes("reasoning") ||
@@ -128,6 +129,10 @@ async function fetchNovitaModels(
 				compat: getProxyModelCompat({ id: m.id, name }),
 				_pricingKnown: hasPricing,
 			} as ProviderModelConfig & { _pricingKnown?: boolean };
+		});
+
+		return await safeEnrichModelsWithModelsDev(mapped, {
+			providerId: PROVIDER_NOVITA,
 		});
 	} catch (error) {
 		_logger.error("[novita] Failed to fetch models:", {

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -31,6 +31,7 @@ import {
 } from "../../constants.ts";
 import { applyHidden } from "../../config.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -157,7 +158,13 @@ async function fetchRoutewayModels(
 		const models = (json.data ?? []).filter(isChatModel);
 
 		_logger.info(`[routeway] Fetched ${models.length} chat models`);
-		return applyHidden(models.map(mapRoutewayModel), PROVIDER_ROUTEWAY);
+		const enriched = await safeEnrichModelsWithModelsDev(
+			models.map(mapRoutewayModel),
+			{
+				providerId: PROVIDER_ROUTEWAY,
+			},
+		);
+		return applyHidden(enriched, PROVIDER_ROUTEWAY);
 	} catch (error) {
 		_logger.error("[routeway] Failed to fetch models", {
 			error: error instanceof Error ? error.message : String(error),

--- a/providers/together/together.ts
+++ b/providers/together/together.ts
@@ -41,6 +41,7 @@ import {
 	PROVIDER_TOGETHER,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -100,7 +101,7 @@ async function fetchTogetherModels(
 
 	_logger.info(`[together] Fetched ${models.length} models`);
 
-	return models
+	const mapped = models
 		.filter((m) => m.type === "chat" && m.id && !m.id.includes("embed"))
 		.map((m): ProviderModelConfig => {
 			const name = m.display_name || m.id.split("/").pop() || m.id;
@@ -128,6 +129,10 @@ async function fetchTogetherModels(
 				_pricingKnown: m.pricing !== undefined,
 			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
+
+	return await safeEnrichModelsWithModelsDev(mapped, {
+		providerId: PROVIDER_TOGETHER,
+	});
 }
 
 // =============================================================================

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -27,6 +27,7 @@ import {
 	PROVIDER_TOKENROUTER,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
@@ -148,7 +149,11 @@ async function fetchTokenRouterModels(
 		const models = (json.data ?? []).filter(isTextChatModel);
 
 		_logger.info(`[tokenrouter] Fetched ${models.length} text chat models`);
-		return applyHidden(models.map(mapTokenRouterModel), PROVIDER_TOKENROUTER);
+		const enriched = await safeEnrichModelsWithModelsDev(
+			models.map(mapTokenRouterModel),
+			{ providerId: PROVIDER_TOKENROUTER },
+		);
+		return applyHidden(enriched, PROVIDER_TOKENROUTER);
 	} catch (error) {
 		_logger.error("[tokenrouter] Failed to fetch models", {
 			error: error instanceof Error ? error.message : String(error),

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -27,6 +27,7 @@ import {
 	PROVIDER_ZENMUX,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
@@ -97,7 +98,7 @@ async function fetchZenmuxModels(
 
 		_logger.info(`[zenmux] Fetched ${models.length} models`);
 
-		return models.map((m) => {
+		const mapped = models.map((m) => {
 			const hasPricings = m.pricings !== undefined;
 			return {
 				id: m.id,
@@ -117,6 +118,10 @@ async function fetchZenmuxModels(
 				compat: getProxyModelCompat(m),
 				_pricingKnown: hasPricings,
 			} as ProviderModelConfig & { _pricingKnown?: boolean };
+		});
+
+		return await safeEnrichModelsWithModelsDev(mapped, {
+			providerId: PROVIDER_ZENMUX,
 		});
 	} catch (error) {
 		_logger.error("[zenmux] Failed to fetch models:", {

--- a/tests/benchmark-lookup.test.ts
+++ b/tests/benchmark-lookup.test.ts
@@ -39,11 +39,7 @@ describe("Benchmark Lookup", () => {
 
 		it("should not throw for Ollama colon format", () => {
 			expect(() =>
-				enhanceModelNameWithCodingIndex(
-					"Llama 3",
-					"llama3:latest",
-					"ollama",
-				),
+				enhanceModelNameWithCodingIndex("Llama 3", "llama3:latest", "ollama"),
 			).not.toThrow();
 		});
 
@@ -89,11 +85,7 @@ describe("Benchmark Lookup", () => {
 
 		it("should not throw for models with date suffixes", () => {
 			expect(() =>
-				enhanceModelNameWithCodingIndex(
-					"GPT-4o",
-					"gpt-4o-20250514",
-					"openai",
-				),
+				enhanceModelNameWithCodingIndex("GPT-4o", "gpt-4o-20250514", "openai"),
 			).not.toThrow();
 		});
 
@@ -177,6 +169,38 @@ describe("Benchmark Lookup", () => {
 			);
 			expect(result).toBeNull();
 		});
+
+		it("should use models.dev hints for opaque gateway IDs", () => {
+			expect(
+				findHardcodedBenchmark("Opaque Gateway Model", "opaque-id", "gateway"),
+			).toBeNull();
+
+			const result = findHardcodedBenchmark(
+				"Opaque Gateway Model",
+				"opaque-id",
+				"gateway",
+				{
+					id: "moonshotai/Kimi-K2.6",
+					name: "Kimi K2.6",
+					family: "kimi-k2",
+					provider: "moonshotai",
+				},
+			);
+
+			expect(result?.codingIndex).toBeCloseTo(47.1);
+			expect(result?.originalModel).toBe("Kimi K2.6");
+		});
+
+		it("should ignore non-matching family-only hints in prefix fallback", () => {
+			const result = findHardcodedBenchmark(
+				"Opaque Gateway Model",
+				"opaque-id",
+				"gateway",
+				{ family: "this-fam-does-not-exist-12345" },
+			);
+
+			expect(result).toBeNull();
+		});
 	});
 
 	describe("getHardcodedScore", () => {
@@ -189,6 +213,48 @@ describe("Benchmark Lookup", () => {
 		it("should return null for unknown models", () => {
 			const score = getHardcodedScore("Unknown", "unknown", "test");
 			expect(score).toBeNull();
+		});
+
+		it("should return a score from models.dev hints", () => {
+			const score = getHardcodedScore(
+				"Opaque Gateway Model",
+				"opaque-id",
+				"gateway",
+				{ id: "moonshotai/Kimi-K2.6" },
+			);
+			expect(score).toBeCloseTo(47.1);
+		});
+	});
+
+	describe("models.dev match hints", () => {
+		it("should enhance names using models.dev hints", () => {
+			const name = enhanceModelNameWithCodingIndex(
+				"Opaque Gateway Model",
+				"opaque-id",
+				"gateway",
+				{ id: "moonshotai/Kimi-K2.6" },
+			);
+			expect(name).toBe("Opaque Gateway Model [CI: 47.1]");
+		});
+
+		it("should enhance names using models.dev name-only hints", () => {
+			const name = enhanceModelNameWithCodingIndex(
+				"Opaque Gateway Model",
+				"opaque-id",
+				"gateway",
+				{ name: "Kimi K2.6" },
+			);
+			expect(name).toBe("Opaque Gateway Model [CI: 47.1]");
+		});
+
+		it("should leave names unchanged when hints do not match", () => {
+			const name = enhanceModelNameWithCodingIndex(
+				"Opaque Gateway Model",
+				"opaque-id",
+				"gateway",
+				{ id: "unknown-canonical-model" },
+			);
+			expect(name).toBe("Opaque Gateway Model");
 		});
 	});
 
@@ -211,7 +277,9 @@ describe("Benchmark Lookup", () => {
 			const matches = content.match(replaceAllRegex) || [];
 
 			// Filter out false positives where 'g' might be present but not captured
-			const nonGlobalMatches = matches.filter((m: string) => !m.includes("/g,"));
+			const nonGlobalMatches = matches.filter(
+				(m: string) => !m.includes("/g,"),
+			);
 
 			if (nonGlobalMatches.length > 0) {
 				throw new Error(

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -1,0 +1,185 @@
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	enrichModelsWithModelsDev,
+	fetchModelsDevMeta,
+} from "../lib/model-metadata.ts";
+
+const baseModel: ProviderModelConfig = {
+	id: "opaque/model-id",
+	name: "Opaque Model",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_384,
+};
+
+function mockModelsDev(catalog: unknown) {
+	vi.spyOn(globalThis, "fetch").mockResolvedValue({
+		ok: true,
+		json: async () => catalog,
+	} as Response);
+}
+
+describe("models.dev metadata enrichment", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("enriches fallback limits, modalities, reasoning, thinking map, compat, and CI hints", async () => {
+		mockModelsDev({
+			deepinfra: {
+				id: "deepinfra",
+				models: {
+					"opaque/model-id": {
+						id: "moonshotai/Kimi-K2.6",
+						name: "Kimi K2.6",
+						family: "kimi-k2",
+						provider: "moonshotai",
+						reasoning: true,
+						reasoning_options: [
+							{ type: "effort", values: ["low", "medium", "high"] },
+						],
+						modalities: { input: ["text", "image"], output: ["text"] },
+						limit: { context: 262_144, output: 32_768 },
+						cost: { input: 1, output: 3, cache_read: 0.2, cache_write: 1 },
+					},
+				},
+			},
+		});
+
+		const [model] = await enrichModelsWithModelsDev([baseModel], {
+			providerId: "deepinfra",
+		});
+
+		expect(model.contextWindow).toBe(262_144);
+		expect(model.maxTokens).toBe(32_768);
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.reasoning).toBe(true);
+		expect(model.thinkingLevelMap).toEqual({
+			off: null,
+			minimal: null,
+			low: "low",
+			medium: "medium",
+			high: "high",
+			xhigh: null,
+		});
+		expect(model.compat).toEqual({
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: true,
+			requiresReasoningContentOnAssistantMessages: true,
+		});
+		expect(model.modelsDev).toEqual({
+			id: "moonshotai/Kimi-K2.6",
+			name: "Kimi K2.6",
+			family: "kimi-k2",
+			provider: "moonshotai",
+		});
+		// Cost is intentionally not trusted by default for gateway providers.
+		expect(model.cost).toEqual(baseModel.cost);
+	});
+
+	it("preserves explicit provider values and compat keys", async () => {
+		mockModelsDev({
+			openrouter: {
+				id: "openrouter",
+				models: {
+					"opaque/model-id": {
+						id: "deepseek/deepseek-v3.2",
+						name: "DeepSeek V3.2",
+						family: "deepseek-v3",
+						reasoning: true,
+						modalities: { input: ["text", "image"], output: ["text"] },
+						limit: { context: 262_144, output: 32_768 },
+					},
+				},
+			},
+		});
+		const explicit: ProviderModelConfig = {
+			...baseModel,
+			input: ["text", "image"],
+			contextWindow: 131_072,
+			maxTokens: 8_192,
+			compat: { supportsDeveloperRole: true },
+		};
+
+		const [model] = await enrichModelsWithModelsDev([explicit], {
+			providerId: "openrouter",
+		});
+
+		expect(model.contextWindow).toBe(131_072);
+		expect(model.maxTokens).toBe(8_192);
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.compat).toEqual({
+			supportsStore: false,
+			supportsDeveloperRole: true,
+			supportsReasoningEffort: true,
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
+		});
+	});
+
+	it("can enrich fallback costs when explicitly enabled", async () => {
+		mockModelsDev({
+			openrouter: {
+				id: "openrouter",
+				models: {
+					"opaque/model-id": {
+						id: "opaque/model-id",
+						name: "Opaque Model",
+						reasoning: false,
+						limit: { context: 128_000, output: 16_384 },
+						cost: { input: 2, output: 8, cache_read: 0.5, cache_write: 1 },
+					},
+				},
+			},
+		});
+
+		const [model] = await enrichModelsWithModelsDev([baseModel], {
+			providerId: "openrouter",
+			enrichCost: "fallback-only",
+		});
+
+		expect(model.cost).toEqual({
+			input: 0.000002,
+			output: 0.000008,
+			cacheRead: 0.0000005,
+			cacheWrite: 0.000001,
+		});
+	});
+
+	it("uses provider aliases and falls back to the full catalog", async () => {
+		mockModelsDev({
+			togetherai: {
+				id: "togetherai",
+				models: {
+					"Qwen/Qwen3.6-Plus": {
+						id: "Qwen/Qwen3.6-Plus",
+						name: "Qwen3.6 Plus",
+						reasoning: true,
+						limit: { context: 131_072, output: 16_384 },
+					},
+				},
+			},
+		});
+
+		expect(
+			(await fetchModelsDevMeta("together"))["Qwen/Qwen3.6-Plus"],
+		).toBeDefined();
+		const [model] = await enrichModelsWithModelsDev(
+			[{ ...baseModel, id: "Qwen/Qwen3.6-Plus" }],
+			{ providerId: "gateway-not-in-catalog" },
+		);
+		expect(model.contextWindow).toBe(131_072);
+	});
+
+	it("fails open when metadata cannot be fetched", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+		await expect(enrichModelsWithModelsDev([baseModel])).resolves.toEqual([
+			baseModel,
+		]);
+	});
+});

--- a/tests/provider-compat.test.ts
+++ b/tests/provider-compat.test.ts
@@ -19,6 +19,15 @@ describe("provider-compat", () => {
 			).toBe(true);
 		});
 
+		it("detects DeepSeek from metadata family or provider case-insensitively", () => {
+			expect(isDeepSeekModel({ id: "opaque", family: "DeepSeek-V3" })).toBe(
+				true,
+			);
+			expect(isDeepSeekModel({ id: "opaque", provider: "DEEPSEEK" })).toBe(
+				true,
+			);
+		});
+
 		it("returns false for non-DeepSeek models", () => {
 			expect(isDeepSeekModel({ id: "openai/gpt-4.1" })).toBe(false);
 			expect(


### PR DESCRIPTION
## Summary
- add fail-open models.dev metadata enrichment for context/output limits, modalities, reasoning/thinking maps, additive compat, and optional fallback cost data
- wire enrichment into OpenRouter-compatible, dynamic built-in, Cline, and gateway provider fetchers with provider-scoped lookups
- pass explicit models.dev hints into Coding Index matching for opaque gateway model IDs
- add tests for enrichment, benchmark hint matching, and metadata-based compat detection

## Validation
- npx tsc --noEmit --pretty false
- npm run test:run
- DRYKISS local autoreview: 0 findings, 100/100, quality gate pass
