### PR TITLE
fix(cline): recover heredoc file writes as write tool calls

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -291,6 +291,106 @@ function executeCommandBridge(tool?: Tool): ToolBridge {
 	};
 }
 
+type HeredocWriteCommand = {
+	path: string;
+	content: string;
+};
+
+function shellSplitLine(line: string): string[] {
+	const tokens: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+
+	for (let i = 0; i < line.length; i++) {
+		const char = line[i];
+		if (quote) {
+			if (char === quote) {
+				quote = undefined;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+		if (char === '"' || char === "'") {
+			quote = char;
+			continue;
+		}
+		if (char === " " || char === "\t") {
+			if (current) {
+				tokens.push(current);
+				current = "";
+			}
+			continue;
+		}
+		current += char;
+	}
+
+	if (current) tokens.push(current);
+	return tokens;
+}
+
+function parseCatHeredocWriteCommand(
+	command: string,
+): HeredocWriteCommand | undefined {
+	const normalized = command.replaceAll("\r\n", "\n").trim();
+	const lines = normalized.split("\n");
+	if (lines.length < 3) return undefined;
+
+	const tokens = shellSplitLine(lines[0].trim());
+	if (tokens[0] !== "cat") return undefined;
+	const redirectIndex = tokens.indexOf(">");
+	if (redirectIndex === -1) return undefined;
+	const path = tokens[redirectIndex + 1];
+	if (!path) return undefined;
+
+	let delimiter = "";
+	for (let i = redirectIndex + 2; i < tokens.length; i++) {
+		const token = tokens[i];
+		if (token === "<<") {
+			delimiter = tokens[i + 1] ?? "";
+			break;
+		}
+		if (token.startsWith("<<")) {
+			delimiter = token.slice(2);
+			break;
+		}
+	}
+	if (!delimiter) return undefined;
+
+	let delimiterLine = -1;
+	for (let i = 1; i < lines.length; i++) {
+		if (lines[i].trim() === delimiter) {
+			delimiterLine = i;
+			break;
+		}
+	}
+	if (delimiterLine === -1) return undefined;
+
+	const trailing = lines.slice(delimiterLine + 1).join("\n").trim();
+	if (trailing) {
+		const trailingLines = trailing.split("\n").filter((line) => line.trim());
+		if (trailingLines.length !== 1) return undefined;
+		const trailingTokens = shellSplitLine(trailingLines[0].trim());
+		if (trailingTokens.length !== 2 || trailingTokens[0] !== "cat") {
+			return undefined;
+		}
+		if (trailingTokens[1] !== path) return undefined;
+	}
+
+	return {
+		path,
+		content: lines.slice(1, delimiterLine).join("\n"),
+	};
+}
+
+function getWriteRuntimeToolName(tools: Tool[] | undefined): string | undefined {
+	if ((tools ?? []).some((tool) => tool.name === "write_to_file")) {
+		return "write_to_file";
+	}
+	if ((tools ?? []).some((tool) => tool.name === "write")) return "write";
+	return undefined;
+}
+
 function listFilesBridge(): ToolBridge {
 	return {
 		remoteName: "list_files",
@@ -716,10 +816,19 @@ function parseXmlToolCalls(
 		const block = sourceText.slice(next.index + next.openTag.length, blockEnd);
 		const bridge = bridgeByRemoteName.get(next.name);
 		const remoteArgs = parseToolArguments(block);
-		toolCalls.push({
-			name: bridge?.runtimeName ?? next.name,
-			arguments: bridge?.toRuntimeArgs(remoteArgs) ?? remoteArgs,
-		});
+		const writeRuntimeName = getWriteRuntimeToolName(tools);
+		const heredocWrite =
+			next.name === "execute_command" && writeRuntimeName
+				? parseCatHeredocWriteCommand(stringArg(remoteArgs, "command"))
+				: undefined;
+		if (heredocWrite && writeRuntimeName) {
+			toolCalls.push({ name: writeRuntimeName, arguments: { ...heredocWrite } });
+		} else {
+			toolCalls.push({
+				name: bridge?.runtimeName ?? next.name,
+				arguments: bridge?.toRuntimeArgs(remoteArgs) ?? remoteArgs,
+			});
+		}
 		cursor =
 			closeStart === -1 ? sourceText.length : closeStart + closeTag.length;
 	}

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -45,6 +45,53 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("recovers Cline heredoc file writes as Pi write tool calls", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"The user wants to continue scaffolding. Let me write the package.json properly.",
+					"</thinking>",
+					"<execute_command>",
+					"<command>cat > \"C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json\" << 'JSONEOF'",
+					"{",
+					'  "name": "plegma",',
+					'  "version": "0.1.0",',
+					'  "type": "module",',
+					'  "main": "./index.ts",',
+					'  "private": true,',
+					'  "pi": {',
+					'    "extensions": ["./index.ts"]',
+					"  }",
+					"}",
+					"JSONEOF",
+					"cat \"C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json\"</command>",
+					"</execute_command>",
+				].join("\n"),
+				[tool("bash"), tool("write")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "write",
+					arguments: {
+						path: "C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json",
+						content: [
+							"{",
+							'  "name": "plegma",',
+							'  "version": "0.1.0",',
+							'  "type": "module",',
+							'  "main": "./index.ts",',
+							'  "private": true,',
+							'  "pi": {',
+							'    "extensions": ["./index.ts"]',
+							"  }",
+							"}",
+						].join("\n"),
+					},
+				},
+			]);
+		});
+
 		it("recovers top-level escaped XML tool calls", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				"&lt;read_file&gt;&lt;path&gt;package.json&lt;/path&gt;&lt;/read_file&gt;",


### PR DESCRIPTION
## Summary
- recover simple Cline `execute_command` heredoc writes like `cat > file << 'EOF' ... EOF` as structured Pi `write` tool calls
- preserves ordinary `execute_command` usage as `bash`
- strips the dangling thinking close from the reported output before parsing the tool call

## Why
Some Cline models avoid `write_to_file` after prior serialization issues and fall back to shell heredocs. This keeps file writes on the safer structured `write` path instead of executing a shell write command.

## Validation
- `npx vitest run tests/cline-xml-bridge.test.ts --reporter=dot`
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files