### PR TITLE
fix(cline): preserve JSON file content as string in write_to_file XML

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -661,9 +661,17 @@ function parseToolArguments(block: string): Record<string, unknown> {
 				: block.indexOf(close, openEnd + 1);
 		if (closeStart === -1 || closeStart < openEnd) break;
 		const raw = decodeXmlEntities(block.slice(openEnd + 1, closeStart).trim());
-		try {
-			args[tag] = JSON.parse(raw);
-		} catch {
+		// `content` and `diff` are explicitly string parameters (file bodies,
+		// SEARCH/REPLACE diffs). Parsing them as JSON corrupts JSON file content
+		// into "[object Object]".
+		const shouldParseJson = tag !== "content" && tag !== "diff";
+		if (shouldParseJson) {
+			try {
+				args[tag] = JSON.parse(raw);
+			} catch {
+				args[tag] = raw;
+			}
+		} else {
 			args[tag] = raw;
 		}
 		cursor = closeStart + close.length;

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -230,6 +230,37 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("preserves JSON file content as a string in write_to_file", () => {
+			const jsonContent = JSON.stringify(
+				{
+					name: "plegma",
+					version: "0.1.0",
+					pi: { extensions: ["./index.ts"] },
+				},
+				null,
+				2,
+			);
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<write_to_file>",
+					"<path>C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json</path>",
+					`<content>${jsonContent}</content>`,
+					"</write_to_file>",
+				].join("\n"),
+				[tool("write")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "write",
+					arguments: {
+						path: "C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json",
+						content: jsonContent,
+					},
+				},
+			]);
+		});
+
 		it("maps Cline replace_in_file XML to Pi edit tool calls", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[


### PR DESCRIPTION
## Problem

When a Cline model emits `write_to_file` with JSON content inside `<content>`, the bridge's `parseToolArguments` helper ran `JSON.parse()` on the raw content. This turned valid JSON like `{"name":"plegma"}` into a JS object, and `writeToFileBridge.toRuntimeArgs` then called `stringArg(args, "content")`, which stringified the object back into `[object Object]`. The file on disk ended up containing literally `[object Object]` instead of the intended JSON.

## Fix

Skip `JSON.parse()` for `<content>` and `<diff>` tags in `parseToolArguments`. These tags represent raw string blobs (file bodies and SEARCH/REPLACE diffs), not structured JSON arguments.

## Validation

- Added regression test `preserves JSON file content as a string in write_to_file`.
- `npx vitest run tests/cline-xml-bridge.test.ts` ✅ — 20 tests
- `npx tsc --noEmit --pretty false` ✅
- `npm run test:run` ✅ — 27 files / 366 tests
- `npm run smoke:cline` ✅

No DRYKISS rerun.
