### PR TITLE
fix: treat dangling Cline thinking close as thinking, not text

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -573,7 +573,10 @@ function extractThinkingXml(text: string): {
 		const closeStart = text.indexOf(closeTag, cursor);
 
 		if (closeStart !== -1 && (openStart === -1 || closeStart < openStart)) {
-			parts.push(text.slice(cursor, closeStart));
+			const danglingThinking = decodeXmlEntities(
+				text.slice(cursor, closeStart).trim(),
+			);
+			if (danglingThinking) thinking.push(danglingThinking);
 			cursor = closeStart + closeTag.length;
 			continue;
 		}
@@ -594,6 +597,9 @@ function extractThinkingXml(text: string): {
 		cursor = valueEnd + closeTag.length;
 	}
 
+	if (cursor === 0) {
+		return { text, thinking };
+	}
 	parts.push(text.slice(cursor));
 	return { text: parts.join(""), thinking };
 }

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -113,6 +113,45 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("treats plain text before dangling thinking close as thinking", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"We need create new file pi capabilities.md and update proposed implementation to reference it.",
+					"Probably add section referencing pi capabilities. Need edit implementation to add section about leveraging pi capabilities. Use edit.",
+					"</thinking>",
+				].join("\n"),
+				[tool("edit"), tool("write")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([]);
+		});
+
+		it("parses Cline write_to_file with Windows path and multi-line content", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<write_to_file>",
+					" <path>C:/Users/R3LiC/Desktop/pi-plegma/pi capabilities.md</path>",
+					" <content># Pi SDK Capabilities for Plegma",
+					"This document maps pi's existing SDK capabilities to Plegma's requirements.</content>",
+					"</write_to_file>",
+				].join("\n"),
+				[tool("write")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "write",
+					arguments: {
+						path: "C:/Users/R3LiC/Desktop/pi-plegma/pi capabilities.md",
+						content:
+							"# Pi SDK Capabilities for Plegma\nThis document maps pi's existing SDK capabilities to Plegma's requirements.",
+					},
+				},
+			]);
+		});
+
 		it("does not leak XML code fence markers as text", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[


### PR DESCRIPTION
## Problem

MiMo/Cline sometimes emits plan text without an opening `<thinking>` tag, followed by a dangling closing tag:

```text
We need create new file pi capabilities.md and update proposed implementation to reference it.
Probably add section referencing pi capabilities. Need edit implementation to add section about leveraging pi capabilities. Use edit.
</thinking>
```

Previously the bridge stripped the closing tag but left the preceding plan text as visible assistant output, so Pi treated the response as a completed answer and stopped instead of emitting a tool call.

## Fix

- Update `extractThinkingXml` so that when it sees a `</thinking>` with no matching opening tag, the text before that close tag is captured as thinking rather than exposed as assistant text.
- Add regression test with the exact MiMo output shape.
- Drop the previous overly-optimistic prompt-hardening wording; the parser change is the actual fix.

## Validation

- `npx vitest run tests/cline-xml-bridge.test.ts` ✅ — 17 tests
- `npx tsc --noEmit --pretty false` ✅
- `npm run test:run` ✅ — 27 files / 359 tests
- `npm run smoke:cline` ✅
  - `xiaomi/mimo-v2.5`
  - `nex-agi/nex-n2-pro:free"

No DRYKISS rerun.