### PR TITLE
fix(cline): recover XML tools from reasoning channel

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -366,7 +366,10 @@ function parseCatHeredocWriteCommand(
 	}
 	if (delimiterLine === -1) return undefined;
 
-	const trailing = lines.slice(delimiterLine + 1).join("\n").trim();
+	const trailing = lines
+		.slice(delimiterLine + 1)
+		.join("\n")
+		.trim();
 	if (trailing) {
 		const trailingLines = trailing.split("\n").filter((line) => line.trim());
 		if (trailingLines.length !== 1) return undefined;
@@ -383,7 +386,9 @@ function parseCatHeredocWriteCommand(
 	};
 }
 
-function getWriteRuntimeToolName(tools: Tool[] | undefined): string | undefined {
+function getWriteRuntimeToolName(
+	tools: Tool[] | undefined,
+): string | undefined {
 	if ((tools ?? []).some((tool) => tool.name === "write_to_file")) {
 		return "write_to_file";
 	}
@@ -826,7 +831,10 @@ function parseXmlToolCalls(
 				? parseCatHeredocWriteCommand(stringArg(remoteArgs, "command"))
 				: undefined;
 		if (heredocWrite && writeRuntimeName) {
-			toolCalls.push({ name: writeRuntimeName, arguments: { ...heredocWrite } });
+			toolCalls.push({
+				name: writeRuntimeName,
+				arguments: { ...heredocWrite },
+			});
 		} else {
 			toolCalls.push({
 				name: bridge?.runtimeName ?? next.name,

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -781,13 +781,15 @@ function parseToolArguments(block: string): Record<string, unknown> {
 	return args;
 }
 
+type ParsedToolCalls = {
+	text: string;
+	toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>;
+};
+
 function parseXmlToolCalls(
 	rawText: string,
 	tools: Tool[] | undefined,
-): {
-	text: string;
-	toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>;
-} {
+): ParsedToolCalls {
 	const bridgeByRemoteName = new Map(
 		getParseToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
 	);
@@ -837,6 +839,24 @@ function parseXmlToolCalls(
 
 	pushTextFragment(textParts, sourceText.slice(cursor));
 	return { text: textParts.join("\n\n").trim(), toolCalls };
+}
+
+function parseReasoningToolCalls(
+	reasoning: string,
+	tools: Tool[] | undefined,
+): { thinking: string[]; toolCalls: ParsedToolCalls["toolCalls"] } {
+	if (!reasoning.trim()) return { thinking: [], toolCalls: [] };
+
+	const extracted = extractThinkingXml(reasoning);
+	const parsed = parseXmlToolCalls(extracted.text, tools);
+	const thinking = [...extracted.thinking];
+	if (parsed.toolCalls.length > 0 && parsed.text) {
+		thinking.push(parsed.text);
+	} else if (parsed.toolCalls.length === 0 && extracted.thinking.length === 0) {
+		thinking.push(reasoning.trim());
+	}
+
+	return { thinking, toolCalls: parsed.toolCalls };
 }
 
 function usageFromChunkUsage(usage: ClineXmlChunk["usage"] | undefined): Usage {
@@ -1047,21 +1067,23 @@ export function streamClineXml(
 
 			assistant.usage = usageFromChunkUsage(usage);
 			const extractedThinking = extractThinkingXml(rawText);
+			const parsedReasoning = parseReasoningToolCalls(thinking, context.tools);
 			pushThinking(
 				assistant,
-				[thinking.trim(), ...extractedThinking.thinking]
+				[...parsedReasoning.thinking, ...extractedThinking.thinking]
 					.filter(Boolean)
 					.join("\n\n"),
 				stream,
 			);
 			const parsed = parseXmlToolCalls(extractedThinking.text, context.tools);
+			const toolCalls = [...parsed.toolCalls, ...parsedReasoning.toolCalls];
 			pushText(assistant, parsed.text, stream);
-			for (const toolCall of parsed.toolCalls) {
+			for (const toolCall of toolCalls) {
 				pushToolCall(assistant, toolCall, stream);
 			}
 
 			assistant.stopReason =
-				parsed.toolCalls.length > 0
+				toolCalls.length > 0
 					? "toolUse"
 					: finishReason === "length"
 						? "length"
@@ -1088,6 +1110,7 @@ export function streamClineXml(
 
 export const __test__ = {
 	buildClineXmlMessages,
+	parseReasoningToolCalls,
 	parseXmlToolCalls,
 	serializeXmlToolCall,
 };

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -225,6 +225,42 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("recovers write_to_file emitted in the reasoning channel", () => {
+			const parsed = __test__.parseReasoningToolCalls(
+				[
+					"Good, the package.json is created correctly. Now I need to write index.ts.",
+					"</thinking>",
+					"<write_to_file>",
+					"<path>C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/index.ts</path>",
+					"<content>/**",
+					" * Plegma extension",
+					" */",
+					"const branch = `plegma-${runId}-${role}`;",
+					"</content>",
+					"</write_to_file>",
+				].join("\n"),
+				[tool("write")],
+			);
+
+			expect(parsed.thinking).toEqual([
+				"Good, the package.json is created correctly. Now I need to write index.ts.",
+			]);
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "write",
+					arguments: {
+						path: "C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/index.ts",
+						content: [
+							"/**",
+							" * Plegma extension",
+							" */",
+							"const branch = `plegma-${runId}-${role}`;",
+						].join("\n"),
+					},
+				},
+			]);
+		});
+
 		it("does not leak XML code fence markers as text", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -63,7 +63,7 @@ describe("Cline XML bridge", () => {
 					"  }",
 					"}",
 					"JSONEOF",
-					"cat \"C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json\"</command>",
+					'cat "C:/Users/R3LiC/Desktop/pi-plegma/.pi/extensions/plegma/package.json"</command>',
 					"</execute_command>",
 				].join("\n"),
 				[tool("bash"), tool("write")],


### PR DESCRIPTION
## Summary
- recover Cline XML tool calls emitted through the reasoning/thinking stream instead of normal content
- fixes cases where a dangling `</thinking>` is followed by `<write_to_file>...`, which previously became hidden thinking and never executed
- keeps pre-tool reasoning hidden while converting the XML to structured Pi tool calls

## Validation
- `npx vitest run tests/cline-xml-bridge.test.ts --reporter=dot` (22 passed)
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files

## Session evidence
Observed in session `019ec7e5-ef25-7e6a-8773-7e6c632e8661`: Cline returned `<write_to_file>...index.ts...</write_to_file>` inside a thinking block, so the assistant turn ended with `stop` instead of `toolUse`.