### PR TITLE
fix(tokenrouter): patch nested MiniMax thinking payloads

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -568,7 +568,9 @@ function extractThinkingXml(text: string): {
 	const closeTag = "</thinking>";
 	let cursor = 0;
 
-	function findNextOpenTag(from: number): { index: number; tag: string } | null {
+	function findNextOpenTag(
+		from: number,
+	): { index: number; tag: string } | null {
 		let best: { index: number; tag: string } | null = null;
 		for (const tag of openTags) {
 			const index = text.indexOf(tag, from);

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -204,22 +204,57 @@ export function normalizeAssistantMessage(message: AssistantMessage): AssistantM
 	return { ...message, content: newContent };
 }
 
-export function patchTokenRouterMinimaxThinkingPayload(payload: unknown): unknown {
-	if (typeof payload !== "object" || payload === null) return payload;
-	const body = payload as {
-		model?: unknown;
-		thinking?: { type?: unknown };
-	};
-	if (!isTokenRouterMinimaxModel(String(body.model ?? ""))) return payload;
-	if (body.thinking?.type !== "enabled") return payload;
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-	return {
-		...body,
-		thinking: {
-			...body.thinking,
-			type: "adaptive",
-		},
-	};
+function containsTokenRouterMinimaxModel(value: unknown): boolean {
+	if (Array.isArray(value)) {
+		return value.some(containsTokenRouterMinimaxModel);
+	}
+	if (!isRecord(value)) return false;
+
+	for (const [key, child] of Object.entries(value)) {
+		if (key === "model" && isTokenRouterMinimaxModel(String(child ?? ""))) {
+			return true;
+		}
+		if (containsTokenRouterMinimaxModel(child)) return true;
+	}
+	return false;
+}
+
+function patchThinkingType(value: unknown): { value: unknown; changed: boolean } {
+	if (Array.isArray(value)) {
+		let changed = false;
+		const patched = value.map((child) => {
+			const result = patchThinkingType(child);
+			changed ||= result.changed;
+			return result.value;
+		});
+		return changed ? { value: patched, changed } : { value, changed: false };
+	}
+	if (!isRecord(value)) return { value, changed: false };
+
+	let changed = false;
+	const patched: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value)) {
+		let next = patchThinkingType(child).value;
+		if (key === "thinking" && isRecord(next) && next.type === "enabled") {
+			next = { ...next, type: "adaptive" };
+			changed = true;
+		} else {
+			changed ||= next !== child;
+		}
+		patched[key] = next;
+	}
+
+	return changed ? { value: patched, changed } : { value, changed: false };
+}
+
+export function patchTokenRouterMinimaxThinkingPayload(payload: unknown): unknown {
+	if (!containsTokenRouterMinimaxModel(payload)) return payload;
+	const result = patchThinkingType(payload);
+	return result.changed ? result.value : payload;
 }
 
 export function mapTokenRouterModel(model: TokenRouterModel): ProviderModelConfig & {

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -16,10 +16,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import type {
-	AssistantMessage,
-	ThinkingContent,
-} from "@earendil-works/pi-ai";
+import type { AssistantMessage, ThinkingContent } from "@earendil-works/pi-ai";
 import {
 	getTokenrouterApiKey,
 	getTokenrouterShowPaid,
@@ -173,7 +170,9 @@ export function finalizeTokenRouterModel(
 	};
 }
 
-export function normalizeAssistantMessage(message: AssistantMessage): AssistantMessage {
+export function normalizeAssistantMessage(
+	message: AssistantMessage,
+): AssistantMessage {
 	const newContent: AssistantMessage["content"] = [];
 	let extractedThinking = "";
 
@@ -223,7 +222,10 @@ function containsTokenRouterMinimaxModel(value: unknown): boolean {
 	return false;
 }
 
-function patchThinkingType(value: unknown): { value: unknown; changed: boolean } {
+function patchThinkingType(value: unknown): {
+	value: unknown;
+	changed: boolean;
+} {
 	if (Array.isArray(value)) {
 		let changed = false;
 		const patched = value.map((child) => {
@@ -251,13 +253,17 @@ function patchThinkingType(value: unknown): { value: unknown; changed: boolean }
 	return changed ? { value: patched, changed } : { value, changed: false };
 }
 
-export function patchTokenRouterMinimaxThinkingPayload(payload: unknown): unknown {
+export function patchTokenRouterMinimaxThinkingPayload(
+	payload: unknown,
+): unknown {
 	if (!containsTokenRouterMinimaxModel(payload)) return payload;
 	const result = patchThinkingType(payload);
 	return result.changed ? result.value : payload;
 }
 
-export function mapTokenRouterModel(model: TokenRouterModel): ProviderModelConfig & {
+export function mapTokenRouterModel(
+	model: TokenRouterModel,
+): ProviderModelConfig & {
 	_pricingKnown?: boolean;
 	_freeKnown?: boolean;
 	_isFree?: boolean;

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -103,6 +103,32 @@ describe("TokenRouter free model detection", () => {
 		});
 	});
 
+	it("patches nested MiniMax-M3 thinking payloads used by compaction", () => {
+		expect(
+			patchTokenRouterMinimaxThinkingPayload({
+				model: "MiniMax-M3",
+				extra_body: {
+					thinking: { type: "enabled", budget_tokens: 1024 },
+				},
+				provider_options: {
+					tokenrouter: {
+						thinking: { type: "enabled" },
+					},
+				},
+			}),
+		).toEqual({
+			model: "MiniMax-M3",
+			extra_body: {
+				thinking: { type: "adaptive", budget_tokens: 1024 },
+			},
+			provider_options: {
+				tokenrouter: {
+					thinking: { type: "adaptive" },
+				},
+			},
+		});
+	});
+
 	it("leaves non-MiniMax and disabled thinking payloads unchanged", () => {
 		const disabled = {
 			model: "MiniMax-M3",

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -213,6 +213,8 @@ describe("TokenRouter MiniMax reasoning cleanup", () => {
 		const message = assistantMessage("Just plain text.");
 		const normalized = normalizeAssistantMessage(message as any);
 
-		expect(normalized.content).toEqual([{ type: "text", text: "Just plain text." }]);
+		expect(normalized.content).toEqual([
+			{ type: "text", text: "Just plain text." },
+		]);
 	});
 });


### PR DESCRIPTION
## Summary
- recursively patch TokenRouter MiniMax request payloads so any nested `thinking.type: enabled` becomes `adaptive`
- covers auto-compact and `/compact` summarization payload shapes, not just top-level chat payloads
- keeps non-MiniMax payloads and disabled thinking unchanged

## Validation
- `npx vitest run tests/tokenrouter-free.test.ts --reporter=dot`
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files