### PR TITLE
fix: adapt TokenRouter MiniMax thinking payloads

### DIFF
--- a/lib/provider-compat.ts
+++ b/lib/provider-compat.ts
@@ -65,7 +65,6 @@ function isDeepSeekStyleModel(model: ProviderModelIdentity): boolean {
 	const id = model.id.toLowerCase();
 	return (
 		isDeepSeekModel(model) ||
-		id.includes("minimax") ||
 		id.includes("qwen3.7") ||
 		id.includes("qwen3-7")
 	);

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -29,6 +29,7 @@ import {
 import { createLogger } from "../../lib/logger.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import {
+	DEEPSEEK_PROXY_COMPAT,
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
@@ -44,7 +45,12 @@ const _logger = createLogger("tokenrouter");
 // are hardcoded. Detected via name suffix also catches `:free`-tagged models.
 // =============================================================================
 
-const KNOWN_FREE_MODELS = new Set(["MiniMax-M3"]);
+const MINIMAX_M3_ID = "MiniMax-M3";
+const KNOWN_FREE_MODELS = new Set([MINIMAX_M3_ID]);
+const MINIMAX_ADAPTIVE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
+	...DEEPSEEK_PROXY_COMPAT,
+	thinkingFormat: "deepseek",
+};
 
 // =============================================================================
 // Types
@@ -85,13 +91,53 @@ function isTextChatModel(model: TokenRouterModel): boolean {
 	return model.supported_endpoint_types.some((t) => CHAT_ENDPOINT_TYPES.has(t));
 }
 
-function mapTokenRouterModel(model: TokenRouterModel): ProviderModelConfig & {
+function isTokenRouterMinimaxModel(modelId: string): boolean {
+	return modelId.toLowerCase().includes("minimax");
+}
+
+export function finalizeTokenRouterModel(
+	model: ProviderModelConfig,
+): ProviderModelConfig {
+	if (!isTokenRouterMinimaxModel(model.id)) return model;
+
+	return {
+		...model,
+		reasoning: true,
+		compat: {
+			...MINIMAX_ADAPTIVE_COMPAT,
+			...(model.compat ?? {}),
+			thinkingFormat: "deepseek",
+			supportsReasoningEffort: true,
+		},
+	};
+}
+
+export function patchTokenRouterMinimaxThinkingPayload(payload: unknown): unknown {
+	if (typeof payload !== "object" || payload === null) return payload;
+	const body = payload as {
+		model?: unknown;
+		thinking?: { type?: unknown };
+	};
+	if (!isTokenRouterMinimaxModel(String(body.model ?? ""))) return payload;
+	if (body.thinking?.type !== "enabled") return payload;
+
+	return {
+		...body,
+		thinking: {
+			...body.thinking,
+			type: "adaptive",
+		},
+	};
+}
+
+export function mapTokenRouterModel(model: TokenRouterModel): ProviderModelConfig & {
 	_pricingKnown?: boolean;
 	_freeKnown?: boolean;
 	_isFree?: boolean;
 } {
 	const name = cleanModelName(model.id);
-	const reasoning = isLikelyReasoningModel({ id: model.id, name });
+	const isMinimax = isTokenRouterMinimaxModel(model.id);
+	const reasoning = isMinimax || isLikelyReasoningModel({ id: model.id, name });
 	const isResponseApi =
 		model.supported_endpoint_types.includes("openai-response");
 	const isKnownFree = KNOWN_FREE_MODELS.has(model.id);
@@ -105,7 +151,9 @@ function mapTokenRouterModel(model: TokenRouterModel): ProviderModelConfig & {
 		contextWindow: 128_000,
 		maxTokens: 16_384,
 		compat: {
-			...getProxyModelCompat({ id: model.id, name }),
+			...(isMinimax
+				? MINIMAX_ADAPTIVE_COMPAT
+				: getProxyModelCompat({ id: model.id, name })),
 			// openai-response models use a different API shape
 			...(isResponseApi ? { apiType: "openai-response" as const } : {}),
 		},
@@ -153,7 +201,10 @@ async function fetchTokenRouterModels(
 			models.map(mapTokenRouterModel),
 			{ providerId: PROVIDER_TOKENROUTER },
 		);
-		return applyHidden(enriched, PROVIDER_TOKENROUTER);
+		return applyHidden(
+			enriched.map(finalizeTokenRouterModel),
+			PROVIDER_TOKENROUTER,
+		);
 	} catch (error) {
 		_logger.error("[tokenrouter] Failed to fetch models", {
 			error: error instanceof Error ? error.message : String(error),
@@ -197,6 +248,10 @@ export default async function tokenRouterProvider(pi: ExtensionAPI) {
 	});
 
 	registerWithGlobalToggle(PROVIDER_TOKENROUTER, stored, reRegister, true);
+
+	pi.on("before_provider_request", (event) =>
+		patchTokenRouterMinimaxThinkingPayload(event.payload),
+	);
 
 	setupProvider(
 		pi,

--- a/tests/provider-compat.test.ts
+++ b/tests/provider-compat.test.ts
@@ -90,6 +90,11 @@ describe("provider-compat", () => {
 			});
 		});
 
+		it("does not use DeepSeek thinking format for MiniMax models", () => {
+			expect(isLikelyReasoningModel({ id: "MiniMax-M3" })).toBe(true);
+			expect(getProxyModelCompat({ id: "MiniMax-M3" })).toBeUndefined();
+		});
+
 		it("returns undefined for non-DeepSeek models", () => {
 			expect(getProxyModelCompat({ id: "openai/gpt-4.1" })).toBeUndefined();
 			expect(

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { isFreeModel } from "../lib/registry.ts";
+import {
+	finalizeTokenRouterModel,
+	mapTokenRouterModel,
+	patchTokenRouterMinimaxThinkingPayload,
+} from "../providers/tokenrouter/tokenrouter.ts";
 
 describe("TokenRouter free model detection", () => {
 	const freeModel = {
@@ -41,6 +46,74 @@ describe("TokenRouter free model detection", () => {
 		expect(
 			isFreeModel({ ...freeModel, provider: "tokenrouter" }, allModels),
 		).toBe(true);
+	});
+
+	it("uses adaptive-thinking compat for MiniMax-M3", () => {
+		const model = mapTokenRouterModel({
+			id: "MiniMax-M3",
+			object: "model",
+			created: 0,
+			owned_by: "minimax",
+			supported_endpoint_types: ["openai"],
+			tags: "text",
+		});
+
+		expect(model.reasoning).toBe(true);
+		expect(
+			(model.compat as { thinkingFormat?: string } | undefined)?.thinkingFormat,
+		).toBe("deepseek");
+	});
+
+	it("keeps MiniMax-M3 adaptive-thinking compat after metadata enrichment", () => {
+		const model = finalizeTokenRouterModel({
+			...freeModel,
+			reasoning: true,
+			thinkingLevelMap: { high: "high" },
+			compat: {
+				thinkingFormat: "deepseek",
+				supportsReasoningEffort: true,
+				requiresReasoningContentOnAssistantMessages: true,
+				supportsDeveloperRole: false,
+			},
+		});
+
+		expect(model.reasoning).toBe(true);
+		expect(model.thinkingLevelMap).toEqual({ high: "high" });
+		expect(model.compat).toEqual({
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: true,
+			requiresReasoningContentOnAssistantMessages: true,
+			thinkingFormat: "deepseek",
+		});
+	});
+
+	it("patches MiniMax-M3 thinking payloads from enabled to adaptive", () => {
+		expect(
+			patchTokenRouterMinimaxThinkingPayload({
+				model: "MiniMax-M3",
+				thinking: { type: "enabled" },
+				reasoning_effort: "high",
+			}),
+		).toEqual({
+			model: "MiniMax-M3",
+			thinking: { type: "adaptive" },
+			reasoning_effort: "high",
+		});
+	});
+
+	it("leaves non-MiniMax and disabled thinking payloads unchanged", () => {
+		const disabled = {
+			model: "MiniMax-M3",
+			thinking: { type: "disabled" },
+		};
+		const other = {
+			model: "deepseek-r1",
+			thinking: { type: "enabled" },
+		};
+
+		expect(patchTokenRouterMinimaxThinkingPayload(disabled)).toBe(disabled);
+		expect(patchTokenRouterMinimaxThinkingPayload(other)).toBe(other);
 	});
 
 	it("detects :free suffix models as free (name-based Route B)", () => {


### PR DESCRIPTION
## Summary
- keep TokenRouter MiniMax-M3 reasoning enabled
- route MiniMax through Pi's existing DeepSeek-style thinking generation path, then patch the final TokenRouter payload from thinking.type=enabled to thinking.type=adaptive
- keep disabled thinking payloads unchanged
- add regression tests for MiniMax model mapping and payload patching

## Validation
- curl against TokenRouter confirmed thinking.type=adaptive succeeds and thinking.type=enabled fails
- npx tsc --noEmit --pretty false
- npm run test:run

DRYKISS intentionally not rerun per request.
