### PR TITLE
ci: harden workflows and release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  typecheck:
-    name: Type check
+  lint-and-typecheck:
+    name: Lint & type-check
     runs-on: ubuntu-latest
 
     steps:
@@ -22,10 +22,18 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-audit --no-fund
 
-      - name: Type check
-        run: npx tsc --noEmit
+      - name: Lockfile in sync with package.json
+        run: npm run check:lockfile
+
+      # Fail on known-vulnerable production deps — the code that actually ships
+      # to users. DevDeps are excluded because they do not run in Pi installs.
+      - name: Audit production dependencies
+        run: npm run audit:prod
+
+      - name: TypeScript lint
+        run: npm run lint
 
   test:
     name: Unit tests
@@ -39,14 +47,15 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-audit --no-fund
 
       - name: Run tests
-        run: npx vitest run
+        run: npm run test:run
 
   install-test:
     name: Install test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: [lint-and-typecheck, test]
     strategy:
       fail-fast: false
       matrix:
@@ -59,17 +68,38 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
       - name: Pack tarball
         run: npm pack
 
-      - name: Install from tarball (simulates pi install npm:...)
+      - name: Verify required files and no forbidden artifacts in tarball
         shell: bash
         run: |
-          TARBALL=$(ls *.tgz)
+          TARBALL=$(ls pi-free-*.tgz)
+          node scripts/check-tarball.mjs "$TARBALL"
+
+      - name: Install from tarball (simulates pi install npm:pi-free)
+        shell: bash
+        run: |
+          TARBALL=$(ls pi-free-*.tgz)
           npm install -g "$TARBALL"
 
-      - name: Load each extension entry point (catches missing files)
+      - name: Verify published relative imports resolve
         shell: bash
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/check-extensions.mjs "$INSTALL_DIR"
+
+      - name: Smoke-load extension entry (catches missing runtime modules)
+        shell: bash
+        run: |
+          INSTALL_DIR=$(npm root -g)/pi-free
+          if command -v cygpath >/dev/null 2>&1; then
+            INSTALL_DIR=$(cygpath -w "$INSTALL_DIR")
+          fi
+          export P="$INSTALL_DIR/package.json"
+          ENTRY=$(node -p "require(process.env.P).pi.extensions[0]")
+          echo "Loading entry: $INSTALL_DIR/$ENTRY"
+          node --import tsx "$INSTALL_DIR/$ENTRY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,180 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      should_release: ${{ steps.meta.outputs.should_release }}
+      has_npm_token: ${{ steps.meta.outputs.has_npm_token }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute release metadata
+        id: meta
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            SHOULD_RELEASE=false
+          else
+            SHOULD_RELEASE=true
+          fi
+
+          if [ -n "$NPM_TOKEN" ]; then
+            HAS_NPM_TOKEN=true
+          else
+            HAS_NPM_TOKEN=false
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "has_npm_token=$HAS_NPM_TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Verify changelog entry exists
+        if: steps.meta.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "Missing CHANGELOG entry for version $VERSION"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v6
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        run: npm install --no-audit --no-fund
+
+      - name: Lockfile in sync with package.json
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        run: npm run check:lockfile
+
+      - name: Audit production dependencies
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        run: npm run audit:prod
+
+      - name: Type-check
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        run: npm run lint
+
+      - name: Run tests
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        run: npm run test:run
+
+      - name: Dry-run publish (validates tarball + registry auth)
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --dry-run
+
+      - name: Pack tarball for verification
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        run: npm pack
+
+      - name: Verify tarball contents
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        shell: bash
+        run: |
+          TARBALL=$(ls pi-free-*.tgz)
+          node scripts/check-tarball.mjs "$TARBALL"
+
+      - name: Smoke-load source entry
+        if: >-
+          steps.meta.outputs.should_release == 'true' &&
+          steps.meta.outputs.has_npm_token == 'true'
+        shell: bash
+        run: |
+          ENTRY=$(node -p "require('./package.json').pi.extensions[0]")
+          echo "Loading entry: $ENTRY"
+          node --import tsx "$ENTRY"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create and push tag
+        shell: bash
+        run: |
+          git tag "${{ needs.prepare.outputs.tag }}"
+          git push origin "${{ needs.prepare.outputs.tag }}"
+
+      - name: Create GitHub release
+        uses: >-
+          softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: ${{ needs.prepare.outputs.tag }}
+          generate_release_notes: true
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: [prepare, release]
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      needs.prepare.outputs.has_npm_token == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
 		"scripts/check-extensions.mjs"
 	],
 	"scripts": {
+		"audit:prod": "npm audit --omit=dev --audit-level=high",
 		"check": "node scripts/check-extensions.mjs",
+		"check:lockfile": "node scripts/check-lockfile-sync.mjs",
+		"check:tarball": "node scripts/check-tarball.mjs",
+		"lint": "tsc --noEmit",
 		"test": "vitest",
 		"test:ui": "vitest --ui",
 		"test:run": "vitest run",

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -14,29 +14,45 @@ import { dirname, join, resolve } from "node:path";
 const installDir = resolve(process.argv[2] ?? ".");
 const fromSource = process.argv[2] == null;
 
-/** Resolve npm to an absolute path to avoid S4036 PATH-lookup flags. */
-function resolveNpm() {
+function resolveNpmCli() {
 	for (const p of [
-		"/usr/bin/npm",
-		"/usr/local/bin/npm",
-		process.platform === "win32"
-			? String.raw`C:\Program Files\nodejs\npm.cmd`
-			: "",
+		join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+		"/usr/lib/node_modules/npm/bin/npm-cli.js",
+		"/usr/local/lib/node_modules/npm/bin/npm-cli.js",
+		"/usr/share/nodejs/npm/bin/npm-cli.js",
 	]) {
-		if (p && existsSync(p)) return p;
+		if (existsSync(p)) return p;
 	}
-	return "npm"; // fallback
+	throw new Error("Could not find npm-cli.js in known Node/npm locations");
 }
+
+function runNpmPackDryRun() {
+	return execFileSync(
+		process.execPath,
+		[resolveNpmCli(), "pack", "--dry-run", "--json"],
+		{ encoding: "utf8" },
+	);
+}
+
+function parsePackFileList(out) {
+	try {
+		const packed = JSON.parse(out);
+		return packed.flatMap((entry) =>
+			(entry.files ?? []).map((file) => file.path).filter(Boolean),
+		);
+	} catch {
+		return out
+			.split("\n")
+			.map((line) => line.match(/npm notice \S+\s+(.+)/)?.[1]?.trim())
+			.filter(Boolean);
+	}
+} 
 
 function getFiles() {
 	if (fromSource) {
-		// Use npm pack --dry-run with an absolute executable path.
-		const out = execFileSync(resolveNpm(), ["pack", "--dry-run"], {
-			encoding: "utf8",
-		});
-		return out
-			.split("\n")
-			.map((l) => l.match(/npm notice \S+\s+(.+)/)?.[1]?.trim())
+		// Use npm pack --dry-run to inspect exactly what would be published.
+		const out = runNpmPackDryRun();
+		return parsePackFileList(out)
 			.filter((f) => f && (f.endsWith(".ts") || f.endsWith(".mjs")))
 			.map((f) => join(installDir, f));
 	}

--- a/scripts/check-lockfile-sync.mjs
+++ b/scripts/check-lockfile-sync.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Fail if package-lock.json's root dependency specs drift from package.json.
+ *
+ * This is intentionally deterministic: it compares spec strings only, not
+ * resolved transitive versions. Fix failures with `npm install` and commit the
+ * updated lockfile.
+ */
+import * as fs from "node:fs";
+
+function readJson(file) {
+	try {
+		return JSON.parse(fs.readFileSync(file, "utf-8"));
+	} catch (error) {
+		console.error(`Cannot read ${file}: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}
+
+const pkg = readJson("package.json");
+const lock = readJson("package-lock.json");
+const root = lock.packages?.[""] ?? {};
+
+const SECTIONS = [
+	"dependencies",
+	"devDependencies",
+	"optionalDependencies",
+	"peerDependencies",
+];
+
+const problems = [];
+for (const section of SECTIONS) {
+	const pkgDeps = pkg[section] ?? {};
+	const lockDeps = root[section] ?? {};
+
+	for (const [name, spec] of Object.entries(pkgDeps)) {
+		if (lockDeps[name] !== spec) {
+			problems.push(
+				`${section}.${name}: package.json="${spec}" lock="${lockDeps[name] ?? "(missing)"}"`,
+			);
+		}
+	}
+
+	for (const name of Object.keys(lockDeps)) {
+		if (!(name in pkgDeps)) {
+			problems.push(`${section}.${name}: in lock but not package.json`);
+		}
+	}
+}
+
+if (problems.length > 0) {
+	console.error("package-lock.json is out of sync with package.json:\n");
+	for (const problem of problems) console.error(`  • ${problem}`);
+	console.error("\nRun `npm install` and commit the updated package-lock.json.");
+	process.exit(1);
+}
+
+console.log("package-lock.json is in sync with package.json ✓");

--- a/scripts/check-tarball.mjs
+++ b/scripts/check-tarball.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Verify the npm tarball contains the files pi needs and excludes common
+ * accidental/secrets/debug artifacts.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function fail(message) {
+	console.error(`ERROR: ${message}`);
+	process.exit(1);
+}
+
+function resolveTar() {
+	for (const p of [
+		process.platform === "win32" ? String.raw`C:\Windows\System32\tar.exe` : "",
+		"/usr/bin/tar",
+		"/bin/tar",
+		"/usr/local/bin/tar",
+	]) {
+		if (p && existsSync(p)) return p;
+	}
+	throw new Error("Could not find tar in known system locations");
+}
+
+function findTarball() {
+	const explicit = process.argv[2];
+	if (explicit) return explicit;
+	const files = readdirSync(".").filter((entry) => /^pi-free-.+\.tgz$/.test(entry));
+	if (files.length !== 1) {
+		fail(`expected exactly one pi-free-*.tgz tarball, found ${files.length}`);
+	}
+	return files[0];
+}
+
+function assertSafeTarEntries(entries) {
+	for (const entry of entries) {
+		if (
+			entry.startsWith("/") ||
+			entry.includes("../") ||
+			entry.includes("..\\") ||
+			!entry.startsWith("package/")
+		) {
+			fail(`unsafe tarball entry path: ${entry}`);
+		}
+	}
+}
+
+function listTarball(tarball) {
+	return execFileSync(resolveTar(), ["-tzf", tarball], { encoding: "utf8" })
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+function extractTarball(tarball) {
+	const dir = mkdtempSync(join(tmpdir(), "pi-free-tarball-"));
+	execFileSync(resolveTar(), ["-xzf", tarball, "-C", dir]);
+	return dir;
+}
+
+const tarball = findTarball();
+if (!existsSync(tarball)) fail(`tarball not found: ${tarball}`);
+
+console.log(`Checking tarball: ${tarball}`);
+const entries = listTarball(tarball);
+assertSafeTarEntries(entries);
+const entrySet = new Set(entries);
+
+const required = [
+	"package/package.json",
+	"package/index.ts",
+	"package/config.ts",
+	"package/constants.ts",
+	"package/provider-helper.ts",
+	"package/README.md",
+	"package/CHANGELOG.md",
+	"package/LICENSE",
+	"package/scripts/check-extensions.mjs",
+];
+
+for (const file of required) {
+	if (!entrySet.has(file)) fail(`required file missing from tarball: ${file}`);
+	console.log(`OK: ${file}`);
+}
+
+const forbiddenPatterns = [
+	/^package\/(?:node_modules|tests|\.github|\.pi|\.claude|\.pisessionsummaries)\//,
+	/^package\/dist\//,
+	/^package\/.+\.log$/,
+	/^package\/.+\.tsbuildinfo$/,
+	/^package\/.+\.tgz$/,
+	/^package\/.+\.env(?:\..*)?$/,
+	/^package\/(?:\.env(?:\..*)?|npm-debug\.log|yarn-error\.log)$/,
+	/^package\/scripts\/(?!check-extensions\.mjs$).+/,
+];
+
+const forbidden = entries.filter((entry) =>
+	forbiddenPatterns.some((pattern) => pattern.test(entry)),
+);
+if (forbidden.length > 0) {
+	console.error("Forbidden files found in tarball:");
+	for (const entry of forbidden) console.error(`  • ${entry}`);
+	process.exit(1);
+}
+console.log("No forbidden tarball artifacts found ✓");
+
+const extractDir = extractTarball(tarball);
+try {
+	const packageDir = join(extractDir, "package");
+	const pkg = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+	const extensions = pkg.pi?.extensions ?? [];
+	if (!Array.isArray(extensions) || extensions.length === 0) {
+		fail("package.json has no pi.extensions entries");
+	}
+	for (const extension of extensions) {
+		const normalized = String(extension).replace(/^\.\//, "");
+		if (!entrySet.has(`package/${normalized}`)) {
+			fail(`pi.extensions entry missing from tarball: ${extension}`);
+		}
+		console.log(`OK: pi.extensions -> ${extension}`);
+	}
+	if (pkg.main) {
+		const normalized = String(pkg.main).replace(/^\.\//, "");
+		if (!entrySet.has(`package/${normalized}`)) {
+			fail(`package.json main points to missing file: ${pkg.main}`);
+		}
+		console.log(`OK: main -> ${pkg.main}`);
+	}
+} finally {
+	rmSync(extractDir, { recursive: true, force: true });
+}
+
+console.log("Tarball verification OK ✓");


### PR DESCRIPTION
## Summary

Mimics the pi-lens CI/release hardening pattern for pi-free, adapted to pi-free's source-shipped extension model.

## CI hardening

- Replaces the lightweight CI with pi-lens-style jobs:
  - lint/type-check
  - unit tests
  - cross-platform install test
- Adds lockfile drift detection via `scripts/check-lockfile-sync.mjs`
- Adds production dependency audit via `npm audit --omit=dev --audit-level=high`
- Adds tarball verification via `scripts/check-tarball.mjs`:
  - required package files exist
  - `pi.extensions` entries point to real files
  - common accidental artifacts/secrets are excluded
- Hardens `scripts/check-extensions.mjs`:
  - uses `npm pack --dry-run --json` so source checks actually see packed files
  - fixes Windows npm invocation
- Adds installed-tarball source entry smoke-load in CI using `node --import tsx`

## Release automation

Adds `.github/workflows/release.yml`:

- release metadata from `package.json` version
- skip if matching git tag already exists
- require matching CHANGELOG entry for new versions
- optional NPM-token gated checks:
  - lockfile check
  - production audit
  - type-check
  - tests
  - `npm publish --dry-run`
  - tarball verification
  - source entry smoke-load
- create git tag + GitHub release
- publish to npm when `NPM_TOKEN` is configured

## Dependency/security automation

Adds Dependabot config for:

- npm dependencies, grouped by production vs development deps
- GitHub Actions updates

## Validation

- `npm run check:lockfile` ✅
- `npm run audit:prod` ✅ — 0 vulnerabilities
- `npm run lint` ✅
- `npm run test:run` ✅ — 27 files / 351 tests
- `npm run check` ✅ — 57 packed files / 228 imports
- `npm pack` + `node scripts/check-tarball.mjs` ✅
- installed-tarball import check + source entry smoke-load ✅

Note: local `npm publish --dry-run` correctly refuses the already-published current version `2.0.15`; the release workflow skips publish checks when tag `v2.0.15` already exists.