### PR TITLE
fix: strip Cline thinking XML before tool parsing

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -246,8 +246,7 @@ function replaceInFileBridge(tool?: Tool): ToolBridge {
 		remoteName: "replace_in_file",
 		runtimeName: tool?.name === "replace_in_file" ? "replace_in_file" : "edit",
 		description:
-			tool?.description ??
-			"Edit a file using Cline SEARCH/REPLACE blocks",
+			tool?.description ?? "Edit a file using Cline SEARCH/REPLACE blocks",
 		parameters: ["path", "diff"],
 		toRuntimeArgs: (args) => ({
 			path: stringArg(args, "path"),
@@ -262,11 +261,11 @@ function replaceInFileBridge(tool?: Tool): ToolBridge {
 						}))
 						.filter((edit) => edit.oldText || edit.newText)
 				: [
-					{
-						oldText: stringArg(args, "oldText"),
-						newText: stringArg(args, "newText"),
-					},
-				].filter((edit) => edit.oldText || edit.newText);
+						{
+							oldText: stringArg(args, "oldText"),
+							newText: stringArg(args, "newText"),
+						},
+					].filter((edit) => edit.oldText || edit.newText);
 			return {
 				path: args.path,
 				diff: buildSearchReplaceDiff(edits),
@@ -559,6 +558,46 @@ function pushTextFragment(textParts: string[], fragment: string): void {
 	textParts.push(trimmed);
 }
 
+function extractThinkingXml(text: string): {
+	text: string;
+	thinking: string[];
+} {
+	const thinking: string[] = [];
+	const parts: string[] = [];
+	const openTag = "<thinking>";
+	const closeTag = "</thinking>";
+	let cursor = 0;
+
+	while (cursor < text.length) {
+		const openStart = text.indexOf(openTag, cursor);
+		const closeStart = text.indexOf(closeTag, cursor);
+
+		if (closeStart !== -1 && (openStart === -1 || closeStart < openStart)) {
+			parts.push(text.slice(cursor, closeStart));
+			cursor = closeStart + closeTag.length;
+			continue;
+		}
+
+		if (openStart === -1) break;
+		parts.push(text.slice(cursor, openStart));
+		const valueStart = openStart + openTag.length;
+		const valueEnd = text.indexOf(closeTag, valueStart);
+		if (valueEnd === -1) {
+			const value = decodeXmlEntities(text.slice(valueStart).trim());
+			if (value) thinking.push(value);
+			cursor = text.length;
+			break;
+		}
+
+		const value = decodeXmlEntities(text.slice(valueStart, valueEnd).trim());
+		if (value) thinking.push(value);
+		cursor = valueEnd + closeTag.length;
+	}
+
+	parts.push(text.slice(cursor));
+	return { text: parts.join(""), thinking };
+}
+
 function extractTagContent(text: string, tag: string): string | undefined {
 	const open = `<${tag}>`;
 	const close = `</${tag}>`;
@@ -626,11 +665,14 @@ function parseXmlToolCalls(
 		getParseToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
 	);
 	const toolNames = new Set(bridgeByRemoteName.keys());
-	if (toolNames.size === 0) return { text: rawText.trim(), toolCalls: [] };
+	const textWithoutThinking = extractThinkingXml(rawText).text;
+	if (toolNames.size === 0) {
+		return { text: textWithoutThinking.trim(), toolCalls: [] };
+	}
 
-	const sourceText = findNextToolStart(rawText, toolNames, 0)
-		? rawText
-		: decodeXmlEntities(rawText);
+	const sourceText = findNextToolStart(textWithoutThinking, toolNames, 0)
+		? textWithoutThinking
+		: decodeXmlEntities(textWithoutThinking);
 	const textParts: string[] = [];
 	const toolCalls: Array<{ name: string; arguments: Record<string, unknown> }> =
 		[];
@@ -868,8 +910,15 @@ export function streamClineXml(
 			}
 
 			assistant.usage = usageFromChunkUsage(usage);
-			pushThinking(assistant, thinking.trim(), stream);
-			const parsed = parseXmlToolCalls(rawText, context.tools);
+			const extractedThinking = extractThinkingXml(rawText);
+			pushThinking(
+				assistant,
+				[thinking.trim(), ...extractedThinking.thinking]
+					.filter(Boolean)
+					.join("\n\n"),
+				stream,
+			);
+			const parsed = parseXmlToolCalls(extractedThinking.text, context.tools);
 			pushText(assistant, parsed.text, stream);
 			for (const toolCall of parsed.toolCalls) {
 				pushToolCall(assistant, toolCall, stream);

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -46,7 +46,7 @@ function parsePackFileList(out) {
 			.map((line) => line.match(/npm notice \S+\s+(.+)/)?.[1]?.trim())
 			.filter(Boolean);
 	}
-} 
+}
 
 function getFiles() {
 	if (fromSource) {

--- a/scripts/check-tarball.mjs
+++ b/scripts/check-tarball.mjs
@@ -4,7 +4,13 @@
  * accidental/secrets/debug artifacts.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -28,7 +34,9 @@ function resolveTar() {
 function findTarball() {
 	const explicit = process.argv[2];
 	if (explicit) return explicit;
-	const files = readdirSync(".").filter((entry) => /^pi-free-.+\.tgz$/.test(entry));
+	const files = readdirSync(".").filter((entry) =>
+		/^pi-free-.+\.tgz$/.test(entry),
+	);
 	if (files.length !== 1) {
 		fail(`expected exactly one pi-free-*.tgz tarball, found ${files.length}`);
 	}
@@ -110,7 +118,9 @@ console.log("No forbidden tarball artifacts found ✓");
 const extractDir = extractTarball(tarball);
 try {
 	const packageDir = join(extractDir, "package");
-	const pkg = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+	const pkg = JSON.parse(
+		readFileSync(join(packageDir, "package.json"), "utf8"),
+	);
 	const extensions = pkg.pi?.extensions ?? [];
 	if (!Array.isArray(extensions) || extensions.length === 0) {
 		fail("package.json has no pi.extensions entries");

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -56,6 +56,63 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("strips orphan thinking close tags before multiple Cline read calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				String.raw`</thinking>
+<read_file>
+<path>C:\Users\R3LiC\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\docs\sdk.md</path>
+</read_file>
+<read_file>
+<path>C:\Users\R3LiC\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\docs\session-format.md</path>
+</read_file>
+<read_file>
+<path>C:\Users\R3LiC\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\docs\tui.md</path>
+</read_file>`,
+				[tool("read")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "read",
+					arguments: {
+						path: String.raw`C:\Users\R3LiC\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\docs\sdk.md`,
+					},
+				},
+				{
+					name: "read",
+					arguments: {
+						path: String.raw`C:\Users\R3LiC\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\docs\session-format.md`,
+					},
+				},
+				{
+					name: "read",
+					arguments: {
+						path: String.raw`C:\Users\R3LiC\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\docs\tui.md`,
+					},
+				},
+			]);
+		});
+
+		it("strips XML thinking blocks before Cline tool calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<thinking>",
+					"I should inspect the docs first.",
+					"</thinking>",
+					"<read_file>",
+					"<path>README.md</path>",
+					"</read_file>",
+				].join("\n"),
+				[tool("read")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{ name: "read", arguments: { path: "README.md" } },
+			]);
+		});
+
 		it("does not leak XML code fence markers as text", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
@@ -130,7 +187,9 @@ describe("Cline XML bridge", () => {
 					name: "edit",
 					arguments: {
 						path: "src/example.ts",
-						edits: [{ oldText: "const value = 1;", newText: "const value = 2;" }],
+						edits: [
+							{ oldText: "const value = 1;", newText: "const value = 2;" },
+						],
 					},
 				},
 			]);
@@ -277,7 +336,10 @@ describe("Cline XML bridge", () => {
 								arguments: {
 									path: "src/example.ts",
 									edits: [
-										{ oldText: "const value = 1;", newText: "const value = 2;" },
+										{
+											oldText: "const value = 1;",
+											newText: "const value = 2;",
+										},
 									],
 								},
 							},


### PR DESCRIPTION
## Problem

MiMo/Cline can emit XML tool calls with leftover thinking tags in the content stream, for example:

```xml
</thinking>
<read_file>
  <path>.../docs/sdk.md</path>
</read_file>
<read_file>
  <path>.../docs/session-format.md</path>
</read_file>
```

The bridge already parsed the `read_file` calls, but the orphan `</thinking>` became visible assistant text before the tool calls. Full `<thinking>...</thinking>` blocks in content could similarly leak instead of being treated as thinking metadata.

## Fix

- Add string-scanner based extraction for Cline XML thinking artifacts:
  - strips orphan `</thinking>`
  - strips/captures complete `<thinking>...</thinking>` blocks
  - handles incomplete opening `<thinking>...` by treating the remainder as thinking
- Parse tools from the thinking-stripped content
- Append extracted XML thinking to provider reasoning chunks before emitting Pi thinking blocks
- Add regressions for MiMo-style multiple `read_file` calls with Windows paths

## Validation

- `npx vitest run tests/cline-xml-bridge.test.ts` ✅ — 16 tests
- `npx tsc --noEmit --pretty false` ✅
- `npm run test:run` ✅ — 27 files / 358 tests
- `npm run smoke:cline` ✅
  - `xiaomi/mimo-v2.5`
  - `nex-agi/nex-n2-pro:free`

No DRYKISS rerun.