### PR TITLE
fix: harden Cline XML tool parsing

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -91,50 +91,171 @@ type ToolBridge = {
 	fromRuntimeArgs(args: Record<string, unknown>): Record<string, unknown>;
 };
 
+const CORE_CLINE_TOOL_NAMES = [
+	"read_file",
+	"write_to_file",
+	"execute_command",
+	"list_files",
+	"search_files",
+	"list_code_definition_names",
+] as const;
+
 function stringArg(args: Record<string, unknown>, key: string): string {
 	const value = args[key];
 	return typeof value === "string" ? value : value == null ? "" : String(value);
 }
 
+function booleanArg(args: Record<string, unknown>, key: string): boolean {
+	return String(args[key]).toLowerCase() === "true";
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function buildListFilesCommand(args: Record<string, unknown>): string {
+	const path = shellQuote(stringArg(args, "path") || ".");
+	return booleanArg(args, "recursive")
+		? `find ${path} | sort`
+		: `find ${path} -mindepth 1 -maxdepth 1 | sort`;
+}
+
+function buildSearchFilesCommand(args: Record<string, unknown>): string {
+	const path = shellQuote(stringArg(args, "path") || ".");
+	const regex = shellQuote(stringArg(args, "regex"));
+	const filePattern = stringArg(args, "file_pattern");
+	return [
+		"rg",
+		"-n",
+		"--no-heading",
+		"--color",
+		"never",
+		filePattern ? `-g ${shellQuote(filePattern)}` : "",
+		`-e ${regex}`,
+		path,
+	]
+		.filter(Boolean)
+		.join(" ");
+}
+
+function buildListCodeDefinitionNamesCommand(
+	args: Record<string, unknown>,
+): string {
+	const path = shellQuote(stringArg(args, "path") || ".");
+	const globArgs = [
+		"-g '*.ts'",
+		"-g '*.tsx'",
+		"-g '*.js'",
+		"-g '*.jsx'",
+		"-g '*.mjs'",
+		"-g '*.cjs'",
+		"-g '*.py'",
+		"-g '*.go'",
+		"-g '*.rs'",
+		"-g '*.java'",
+		"-g '*.kt'",
+		"-g '*.swift'",
+	].join(" ");
+	const regex =
+		"^(export\\s+)?(async\\s+function|function|class|interface|type|enum)\\s+[A-Za-z_][A-Za-z0-9_]*|^(export\\s+)?const\\s+[A-Za-z_][A-Za-z0-9_]*\\s*=\\s*(async\\s*)?\\(";
+	return [
+		"rg",
+		"-n",
+		"--no-heading",
+		"--color",
+		"never",
+		globArgs,
+		`-e ${shellQuote(regex)}`,
+		path,
+	].join(" ");
+}
+
+function readFileBridge(tool?: Tool): ToolBridge {
+	return {
+		remoteName: "read_file",
+		runtimeName: tool?.name === "read_file" ? "read_file" : "read",
+		description: tool?.description ?? "Read a file from disk",
+		parameters: ["path"],
+		toRuntimeArgs: (args) => ({ path: stringArg(args, "path") }),
+		fromRuntimeArgs: (args) => ({ path: args.path }),
+	};
+}
+
+function writeToFileBridge(tool?: Tool): ToolBridge {
+	return {
+		remoteName: "write_to_file",
+		runtimeName: tool?.name === "write_to_file" ? "write_to_file" : "write",
+		description: tool?.description ?? "Write content to a file",
+		parameters: ["path", "content"],
+		toRuntimeArgs: (args) => ({
+			path: stringArg(args, "path"),
+			content: stringArg(args, "content"),
+		}),
+		fromRuntimeArgs: (args) => ({ path: args.path, content: args.content }),
+	};
+}
+
+function executeCommandBridge(tool?: Tool): ToolBridge {
+	return {
+		remoteName: "execute_command",
+		runtimeName: tool?.name === "execute_command" ? "execute_command" : "bash",
+		description: tool?.description ?? "Execute a shell command",
+		parameters: ["command", "timeout"],
+		toRuntimeArgs: (args) => ({
+			command: stringArg(args, "command"),
+			...(args.timeout !== undefined ? { timeout: Number(args.timeout) } : {}),
+		}),
+		fromRuntimeArgs: (args) => ({
+			command: args.command,
+			...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
+		}),
+	};
+}
+
+function listFilesBridge(): ToolBridge {
+	return {
+		remoteName: "list_files",
+		runtimeName: "bash",
+		description: "List files in a directory",
+		parameters: ["path", "recursive"],
+		toRuntimeArgs: (args) => ({ command: buildListFilesCommand(args) }),
+		fromRuntimeArgs: (args) => ({ command: args.command }),
+	};
+}
+
+function searchFilesBridge(): ToolBridge {
+	return {
+		remoteName: "search_files",
+		runtimeName: "bash",
+		description: "Search files by regex",
+		parameters: ["path", "regex", "file_pattern"],
+		toRuntimeArgs: (args) => ({ command: buildSearchFilesCommand(args) }),
+		fromRuntimeArgs: (args) => ({ command: args.command }),
+	};
+}
+
+function listCodeDefinitionNamesBridge(): ToolBridge {
+	return {
+		remoteName: "list_code_definition_names",
+		runtimeName: "bash",
+		description: "List code definition names in source files",
+		parameters: ["path"],
+		toRuntimeArgs: (args) => ({
+			command: buildListCodeDefinitionNamesCommand(args),
+		}),
+		fromRuntimeArgs: (args) => ({ command: args.command }),
+	};
+}
+
 function getToolBridge(tool: Tool): ToolBridge {
-	if (tool.name === "read") {
-		return {
-			remoteName: "read_file",
-			runtimeName: "read",
-			description: tool.description,
-			parameters: ["path"],
-			toRuntimeArgs: (args) => ({ path: stringArg(args, "path") }),
-			fromRuntimeArgs: (args) => ({ path: args.path }),
-		};
+	if (tool.name === "read" || tool.name === "read_file") {
+		return readFileBridge(tool);
 	}
-	if (tool.name === "write") {
-		return {
-			remoteName: "write_to_file",
-			runtimeName: "write",
-			description: tool.description,
-			parameters: ["path", "content"],
-			toRuntimeArgs: (args) => ({
-				path: stringArg(args, "path"),
-				content: stringArg(args, "content"),
-			}),
-			fromRuntimeArgs: (args) => ({ path: args.path, content: args.content }),
-		};
+	if (tool.name === "write" || tool.name === "write_to_file") {
+		return writeToFileBridge(tool);
 	}
-	if (tool.name === "bash") {
-		return {
-			remoteName: "execute_command",
-			runtimeName: "bash",
-			description: tool.description,
-			parameters: ["command", "timeout"],
-			toRuntimeArgs: (args) => ({
-				command: stringArg(args, "command"),
-				...(args.timeout !== undefined ? { timeout: Number(args.timeout) } : {}),
-			}),
-			fromRuntimeArgs: (args) => ({
-				command: args.command,
-				...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
-			}),
-		};
+	if (tool.name === "bash" || tool.name === "execute_command") {
+		return executeCommandBridge(tool);
 	}
 	const parameters = schemaProperties(tool);
 	return {
@@ -148,7 +269,48 @@ function getToolBridge(tool: Tool): ToolBridge {
 }
 
 function getToolBridges(tools: Tool[] | undefined): ToolBridge[] {
-	return (tools ?? []).map(getToolBridge);
+	const bridges: ToolBridge[] = [];
+	for (const tool of tools ?? []) {
+		bridges.push(getToolBridge(tool));
+		if (tool.name === "bash" || tool.name === "execute_command") {
+			bridges.push(
+				listFilesBridge(),
+				searchFilesBridge(),
+				listCodeDefinitionNamesBridge(),
+			);
+		}
+	}
+	return bridges;
+}
+
+function getParseToolBridges(tools: Tool[] | undefined): ToolBridge[] {
+	const bridges = getToolBridges(tools);
+	const remoteNames = new Set(bridges.map((bridge) => bridge.remoteName));
+	const toolsByName = new Map((tools ?? []).map((tool) => [tool.name, tool]));
+
+	for (const remoteName of CORE_CLINE_TOOL_NAMES) {
+		if (remoteNames.has(remoteName)) continue;
+		if (remoteName === "read_file") {
+			bridges.push(readFileBridge(toolsByName.get("read_file")));
+		}
+		if (remoteName === "write_to_file") {
+			bridges.push(writeToFileBridge(toolsByName.get("write_to_file")));
+		}
+		if (remoteName === "execute_command") {
+			bridges.push(executeCommandBridge(toolsByName.get("execute_command")));
+		}
+		if (remoteName === "list_files") {
+			bridges.push(listFilesBridge());
+		}
+		if (remoteName === "search_files") {
+			bridges.push(searchFilesBridge());
+		}
+		if (remoteName === "list_code_definition_names") {
+			bridges.push(listCodeDefinitionNamesBridge());
+		}
+	}
+
+	return bridges;
 }
 
 function serializeXmlToolCall(
@@ -168,9 +330,12 @@ function assistantMessageToText(
 	message: Extract<Message, { role: "assistant" }>,
 	tools: Tool[] | undefined,
 ): string {
-	const bridgeByRuntimeName = new Map(
-		getToolBridges(tools).map((bridge) => [bridge.runtimeName, bridge]),
-	);
+	const bridgeByRuntimeName = new Map<string, ToolBridge>();
+	for (const bridge of getToolBridges(tools)) {
+		if (!bridgeByRuntimeName.has(bridge.runtimeName)) {
+			bridgeByRuntimeName.set(bridge.runtimeName, bridge);
+		}
+	}
 	return message.content
 		.map((part) => {
 			if (part.type === "text") return part.text;
@@ -283,6 +448,17 @@ function findNextToolStart(
 	return best;
 }
 
+function isFenceOnlyText(text: string): boolean {
+	const trimmed = text.trim().toLowerCase();
+	return trimmed === "```" || trimmed === "```xml";
+}
+
+function pushTextFragment(textParts: string[], fragment: string): void {
+	const trimmed = fragment.trim();
+	if (!trimmed || isFenceOnlyText(trimmed)) return;
+	textParts.push(trimmed);
+}
+
 function extractTagContent(text: string, tag: string): string | undefined {
 	const open = `<${tag}>`;
 	const close = `</${tag}>`;
@@ -347,39 +523,41 @@ function parseXmlToolCalls(
 	toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>;
 } {
 	const bridgeByRemoteName = new Map(
-		getToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
+		getParseToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
 	);
 	const toolNames = new Set(bridgeByRemoteName.keys());
 	if (toolNames.size === 0) return { text: rawText.trim(), toolCalls: [] };
 
+	const sourceText = findNextToolStart(rawText, toolNames, 0)
+		? rawText
+		: decodeXmlEntities(rawText);
 	const textParts: string[] = [];
 	const toolCalls: Array<{ name: string; arguments: Record<string, unknown> }> =
 		[];
 	let cursor = 0;
 
-	while (cursor < rawText.length) {
-		const next = findNextToolStart(rawText, toolNames, cursor);
+	while (cursor < sourceText.length) {
+		const next = findNextToolStart(sourceText, toolNames, cursor);
 		if (!next) break;
 		const closeTag = `</${next.name}>`;
-		const closeStart = rawText.indexOf(
+		const closeStart = sourceText.indexOf(
 			closeTag,
 			next.index + next.openTag.length,
 		);
-		if (closeStart === -1) break;
-		const before = rawText.slice(cursor, next.index).trim();
-		if (before) textParts.push(before);
-		const block = rawText.slice(next.index + next.openTag.length, closeStart);
+		pushTextFragment(textParts, sourceText.slice(cursor, next.index));
+		const blockEnd = closeStart === -1 ? sourceText.length : closeStart;
+		const block = sourceText.slice(next.index + next.openTag.length, blockEnd);
 		const bridge = bridgeByRemoteName.get(next.name);
 		const remoteArgs = parseToolArguments(block);
 		toolCalls.push({
 			name: bridge?.runtimeName ?? next.name,
 			arguments: bridge?.toRuntimeArgs(remoteArgs) ?? remoteArgs,
 		});
-		cursor = closeStart + closeTag.length;
+		cursor =
+			closeStart === -1 ? sourceText.length : closeStart + closeTag.length;
 	}
 
-	const rest = rawText.slice(cursor).trim();
-	if (rest) textParts.push(rest);
+	pushTextFragment(textParts, sourceText.slice(cursor));
 	return { text: textParts.join("\n\n").trim(), toolCalls };
 }
 

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -1,0 +1,183 @@
+import type { Tool } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { __test__ } from "../providers/cline/cline-xml-bridge.ts";
+
+function tool(name: string): Tool {
+	return {
+		name,
+		description: `${name} tool`,
+		parameters: { type: "object", properties: {} } as Tool["parameters"],
+	};
+}
+
+describe("Cline XML bridge", () => {
+	describe("parseXmlToolCalls", () => {
+		it("maps Cline execute_command XML to Pi bash tool calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<execute_command>",
+					' <command>cat C:/Users/R3LiC/Desktop/pi-free/.github/workflows/ci.yml 2&gt;/dev/null || echo "No ci.yml"</command>',
+					"</execute_command>",
+				].join("\n"),
+				[tool("bash")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "bash",
+					arguments: {
+						command:
+							'cat C:/Users/R3LiC/Desktop/pi-free/.github/workflows/ci.yml 2>/dev/null || echo "No ci.yml"',
+					},
+				},
+			]);
+		});
+
+		it("recognizes core Cline tool names even if the context tool list is missing", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				"<execute_command>\n<command>npm test</command>\n</execute_command>",
+				undefined,
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{ name: "bash", arguments: { command: "npm test" } },
+			]);
+		});
+
+		it("recovers top-level escaped XML tool calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				"&lt;read_file&gt;&lt;path&gt;package.json&lt;/path&gt;&lt;/read_file&gt;",
+				[tool("read")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{ name: "read", arguments: { path: "package.json" } },
+			]);
+		});
+
+		it("does not leak XML code fence markers as text", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"```xml",
+					"<read_file>",
+					"<path>package.json</path>",
+					"</read_file>",
+					"```",
+				].join("\n"),
+				[tool("read")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{ name: "read", arguments: { path: "package.json" } },
+			]);
+		});
+
+		it("parses a final incomplete Cline tool block instead of leaking it as text", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				"<execute_command>\n<command>npm run test:run</command>",
+				[tool("bash")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{ name: "bash", arguments: { command: "npm run test:run" } },
+			]);
+		});
+
+		it("maps Cline list_files to a safe bash-backed command", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				"<list_files>\n<path>src</path>\n<recursive>true</recursive>\n</list_files>",
+				[tool("bash")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{ name: "bash", arguments: { command: "find 'src' | sort" } },
+			]);
+		});
+
+		it("maps Cline search_files to ripgrep through bash", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<search_files>",
+					"<path>.</path>",
+					"<regex>streamClineXml</regex>",
+					"<file_pattern>*.ts</file_pattern>",
+					"</search_files>",
+				].join("\n"),
+				[tool("bash")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "bash",
+					arguments: {
+						command:
+							"rg -n --no-heading --color never -g '*.ts' -e 'streamClineXml' '.'",
+					},
+				},
+			]);
+		});
+
+		it("maps Cline list_code_definition_names to ripgrep through bash", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				"<list_code_definition_names>\n<path>providers</path>\n</list_code_definition_names>",
+				[tool("bash")],
+			);
+
+			expect(parsed.toolCalls[0]?.name).toBe("bash");
+			expect(parsed.toolCalls[0]?.arguments.command).toContain("rg -n");
+			expect(parsed.toolCalls[0]?.arguments.command).toContain("'providers'");
+		});
+	});
+
+	describe("buildClineXmlMessages", () => {
+		it("serializes previous Pi bash calls back to Cline execute_command XML", () => {
+			const messages = __test__.buildClineXmlMessages({
+				systemPrompt: "system",
+				tools: [tool("bash")],
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "run tests" }],
+						timestamp: Date.now(),
+					},
+					{
+						role: "assistant",
+						api: "cline-xml-tools",
+						provider: "cline",
+						model: "mimo",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								total: 0,
+							},
+						},
+						stopReason: "toolUse",
+						timestamp: Date.now(),
+						content: [
+							{
+								type: "toolCall",
+								id: "call_1",
+								name: "bash",
+								arguments: { command: "npm test" },
+							},
+						],
+					},
+				],
+			});
+
+			expect(messages[2]?.content).toContain("<execute_command>");
+			expect(messages[2]?.content).toContain("<command>npm test</command>");
+		});
+	});
+});


### PR DESCRIPTION
## Problem

After the Cline XML bridge landed, MiMo could still emit raw Cline XML like:

```xml
<execute_command>
  <command>cat .github/workflows/ci.yml 2&gt;/dev/null || echo "No ci.yml"</command>
</execute_command>
```

If the bridge parser did not recognize that Cline-native tool name in the current runtime context, Pi displayed it as text instead of executing a tool call.

## Fix

Harden the Cline XML bridge parser:

- Always recognize core Cline tool names during parsing:
  - `read_file` → Pi `read`
  - `write_to_file` → Pi `write`
  - `execute_command` → Pi `bash`
- Add common Cline read-only bash-backed aliases:
  - `list_files` → Pi `bash`
  - `search_files` → Pi `bash`
  - `list_code_definition_names` → Pi `bash`
- Recover top-level escaped XML, e.g. `&lt;read_file&gt;...`
- Ignore XML code-fence markers instead of leaking them as assistant text
- Parse a final incomplete tool block rather than leaking it as text
- Preserve previous Pi `bash` calls as Cline `execute_command` XML when replaying conversation history

Unknown/custom Pi tools still pass through by their original names when present in `context.tools`.

## Validation

- `npx vitest run tests/cline-xml-bridge.test.ts` ✅
- `npx tsc --noEmit --pretty false` ✅
- Full test suite: 27 files / 351 tests ✅
- `npm run smoke:cline` ✅
  - `xiaomi/mimo-v2.5`
  - `nex-agi/nex-n2-pro:free`

No DRYKISS rerun.