### PR TITLE
fix: map Cline replace_in_file to Pi edit

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -94,6 +94,7 @@ type ToolBridge = {
 const CORE_CLINE_TOOL_NAMES = [
 	"read_file",
 	"write_to_file",
+	"replace_in_file",
 	"execute_command",
 	"list_files",
 	"search_files",
@@ -136,6 +137,51 @@ function buildSearchFilesCommand(args: Record<string, unknown>): string {
 	]
 		.filter(Boolean)
 		.join(" ");
+}
+
+function buildSearchReplaceDiff(
+	edits: Array<{ oldText: string; newText: string }>,
+): string {
+	return edits
+		.map((edit) =>
+			[
+				"------- SEARCH",
+				edit.oldText,
+				"=======",
+				edit.newText,
+				"+++++++ REPLACE",
+			].join("\n"),
+		)
+		.join("\n");
+}
+
+function parseSearchReplaceBlocks(
+	diff: string,
+): Array<{ oldText: string; newText: string }> {
+	const edits: Array<{ oldText: string; newText: string }> = [];
+	const normalized = diff.replaceAll("\r\n", "\n");
+	let cursor = 0;
+
+	while (cursor < normalized.length) {
+		const searchMarker = "------- SEARCH\n";
+		const replaceMarker = "\n=======\n";
+		const endMarker = "\n+++++++ REPLACE";
+		const searchStart = normalized.indexOf(searchMarker, cursor);
+		if (searchStart === -1) break;
+		const oldTextStart = searchStart + searchMarker.length;
+		const replaceStart = normalized.indexOf(replaceMarker, oldTextStart);
+		if (replaceStart === -1) break;
+		const newTextStart = replaceStart + replaceMarker.length;
+		const endStart = normalized.indexOf(endMarker, newTextStart);
+		if (endStart === -1) break;
+		edits.push({
+			oldText: normalized.slice(oldTextStart, replaceStart),
+			newText: normalized.slice(newTextStart, endStart),
+		});
+		cursor = endStart + endMarker.length;
+	}
+
+	return edits;
 }
 
 function buildListCodeDefinitionNamesCommand(
@@ -192,6 +238,40 @@ function writeToFileBridge(tool?: Tool): ToolBridge {
 			content: stringArg(args, "content"),
 		}),
 		fromRuntimeArgs: (args) => ({ path: args.path, content: args.content }),
+	};
+}
+
+function replaceInFileBridge(tool?: Tool): ToolBridge {
+	return {
+		remoteName: "replace_in_file",
+		runtimeName: tool?.name === "replace_in_file" ? "replace_in_file" : "edit",
+		description:
+			tool?.description ??
+			"Edit a file using Cline SEARCH/REPLACE blocks",
+		parameters: ["path", "diff"],
+		toRuntimeArgs: (args) => ({
+			path: stringArg(args, "path"),
+			edits: parseSearchReplaceBlocks(stringArg(args, "diff")),
+		}),
+		fromRuntimeArgs: (args) => {
+			const edits = Array.isArray(args.edits)
+				? args.edits
+						.map((edit) => ({
+							oldText: stringArg(edit as Record<string, unknown>, "oldText"),
+							newText: stringArg(edit as Record<string, unknown>, "newText"),
+						}))
+						.filter((edit) => edit.oldText || edit.newText)
+				: [
+					{
+						oldText: stringArg(args, "oldText"),
+						newText: stringArg(args, "newText"),
+					},
+				].filter((edit) => edit.oldText || edit.newText);
+			return {
+				path: args.path,
+				diff: buildSearchReplaceDiff(edits),
+			};
+		},
 	};
 }
 
@@ -254,6 +334,9 @@ function getToolBridge(tool: Tool): ToolBridge {
 	if (tool.name === "write" || tool.name === "write_to_file") {
 		return writeToFileBridge(tool);
 	}
+	if (tool.name === "edit" || tool.name === "replace_in_file") {
+		return replaceInFileBridge(tool);
+	}
 	if (tool.name === "bash" || tool.name === "execute_command") {
 		return executeCommandBridge(tool);
 	}
@@ -295,6 +378,9 @@ function getParseToolBridges(tools: Tool[] | undefined): ToolBridge[] {
 		}
 		if (remoteName === "write_to_file") {
 			bridges.push(writeToFileBridge(toolsByName.get("write_to_file")));
+		}
+		if (remoteName === "replace_in_file") {
+			bridges.push(replaceInFileBridge(toolsByName.get("replace_in_file")));
 		}
 		if (remoteName === "execute_command") {
 			bridges.push(executeCommandBridge(toolsByName.get("execute_command")));
@@ -367,9 +453,23 @@ function buildToolInstructions(tools: Tool[] | undefined): string {
 	if (bridges.length === 0) return "";
 
 	const sections = bridges.map((bridge) => {
-		const params = bridge.parameters.length
-			? bridge.parameters.map((name) => `  <${name}>value</${name}>`).join("\n")
-			: "  <arguments>{}</arguments>";
+		const params =
+			bridge.remoteName === "replace_in_file"
+				? [
+						"  <path>path/to/file</path>",
+						"  <diff>",
+						"------- SEARCH",
+						"exact text to replace",
+						"=======",
+						"new text",
+						"+++++++ REPLACE",
+						"  </diff>",
+					].join("\n")
+				: bridge.parameters.length
+					? bridge.parameters
+							.map((name) => `  <${name}>value</${name}>`)
+							.join("\n")
+					: "  <arguments>{}</arguments>";
 		return [
 			`Tool: ${bridge.remoteName}`,
 			`Description: ${bridge.description ?? bridge.runtimeName}`,
@@ -500,7 +600,7 @@ function parseToolArguments(block: string): Record<string, unknown> {
 		}
 		const close = `</${tag}>`;
 		const closeStart =
-			tag === "content"
+			tag === "content" || tag === "diff"
 				? block.lastIndexOf(close)
 				: block.indexOf(close, openEnd + 1);
 		if (closeStart === -1 || closeStart < openEnd) break;

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -86,6 +86,92 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("maps Cline write_to_file XML to Pi write tool calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<write_to_file>",
+					"<path>src/new-file.ts</path>",
+					"<content>export const value = 1;</content>",
+					"</write_to_file>",
+				].join("\n"),
+				[tool("write")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "write",
+					arguments: {
+						path: "src/new-file.ts",
+						content: "export const value = 1;",
+					},
+				},
+			]);
+		});
+
+		it("maps Cline replace_in_file XML to Pi edit tool calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<replace_in_file>",
+					"<path>src/example.ts</path>",
+					"<diff>",
+					"------- SEARCH",
+					"const value = 1;",
+					"=======",
+					"const value = 2;",
+					"+++++++ REPLACE",
+					"</diff>",
+					"</replace_in_file>",
+				].join("\n"),
+				[tool("edit")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "edit",
+					arguments: {
+						path: "src/example.ts",
+						edits: [{ oldText: "const value = 1;", newText: "const value = 2;" }],
+					},
+				},
+			]);
+		});
+
+		it("maps multi-block Cline replace_in_file XML to one Pi edit call", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<replace_in_file>",
+					"<path>src/example.ts</path>",
+					"<diff>",
+					"------- SEARCH",
+					"const first = 1;",
+					"=======",
+					"const first = 2;",
+					"+++++++ REPLACE",
+					"------- SEARCH",
+					"const second = 1;",
+					"=======",
+					"const second = 2;",
+					"+++++++ REPLACE",
+					"</diff>",
+					"</replace_in_file>",
+				].join("\n"),
+				[tool("edit")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "edit",
+					arguments: {
+						path: "src/example.ts",
+						edits: [
+							{ oldText: "const first = 1;", newText: "const first = 2;" },
+							{ oldText: "const second = 1;", newText: "const second = 2;" },
+						],
+					},
+				},
+			]);
+		});
+
 		it("maps Cline list_files to a safe bash-backed command", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				"<list_files>\n<path>src</path>\n<recursive>true</recursive>\n</list_files>",
@@ -133,6 +219,80 @@ describe("Cline XML bridge", () => {
 	});
 
 	describe("buildClineXmlMessages", () => {
+		it("advertises Pi edit as Cline replace_in_file with SEARCH/REPLACE format", () => {
+			const messages = __test__.buildClineXmlMessages({
+				systemPrompt: "system",
+				tools: [tool("edit")],
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "edit file" }],
+						timestamp: Date.now(),
+					},
+				],
+			});
+
+			expect(messages[0]?.content).toContain("Tool: replace_in_file");
+			expect(messages[0]?.content).toContain("<diff>");
+			expect(messages[0]?.content).toContain("------- SEARCH");
+			expect(messages[0]?.content).toContain("+++++++ REPLACE");
+		});
+
+		it("serializes previous Pi edit calls back to Cline replace_in_file XML", () => {
+			const messages = __test__.buildClineXmlMessages({
+				systemPrompt: "system",
+				tools: [tool("edit")],
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "edit file" }],
+						timestamp: Date.now(),
+					},
+					{
+						role: "assistant",
+						api: "cline-xml-tools",
+						provider: "cline",
+						model: "mimo",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								total: 0,
+							},
+						},
+						stopReason: "toolUse",
+						timestamp: Date.now(),
+						content: [
+							{
+								type: "toolCall",
+								id: "call_1",
+								name: "edit",
+								arguments: {
+									path: "src/example.ts",
+									edits: [
+										{ oldText: "const value = 1;", newText: "const value = 2;" },
+									],
+								},
+							},
+						],
+					},
+				],
+			});
+
+			expect(messages[2]?.content).toContain("<replace_in_file>");
+			expect(messages[2]?.content).toContain("<path>src/example.ts</path>");
+			expect(messages[2]?.content).toContain("------- SEARCH");
+			expect(messages[2]?.content).toContain("const value = 1;");
+			expect(messages[2]?.content).toContain("const value = 2;");
+		});
+
 		it("serializes previous Pi bash calls back to Cline execute_command XML", () => {
 			const messages = __test__.buildClineXmlMessages({
 				systemPrompt: "system",


### PR DESCRIPTION
## Summary

Adds Cline-native write/edit parity to the XML bridge.

## Changes

- Keeps/validates `write_to_file` → Pi `write`
- Adds `replace_in_file` → Pi `edit`
- Parses Cline SEARCH/REPLACE diff blocks into Pi's native multi-edit schema:
  - `{ path, edits: [{ oldText, newText }, ...] }`
- Supports multi-block `replace_in_file` diffs as one Pi `edit` call with multiple edits
- Serializes previous Pi `edit` calls back into Cline `replace_in_file` XML for conversation continuity
- Advertises Pi `edit` as Cline `replace_in_file` with explicit SEARCH/REPLACE format in tool instructions
- Treats `<diff>...</diff>` like `<content>...</content>` so embedded XML-ish text inside diffs is less likely to break parsing

## Validation

- `npx vitest run tests/cline-xml-bridge.test.ts` ✅ — 14 tests
- `npx tsc --noEmit --pretty false` ✅
- `npm run test:run` ✅ — 27 files / 356 tests
- `npm run smoke:cline` ✅
  - `xiaomi/mimo-v2.5`
  - `nex-agi/nex-n2-pro:free`

No DRYKISS rerun.