### PR TITLE
fix: use Cline XML tool bridge instead of OpenAI tool calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
 		"check": "node scripts/check-extensions.mjs",
 		"test": "vitest",
 		"test:ui": "vitest --ui",
-		"test:run": "vitest run"
+		"test:run": "vitest run",
+		"smoke:cline": "tsx scripts/smoke-cline-xml-bridge.ts"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -1,0 +1,630 @@
+import type {
+	AssistantMessage,
+	Context,
+	Message,
+	Model,
+	SimpleStreamOptions,
+	Tool,
+	ToolCall,
+	ToolResultMessage,
+	Usage,
+} from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
+
+const DEFAULT_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+type ClineXmlChatMessage = {
+	role: "assistant" | "system" | "user";
+	content: string | Array<{ type: "text"; text: string }>;
+};
+
+type ClineXmlChunk = {
+	error?: { message?: string; code?: string };
+	usage?: {
+		prompt_tokens?: number;
+		completion_tokens?: number;
+		total_tokens?: number;
+	};
+	choices?: Array<{
+		delta?: { content?: string | null; reasoning?: string | null };
+		finish_reason?: string | null;
+		error?: { message?: string; code?: string };
+	}>;
+};
+
+function normalizeApiModelId(modelId: string): string {
+	return modelId.startsWith(`${PROVIDER_CLINE}/`)
+		? modelId.slice(`${PROVIDER_CLINE}/`.length)
+		: modelId;
+}
+
+function xmlEscape(value: unknown): string {
+	return String(value)
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;");
+}
+
+function decodeXmlEntities(value: string): string {
+	return value
+		.replaceAll("&lt;", "<")
+		.replaceAll("&gt;", ">")
+		.replaceAll("&quot;", '"')
+		.replaceAll("&#39;", "'")
+		.replaceAll("&amp;", "&");
+}
+
+function contentToText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) => {
+			if (part?.type === "text" && typeof part.text === "string") {
+				return part.text;
+			}
+			if (part?.type === "image")
+				return `[image:${part.mimeType ?? "unknown"}]`;
+			return "";
+		})
+		.filter(Boolean)
+		.join("\n");
+}
+
+function toolResultToText(message: ToolResultMessage): string {
+	return message.content.map((part) => contentToText([part])).join("\n");
+}
+
+type ToolBridge = {
+	remoteName: string;
+	runtimeName: string;
+	description?: string;
+	parameters: string[];
+	toRuntimeArgs(args: Record<string, unknown>): Record<string, unknown>;
+	fromRuntimeArgs(args: Record<string, unknown>): Record<string, unknown>;
+};
+
+function stringArg(args: Record<string, unknown>, key: string): string {
+	const value = args[key];
+	return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function getToolBridge(tool: Tool): ToolBridge {
+	if (tool.name === "read") {
+		return {
+			remoteName: "read_file",
+			runtimeName: "read",
+			description: tool.description,
+			parameters: ["path"],
+			toRuntimeArgs: (args) => ({ path: stringArg(args, "path") }),
+			fromRuntimeArgs: (args) => ({ path: args.path }),
+		};
+	}
+	if (tool.name === "write") {
+		return {
+			remoteName: "write_to_file",
+			runtimeName: "write",
+			description: tool.description,
+			parameters: ["path", "content"],
+			toRuntimeArgs: (args) => ({
+				path: stringArg(args, "path"),
+				content: stringArg(args, "content"),
+			}),
+			fromRuntimeArgs: (args) => ({ path: args.path, content: args.content }),
+		};
+	}
+	if (tool.name === "bash") {
+		return {
+			remoteName: "execute_command",
+			runtimeName: "bash",
+			description: tool.description,
+			parameters: ["command", "timeout"],
+			toRuntimeArgs: (args) => ({
+				command: stringArg(args, "command"),
+				...(args.timeout !== undefined ? { timeout: Number(args.timeout) } : {}),
+			}),
+			fromRuntimeArgs: (args) => ({
+				command: args.command,
+				...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
+			}),
+		};
+	}
+	const parameters = schemaProperties(tool);
+	return {
+		remoteName: tool.name,
+		runtimeName: tool.name,
+		description: tool.description,
+		parameters,
+		toRuntimeArgs: (args) => args,
+		fromRuntimeArgs: (args) => args,
+	};
+}
+
+function getToolBridges(tools: Tool[] | undefined): ToolBridge[] {
+	return (tools ?? []).map(getToolBridge);
+}
+
+function serializeXmlToolCall(
+	name: string,
+	args: Record<string, unknown>,
+): string {
+	const parts = [`<${name}>`];
+	for (const [key, value] of Object.entries(args)) {
+		const text = typeof value === "string" ? value : JSON.stringify(value);
+		parts.push(`<${key}>${xmlEscape(text)}</${key}>`);
+	}
+	parts.push(`</${name}>`);
+	return parts.join("\n");
+}
+
+function assistantMessageToText(
+	message: Extract<Message, { role: "assistant" }>,
+	tools: Tool[] | undefined,
+): string {
+	const bridgeByRuntimeName = new Map(
+		getToolBridges(tools).map((bridge) => [bridge.runtimeName, bridge]),
+	);
+	return message.content
+		.map((part) => {
+			if (part.type === "text") return part.text;
+			if (part.type === "thinking") {
+				return `<thinking>\n${xmlEscape(part.thinking)}\n</thinking>`;
+			}
+			if (part.type === "toolCall") {
+				const bridge = bridgeByRuntimeName.get(part.name);
+				return serializeXmlToolCall(
+					bridge?.remoteName ?? part.name,
+					bridge?.fromRuntimeArgs(part.arguments) ?? part.arguments,
+				);
+			}
+			return "";
+		})
+		.filter(Boolean)
+		.join("\n\n");
+}
+
+function schemaProperties(tool: Tool): string[] {
+	const parameters = tool.parameters as unknown as {
+		properties?: Record<string, unknown>;
+	};
+	return Object.keys(parameters.properties ?? {});
+}
+
+function buildToolInstructions(tools: Tool[] | undefined): string {
+	const bridges = getToolBridges(tools);
+	if (bridges.length === 0) return "";
+
+	const sections = bridges.map((bridge) => {
+		const params = bridge.parameters.length
+			? bridge.parameters.map((name) => `  <${name}>value</${name}>`).join("\n")
+			: "  <arguments>{}</arguments>";
+		return [
+			`Tool: ${bridge.remoteName}`,
+			`Description: ${bridge.description ?? bridge.runtimeName}`,
+			"XML usage:",
+			`<${bridge.remoteName}>`,
+			params,
+			`</${bridge.remoteName}>`,
+		].join("\n");
+	});
+
+	return [
+		"You have access to tools. Use XML tool calls instead of OpenAI function calling.",
+		"When you need a tool, output exactly one XML tool call using one of the tool names below.",
+		"Do not wrap XML tool calls in markdown fences. Do not invent tool names.",
+		"Available tools:",
+		sections.join("\n\n"),
+	].join("\n\n");
+}
+
+function buildClineXmlMessages(context: Context): ClineXmlChatMessage[] {
+	const messages: ClineXmlChatMessage[] = [];
+	const systemParts = [
+		context.systemPrompt,
+		buildToolInstructions(context.tools),
+	]
+		.filter(Boolean)
+		.join("\n\n");
+	if (systemParts) messages.push({ role: "system", content: systemParts });
+
+	let firstUser = true;
+	for (const message of context.messages) {
+		if (message.role === "user") {
+			const text = contentToText(message.content).trim();
+			if (!text) continue;
+			messages.push({
+				role: "user",
+				content: firstUser ? `<task>\n${text}\n</task>` : text,
+			});
+			firstUser = false;
+			continue;
+		}
+
+		if (message.role === "assistant") {
+			const text = assistantMessageToText(message, context.tools).trim();
+			if (text) messages.push({ role: "assistant", content: text });
+			continue;
+		}
+
+		if (message.role === "toolResult") {
+			const text = toolResultToText(message).trim();
+			const bridge = getToolBridges(context.tools).find(
+				(candidate) => candidate.runtimeName === message.toolName,
+			);
+			messages.push({
+				role: "user",
+				content: `Tool result for ${bridge?.remoteName ?? message.toolName}:\n${text || "(no output)"}`,
+			});
+		}
+	}
+
+	return messages;
+}
+
+function findNextToolStart(
+	text: string,
+	toolNames: Set<string>,
+	from: number,
+): { index: number; name: string; openTag: string } | null {
+	let best: { index: number; name: string; openTag: string } | null = null;
+	for (const name of toolNames) {
+		const openTag = `<${name}>`;
+		const index = text.indexOf(openTag, from);
+		if (index === -1) continue;
+		if (!best || index < best.index) best = { index, name, openTag };
+	}
+	return best;
+}
+
+function extractTagContent(text: string, tag: string): string | undefined {
+	const open = `<${tag}>`;
+	const close = `</${tag}>`;
+	const start = text.indexOf(open);
+	if (start === -1) return undefined;
+	const valueStart = start + open.length;
+	const end =
+		tag === "content"
+			? text.lastIndexOf(close)
+			: text.indexOf(close, valueStart);
+	if (end === -1 || end < valueStart) return undefined;
+	return decodeXmlEntities(text.slice(valueStart, end).trim());
+}
+
+function parseToolArguments(block: string): Record<string, unknown> {
+	const explicitArgs = extractTagContent(block, "arguments");
+	if (explicitArgs) {
+		try {
+			const parsed = JSON.parse(explicitArgs);
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				return parsed as Record<string, unknown>;
+			}
+		} catch {
+			return { arguments: explicitArgs };
+		}
+	}
+
+	const args: Record<string, unknown> = {};
+	let cursor = 0;
+	while (cursor < block.length) {
+		const openStart = block.indexOf("<", cursor);
+		if (openStart === -1) break;
+		const openEnd = block.indexOf(">", openStart + 1);
+		if (openEnd === -1) break;
+		const tag = block.slice(openStart + 1, openEnd).trim();
+		if (!tag || tag.startsWith("/") || tag.includes(" ")) {
+			cursor = openEnd + 1;
+			continue;
+		}
+		const close = `</${tag}>`;
+		const closeStart =
+			tag === "content"
+				? block.lastIndexOf(close)
+				: block.indexOf(close, openEnd + 1);
+		if (closeStart === -1 || closeStart < openEnd) break;
+		const raw = decodeXmlEntities(block.slice(openEnd + 1, closeStart).trim());
+		try {
+			args[tag] = JSON.parse(raw);
+		} catch {
+			args[tag] = raw;
+		}
+		cursor = closeStart + close.length;
+	}
+	return args;
+}
+
+function parseXmlToolCalls(
+	rawText: string,
+	tools: Tool[] | undefined,
+): {
+	text: string;
+	toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>;
+} {
+	const bridgeByRemoteName = new Map(
+		getToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
+	);
+	const toolNames = new Set(bridgeByRemoteName.keys());
+	if (toolNames.size === 0) return { text: rawText.trim(), toolCalls: [] };
+
+	const textParts: string[] = [];
+	const toolCalls: Array<{ name: string; arguments: Record<string, unknown> }> =
+		[];
+	let cursor = 0;
+
+	while (cursor < rawText.length) {
+		const next = findNextToolStart(rawText, toolNames, cursor);
+		if (!next) break;
+		const closeTag = `</${next.name}>`;
+		const closeStart = rawText.indexOf(
+			closeTag,
+			next.index + next.openTag.length,
+		);
+		if (closeStart === -1) break;
+		const before = rawText.slice(cursor, next.index).trim();
+		if (before) textParts.push(before);
+		const block = rawText.slice(next.index + next.openTag.length, closeStart);
+		const bridge = bridgeByRemoteName.get(next.name);
+		const remoteArgs = parseToolArguments(block);
+		toolCalls.push({
+			name: bridge?.runtimeName ?? next.name,
+			arguments: bridge?.toRuntimeArgs(remoteArgs) ?? remoteArgs,
+		});
+		cursor = closeStart + closeTag.length;
+	}
+
+	const rest = rawText.slice(cursor).trim();
+	if (rest) textParts.push(rest);
+	return { text: textParts.join("\n\n").trim(), toolCalls };
+}
+
+function usageFromChunkUsage(usage: ClineXmlChunk["usage"] | undefined): Usage {
+	const input = usage?.prompt_tokens ?? 0;
+	const output = usage?.completion_tokens ?? 0;
+	const totalTokens = usage?.total_tokens ?? input + output;
+	return {
+		...DEFAULT_USAGE,
+		input,
+		output,
+		totalTokens,
+	};
+}
+
+async function* parseSse(response: Response): AsyncGenerator<ClineXmlChunk> {
+	const reader = response.body?.getReader();
+	if (!reader) return;
+	const decoder = new TextDecoder();
+	let buffer = "";
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+		const lines = buffer.split(/\r?\n/);
+		buffer = lines.pop() ?? "";
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed.startsWith("data:")) continue;
+			const data = trimmed.slice("data:".length).trim();
+			if (!data || data === "[DONE]") continue;
+			yield JSON.parse(data) as ClineXmlChunk;
+		}
+	}
+}
+
+function createAssistant(model: Model<string>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: DEFAULT_USAGE,
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function pushText(
+	message: AssistantMessage,
+	text: string,
+	stream: ReturnType<typeof createAssistantMessageEventStream>,
+): void {
+	if (!text) return;
+	const index = message.content.length;
+	message.content.push({ type: "text", text: "" });
+	stream.push({ type: "text_start", contentIndex: index, partial: message });
+	(message.content[index] as { type: "text"; text: string }).text = text;
+	stream.push({
+		type: "text_delta",
+		contentIndex: index,
+		delta: text,
+		partial: message,
+	});
+	stream.push({
+		type: "text_end",
+		contentIndex: index,
+		content: text,
+		partial: message,
+	});
+}
+
+function pushThinking(
+	message: AssistantMessage,
+	thinking: string,
+	stream: ReturnType<typeof createAssistantMessageEventStream>,
+): void {
+	if (!thinking) return;
+	const index = message.content.length;
+	message.content.push({ type: "thinking", thinking: "" });
+	stream.push({
+		type: "thinking_start",
+		contentIndex: index,
+		partial: message,
+	});
+	(message.content[index] as { type: "thinking"; thinking: string }).thinking =
+		thinking;
+	stream.push({
+		type: "thinking_delta",
+		contentIndex: index,
+		delta: thinking,
+		partial: message,
+	});
+	stream.push({
+		type: "thinking_end",
+		contentIndex: index,
+		content: thinking,
+		partial: message,
+	});
+}
+
+function pushToolCall(
+	message: AssistantMessage,
+	toolCall: { name: string; arguments: Record<string, unknown> },
+	stream: ReturnType<typeof createAssistantMessageEventStream>,
+): void {
+	const index = message.content.length;
+	const id = `cline_xml_${Date.now()}_${index}`;
+	const block: ToolCall = {
+		type: "toolCall",
+		id,
+		name: toolCall.name,
+		arguments: {},
+	};
+	message.content.push(block);
+	stream.push({
+		type: "toolcall_start",
+		contentIndex: index,
+		partial: message,
+	});
+	const delta = JSON.stringify(toolCall.arguments);
+	stream.push({
+		type: "toolcall_delta",
+		contentIndex: index,
+		delta,
+		partial: message,
+	});
+	block.arguments = toolCall.arguments;
+	stream.push({
+		type: "toolcall_end",
+		contentIndex: index,
+		toolCall: block,
+		partial: message,
+	});
+}
+
+export function streamClineXml(
+	model: Model<string>,
+	context: Context,
+	options: SimpleStreamOptions | undefined,
+	headers: Record<string, string>,
+) {
+	const stream = createAssistantMessageEventStream();
+
+	void (async () => {
+		const assistant = createAssistant(model);
+		stream.push({ type: "start", partial: assistant });
+		try {
+			if (!options?.apiKey) {
+				throw new Error("No Cline access token found. Run /login cline first.");
+			}
+
+			const response = await fetch(`${BASE_URL_CLINE}/chat/completions`, {
+				method: "POST",
+				headers: {
+					...headers,
+					Authorization: `Bearer ${options.apiKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					model: normalizeApiModelId(model.id),
+					temperature: 0,
+					messages: buildClineXmlMessages(context),
+					stream: true,
+					stream_options: { include_usage: true },
+					include_reasoning: true,
+				}),
+				signal: options.signal,
+			});
+			await options.onResponse?.(
+				{
+					status: response.status,
+					headers: Object.fromEntries(response.headers.entries()),
+				},
+				model,
+			);
+
+			if (!response.ok) {
+				throw new Error(
+					`Cline API error ${response.status}: ${await response.text()}`,
+				);
+			}
+
+			let rawText = "";
+			let thinking = "";
+			let finishReason: string | null | undefined;
+			let usage: ClineXmlChunk["usage"] | undefined;
+
+			for await (const chunk of parseSse(response)) {
+				if (chunk.error) {
+					throw new Error(
+						`${chunk.error.code ?? "cline_error"}: ${chunk.error.message ?? "Unknown Cline error"}`,
+					);
+				}
+				if (chunk.usage) usage = chunk.usage;
+				const choice = chunk.choices?.[0];
+				if (!choice) continue;
+				if (choice.error) {
+					throw new Error(
+						`${choice.error.code ?? "cline_error"}: ${choice.error.message ?? "Unknown Cline error"}`,
+					);
+				}
+				if (choice.finish_reason) finishReason = choice.finish_reason;
+				rawText += choice.delta?.content ?? "";
+				thinking += choice.delta?.reasoning ?? "";
+			}
+
+			assistant.usage = usageFromChunkUsage(usage);
+			pushThinking(assistant, thinking.trim(), stream);
+			const parsed = parseXmlToolCalls(rawText, context.tools);
+			pushText(assistant, parsed.text, stream);
+			for (const toolCall of parsed.toolCalls) {
+				pushToolCall(assistant, toolCall, stream);
+			}
+
+			assistant.stopReason =
+				parsed.toolCalls.length > 0
+					? "toolUse"
+					: finishReason === "length"
+						? "length"
+						: "stop";
+			stream.push({
+				type: "done",
+				reason: assistant.stopReason as "stop" | "length" | "toolUse",
+				message: assistant,
+			});
+		} catch (error) {
+			assistant.stopReason = options?.signal?.aborted ? "aborted" : "error";
+			assistant.errorMessage =
+				error instanceof Error ? error.message : String(error);
+			stream.push({
+				type: "error",
+				reason: assistant.stopReason,
+				error: assistant,
+			});
+		}
+	})();
+
+	return stream;
+}
+
+export const __test__ = {
+	buildClineXmlMessages,
+	parseXmlToolCalls,
+	serializeXmlToolCall,
+};

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -34,6 +34,7 @@ import { logWarning } from "../../lib/util.ts";
 import { enhanceWithCI } from "../../provider-helper.ts";
 import { loginCline, refreshClineToken } from "./cline-auth.ts";
 import { fetchClineModels } from "./cline-models.ts";
+import { streamClineXml } from "./cline-xml-bridge.ts";
 
 // =============================================================================
 // Cline API headers (must match real Cline VS Code extension exactly)
@@ -79,83 +80,6 @@ function toApiKey(credentials: OAuthCredentials): string {
 }
 
 // =============================================================================
-// Context shaping — preserve full conversation with tool calls/results
-// =============================================================================
-
-function extractText(content: unknown): string {
-	if (typeof content === "string") return content.trim();
-	if (Array.isArray(content)) {
-		return (content as any[])
-			.filter((p: any) => p?.type === "text" && typeof p?.text === "string")
-			.map((p: any) => p.text)
-			.join("\n\n")
-			.trim();
-	}
-	return "";
-}
-
-/**
- * Format messages for Cline's API while preserving the full conversation
- * history including tool calls and results.
- *
- * Strategy:
- * 1. First user message gets wrapped in <task> (Cline-trained models expect this)
- * 2. Subsequent messages are sent with proper role alternation
- * 3. Tool calls stay in assistant messages (not collapsed)
- * 4. Tool results are sent as "tool" role messages
- *
- * This matches how Cline's native SDK sends messages to the API.
- */
-function shapeMessagesForCline(messages: any[]): any[] {
-	const shaped: any[] = [];
-	let firstUserFound = false;
-
-	for (const msg of messages) {
-		const role = msg?.role ?? "user";
-		const content = msg?.content;
-
-		// Skip empty messages
-		if (!content) continue;
-
-		// System messages: extract text and include
-		if (role === "system") {
-			const text = extractText(content);
-			if (text) shaped.push({ role: "system", content: text });
-			continue;
-		}
-
-		// First user message: wrap in <task> for Cline-trained models
-		if (role === "user" && !firstUserFound) {
-			firstUserFound = true;
-			const text = extractText(content);
-			if (text) {
-				shaped.push({
-					role: "user",
-					content: [{ type: "text", text: `<task>\n${text}\n</task>` }],
-				});
-			}
-			continue;
-		}
-
-		// Tool messages: send as-is with tool role
-		if (role === "tool") {
-			// Tool messages from Pi come as { role: "tool", content: [...] }
-			// or { role: "tool", content: "text" }
-			shaped.push({ role: "tool", content });
-			continue;
-		}
-
-		// Assistant and remaining user messages: send as-is
-		// This preserves tool-call blocks in assistant messages
-		if (role === "assistant" || role === "user") {
-			shaped.push({ role, content });
-		}
-	}
-
-	return shaped;
-}
-
-// =============================================================================
 // Extension entry point
 // =============================================================================
 
@@ -188,9 +112,11 @@ export default async function clineProvider(pi: ExtensionAPI) {
 	const reRegister = (m: typeof allModels) => {
 		pi.registerProvider(PROVIDER_CLINE, {
 			baseUrl: BASE_URL_CLINE,
-			api: "openai-completions" as const,
+			api: "cline-xml-tools" as const,
 			authHeader: false,
 			headers: buildClineHeaders(),
+			streamSimple: (model, context, options) =>
+				streamClineXml(model as any, context, options, buildClineHeaders()),
 			models: enhanceWithCI(m),
 			oauth: {
 				name: "Cline",
@@ -264,12 +190,6 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		_currentTaskId = generateUlid();
 		toggleState.applyCurrent(reRegister);
-	});
-
-	pi.on("context", (event, ctx) => {
-		if (ctx.model?.provider !== PROVIDER_CLINE) return;
-		const sourceMessages = Array.isArray(event.messages) ? event.messages : [];
-		return { messages: shapeMessagesForCline(sourceMessages) };
 	});
 
 	let refreshInFlight: Promise<void> | undefined;

--- a/scripts/smoke-cline-xml-bridge.ts
+++ b/scripts/smoke-cline-xml-bridge.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env tsx
+/**
+ * Live smoke test for the Cline XML tool bridge.
+ *
+ * This intentionally hits the real Cline API and consumes quota/credits.
+ * It is not part of the normal test suite; run explicitly with:
+ *
+ *   npm run smoke:cline
+ *
+ * Requirements:
+ * - Existing Cline OAuth credentials in ~/.pi/agent/auth.json
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Model, OAuthCredentials, ToolCall } from "@earendil-works/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
+import { BASE_URL_CLINE, PROVIDER_CLINE } from "../constants.ts";
+import { refreshClineToken } from "../providers/cline/cline-auth.ts";
+import { streamClineXml } from "../providers/cline/cline-xml-bridge.ts";
+
+const AUTH_PATH = path.join(os.homedir(), ".pi", "agent", "auth.json");
+const DEFAULT_MODELS = ["xiaomi/mimo-v2.5", "nex-agi/nex-n2-pro:free"];
+
+function readAuthFile(): Record<string, unknown> {
+	if (!fs.existsSync(AUTH_PATH)) {
+		throw new Error(`Missing auth file: ${AUTH_PATH}`);
+	}
+	return JSON.parse(fs.readFileSync(AUTH_PATH, "utf8")) as Record<
+		string,
+		unknown
+	>;
+}
+
+function getClineCredentials(auth: Record<string, unknown>): OAuthCredentials {
+	const entry = auth[PROVIDER_CLINE] as Partial<OAuthCredentials> | undefined;
+	if (!entry?.access || !entry.refresh || !entry.expires) {
+		throw new Error("Missing Cline OAuth credentials. Run /login cline first.");
+	}
+	return {
+		access: String(entry.access),
+		refresh: String(entry.refresh),
+		expires: Number(entry.expires),
+	};
+}
+
+async function refreshAndPersistCredentials(): Promise<OAuthCredentials> {
+	const auth = readAuthFile();
+	const credentials = getClineCredentials(auth);
+
+	// Force a refresh: the models endpoint can accept stale-looking access tokens,
+	// while chat/completions may reject them with a generic "latest version" 401.
+	const refreshed = await refreshClineToken({ ...credentials, expires: 0 });
+	auth[PROVIDER_CLINE] = {
+		...(auth[PROVIDER_CLINE] as Record<string, unknown>),
+		...refreshed,
+	};
+	fs.writeFileSync(AUTH_PATH, `${JSON.stringify(auth, null, 2)}\n`);
+	return refreshed;
+}
+
+function toApiKey(credentials: OAuthCredentials): string {
+	return credentials.access.startsWith("workos:")
+		? credentials.access
+		: `workos:${credentials.access}`;
+}
+
+function buildHeaders(modelId: string): Record<string, string> {
+	return {
+		"HTTP-Referer": "https://cline.bot",
+		"X-Title": "Cline",
+		"X-Task-ID": `pi-free-smoke-${modelId.replaceAll("/", "-")}-${Date.now()}`,
+		"X-PLATFORM": "Visual Studio Code",
+		"X-PLATFORM-VERSION": "1.109.3",
+		"X-CLIENT-TYPE": "VSCode Extension",
+		"X-CLIENT-VERSION": "3.76.0",
+		"X-CORE-VERSION": "3.76.0",
+		"X-Is-Multiroot": "false",
+	};
+}
+
+function buildModel(modelId: string): Model<string> {
+	return {
+		id: modelId,
+		name: modelId,
+		api: "cline-xml-tools",
+		provider: PROVIDER_CLINE,
+		baseUrl: BASE_URL_CLINE,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 4_096,
+	};
+}
+
+async function smokeModel(modelId: string, apiKey: string): Promise<void> {
+	const stream = streamClineXml(
+		buildModel(modelId),
+		{
+			systemPrompt: "You are a coding agent. Use tools when needed.",
+			messages: [
+				{
+					role: "user",
+					content: "Read package.json.",
+					timestamp: Date.now(),
+				},
+			],
+			tools: [
+				{
+					name: "read",
+					description: "Read a file from disk",
+					parameters: Type.Object({ path: Type.String() }),
+				},
+			],
+		},
+		{ apiKey },
+		buildHeaders(modelId),
+	);
+
+	let toolCall: ToolCall | undefined;
+	let error: string | undefined;
+	let stopReason: string | undefined;
+
+	for await (const event of stream) {
+		if (event.type === "toolcall_end") {
+			toolCall = event.toolCall;
+		}
+		if (event.type === "done") {
+			stopReason = event.reason;
+		}
+		if (event.type === "error") {
+			error = event.error.errorMessage ?? "unknown error";
+		}
+	}
+
+	if (error) throw new Error(`${modelId}: ${error}`);
+	if (stopReason !== "toolUse") {
+		throw new Error(
+			`${modelId}: expected toolUse, got ${stopReason ?? "none"}`,
+		);
+	}
+	if (!toolCall) throw new Error(`${modelId}: no tool call emitted`);
+	if (toolCall.name !== "read") {
+		throw new Error(`${modelId}: expected read, got ${toolCall.name}`);
+	}
+	if (toolCall.arguments.path !== "package.json") {
+		throw new Error(
+			`${modelId}: expected path package.json, got ${JSON.stringify(toolCall.arguments.path)}`,
+		);
+	}
+
+	console.log(
+		`✓ ${modelId}: ${toolCall.name} ${JSON.stringify(toolCall.arguments)} (via Cline read_file XML)`,
+	);
+}
+
+async function main(): Promise<void> {
+	const models =
+		process.argv.slice(2).length > 0 ? process.argv.slice(2) : DEFAULT_MODELS;
+	const credentials = await refreshAndPersistCredentials();
+	const apiKey = toApiKey(credentials);
+
+	console.log(`Cline XML bridge live smoke: ${models.length} model(s)`);
+	for (const modelId of models) {
+		await smokeModel(modelId, apiKey);
+	}
+	console.log("Cline XML bridge live smoke passed.");
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -110,7 +110,7 @@ describe("Cline Provider", () => {
 			);
 		});
 
-		it("should register event handlers", async () => {
+		it("should register event handlers and XML bridge stream", async () => {
 			vi.mocked(fetchClineModels).mockResolvedValue([]);
 
 			await clineProvider(mockPi);
@@ -119,10 +119,16 @@ describe("Cline Provider", () => {
 				"before_agent_start",
 				expect.any(Function),
 			);
-			expect(mockOn).toHaveBeenCalledWith("context", expect.any(Function));
 			expect(mockOn).toHaveBeenCalledWith(
 				"session_start",
 				expect.any(Function),
+			);
+			expect(mockRegisterProvider).toHaveBeenCalledWith(
+				"cline",
+				expect.objectContaining({
+					api: "cline-xml-tools",
+					streamSimple: expect.any(Function),
+				}),
 			);
 		});
 
@@ -276,7 +282,10 @@ describe("Cline Provider", () => {
 			const sessionStartHandler = mockOn.mock.calls.find(
 				(call) => call[0] === "session_start",
 			)?.[1];
-			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+			await sessionStartHandler(
+				{},
+				{ model: { provider: "cline" }, ui: { notify: vi.fn() } },
+			);
 
 			expect(fetchClineModels).not.toHaveBeenCalled();
 			expect(mockSaveProviderCache).not.toHaveBeenCalled();
@@ -302,10 +311,16 @@ describe("Cline Provider", () => {
 			const sessionStartHandler = mockOn.mock.calls.find(
 				(call) => call[0] === "session_start",
 			)?.[1];
-			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+			await sessionStartHandler(
+				{},
+				{ model: { provider: "cline" }, ui: { notify: vi.fn() } },
+			);
 
 			await vi.waitFor(() => {
-				expect(mockSaveProviderCache).toHaveBeenCalledWith("cline", initialModels);
+				expect(mockSaveProviderCache).toHaveBeenCalledWith(
+					"cline",
+					initialModels,
+				);
 			});
 		});
 
@@ -324,8 +339,14 @@ describe("Cline Provider", () => {
 			const sessionStartHandler = mockOn.mock.calls.find(
 				(call) => call[0] === "session_start",
 			)?.[1];
-			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
-			await sessionStartHandler({}, { model: { provider: "cline" }, ui: { notify: vi.fn() } });
+			await sessionStartHandler(
+				{},
+				{ model: { provider: "cline" }, ui: { notify: vi.fn() } },
+			);
+			await sessionStartHandler(
+				{},
+				{ model: { provider: "cline" }, ui: { notify: vi.fn() } },
+			);
 
 			expect(fetchClineModels).toHaveBeenCalledTimes(1);
 			resolveRefresh([]);


### PR DESCRIPTION
## Problem

Cline-trained models expect Cline-style XML tool calls. The previous pi-free Cline provider sent requests through `openai-completions` with native OpenAI tool messages/tool calls. That caused strict upstreams to reject long/tool-heavy conversations, e.g.:

- `xiaomi/mimo-v2.5`: `Tool message must have tool_call_id`
- `nex-agi/nex-n2-pro:free`: missing `tool_call_id`

A small `tool_call_id` patch helps one symptom, but it does not fix the underlying mismatch with Cline's native protocol.

## Fix

Replace the Cline OpenAI tool-message path with a custom `streamSimple` XML bridge inspired by `pi-cline`:

- Register Cline as custom API `cline-xml-tools`
- Send plain Cline-style messages to `/chat/completions`
- Prompt available Pi tools as XML tool-call instructions
- Preserve Cline reasoning chunks as Pi thinking blocks
- Parse assistant XML tool calls back into Pi `toolCall` blocks
- Replay Pi tool results as user text messages
- Serialize previous Pi assistant tool calls back into XML for conversation continuity

## Cline-native tool mapping

Borrowed the most important remaining pi-cline pattern: semantic tool-name mapping.

The bridge now advertises Cline-native XML names while returning Pi runtime tool calls:

- `read_file` → Pi `read`
- `write_to_file` → Pi `write`
- `execute_command` → Pi `bash`

Unknown/custom tools still pass through by their original names.

This matters because real Pi exposes tools like `read`/`bash`, while Cline-trained models are much more likely to emit `read_file`/`execute_command`.

## Live smoke test

Added explicit live smoke command:

```bash
npm run smoke:cline
```

It reads local Cline OAuth credentials from `~/.pi/agent/auth.json`, refreshes them, hits the real Cline API through the actual bridge, and asserts a Cline `read_file` XML call is converted into a Pi `read { path: "package.json" }` tool call.

Validated live against:

- `xiaomi/mimo-v2.5`
- `nex-agi/nex-n2-pro:free`

Output:

```text
✓ xiaomi/mimo-v2.5: read {"path":"package.json"} (via Cline read_file XML)
✓ nex-agi/nex-n2-pro:free: read {"path":"package.json"} (via Cline read_file XML)
Cline XML bridge live smoke passed.
```

## Validation

- `npm run smoke:cline` ✅
- `npx tsc --noEmit --pretty false` ✅
- Full Vitest suite: 26 files / 342 tests ✅

No DRYKISS rerun.