### PR TITLE
fix: treat DeepSeek-style <think> blocks as thinking

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -564,12 +564,23 @@ function extractThinkingXml(text: string): {
 } {
 	const thinking: string[] = [];
 	const parts: string[] = [];
-	const openTag = "<thinking>";
+	const openTags = ["<thinking>", "<think>"];
 	const closeTag = "</thinking>";
 	let cursor = 0;
 
+	function findNextOpenTag(from: number): { index: number; tag: string } | null {
+		let best: { index: number; tag: string } | null = null;
+		for (const tag of openTags) {
+			const index = text.indexOf(tag, from);
+			if (index === -1) continue;
+			if (!best || index < best.index) best = { index, tag };
+		}
+		return best;
+	}
+
 	while (cursor < text.length) {
-		const openStart = text.indexOf(openTag, cursor);
+		const nextOpen = findNextOpenTag(cursor);
+		const openStart = nextOpen?.index ?? -1;
 		const closeStart = text.indexOf(closeTag, cursor);
 
 		if (closeStart !== -1 && (openStart === -1 || closeStart < openStart)) {
@@ -581,9 +592,9 @@ function extractThinkingXml(text: string): {
 			continue;
 		}
 
-		if (openStart === -1) break;
+		if (openStart === -1 || !nextOpen) break;
 		parts.push(text.slice(cursor, openStart));
-		const valueStart = openStart + openTag.length;
+		const valueStart = openStart + nextOpen.tag.length;
 		const valueEnd = text.indexOf(closeTag, valueStart);
 		if (valueEnd === -1) {
 			const value = decodeXmlEntities(text.slice(valueStart).trim());

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -127,6 +127,32 @@ describe("Cline XML bridge", () => {
 			expect(parsed.toolCalls).toEqual([]);
 		});
 
+		it("treats DeepSeek-style <think> block content as thinking", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<think>",
+					"The user wants me to continue. Let me check what still needs to be done.",
+					"</thinking>",
+					"<read_file>",
+					"<path>C:/Users/R3LiC/Desktop/pi-plegma/proposed implementation.md</path>",
+					"<offset>1100</offset>",
+					"<limit>50</limit>",
+					"</read_file>",
+				].join("\n"),
+				[tool("read")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "read",
+					arguments: {
+						path: "C:/Users/R3LiC/Desktop/pi-plegma/proposed implementation.md",
+					},
+				},
+			]);
+		});
+
 		it("parses Cline write_to_file with Windows path and multi-line content", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[


### PR DESCRIPTION
## Problem

Some Cline/MiMo outputs mix DeepSeek-style thinking tags with Cline-style closing tags:

```xml
<think>
The user wants me to continue...
</thinking>
<read_file>
  <path>.../proposed implementation.md</path>
  <offset>1100</offset>
  <limit>50</limit>
</read_file>
```

Previously the bridge only recognized Cline's `<thinking>` opening tag, so the `<think>` block leaked into assistant content and could be misinterpreted as raw tool calls.

## Fix

- Treat both `<thinking>` and `<think>` as thinking-block open tags.
- Extract their content before parsing Cline XML tool calls.

## Validation

- `npx vitest run tests/cline-xml-bridge.test.ts` ✅ — 19 tests
- `npx tsc --noEmit --pretty false` ✅
- `npm run test:run` ✅ — 27 files / 361 tests
- `npm run smoke:cline` ✅

No DRYKISS rerun.