### PR TITLE
fix(tokenrouter): extract inline MiniMax think blocks into ThinkingContent

### DIFF
--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -16,6 +16,10 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
+import type {
+	AssistantMessage,
+	ThinkingContent,
+} from "@earendil-works/pi-ai";
 import {
 	getTokenrouterApiKey,
 	getTokenrouterShowPaid,
@@ -38,6 +42,63 @@ import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 import { createReRegister, setupProvider } from "../../provider-helper.ts";
 
 const _logger = createLogger("tokenrouter");
+
+// =============================================================================
+// Reasoning cleanup
+// TokenRouter's MiniMax-M3 model sometimes emits DeepSeek-style `<think>`
+// reasoning tags inline in the assistant text. Pi does not strip them, so we
+// extract them into proper ThinkingContent blocks on message_end.
+// =============================================================================
+
+interface ExtractedThinking {
+	text: string;
+	thinking: string;
+}
+
+function collapseWhitespace(text: string): string {
+	return text
+		.replace(/\r\n/g, "\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.replace(/[ \t]+/g, " ")
+		.trim();
+}
+
+function extractThinkBlocks(text: string): ExtractedThinking {
+	const openTag = "<think>";
+	const closeTag = "</think>";
+	const thinkingParts: string[] = [];
+	const textParts: string[] = [];
+	let cursor = 0;
+
+	while (cursor < text.length) {
+		const openStart = text.indexOf(openTag, cursor);
+		if (openStart === -1) {
+			textParts.push(text.slice(cursor));
+			break;
+		}
+
+		textParts.push(text.slice(cursor, openStart));
+		const valueStart = openStart + openTag.length;
+		const closeStart = text.indexOf(closeTag, valueStart);
+		if (closeStart === -1) {
+			// Unclosed think tag: treat remainder as thinking.
+			thinkingParts.push(text.slice(valueStart));
+			break;
+		}
+
+		thinkingParts.push(text.slice(valueStart, closeStart));
+		cursor = closeStart + closeTag.length;
+	}
+
+	return {
+		text: collapseWhitespace(textParts.join("")),
+		thinking: collapseWhitespace(thinkingParts.join("\n\n")),
+	};
+}
+
+function isTokenRouterModel(model: { provider?: string }): boolean {
+	return model.provider === PROVIDER_TOKENROUTER;
+}
 
 // =============================================================================
 // Known Free Models
@@ -110,6 +171,37 @@ export function finalizeTokenRouterModel(
 			supportsReasoningEffort: true,
 		},
 	};
+}
+
+export function normalizeAssistantMessage(message: AssistantMessage): AssistantMessage {
+	const newContent: AssistantMessage["content"] = [];
+	let extractedThinking = "";
+
+	for (const block of message.content) {
+		if (block.type !== "text") {
+			newContent.push(block);
+			continue;
+		}
+
+		const extracted = extractThinkBlocks(block.text);
+		if (extracted.thinking) {
+			extractedThinking = extractedThinking
+				? `${extractedThinking}\n\n${extracted.thinking}`
+				: extracted.thinking;
+		}
+		if (extracted.text) {
+			newContent.push({ ...block, text: extracted.text });
+		}
+	}
+
+	if (extractedThinking) {
+		newContent.push({
+			type: "thinking",
+			thinking: extractedThinking,
+		} as ThinkingContent);
+	}
+
+	return { ...message, content: newContent };
 }
 
 export function patchTokenRouterMinimaxThinkingPayload(payload: unknown): unknown {
@@ -252,6 +344,12 @@ export default async function tokenRouterProvider(pi: ExtensionAPI) {
 	pi.on("before_provider_request", (event) =>
 		patchTokenRouterMinimaxThinkingPayload(event.payload),
 	);
+
+	pi.on("message_end", (event, ctx) => {
+		if (!isTokenRouterModel(ctx.model ?? {})) return;
+		if (event.message.role !== "assistant") return;
+		return { message: normalizeAssistantMessage(event.message) };
+	});
 
 	setupProvider(
 		pi,

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -3,6 +3,7 @@ import { isFreeModel } from "../lib/registry.ts";
 import {
 	finalizeTokenRouterModel,
 	mapTokenRouterModel,
+	normalizeAssistantMessage,
 	patchTokenRouterMinimaxThinkingPayload,
 } from "../providers/tokenrouter/tokenrouter.ts";
 
@@ -126,5 +127,66 @@ describe("TokenRouter free model detection", () => {
 		expect(
 			isFreeModel({ ...paidModel, provider: "tokenrouter" }, allModels),
 		).toBe(false);
+	});
+});
+
+describe("TokenRouter MiniMax reasoning cleanup", () => {
+	function assistantMessage(text: string): {
+		role: "assistant";
+		content: { type: "text"; text: string }[];
+	} {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text }],
+		};
+	}
+
+	it("extracts inline think blocks into ThinkingContent", () => {
+		const message = assistantMessage(
+			"Before\n\n<think>Let me explore the freebuff-npm directory.</think>\n\nAfter",
+		);
+		const normalized = normalizeAssistantMessage(message as any);
+
+		expect(normalized.content).toHaveLength(2);
+		const textBlock = normalized.content[0];
+		expect(textBlock).toMatchObject({ type: "text" });
+		expect((textBlock as { text: string }).text).not.toContain("<think>");
+		expect((textBlock as { text: string }).text).toContain("Before");
+		expect((textBlock as { text: string }).text).toContain("After");
+		expect(normalized.content[1]).toMatchObject({
+			type: "thinking",
+			thinking: "Let me explore the freebuff-npm directory.",
+		});
+	});
+
+	it("handles multiple think blocks", () => {
+		const message = assistantMessage(
+			"<think>first</think> text <think>second</think>",
+		);
+		const normalized = normalizeAssistantMessage(message as any);
+
+		expect(normalized.content[0]).toEqual({ type: "text", text: "text" });
+		expect(normalized.content[1]).toMatchObject({
+			type: "thinking",
+			thinking: "first\n\nsecond",
+		});
+	});
+
+	it("treats unclosed think tag as thinking", () => {
+		const message = assistantMessage("<think>dangling reasoning");
+		const normalized = normalizeAssistantMessage(message as any);
+
+		expect(normalized.content).toHaveLength(1);
+		expect(normalized.content[0]).toMatchObject({
+			type: "thinking",
+			thinking: "dangling reasoning",
+		});
+	});
+
+	it("leaves text without think tags unchanged", () => {
+		const message = assistantMessage("Just plain text.");
+		const normalized = normalizeAssistantMessage(message as any);
+
+		expect(normalized.content).toEqual([{ type: "text", text: "Just plain text." }]);
 	});
 });


### PR DESCRIPTION
## Problem

TokenRouter's MiniMax-M3 model sometimes emits DeepSeek-style "<think>" reasoning tags inline in the assistant text (e.g. "<think>Let me explore the freebuff-npm directory.</think>"). Pi does not strip them, so the reasoning plan leaks into the visible assistant message.

## Fix

- Added a "message_end" handler scoped to TokenRouter.
- Extracts "<think>...</think>" blocks (including unclosed dangling tags) from assistant text content.
- Promotes the extracted content into a proper "ThinkingContent" block so Pi renders it as reasoning instead of visible text.
- Collapses leftover whitespace around the removed tags.

## Validation

- npx vitest run tests/tokenrouter-free.test.ts - 11 tests passed
- npx tsc --noEmit --pretty false - clean
- npm run test:run - 27 files / 365 tests passed

No DRYKISS rerun.