### PR TITLE
fix(tokenrouter): patch MiniMax compaction payloads by active model

### DIFF
--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -255,8 +255,19 @@ function patchThinkingType(value: unknown): {
 
 export function patchTokenRouterMinimaxThinkingPayload(
 	payload: unknown,
+	force = false,
 ): unknown {
-	if (!containsTokenRouterMinimaxModel(payload)) return payload;
+	if (typeof payload === "string") {
+		try {
+			const parsed = JSON.parse(payload) as unknown;
+			const patched = patchTokenRouterMinimaxThinkingPayload(parsed, force);
+			return patched === parsed ? payload : JSON.stringify(patched);
+		} catch {
+			return payload;
+		}
+	}
+
+	if (!force && !containsTokenRouterMinimaxModel(payload)) return payload;
 	const result = patchThinkingType(payload);
 	return result.changed ? result.value : payload;
 }
@@ -382,8 +393,12 @@ export default async function tokenRouterProvider(pi: ExtensionAPI) {
 
 	registerWithGlobalToggle(PROVIDER_TOKENROUTER, stored, reRegister, true);
 
-	pi.on("before_provider_request", (event) =>
-		patchTokenRouterMinimaxThinkingPayload(event.payload),
+	pi.on("before_provider_request", (event, ctx) =>
+		patchTokenRouterMinimaxThinkingPayload(
+			event.payload,
+			isTokenRouterModel(ctx.model ?? {}) &&
+				isTokenRouterMinimaxModel(ctx.model?.id ?? ""),
+		),
 	);
 
 	pi.on("message_end", (event, ctx) => {

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -129,6 +129,28 @@ describe("TokenRouter free model detection", () => {
 		});
 	});
 
+	it("patches compaction payloads without a model field when forced", () => {
+		expect(
+			patchTokenRouterMinimaxThinkingPayload(
+				{
+					messages: [{ role: "user", content: "summarize" }],
+					thinking: { type: "enabled" },
+				},
+				true,
+			),
+		).toEqual({
+			messages: [{ role: "user", content: "summarize" }],
+			thinking: { type: "adaptive" },
+		});
+	});
+
+	it("patches stringified compaction payloads when forced", () => {
+		const payload = JSON.stringify({ thinking: { type: "enabled" } });
+		expect(patchTokenRouterMinimaxThinkingPayload(payload, true)).toBe(
+			JSON.stringify({ thinking: { type: "adaptive" } }),
+		);
+	});
+
 	it("leaves non-MiniMax and disabled thinking payloads unchanged", () => {
 		const disabled = {
 			model: "MiniMax-M3",


### PR DESCRIPTION
## Summary
- follow-up to #247: force the MiniMax thinking payload patch when the active model is TokenRouter MiniMax-M3
- covers /compact and auto-compaction payloads that do not expose a model field inside the request body
- defensively handles stringified JSON payloads

## Validation
- `npx vitest run tests/tokenrouter-free.test.ts --reporter=dot` (14 passed)
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files

## Notes
PR #247 was merged before this follow-up commit landed on its branch, so this PR contains only the missing active-model compaction fix.