### PR TITLE
fix(tokenrouter): patch MiniMax payloads in stream wrapper

### DIFF
--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -16,7 +16,16 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import type { AssistantMessage, ThinkingContent } from "@earendil-works/pi-ai";
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEventStream,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	ThinkingContent,
+} from "@earendil-works/pi-ai";
+import { streamSimpleOpenAICompletions } from "@earendil-works/pi-ai";
 import {
 	getTokenrouterApiKey,
 	getTokenrouterShowPaid,
@@ -36,7 +45,7 @@ import {
 } from "../../lib/provider-compat.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
-import { createReRegister, setupProvider } from "../../provider-helper.ts";
+import { enhanceWithCI, setupProvider } from "../../provider-helper.ts";
 
 const _logger = createLogger("tokenrouter");
 
@@ -105,6 +114,7 @@ function isTokenRouterModel(model: { provider?: string }): boolean {
 
 const MINIMAX_M3_ID = "MiniMax-M3";
 const KNOWN_FREE_MODELS = new Set([MINIMAX_M3_ID]);
+const TOKENROUTER_OPENAI_API = "tokenrouter-openai-completions" as const;
 const MINIMAX_ADAPTIVE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
 	...DEEPSEEK_PROXY_COMPAT,
 	thinkingFormat: "deepseek",
@@ -272,6 +282,35 @@ export function patchTokenRouterMinimaxThinkingPayload(
 	return result.changed ? result.value : payload;
 }
 
+export function streamSimpleTokenRouter(
+	model: Model<Api>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	const forcePatch = isTokenRouterMinimaxModel(model.id);
+	return streamSimpleOpenAICompletions(
+		{ ...model, api: "openai-completions" },
+		context,
+		{
+			...options,
+			onPayload: async (payload, payloadModel) => {
+				const patchedPayload = patchTokenRouterMinimaxThinkingPayload(
+					payload,
+					forcePatch,
+				);
+				const upstreamPayload = await options?.onPayload?.(
+					patchedPayload,
+					payloadModel,
+				);
+				return patchTokenRouterMinimaxThinkingPayload(
+					upstreamPayload ?? patchedPayload,
+					forcePatch,
+				);
+			},
+		},
+	);
+}
+
 export function mapTokenRouterModel(
 	model: TokenRouterModel,
 ): ProviderModelConfig & {
@@ -385,11 +424,16 @@ export default async function tokenRouterProvider(pi: ExtensionAPI) {
 		`[tokenrouter] Registered ${allModels.length} models (${freeModels.length} free)`,
 	);
 
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_TOKENROUTER,
-		baseUrl: BASE_URL_TOKENROUTER,
-		apiKey,
-	});
+	const reRegister = (models: ProviderModelConfig[]) => {
+		pi.registerProvider(PROVIDER_TOKENROUTER, {
+			baseUrl: BASE_URL_TOKENROUTER,
+			apiKey,
+			api: TOKENROUTER_OPENAI_API,
+			streamSimple: streamSimpleTokenRouter,
+			headers: { "User-Agent": "pi-free-providers" },
+			models: enhanceWithCI(models, PROVIDER_TOKENROUTER),
+		});
+	};
 
 	registerWithGlobalToggle(PROVIDER_TOKENROUTER, stored, reRegister, true);
 

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -5,6 +5,7 @@ import {
 	mapTokenRouterModel,
 	normalizeAssistantMessage,
 	patchTokenRouterMinimaxThinkingPayload,
+	streamSimpleTokenRouter,
 } from "../providers/tokenrouter/tokenrouter.ts";
 
 describe("TokenRouter free model detection", () => {
@@ -149,6 +150,60 @@ describe("TokenRouter free model detection", () => {
 		expect(patchTokenRouterMinimaxThinkingPayload(payload, true)).toBe(
 			JSON.stringify({ thinking: { type: "adaptive" } }),
 		);
+	});
+
+	it("patches the actual OpenAI-completions payload before TokenRouter sends it", async () => {
+		let capturedPayload: unknown;
+		const stream = streamSimpleTokenRouter(
+			{
+				id: "MiniMax-M3",
+				name: "MiniMax-M3",
+				provider: "tokenrouter",
+				api: "tokenrouter-openai-completions",
+				baseUrl: "http://127.0.0.1:9/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 16_384,
+				compat: {
+					thinkingFormat: "deepseek",
+					supportsReasoningEffort: true,
+					supportsStore: false,
+					supportsDeveloperRole: false,
+					requiresReasoningContentOnAssistantMessages: true,
+				},
+			},
+			{
+				systemPrompt: "",
+				messages: [
+					{
+						role: "user",
+						content: [{ type: "text", text: "summarize" }],
+						timestamp: Date.now(),
+					},
+				],
+				tools: [],
+			},
+			{
+				apiKey: "test-tokenrouter-key",
+				reasoning: "high",
+				maxRetries: 0,
+				timeoutMs: 1,
+				onPayload: (payload) => {
+					capturedPayload = payload;
+					throw new Error("stop after payload capture");
+				},
+			},
+		);
+
+		await stream.result();
+		expect(capturedPayload).toMatchObject({
+			model: "MiniMax-M3",
+			thinking: { type: "adaptive" },
+			reasoning_effort: "high",
+		});
+		expect(JSON.stringify(capturedPayload)).not.toContain('"enabled"');
 	});
 
 	it("leaves non-MiniMax and disabled thinking payloads unchanged", () => {


### PR DESCRIPTION
## Summary
- register TokenRouter through a provider-specific OpenAI-completions stream wrapper
- patch MiniMax-M3 payloads inside the stream path before the request leaves pi-ai
- keeps the existing extension event patch as a fallback, but no longer relies on /compact going through that event with the right context

## Assertive validation
- added a test that invokes the actual pi-ai OpenAI-completions payload builder through TokenRouter's stream wrapper
- the test enables reasoning for MiniMax-M3 and captures the built outgoing payload before network send
- asserts `thinking.type` is `adaptive` and that the payload does not contain `enabled`

## Validation
- `npx vitest run tests/tokenrouter-free.test.ts --reporter=dot` (15 passed)
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files