### PR TITLE
fix(ui): remove provider count footer statuses

### DIFF
--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -95,7 +95,6 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 		for (const config of activeConfigs) {
 			registerToggleCommand(pi, config);
 		}
-		setupStatusBar(pi, activeConfigs);
 		commandsRegistered = true;
 	}
 
@@ -248,45 +247,6 @@ function modelToProviderConfig(
 	}
 
 	return base;
-}
-
-// =============================================================================
-// Status bar for provider selection
-// =============================================================================
-
-function setupStatusBar(
-	pi: ExtensionAPI,
-	configs: BuiltInToggleConfig[],
-): void {
-	pi.on("model_select", (_event, ctx) => {
-		const selected = _event.model?.provider;
-
-		// Clear status for all fallback-captured built-in providers
-		for (const config of configs) {
-			if (selected !== config.id) {
-				ctx.ui.setStatus(`${config.id}-status`, undefined);
-			}
-		}
-
-		if (!selected) return;
-
-		const state = providerStates.get(selected);
-		if (!state) return;
-
-		const free = state.stored.free.length;
-		const total = state.stored.all.length;
-		const paid = total - free;
-		const mode = state.toggleState.getCurrentMode();
-		let status: string;
-		if (paid === 0) {
-			status = `${selected}: ${free} free models`;
-		} else if (mode === "all") {
-			status = `${selected}: ${total} models (free + paid)`;
-		} else {
-			status = `${selected}: ${free} free \u00b7 ${paid} paid`;
-		}
-		ctx.ui.setStatus(`${selected}-status`, status);
-	});
 }
 
 function getApiKeyEnvForProvider(providerId: string): string {

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -163,29 +163,6 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		},
 	});
 
-	// ── Status bar for provider selection ─────────────────────────
-
-	pi.on("model_select", (_event, ctx) => {
-		if (_event.model?.provider !== PROVIDER_CLINE) {
-			ctx.ui.setStatus(`${PROVIDER_CLINE}-status`, undefined);
-			return;
-		}
-
-		const free = stored.free.length;
-		const total = stored.all.length;
-		const paid = total - free;
-		const mode = toggleState.getCurrentMode();
-		let status: string;
-		if (paid === 0) {
-			status = `cline: ${free} free models`;
-		} else if (mode === "all") {
-			status = `cline: ${total} models (free + paid)`;
-		} else {
-			status = `cline: ${free} free \u00b7 ${paid} paid`;
-		}
-		ctx.ui.setStatus(`${PROVIDER_CLINE}-status`, status);
-	});
-
 	pi.on("before_agent_start", (_event, ctx) => {
 		if (ctx.model?.provider !== PROVIDER_CLINE) return;
 		_currentTaskId = generateUlid();

--- a/providers/codestral/codestral.ts
+++ b/providers/codestral/codestral.ts
@@ -125,15 +125,4 @@ export default async function codestralProvider(pi: ExtensionAPI) {
 
 	_logger.info(`[codestral] Registered codestral-latest via ${keySource}`);
 
-	// Status bar
-	pi.on("model_select", (_event, ctx) => {
-		if (_event.model?.provider !== PROVIDER_CODESTRAL) {
-			ctx.ui.setStatus(`${PROVIDER_CODESTRAL}-status`, undefined);
-			return;
-		}
-		ctx.ui.setStatus(
-			`${PROVIDER_CODESTRAL}-status`,
-			`codestral: 1 model (free tier) 🔑`,
-		);
-	});
 }

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -563,26 +563,6 @@ async function registerProvider(
 		true,
 	);
 
-	// Status bar
-	const pid = config.providerId;
-	pi.on("model_select", (_event, ctx) => {
-		if (_event.model?.provider !== pid) {
-			ctx.ui.setStatus(`${pid}-status`, undefined);
-			return;
-		}
-		const f = freeModels.length;
-		const t = allModels.length;
-		const p = t - f;
-		const mode = toggleState.getCurrentMode();
-		const status =
-			p === 0
-				? `${pid}: ${f} free models`
-				: mode === "all"
-					? `${pid}: ${t} models (free + paid)`
-					: `${pid}: ${f} free \u00b7 ${p} paid`;
-		ctx.ui.setStatus(`${pid}-status`, `${status} 🔑`);
-	});
-
 	// Register models (this swaps in our discovered models over Pi's defaults)
 	toggleState.applyCurrent(reRegister);
 

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -326,27 +326,10 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		},
 	});
 
-	// Status bar + ToS notice on provider selection
+	// ToS notice on provider selection
 	let tosShown = false;
 	pi.on("model_select", async (_event, ctx) => {
-		if (ctx.model?.provider !== PROVIDER_KILO) {
-			ctx.ui.setStatus(`${PROVIDER_KILO}-status`, undefined);
-			return;
-		}
-
-		// Build status line
-		const free = freeModels.length;
-		const total = allModels.length;
-		const paid = total - free;
-		let status: string;
-		if (paid === 0) {
-			status = `kilo: ${free} free models`;
-		} else if (showPaidModels) {
-			status = `kilo: ${total} models (free + paid)`;
-		} else {
-			status = `kilo: ${free} free \u00b7 ${paid} paid`;
-		}
-		ctx.ui.setStatus(`${PROVIDER_KILO}-status`, status);
+		if (ctx.model?.provider !== PROVIDER_KILO) return;
 
 		// ToS notice (once)
 		if (tosShown) return;

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -591,19 +591,6 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 		},
 	});
 
-	// ── Status bar for provider selection ───────────────────────────
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	pi.on("model_select" as any, (_event: any, ctx: any) => {
-		if (_event.model?.provider !== PROVIDER_OLLAMA) {
-			ctx.ui.setStatus(`${PROVIDER_OLLAMA}-status`, undefined);
-			return;
-		}
-
-		const count = allModels.length;
-		ctx.ui.setStatus(`${PROVIDER_OLLAMA}-status`, `ollama: ${count} models`);
-	});
-
 	const runProbeInBackground = (models: ProviderModelConfig[]) => {
 		runOllamaProbe(apiKey, models, applyModelList, { useCache: true }).catch(
 			(error) => {


### PR DESCRIPTION
## Summary
- remove provider-count footer/status entries such as `opencode: 6 free · 10 paid`
- remove equivalent model-count status handlers for dynamic built-ins, Cline, Kilo, Ollama, and Codestral
- keep command notifications and Kilo ToS notice intact

## Validation
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files
- no remaining provider `*-status` count footer calls found