### PR TITLE
fix: apply Kilo gateway compat and filter non-text models

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -370,31 +370,51 @@ export function mapOpenRouterModel(m: {
 	name: string;
 	context_length?: number;
 	max_completion_tokens?: number | null;
-	top_provider?: { max_completion_tokens?: number | null };
-	pricing?: { prompt?: string | null; completion?: string | null };
+	top_provider?: {
+		context_length?: number | null;
+		max_completion_tokens?: number | null;
+	};
+	pricing?: {
+		prompt?: string | null;
+		completion?: string | null;
+		input_cache_read?: string | null;
+		input_cache_write?: string | null;
+	};
 	architecture?: {
 		input_modalities?: string[] | null;
 		output_modalities?: string[] | null;
 	};
+	supported_parameters?: string[] | null;
 	isFree?: boolean;
 }): ProviderModelConfig {
 	const promptPrice = Number.parseFloat(m.pricing?.prompt ?? "0");
 	const completionPrice = Number.parseFloat(m.pricing?.completion ?? "0");
+	const cacheReadPrice = Number.parseFloat(
+		m.pricing?.input_cache_read ?? "0",
+	);
+	const cacheWritePrice = Number.parseFloat(
+		m.pricing?.input_cache_write ?? "0",
+	);
+	const supportedParameters = m.supported_parameters ?? [];
+	const reasoning =
+		supportedParameters.includes("reasoning") ||
+		supportedParameters.includes("reasoning_effort");
 
 	return {
 		id: m.id,
 		name: cleanModelName(m.name),
-		reasoning: false, // OpenRouter doesn't expose reasoning flag directly
+		reasoning,
+		...(reasoning && { thinkingLevelMap: { off: "none" } }),
 		input: m.architecture?.input_modalities?.includes("image")
 			? (["text", "image"] as const)
 			: (["text"] as const),
 		cost: {
 			input: promptPrice,
 			output: completionPrice,
-			cacheRead: 0,
-			cacheWrite: 0,
+			cacheRead: cacheReadPrice,
+			cacheWrite: cacheWritePrice,
 		},
-		contextWindow: m.context_length ?? 4096,
+		contextWindow: m.context_length ?? m.top_provider?.context_length ?? 4096,
 		maxTokens:
 			m.max_completion_tokens ?? m.top_provider?.max_completion_tokens ?? 4096,
 		_pricingKnown: true,

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -36,6 +36,17 @@ import {
 import { loginKilo, refreshKiloToken } from "./kilo-auth.ts";
 import { fetchKiloModels, KILO_GATEWAY_BASE } from "./kilo-models.ts";
 
+/** Kilo Gateway compat overrides, borrowed from pi-kilo-provider. */
+const KILO_COMPAT = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: false,
+	supportsUsageInStreaming: false,
+	supportsStrictMode: false,
+	thinkingFormat: "openrouter" as const,
+	maxTokensField: "max_tokens" as const,
+};
+
 // =============================================================================
 // XML leak detection and auto-retry
 // =============================================================================
@@ -59,7 +70,11 @@ function detectXmlToolLeak(text: string): boolean {
 	);
 }
 
-function findTag(text: string, tag: string, start = 0): { start: number; end: number; content: string } | null {
+function findTag(
+	text: string,
+	tag: string,
+	start = 0,
+): { start: number; end: number; content: string } | null {
 	const open = `<${tag}>`;
 	const close = `</${tag}>`;
 	const openIdx = text.indexOf(open, start);
@@ -143,6 +158,19 @@ const KILO_PROVIDER_CONFIG = {
 	},
 };
 
+/** Apply Kilo-specific compat overrides while preserving provider/model values. */
+function applyKiloCompat<T extends { compat?: ProviderModelConfig["compat"] }>(
+	models: T[],
+): T[] {
+	return models.map((m) => ({
+		...m,
+		compat: {
+			...KILO_COMPAT,
+			...m.compat,
+		},
+	}));
+}
+
 export default async function kiloProvider(pi: ExtensionAPI) {
 	// Try to fetch ALL models at startup (like Cline/OpenRouter)
 	// If no API key, this will return free models only
@@ -176,9 +204,11 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	const stored: StoredModels = { free: freeModels, all: allModels };
 
 	// Create re-register function
-	const reRegister = createReRegister(pi, {
+	const baseReRegister = createReRegister(pi, {
 		...KILO_PROVIDER_CONFIG,
 	});
+	const reRegister = (models: ProviderModelConfig[]) =>
+		baseReRegister(applyKiloCompat(models));
 
 	// Register with global toggle system
 	registerWithGlobalToggle(
@@ -207,9 +237,11 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 				stored.free = freeModels;
 
 				// Update global toggle registration with new lists
-				const globalReRegister = createReRegister(pi, {
+				const baseGlobalReRegister = createReRegister(pi, {
 					...KILO_PROVIDER_CONFIG,
 				});
+				const globalReRegister = (models: ProviderModelConfig[]) =>
+					baseGlobalReRegister(applyKiloCompat(models));
 				registerWithGlobalToggle(PROVIDER_KILO, stored, globalReRegister, true);
 
 				// If paid mode is enabled, show all models
@@ -231,21 +263,24 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 			const template = models.find((m) => m.provider === PROVIDER_KILO);
 			if (!template) return models;
 			const nonKilo = models.filter((m) => m.provider !== PROVIDER_KILO);
-			const fullModels = allModels.map((m) => ({
-				...template,
-				id: m.id,
-				name: cleanModelName(m.name),
-				reasoning: m.reasoning,
-				input: m.input,
-				cost: m.cost,
-				contextWindow: m.contextWindow,
-				maxTokens: m.maxTokens,
-			}));
-			return [...nonKilo, ...fullModels];
+			const fullModels = applyKiloCompat(
+				allModels.map((m) => ({
+					...template,
+					id: m.id,
+					name: cleanModelName(m.name),
+					reasoning: m.reasoning,
+					input: m.input,
+					cost: m.cost,
+					contextWindow: m.contextWindow,
+					maxTokens: m.maxTokens,
+				})),
+			);
+			return [...nonKilo, ...fullModels] as Model<"openai-completions">[];
 		},
 	};
 
 	// Register initial provider (default to free models)
+	const modelsWithCompat = applyKiloCompat(currentModels);
 	pi.registerProvider(PROVIDER_KILO, {
 		baseUrl: KILO_GATEWAY_BASE,
 		apiKey: "$KILO_API_KEY",
@@ -254,7 +289,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 			"X-KILOCODE-EDITORNAME": "Pi",
 			"User-Agent": "pi-free-providers",
 		},
-		models: enhanceWithCI(currentModels),
+		models: enhanceWithCI(modelsWithCompat),
 		oauth: oauthConfig,
 	});
 
@@ -427,9 +462,11 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 					stored.free = freeModels;
 
 					// Update global toggle registration
-					const ctxReRegister = createCtxReRegister(ctx as any, {
+					const baseCtxReRegister = createCtxReRegister(ctx as any, {
 						...KILO_PROVIDER_CONFIG,
 					});
+					const ctxReRegister = (models: ProviderModelConfig[]) =>
+						baseCtxReRegister(applyKiloCompat(models));
 					registerWithGlobalToggle(PROVIDER_KILO, stored, ctxReRegister, true);
 
 					// Apply current view mode

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -23,7 +23,10 @@ interface OpenRouterCompatibleModel {
 		input_modalities?: string[] | null;
 		output_modalities?: string[] | null;
 	};
-	top_provider?: { max_completion_tokens?: number | null };
+	top_provider?: {
+		context_length?: number | null;
+		max_completion_tokens?: number | null;
+	};
 	supported_parameters?: string[];
 	isFree?: boolean;
 }
@@ -98,9 +101,11 @@ export async function fetchOpenRouterCompatibleModels(
 
 	const models = json.data
 		.filter((m) => {
-			// Filter out image generation models
+			// Filter out models that cannot produce text output (image/video/audio
+			// generation, embedding-only, etc.). Keep models with no output
+			// modality info to avoid over-filtering older endpoints.
 			const outputMods = m.architecture?.output_modalities ?? [];
-			if (outputMods.includes("image")) return false;
+			if (outputMods.length > 0 && !outputMods.includes("text")) return false;
 
 			// Filter by provider flag when available, otherwise pricing.
 			if (freeOnly) {

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -87,7 +87,20 @@ describe("Kilo Provider", () => {
 					baseUrl: "https://api.kilo.ai/api/gateway",
 					apiKey: "$KILO_API_KEY",
 					api: "openai-completions",
-					models: mockModels,
+					models: mockModels.map((m) =>
+						expect.objectContaining({
+							id: m.id,
+							compat: {
+								maxTokensField: "max_tokens",
+								supportsDeveloperRole: false,
+								supportsReasoningEffort: false,
+								supportsStore: false,
+								supportsStrictMode: false,
+								supportsUsageInStreaming: false,
+								thinkingFormat: "openrouter",
+							},
+						}),
+					),
 					oauth: expect.any(Object),
 				}),
 			);

--- a/tests/model-fetcher.test.ts
+++ b/tests/model-fetcher.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T) => models,
+}));
+
+import { fetchOpenRouterCompatibleModels } from "../providers/model-fetcher.ts";
+
+describe("fetchOpenRouterCompatibleModels", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function stubModels(data: unknown[]) {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ data }), {
+					status: 200,
+					statusText: "OK",
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		return fetchMock;
+	}
+
+	it("filters models that cannot produce text output", async () => {
+		stubModels([
+			{
+				id: "text-only",
+				name: "Text Only",
+				context_length: 128000,
+				architecture: { output_modalities: ["text"] },
+			},
+			{
+				id: "image-only",
+				name: "Image Only",
+				context_length: 128000,
+				architecture: { output_modalities: ["image"] },
+			},
+			{
+				id: "text-and-image",
+				name: "Text And Image",
+				context_length: 128000,
+				architecture: { output_modalities: ["text", "image"] },
+			},
+			{
+				id: "unknown-output",
+				name: "Unknown Output",
+				context_length: 128000,
+			},
+		]);
+
+		const models = await fetchOpenRouterCompatibleModels({
+			baseUrl: "https://example.test/api/gateway",
+		});
+
+		expect(models.map((m) => m.id)).toEqual([
+			"text-only",
+			"text-and-image",
+			"unknown-output",
+		]);
+	});
+
+	it("maps Kilo/OpenRouter model metadata from provider catalogs", async () => {
+		stubModels([
+			{
+				id: "reasoning-model",
+				name: "Provider : Reasoning Model",
+				top_provider: {
+					context_length: 256000,
+					max_completion_tokens: 32768,
+				},
+				pricing: {
+					prompt: "0.000001",
+					completion: "0.000002",
+					input_cache_read: "0.0000001",
+					input_cache_write: "0.0000003",
+				},
+				supported_parameters: ["tools", "reasoning"],
+			},
+		]);
+
+		const [model] = await fetchOpenRouterCompatibleModels({
+			baseUrl: "https://example.test/api/gateway",
+		});
+
+		expect(model).toMatchObject({
+			id: "reasoning-model",
+			name: "Reasoning Model",
+			reasoning: true,
+			thinkingLevelMap: { off: "none" },
+			cost: {
+				input: 0.000001,
+				output: 0.000002,
+				cacheRead: 0.0000001,
+				cacheWrite: 0.0000003,
+			},
+			contextWindow: 256000,
+			maxTokens: 32768,
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Third-party Kilo providers include useful model-mapping and gateway compatibility assumptions that pi-free was not applying:

- Kilo Gateway expects OpenRouter-style reasoning payloads
- Kilo Gateway should use `max_tokens` rather than `max_completion_tokens`
- Kilo/OpenRouter-compatible catalogs expose reasoning support via `supported_parameters`
- Catalogs may expose cache read/write pricing and `top_provider.context_length`
- Some model lists may include models that cannot produce text output

## Fix

Borrow the useful parts from the external Kilo providers:

1. Add Kilo Gateway compat defaults:
   - `thinkingFormat: "openrouter"`
   - `maxTokensField: "max_tokens"`
   - disable unsupported `store`, developer role, `reasoning_effort`, strict mode, and streaming usage fields
2. Apply those compat defaults consistently across:
   - initial Kilo registration
   - `/toggle-kilo`
   - global toggle re-registration
   - OAuth `modifyModels`
   - authenticated session refresh re-registration
3. Refine OpenRouter-compatible model mapping:
   - mark models as reasoning-capable when `supported_parameters` includes `reasoning` or `reasoning_effort`
   - add `thinkingLevelMap: { off: "none" }` for those reasoning models
   - preserve cache read/write pricing
   - fall back to `top_provider.context_length`
4. Refine OpenRouter-compatible output filtering:
   - exclude models whose declared output modalities do not include text
   - keep text-capable and unknown-modality models to avoid over-filtering

## Validation

- `npx tsc --noEmit --pretty false`
- Full test suite: 26 files / 342 tests pass
- Added targeted model-fetcher tests for text-output filtering and provider-catalog metadata mapping

No DRYKISS rerun.