### PR TITLE
fix(cline): surface reasoning-only responses

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -867,6 +867,31 @@ function parseReasoningToolCalls(
 	return { thinking, toolCalls: parsed.toolCalls };
 }
 
+function prepareClineXmlOutput(
+	parsedText: string,
+	contentThinking: string[],
+	reasoningThinking: string[],
+	toolCalls: ParsedToolCalls["toolCalls"],
+): { visibleText: string; thinkingText: string; toolCalls: ParsedToolCalls["toolCalls"] } {
+	const thinkingParts = [...reasoningThinking, ...contentThinking].filter(Boolean);
+	if (!parsedText && toolCalls.length === 0 && thinkingParts.length > 0) {
+		// Some Cline/DeepSeek responses put the entire assistant answer in the
+		// reasoning stream and send no content/tool XML. Hiding that would produce
+		// a blank `stop` turn, so surface it as a best-effort visible response.
+		return {
+			visibleText: thinkingParts.join("\n\n"),
+			thinkingText: "",
+			toolCalls,
+		};
+	}
+
+	return {
+		visibleText: parsedText,
+		thinkingText: thinkingParts.join("\n\n"),
+		toolCalls,
+	};
+}
+
 function usageFromChunkUsage(usage: ClineXmlChunk["usage"] | undefined): Usage {
 	const input = usage?.prompt_tokens ?? 0;
 	const output = usage?.completion_tokens ?? 0;
@@ -1076,16 +1101,16 @@ export function streamClineXml(
 			assistant.usage = usageFromChunkUsage(usage);
 			const extractedThinking = extractThinkingXml(rawText);
 			const parsedReasoning = parseReasoningToolCalls(thinking, context.tools);
-			pushThinking(
-				assistant,
-				[...parsedReasoning.thinking, ...extractedThinking.thinking]
-					.filter(Boolean)
-					.join("\n\n"),
-				stream,
-			);
 			const parsed = parseXmlToolCalls(extractedThinking.text, context.tools);
-			const toolCalls = [...parsed.toolCalls, ...parsedReasoning.toolCalls];
-			pushText(assistant, parsed.text, stream);
+			const output = prepareClineXmlOutput(
+				parsed.text,
+				extractedThinking.thinking,
+				parsedReasoning.thinking,
+				[...parsed.toolCalls, ...parsedReasoning.toolCalls],
+			);
+			pushThinking(assistant, output.thinkingText, stream);
+			pushText(assistant, output.visibleText, stream);
+			const toolCalls = output.toolCalls;
 			for (const toolCall of toolCalls) {
 				pushToolCall(assistant, toolCall, stream);
 			}
@@ -1120,5 +1145,6 @@ export const __test__ = {
 	buildClineXmlMessages,
 	parseReasoningToolCalls,
 	parseXmlToolCalls,
+	prepareClineXmlOutput,
 	serializeXmlToolCall,
 };

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -456,6 +456,57 @@ describe("Cline XML bridge", () => {
 		});
 	});
 
+	describe("prepareClineXmlOutput", () => {
+		it("surfaces reasoning-only Cline responses instead of returning a blank stop", () => {
+			const output = __test__.prepareClineXmlOutput(
+				"",
+				[],
+				[
+					"The user is prompting me to continue. Let me respond with my thoughts on this UX design.",
+				],
+				[],
+			);
+
+			expect(output).toEqual({
+				visibleText:
+					"The user is prompting me to continue. Let me respond with my thoughts on this UX design.",
+				thinkingText: "",
+				toolCalls: [],
+			});
+		});
+
+		it("keeps reasoning hidden when visible text is present", () => {
+			const output = __test__.prepareClineXmlOutput(
+				"Visible answer",
+				[],
+				["Private plan"],
+				[],
+			);
+
+			expect(output).toEqual({
+				visibleText: "Visible answer",
+				thinkingText: "Private plan",
+				toolCalls: [],
+			});
+		});
+
+		it("keeps reasoning hidden when tool calls are present", () => {
+			const toolCalls = [{ name: "read", arguments: { path: "README.md" } }];
+			const output = __test__.prepareClineXmlOutput(
+				"",
+				[],
+				["I should inspect the file."],
+				toolCalls,
+			);
+
+			expect(output).toEqual({
+				visibleText: "",
+				thinkingText: "I should inspect the file.",
+				toolCalls,
+			});
+		});
+	});
+
 	describe("buildClineXmlMessages", () => {
 		it("advertises Pi edit as Cline replace_in_file with SEARCH/REPLACE format", () => {
 			const messages = __test__.buildClineXmlMessages({


### PR DESCRIPTION
## Summary
- fix blank Cline turns when the API returns only reasoning deltas and no content/tool XML
- keep reasoning hidden when there is visible text or recovered tool calls
- surface reasoning as best-effort visible text only when the alternative would be an empty `stop` turn

## Session evidence
Latest entries in session `019ec7e5-ef25-7e6a-8773-7e6c632e8661` showed Cline `deepseek/deepseek-v4-flash` returning a `stop` turn with only a thinking block and no text/tool calls.

## Validation
- `npx vitest run tests/cline-xml-bridge.test.ts --reporter=dot` (25 passed)
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files