### PR TITLE
fix(cline): hide internal artifacts and retry MiMo stream errors

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -965,7 +965,11 @@ function prepareClineXmlOutput(
 		Boolean,
 	);
 	const thinkingText = thinkingParts.join("\n\n");
-	if (toolCalls.length === 0 && parsedText && isInternalPlanningArtifact(parsedText)) {
+	if (
+		toolCalls.length === 0 &&
+		parsedText &&
+		isInternalPlanningArtifact(parsedText)
+	) {
 		return {
 			visibleText: INTERNAL_ONLY_RESPONSE,
 			thinkingText: [thinkingText, parsedText].filter(Boolean).join("\n\n"),
@@ -1042,7 +1046,7 @@ function isRetryableClineReasoningStreamError(error: unknown): boolean {
 	const message = error.message.toLowerCase();
 	return (
 		message.includes("stream error occurred") ||
-		message.includes("reasoning") && message.includes("stream")
+		(message.includes("reasoning") && message.includes("stream"))
 	);
 }
 
@@ -1109,7 +1113,9 @@ async function fetchClineXmlResponse(
 	);
 
 	if (!response.ok) {
-		throw new Error(`Cline API error ${response.status}: ${await response.text()}`);
+		throw new Error(
+			`Cline API error ${response.status}: ${await response.text()}`,
+		);
 	}
 
 	return readClineXmlResponse(response);

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -46,6 +46,73 @@ function normalizeApiModelId(modelId: string): string {
 		: modelId;
 }
 
+/**
+ * Some MiMo/Cline models emit XML tags wrapped in Unicode math-italic
+ * characters that spell out "anthml:" before the real tag name:
+ *   <𝑎𝑛𝑡𝑚𝑙:thinking>...</𝑎𝑛𝑡𝑚𝑙:thinking>
+ *   <𝑎𝑛𝑡𝑚𝑙:read_file>...</𝑎𝑛𝑡𝑚𝑙:read_file>
+ *
+ * This function strips the Unicode-decorated prefix so the rest of the
+ * parser sees standard ASCII XML tags.
+ */
+function normalizeDecoratedXmlTags(text: string): string {
+	const parts: string[] = [];
+	let cursor = 0;
+
+	while (cursor < text.length) {
+		const ltIndex = text.indexOf("<", cursor);
+		if (ltIndex === -1) {
+			parts.push(text.slice(cursor));
+			break;
+		}
+
+		parts.push(text.slice(cursor, ltIndex));
+		let contentStart = ltIndex + 1;
+		let prefix = "<";
+
+		// Handle closing tags: </𝑎𝑛𝑡𝑚𝑙:thinking> → </thinking>
+		if (contentStart < text.length && text[contentStart] === "/") {
+			prefix = "</";
+			contentStart += 1;
+		}
+
+		const gtIndex = text.indexOf(">", contentStart);
+		const colonIndex = text.indexOf(":", contentStart);
+		const spaceIndex = text.indexOf(" ", contentStart);
+		if (
+			colonIndex === -1 ||
+			colonIndex === contentStart ||
+			(gtIndex !== -1 && colonIndex > gtIndex) ||
+			(spaceIndex !== -1 && spaceIndex < colonIndex)
+		) {
+			parts.push(prefix);
+			cursor = contentStart;
+			continue;
+		}
+
+		// Strip non-ASCII bytes between prefix and : to undo Unicode-decorated
+		// prefixes like <𝑎𝑛𝑡𝑚𝑙:thinking> → <thinking>.
+		let hasNonAscii = false;
+		for (let i = contentStart; i < colonIndex; i++) {
+			if (text.charCodeAt(i) > 127) {
+				hasNonAscii = true;
+				break;
+			}
+		}
+
+		if (hasNonAscii) {
+			parts.push(prefix);
+			cursor = colonIndex + 1;
+		} else {
+			// No decorated prefix - emit < and re-include everything after it
+			parts.push("<");
+			cursor = ltIndex + 1;
+		}
+	}
+
+	return parts.join("");
+}
+
 function xmlEscape(value: unknown): string {
 	return String(value)
 		.replaceAll("&", "&amp;")
@@ -1061,7 +1128,15 @@ async function readClineXmlResponse(
 		throw new Error("Cline returned empty response");
 	}
 
-	return { rawText, thinking, finishReason, usage };
+	// Some MiMo/Cline models wrap XML tags in Unicode math-italic characters
+	// forming "anthml:" prefixes (e.g. <𝑎𝑛𝑡𝑚𝑙:thinking>, <𝑎𝑛𝑡𝑚𝑙:read_file>).
+	// Strip these so the rest of the parser sees standard ASCII XML tags.
+	return {
+		rawText: normalizeDecoratedXmlTags(rawText),
+		thinking: normalizeDecoratedXmlTags(thinking),
+		finishReason,
+		usage,
+	};
 }
 
 async function fetchClineXmlResponse(
@@ -1295,6 +1370,7 @@ export function streamClineXml(
 export const __test__ = {
 	buildClineXmlMessages,
 	isRetryableClineReasoningStreamError,
+	normalizeDecoratedXmlTags,
 	parseReasoningHiddenToolCalls,
 	parseReasoningToolCalls,
 	parseXmlToolCalls,

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -841,14 +841,9 @@ function parseXmlToolCalls(
 		getParseToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
 	);
 	const toolNames = new Set(bridgeByRemoteName.keys());
-	const extracted = extractThinkingXml(rawText);
-	const textWithoutThinking = extracted.text;
-	const hiddenParsed = parseHiddenThoughtToolCalls(extracted.thinking, tools);
+	const textWithoutThinking = extractThinkingXml(rawText).text;
 	if (toolNames.size === 0) {
-		return {
-			text: textWithoutThinking.trim(),
-			toolCalls: hiddenParsed.toolCalls,
-		};
+		return { text: textWithoutThinking.trim(), toolCalls: [] };
 	}
 
 	const sourceText = findNextToolStart(textWithoutThinking, toolNames, 0)
@@ -893,26 +888,34 @@ function parseXmlToolCalls(
 	}
 
 	pushTextFragment(textParts, sourceText.slice(cursor));
-	return {
-		text: textParts.join("\n\n").trim(),
-		toolCalls: [...toolCalls, ...hiddenParsed.toolCalls],
-	};
+	return { text: textParts.join("\n\n").trim(), toolCalls };
 }
 
-function parseHiddenThoughtToolCalls(
+function parseReasoningHiddenToolCalls(
 	thinkingParts: string[],
 	tools: Tool[] | undefined,
+	depth = 3,
 ): { thinking: string[]; toolCalls: ParsedToolCalls["toolCalls"] } {
 	const thinking: string[] = [];
 	const toolCalls: ParsedToolCalls["toolCalls"] = [];
 	for (const part of thinkingParts) {
 		const trimmed = part.trim();
 		if (!trimmed) continue;
-		const parsed = parseXmlToolCalls(trimmed, tools);
-		toolCalls.push(...parsed.toolCalls);
-		if (parsed.text) {
-			thinking.push(parsed.text);
-		} else if (parsed.toolCalls.length === 0) {
+		if (depth <= 0) {
+			thinking.push(trimmed);
+			continue;
+		}
+		const extracted = extractThinkingXml(trimmed);
+		const nested = parseReasoningHiddenToolCalls(
+			extracted.thinking,
+			tools,
+			depth - 1,
+		);
+		const parsed = parseXmlToolCalls(extracted.text, tools);
+		toolCalls.push(...parsed.toolCalls, ...nested.toolCalls);
+		if (parsed.text) thinking.push(parsed.text);
+		thinking.push(...nested.thinking);
+		if (!parsed.text && parsed.toolCalls.length === 0 && nested.toolCalls.length === 0 && nested.thinking.length === 0) {
 			thinking.push(trimmed);
 		}
 	}
@@ -926,7 +929,7 @@ function parseReasoningToolCalls(
 	if (!reasoning.trim()) return { thinking: [], toolCalls: [] };
 
 	const extracted = extractThinkingXml(reasoning);
-	const hiddenParsed = parseHiddenThoughtToolCalls(extracted.thinking, tools);
+	const hiddenParsed = parseReasoningHiddenToolCalls(extracted.thinking, tools);
 	const parsed = parseXmlToolCalls(extracted.text, tools);
 	const thinking = [...hiddenParsed.thinking];
 	if (parsed.toolCalls.length > 0 && parsed.text) {
@@ -1080,10 +1083,7 @@ type ClineXmlResponseData = {
 function isRetryableClineReasoningStreamError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	const message = error.message.toLowerCase();
-	return (
-		message.includes("stream error occurred") ||
-		(message.includes("reasoning") && message.includes("stream"))
-	);
+	return message.includes("stream error occurred");
 }
 
 async function readClineXmlResponse(
@@ -1111,6 +1111,10 @@ async function readClineXmlResponse(
 		if (choice.finish_reason) finishReason = choice.finish_reason;
 		rawText += choice.delta?.content ?? "";
 		thinking += choice.delta?.reasoning ?? "";
+	}
+
+	if (!rawText.trim() && !thinking.trim()) {
+		throw new Error("Cline returned empty response");
 	}
 
 	return { rawText, thinking, finishReason, usage };
@@ -1303,21 +1307,13 @@ export function streamClineXml(
 
 			assistant.usage = usageFromChunkUsage(usage);
 			const extractedThinking = extractThinkingXml(rawText);
-			const parsedHiddenContent = parseHiddenThoughtToolCalls(
-				extractedThinking.thinking,
-				context.tools,
-			);
 			const parsedReasoning = parseReasoningToolCalls(thinking, context.tools);
 			const parsed = parseXmlToolCalls(extractedThinking.text, context.tools);
 			const output = prepareClineXmlOutput(
 				parsed.text,
-				parsedHiddenContent.thinking,
+				extractedThinking.thinking,
 				parsedReasoning.thinking,
-				[
-					...parsed.toolCalls,
-					...parsedHiddenContent.toolCalls,
-					...parsedReasoning.toolCalls,
-				],
+				[...parsed.toolCalls, ...parsedReasoning.toolCalls],
 			);
 			pushThinking(assistant, output.thinkingText, stream);
 			pushText(assistant, output.visibleText, stream);
@@ -1355,7 +1351,7 @@ export function streamClineXml(
 export const __test__ = {
 	buildClineXmlMessages,
 	isRetryableClineReasoningStreamError,
-	parseHiddenThoughtToolCalls,
+	parseReasoningHiddenToolCalls,
 	parseReasoningToolCalls,
 	parseXmlToolCalls,
 	prepareClineXmlOutput,

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -951,45 +951,6 @@ function parseReasoningToolCalls(
 const INTERNAL_ONLY_RESPONSE =
 	"Cline returned internal reasoning only and did not produce a user-visible response. Please retry or ask it to continue.";
 
-function startsWithAny(value: string, prefixes: string[]): boolean {
-	for (const prefix of prefixes) {
-		if (value.startsWith(prefix)) return true;
-	}
-	return false;
-}
-
-function includesAny(value: string, needles: string[]): boolean {
-	for (const needle of needles) {
-		if (value.includes(needle)) return true;
-	}
-	return false;
-}
-
-function isInternalPlanningArtifact(text: string): boolean {
-	const trimmed = text.trim();
-	if (!trimmed) return false;
-	const lower = trimmed.toLowerCase();
-	return (
-		startsWithAny(lower, [
-			"the user ",
-			"let me ",
-			"i need to ",
-			"i should ",
-			"we need ",
-			"now i ",
-		]) ||
-		includesAny(lower, HIDDEN_THOUGHT_CLOSE_TAGS) ||
-		includesAny(lower, [
-			"the user wants me to",
-			"the user is asking",
-			"the user is prompting",
-			"let me check",
-			"let me update",
-			"let me rewrite",
-		])
-	);
-}
-
 function prepareClineXmlOutput(
 	parsedText: string,
 	contentThinking: string[],
@@ -1004,32 +965,15 @@ function prepareClineXmlOutput(
 		Boolean,
 	);
 	const thinkingText = thinkingParts.join("\n\n");
-	if (
-		toolCalls.length === 0 &&
-		parsedText &&
-		isInternalPlanningArtifact(parsedText)
-	) {
+	if (!parsedText && toolCalls.length === 0 && thinkingText) {
+		// Never return a blank stop, but also do not surface hidden reasoning as
+		// user-visible answer text. If Cline sends only hidden/reasoning content,
+		// show a stable visible fallback and keep the raw content in thinking.
 		return {
 			visibleText: INTERNAL_ONLY_RESPONSE,
-			thinkingText: [thinkingText, parsedText].filter(Boolean).join("\n\n"),
+			thinkingText,
 			toolCalls,
 		};
-	}
-	if (!parsedText && toolCalls.length === 0 && thinkingText) {
-		// Some Cline/DeepSeek responses put the entire assistant answer in the
-		// reasoning stream and send no content/tool XML. Surface answer-like text,
-		// but never leak obvious internal planning as a user-facing response.
-		return isInternalPlanningArtifact(thinkingText)
-			? {
-					visibleText: INTERNAL_ONLY_RESPONSE,
-					thinkingText,
-					toolCalls,
-				}
-			: {
-					visibleText: thinkingText,
-					thinkingText: "",
-					toolCalls,
-				};
 	}
 
 	return {

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -841,9 +841,14 @@ function parseXmlToolCalls(
 		getParseToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
 	);
 	const toolNames = new Set(bridgeByRemoteName.keys());
-	const textWithoutThinking = extractThinkingXml(rawText).text;
+	const extracted = extractThinkingXml(rawText);
+	const textWithoutThinking = extracted.text;
+	const hiddenParsed = parseHiddenThoughtToolCalls(extracted.thinking, tools);
 	if (toolNames.size === 0) {
-		return { text: textWithoutThinking.trim(), toolCalls: [] };
+		return {
+			text: textWithoutThinking.trim(),
+			toolCalls: hiddenParsed.toolCalls,
+		};
 	}
 
 	const sourceText = findNextToolStart(textWithoutThinking, toolNames, 0)
@@ -888,7 +893,30 @@ function parseXmlToolCalls(
 	}
 
 	pushTextFragment(textParts, sourceText.slice(cursor));
-	return { text: textParts.join("\n\n").trim(), toolCalls };
+	return {
+		text: textParts.join("\n\n").trim(),
+		toolCalls: [...toolCalls, ...hiddenParsed.toolCalls],
+	};
+}
+
+function parseHiddenThoughtToolCalls(
+	thinkingParts: string[],
+	tools: Tool[] | undefined,
+): { thinking: string[]; toolCalls: ParsedToolCalls["toolCalls"] } {
+	const thinking: string[] = [];
+	const toolCalls: ParsedToolCalls["toolCalls"] = [];
+	for (const part of thinkingParts) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		const parsed = parseXmlToolCalls(trimmed, tools);
+		toolCalls.push(...parsed.toolCalls);
+		if (parsed.text) {
+			thinking.push(parsed.text);
+		} else if (parsed.toolCalls.length === 0) {
+			thinking.push(trimmed);
+		}
+	}
+	return { thinking, toolCalls };
 }
 
 function parseReasoningToolCalls(
@@ -898,15 +926,23 @@ function parseReasoningToolCalls(
 	if (!reasoning.trim()) return { thinking: [], toolCalls: [] };
 
 	const extracted = extractThinkingXml(reasoning);
+	const hiddenParsed = parseHiddenThoughtToolCalls(extracted.thinking, tools);
 	const parsed = parseXmlToolCalls(extracted.text, tools);
-	const thinking = [...extracted.thinking];
+	const thinking = [...hiddenParsed.thinking];
 	if (parsed.toolCalls.length > 0 && parsed.text) {
 		thinking.push(parsed.text);
-	} else if (parsed.toolCalls.length === 0 && extracted.thinking.length === 0) {
+	} else if (
+		parsed.toolCalls.length === 0 &&
+		hiddenParsed.thinking.length === 0 &&
+		extracted.thinking.length === 0
+	) {
 		thinking.push(reasoning.trim());
 	}
 
-	return { thinking, toolCalls: parsed.toolCalls };
+	return {
+		thinking,
+		toolCalls: [...parsed.toolCalls, ...hiddenParsed.toolCalls],
+	};
 }
 
 const INTERNAL_ONLY_RESPONSE =
@@ -1267,13 +1303,21 @@ export function streamClineXml(
 
 			assistant.usage = usageFromChunkUsage(usage);
 			const extractedThinking = extractThinkingXml(rawText);
+			const parsedHiddenContent = parseHiddenThoughtToolCalls(
+				extractedThinking.thinking,
+				context.tools,
+			);
 			const parsedReasoning = parseReasoningToolCalls(thinking, context.tools);
 			const parsed = parseXmlToolCalls(extractedThinking.text, context.tools);
 			const output = prepareClineXmlOutput(
 				parsed.text,
-				extractedThinking.thinking,
+				parsedHiddenContent.thinking,
 				parsedReasoning.thinking,
-				[...parsed.toolCalls, ...parsedReasoning.toolCalls],
+				[
+					...parsed.toolCalls,
+					...parsedHiddenContent.toolCalls,
+					...parsedReasoning.toolCalls,
+				],
 			);
 			pushThinking(assistant, output.thinkingText, stream);
 			pushText(assistant, output.visibleText, stream);
@@ -1311,6 +1355,7 @@ export function streamClineXml(
 export const __test__ = {
 	buildClineXmlMessages,
 	isRetryableClineReasoningStreamError,
+	parseHiddenThoughtToolCalls,
 	parseReasoningToolCalls,
 	parseXmlToolCalls,
 	prepareClineXmlOutput,

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -663,56 +663,98 @@ function pushTextFragment(textParts: string[], fragment: string): void {
 	textParts.push(trimmed);
 }
 
+type HiddenThoughtTag = {
+	open: string;
+	closes: string[];
+};
+
+const HIDDEN_THOUGHT_TAGS: HiddenThoughtTag[] = [
+	{ open: "<thinking>", closes: ["</thinking>"] },
+	// Some DeepSeek/Cline variants open with <think> but close with </thinking>.
+	{ open: "<think>", closes: ["</think>", "</thinking>"] },
+	// Compaction/summary artifacts can leak into Cline content as </summary>.
+	{ open: "<summary>", closes: ["</summary>"] },
+	// Cline may emit persistent issue-checking as hidden deliberation.
+	{
+		open: "<persistent_issue_checking>",
+		closes: ["</persistent_issue_checking>"],
+	},
+];
+
+const HIDDEN_THOUGHT_CLOSE_TAGS = Array.from(
+	new Set(HIDDEN_THOUGHT_TAGS.flatMap((tag) => tag.closes)),
+);
+
+function findNextHiddenOpenTag(
+	text: string,
+	from: number,
+): { index: number; tag: HiddenThoughtTag } | null {
+	let best: { index: number; tag: HiddenThoughtTag } | null = null;
+	for (const tag of HIDDEN_THOUGHT_TAGS) {
+		const index = text.indexOf(tag.open, from);
+		if (index === -1) continue;
+		if (!best || index < best.index) best = { index, tag };
+	}
+	return best;
+}
+
+function findNextCloseTag(
+	text: string,
+	from: number,
+	closeTags: string[],
+): { index: number; tag: string } | null {
+	let best: { index: number; tag: string } | null = null;
+	for (const tag of closeTags) {
+		const index = text.indexOf(tag, from);
+		if (index === -1) continue;
+		if (!best || index < best.index) best = { index, tag };
+	}
+	return best;
+}
+
 function extractThinkingXml(text: string): {
 	text: string;
 	thinking: string[];
 } {
 	const thinking: string[] = [];
 	const parts: string[] = [];
-	const openTags = ["<thinking>", "<think>"];
-	const closeTag = "</thinking>";
 	let cursor = 0;
 
-	function findNextOpenTag(
-		from: number,
-	): { index: number; tag: string } | null {
-		let best: { index: number; tag: string } | null = null;
-		for (const tag of openTags) {
-			const index = text.indexOf(tag, from);
-			if (index === -1) continue;
-			if (!best || index < best.index) best = { index, tag };
-		}
-		return best;
-	}
-
 	while (cursor < text.length) {
-		const nextOpen = findNextOpenTag(cursor);
+		const nextOpen = findNextHiddenOpenTag(text, cursor);
 		const openStart = nextOpen?.index ?? -1;
-		const closeStart = text.indexOf(closeTag, cursor);
+		const nextClose = findNextCloseTag(text, cursor, HIDDEN_THOUGHT_CLOSE_TAGS);
+		const closeStart = nextClose?.index ?? -1;
 
-		if (closeStart !== -1 && (openStart === -1 || closeStart < openStart)) {
+		if (nextClose && (openStart === -1 || closeStart < openStart)) {
 			const danglingThinking = decodeXmlEntities(
 				text.slice(cursor, closeStart).trim(),
 			);
 			if (danglingThinking) thinking.push(danglingThinking);
-			cursor = closeStart + closeTag.length;
+			cursor = closeStart + nextClose.tag.length;
 			continue;
 		}
 
 		if (openStart === -1 || !nextOpen) break;
 		parts.push(text.slice(cursor, openStart));
-		const valueStart = openStart + nextOpen.tag.length;
-		const valueEnd = text.indexOf(closeTag, valueStart);
-		if (valueEnd === -1) {
+		const valueStart = openStart + nextOpen.tag.open.length;
+		const nextValueClose = findNextCloseTag(
+			text,
+			valueStart,
+			nextOpen.tag.closes,
+		);
+		if (!nextValueClose) {
 			const value = decodeXmlEntities(text.slice(valueStart).trim());
 			if (value) thinking.push(value);
 			cursor = text.length;
 			break;
 		}
 
-		const value = decodeXmlEntities(text.slice(valueStart, valueEnd).trim());
+		const value = decodeXmlEntities(
+			text.slice(valueStart, nextValueClose.index).trim(),
+		);
 		if (value) thinking.push(value);
-		cursor = valueEnd + closeTag.length;
+		cursor = nextValueClose.index + nextValueClose.tag.length;
 	}
 
 	if (cursor === 0) {
@@ -867,27 +909,89 @@ function parseReasoningToolCalls(
 	return { thinking, toolCalls: parsed.toolCalls };
 }
 
+const INTERNAL_ONLY_RESPONSE =
+	"Cline returned internal reasoning only and did not produce a user-visible response. Please retry or ask it to continue.";
+
+function startsWithAny(value: string, prefixes: string[]): boolean {
+	for (const prefix of prefixes) {
+		if (value.startsWith(prefix)) return true;
+	}
+	return false;
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+	for (const needle of needles) {
+		if (value.includes(needle)) return true;
+	}
+	return false;
+}
+
+function isInternalPlanningArtifact(text: string): boolean {
+	const trimmed = text.trim();
+	if (!trimmed) return false;
+	const lower = trimmed.toLowerCase();
+	return (
+		startsWithAny(lower, [
+			"the user ",
+			"let me ",
+			"i need to ",
+			"i should ",
+			"we need ",
+			"now i ",
+		]) ||
+		includesAny(lower, HIDDEN_THOUGHT_CLOSE_TAGS) ||
+		includesAny(lower, [
+			"the user wants me to",
+			"the user is asking",
+			"the user is prompting",
+			"let me check",
+			"let me update",
+			"let me rewrite",
+		])
+	);
+}
+
 function prepareClineXmlOutput(
 	parsedText: string,
 	contentThinking: string[],
 	reasoningThinking: string[],
 	toolCalls: ParsedToolCalls["toolCalls"],
-): { visibleText: string; thinkingText: string; toolCalls: ParsedToolCalls["toolCalls"] } {
-	const thinkingParts = [...reasoningThinking, ...contentThinking].filter(Boolean);
-	if (!parsedText && toolCalls.length === 0 && thinkingParts.length > 0) {
-		// Some Cline/DeepSeek responses put the entire assistant answer in the
-		// reasoning stream and send no content/tool XML. Hiding that would produce
-		// a blank `stop` turn, so surface it as a best-effort visible response.
+): {
+	visibleText: string;
+	thinkingText: string;
+	toolCalls: ParsedToolCalls["toolCalls"];
+} {
+	const thinkingParts = [...reasoningThinking, ...contentThinking].filter(
+		Boolean,
+	);
+	const thinkingText = thinkingParts.join("\n\n");
+	if (toolCalls.length === 0 && parsedText && isInternalPlanningArtifact(parsedText)) {
 		return {
-			visibleText: thinkingParts.join("\n\n"),
-			thinkingText: "",
+			visibleText: INTERNAL_ONLY_RESPONSE,
+			thinkingText: [thinkingText, parsedText].filter(Boolean).join("\n\n"),
 			toolCalls,
 		};
+	}
+	if (!parsedText && toolCalls.length === 0 && thinkingText) {
+		// Some Cline/DeepSeek responses put the entire assistant answer in the
+		// reasoning stream and send no content/tool XML. Surface answer-like text,
+		// but never leak obvious internal planning as a user-facing response.
+		return isInternalPlanningArtifact(thinkingText)
+			? {
+					visibleText: INTERNAL_ONLY_RESPONSE,
+					thinkingText,
+					toolCalls,
+				}
+			: {
+					visibleText: thinkingText,
+					thinkingText: "",
+					toolCalls,
+				};
 	}
 
 	return {
 		visibleText: parsedText,
-		thinkingText: thinkingParts.join("\n\n"),
+		thinkingText,
 		toolCalls,
 	};
 }
@@ -923,6 +1027,110 @@ async function* parseSse(response: Response): AsyncGenerator<ClineXmlChunk> {
 			if (!data || data === "[DONE]") continue;
 			yield JSON.parse(data) as ClineXmlChunk;
 		}
+	}
+}
+
+type ClineXmlResponseData = {
+	rawText: string;
+	thinking: string;
+	finishReason: string | null | undefined;
+	usage: ClineXmlChunk["usage"] | undefined;
+};
+
+function isRetryableClineReasoningStreamError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message.toLowerCase();
+	return (
+		message.includes("stream error occurred") ||
+		message.includes("reasoning") && message.includes("stream")
+	);
+}
+
+async function readClineXmlResponse(
+	response: Response,
+): Promise<ClineXmlResponseData> {
+	let rawText = "";
+	let thinking = "";
+	let finishReason: string | null | undefined;
+	let usage: ClineXmlChunk["usage"] | undefined;
+
+	for await (const chunk of parseSse(response)) {
+		if (chunk.error) {
+			throw new Error(
+				`${chunk.error.code ?? "cline_error"}: ${chunk.error.message ?? "Unknown Cline error"}`,
+			);
+		}
+		if (chunk.usage) usage = chunk.usage;
+		const choice = chunk.choices?.[0];
+		if (!choice) continue;
+		if (choice.error) {
+			throw new Error(
+				`${choice.error.code ?? "cline_error"}: ${choice.error.message ?? "Unknown Cline error"}`,
+			);
+		}
+		if (choice.finish_reason) finishReason = choice.finish_reason;
+		rawText += choice.delta?.content ?? "";
+		thinking += choice.delta?.reasoning ?? "";
+	}
+
+	return { rawText, thinking, finishReason, usage };
+}
+
+async function fetchClineXmlResponse(
+	model: Model<string>,
+	context: Context,
+	options: SimpleStreamOptions,
+	headers: Record<string, string>,
+	includeReasoning: boolean,
+): Promise<ClineXmlResponseData> {
+	const response = await fetch(`${BASE_URL_CLINE}/chat/completions`, {
+		method: "POST",
+		headers: {
+			...headers,
+			Authorization: `Bearer ${options.apiKey}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			model: normalizeApiModelId(model.id),
+			temperature: 0,
+			messages: buildClineXmlMessages(context),
+			stream: true,
+			stream_options: { include_usage: true },
+			...(includeReasoning ? { include_reasoning: true } : {}),
+		}),
+		signal: options.signal,
+	});
+	await options.onResponse?.(
+		{
+			status: response.status,
+			headers: Object.fromEntries(response.headers.entries()),
+		},
+		model,
+	);
+
+	if (!response.ok) {
+		throw new Error(`Cline API error ${response.status}: ${await response.text()}`);
+	}
+
+	return readClineXmlResponse(response);
+}
+
+async function fetchClineXmlResponseWithReasoningFallback(
+	model: Model<string>,
+	context: Context,
+	options: SimpleStreamOptions,
+	headers: Record<string, string>,
+): Promise<ClineXmlResponseData> {
+	try {
+		return await fetchClineXmlResponse(model, context, options, headers, true);
+	} catch (error) {
+		if (
+			options.signal?.aborted ||
+			!isRetryableClineReasoningStreamError(error)
+		) {
+			throw error;
+		}
+		return fetchClineXmlResponse(model, context, options, headers, false);
 	}
 }
 
@@ -1043,60 +1251,13 @@ export function streamClineXml(
 				throw new Error("No Cline access token found. Run /login cline first.");
 			}
 
-			const response = await fetch(`${BASE_URL_CLINE}/chat/completions`, {
-				method: "POST",
-				headers: {
-					...headers,
-					Authorization: `Bearer ${options.apiKey}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					model: normalizeApiModelId(model.id),
-					temperature: 0,
-					messages: buildClineXmlMessages(context),
-					stream: true,
-					stream_options: { include_usage: true },
-					include_reasoning: true,
-				}),
-				signal: options.signal,
-			});
-			await options.onResponse?.(
-				{
-					status: response.status,
-					headers: Object.fromEntries(response.headers.entries()),
-				},
-				model,
-			);
-
-			if (!response.ok) {
-				throw new Error(
-					`Cline API error ${response.status}: ${await response.text()}`,
+			const { rawText, thinking, finishReason, usage } =
+				await fetchClineXmlResponseWithReasoningFallback(
+					model,
+					context,
+					options,
+					headers,
 				);
-			}
-
-			let rawText = "";
-			let thinking = "";
-			let finishReason: string | null | undefined;
-			let usage: ClineXmlChunk["usage"] | undefined;
-
-			for await (const chunk of parseSse(response)) {
-				if (chunk.error) {
-					throw new Error(
-						`${chunk.error.code ?? "cline_error"}: ${chunk.error.message ?? "Unknown Cline error"}`,
-					);
-				}
-				if (chunk.usage) usage = chunk.usage;
-				const choice = chunk.choices?.[0];
-				if (!choice) continue;
-				if (choice.error) {
-					throw new Error(
-						`${choice.error.code ?? "cline_error"}: ${choice.error.message ?? "Unknown Cline error"}`,
-					);
-				}
-				if (choice.finish_reason) finishReason = choice.finish_reason;
-				rawText += choice.delta?.content ?? "";
-				thinking += choice.delta?.reasoning ?? "";
-			}
 
 			assistant.usage = usageFromChunkUsage(usage);
 			const extractedThinking = extractThinkingXml(rawText);
@@ -1143,6 +1304,7 @@ export function streamClineXml(
 
 export const __test__ = {
 	buildClineXmlMessages,
+	isRetryableClineReasoningStreamError,
 	parseReasoningToolCalls,
 	parseXmlToolCalls,
 	prepareClineXmlOutput,

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -202,7 +202,7 @@ describe("Cline XML bridge", () => {
 			expect(parsed.toolCalls).toEqual([]);
 		});
 
-		it("recovers tool calls inside hidden summary wrappers", () => {
+		it("does not execute tool calls hidden in visible summary wrappers", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
 					"<summary>",
@@ -216,12 +216,10 @@ describe("Cline XML bridge", () => {
 			);
 
 			expect(parsed.text).toBe("");
-			expect(parsed.toolCalls).toEqual([
-				{ name: "read", arguments: { path: "README.md" } },
-			]);
+			expect(parsed.toolCalls).toEqual([]);
 		});
 
-		it("recovers tool calls inside hidden persistent issue wrappers", () => {
+		it("does not execute tool calls hidden in visible persistent issue wrappers", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
 					"<persistent_issue_checking>",
@@ -235,13 +233,11 @@ describe("Cline XML bridge", () => {
 			);
 
 			expect(parsed.text).toBe("");
-			expect(parsed.toolCalls).toEqual([
-				{ name: "bash", arguments: { command: "npm run check" } },
-			]);
+			expect(parsed.toolCalls).toEqual([]);
 		});
 
-		it("keeps non-tool text from hidden wrappers hidden after recovering tools", () => {
-			const parsed = __test__.parseHiddenThoughtToolCalls(
+		it("recovers tool calls inside reasoning-channel hidden wrappers", () => {
+			const parsed = __test__.parseReasoningHiddenToolCalls(
 				[
 					[
 						"The user wants me to inspect the file first.",

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -558,43 +558,22 @@ describe("Cline XML bridge", () => {
 	});
 
 	describe("prepareClineXmlOutput", () => {
-		it("surfaces answer-like reasoning-only Cline responses instead of returning a blank stop", () => {
-			const output = __test__.prepareClineXmlOutput(
-				"",
-				[],
-				[
-					"Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch.",
-				],
-				[],
-			);
+		it("returns a visible fallback for reasoning-only Cline responses instead of blank stopping", () => {
+			const reasoning =
+				"Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch.";
+			const output = __test__.prepareClineXmlOutput("", [], [reasoning], []);
 
-			expect(output).toEqual({
-				visibleText:
-					"Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch.",
-				thinkingText: "",
-				toolCalls: [],
-			});
+			expect(output.visibleText).toContain(
+				"Cline returned internal reasoning only",
+			);
+			expect(output.thinkingText).toBe(reasoning);
+			expect(output.toolCalls).toEqual([]);
 		});
 
 		it("does not surface internal planning from reasoning-only Cline responses", () => {
 			const internal =
 				"The user is prompting me to continue. Let me respond with my thoughts on this UX design.";
 			const output = __test__.prepareClineXmlOutput("", [], [internal], []);
-
-			expect(output.visibleText).toContain(
-				"Cline returned internal reasoning only",
-			);
-			expect(output.thinkingText).toBe(internal);
-			expect(output.toolCalls).toEqual([]);
-		});
-
-		it("does not surface visible text that is actually internal Cline planning", () => {
-			const internal = [
-				"The user makes a good point about worker diversity - each worker should come from a different provider.",
-				"Let me also fix the biome issues and the empty catch blocks.",
-				"</summary>",
-			].join("\n\n");
-			const output = __test__.prepareClineXmlOutput(internal, [], [], []);
 
 			expect(output.visibleText).toContain(
 				"Cline returned internal reasoning only",

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -507,7 +507,9 @@ describe("Cline XML bridge", () => {
 			const output = __test__.prepareClineXmlOutput(
 				"",
 				[],
-				["Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch."],
+				[
+					"Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch.",
+				],
 				[],
 			);
 

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -202,6 +202,65 @@ describe("Cline XML bridge", () => {
 			expect(parsed.toolCalls).toEqual([]);
 		});
 
+		it("recovers tool calls inside hidden summary wrappers", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<summary>",
+					"The user wants me to inspect the file first.",
+					"<read_file>",
+					"<path>README.md</path>",
+					"</read_file>",
+					"</summary>",
+				].join("\n"),
+				[tool("read")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{ name: "read", arguments: { path: "README.md" } },
+			]);
+		});
+
+		it("recovers tool calls inside hidden persistent issue wrappers", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<persistent_issue_checking>",
+					"Let me fix the formatter issues now.",
+					"<execute_command>",
+					"<command>npm run check</command>",
+					"</execute_command>",
+					"</persistent_issue_checking>",
+				].join("\n"),
+				[tool("bash")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([
+				{ name: "bash", arguments: { command: "npm run check" } },
+			]);
+		});
+
+		it("keeps non-tool text from hidden wrappers hidden after recovering tools", () => {
+			const parsed = __test__.parseHiddenThoughtToolCalls(
+				[
+					[
+						"The user wants me to inspect the file first.",
+						"<read_file>",
+						"<path>README.md</path>",
+						"</read_file>",
+					].join("\n"),
+				],
+				[tool("read")],
+			);
+
+			expect(parsed.thinking).toEqual([
+				"The user wants me to inspect the file first.",
+			]);
+			expect(parsed.toolCalls).toEqual([
+				{ name: "read", arguments: { path: "README.md" } },
+			]);
+		});
+
 		it("treats DeepSeek-style <think> block content as thinking", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -1,6 +1,9 @@
-import type { Tool } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
-import { __test__ } from "../providers/cline/cline-xml-bridge.ts";
+import type { Context, Model, Tool } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	__test__,
+	streamClineXml,
+} from "../providers/cline/cline-xml-bridge.ts";
 
 function tool(name: string): Tool {
 	return {
@@ -9,6 +12,45 @@ function tool(name: string): Tool {
 		parameters: { type: "object", properties: {} } as Tool["parameters"],
 	};
 }
+
+function clineModel(id = "xiaomi/mimo-v2.5"): Model<string> {
+	return {
+		id,
+		name: id,
+		api: "cline-xml-tools",
+		provider: "cline",
+	} as Model<string>;
+}
+
+function clineContext(): Context {
+	return {
+		systemPrompt: "system",
+		messages: [
+			{
+				role: "user",
+				content: [{ type: "text", text: "continue" }],
+				timestamp: 1,
+			},
+		],
+		tools: [tool("read")],
+	};
+}
+
+function sseResponse(chunks: unknown[], status = 200): Response {
+	const body = `${chunks
+		.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+		.join("")}data: [DONE]\n\n`;
+	return new Response(body, { status });
+}
+
+function requestBody(fetchMock: ReturnType<typeof vi.spyOn>, index: number) {
+	const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined;
+	return JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("Cline XML bridge", () => {
 	describe("parseXmlToolCalls", () => {
@@ -536,6 +578,70 @@ describe("Cline XML bridge", () => {
 			expect(parsed.toolCalls[0]?.name).toBe("bash");
 			expect(parsed.toolCalls[0]?.arguments.command).toContain("rg -n");
 			expect(parsed.toolCalls[0]?.arguments.command).toContain("'providers'");
+		});
+	});
+
+	describe("streamClineXml", () => {
+		it("retries MiMo generic stream errors once without include_reasoning", async () => {
+			const fetchMock = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValueOnce(
+					sseResponse([
+						{
+							error: {
+								code: "error",
+								message: "Stream error occurred",
+							},
+						},
+					]),
+				)
+				.mockResolvedValueOnce(
+					sseResponse([
+						{
+							choices: [
+								{
+									delta: { content: "Recovered without reasoning" },
+									finish_reason: "stop",
+								},
+							],
+						},
+					]),
+				);
+
+			const stream = streamClineXml(
+				clineModel(),
+				clineContext(),
+				{ apiKey: "token" },
+				{},
+			);
+			const result = await stream.result();
+
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			expect(requestBody(fetchMock, 0).include_reasoning).toBe(true);
+			expect(requestBody(fetchMock, 1)).not.toHaveProperty(
+				"include_reasoning",
+			);
+			expect(result.stopReason).toBe("stop");
+			expect(result.content).toContainEqual({
+				type: "text",
+				text: "Recovered without reasoning",
+			});
+		});
+
+		it("returns an error instead of a blank stop when Cline streams no content", async () => {
+			vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(sseResponse([]));
+
+			const stream = streamClineXml(
+				clineModel(),
+				clineContext(),
+				{ apiKey: "token" },
+				{},
+			);
+			const result = await stream.result();
+
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toBe("Cline returned empty response");
+			expect(result.content).toEqual([]);
 		});
 	});
 

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -174,6 +174,34 @@ describe("Cline XML bridge", () => {
 			expect(parsed.toolCalls).toEqual([]);
 		});
 
+		it("treats plain text before dangling summary close as hidden thinking", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"The user makes a good point about worker diversity.",
+					"Let me check if the diversePanel function already handles this.",
+					"</summary>",
+				].join("\n"),
+				[tool("edit"), tool("write")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([]);
+		});
+
+		it("treats plain text before dangling persistent issue close as hidden thinking", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"The user wants me to continue. Let me fix the issues found by the diagnostics.",
+					"The main things to fix are remove unused imports and fix empty catch blocks.",
+					"</persistent_issue_checking>",
+				].join("\n"),
+				[tool("edit"), tool("write")],
+			);
+
+			expect(parsed.text).toBe("");
+			expect(parsed.toolCalls).toEqual([]);
+		});
+
 		it("treats DeepSeek-style <think> block content as thinking", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
@@ -456,23 +484,66 @@ describe("Cline XML bridge", () => {
 		});
 	});
 
+	describe("isRetryableClineReasoningStreamError", () => {
+		it("retries generic Cline stream errors without reasoning", () => {
+			expect(
+				__test__.isRetryableClineReasoningStreamError(
+					new Error("error: Stream error occurred"),
+				),
+			).toBe(true);
+		});
+
+		it("does not retry quota or auth errors", () => {
+			expect(
+				__test__.isRetryableClineReasoningStreamError(
+					new Error("Cline API error 429: Daily free limit reached"),
+				),
+			).toBe(false);
+		});
+	});
+
 	describe("prepareClineXmlOutput", () => {
-		it("surfaces reasoning-only Cline responses instead of returning a blank stop", () => {
+		it("surfaces answer-like reasoning-only Cline responses instead of returning a blank stop", () => {
 			const output = __test__.prepareClineXmlOutput(
 				"",
 				[],
-				[
-					"The user is prompting me to continue. Let me respond with my thoughts on this UX design.",
-				],
+				["Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch."],
 				[],
 			);
 
 			expect(output).toEqual({
 				visibleText:
-					"The user is prompting me to continue. Let me respond with my thoughts on this UX design.",
+					"Yes — that UX matches. Keep `/toggle-plegma` as the simple activation switch.",
 				thinkingText: "",
 				toolCalls: [],
 			});
+		});
+
+		it("does not surface internal planning from reasoning-only Cline responses", () => {
+			const internal =
+				"The user is prompting me to continue. Let me respond with my thoughts on this UX design.";
+			const output = __test__.prepareClineXmlOutput("", [], [internal], []);
+
+			expect(output.visibleText).toContain(
+				"Cline returned internal reasoning only",
+			);
+			expect(output.thinkingText).toBe(internal);
+			expect(output.toolCalls).toEqual([]);
+		});
+
+		it("does not surface visible text that is actually internal Cline planning", () => {
+			const internal = [
+				"The user makes a good point about worker diversity - each worker should come from a different provider.",
+				"Let me also fix the biome issues and the empty catch blocks.",
+				"</summary>",
+			].join("\n\n");
+			const output = __test__.prepareClineXmlOutput(internal, [], [], []);
+
+			expect(output.visibleText).toContain(
+				"Cline returned internal reasoning only",
+			);
+			expect(output.thinkingText).toBe(internal);
+			expect(output.toolCalls).toEqual([]);
 		});
 
 		it("keeps reasoning hidden when visible text is present", () => {

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -720,6 +720,40 @@ describe("Cline XML bridge", () => {
 		});
 	});
 
+	describe("normalizeDecoratedXmlTags", () => {
+		it("strips Unicode math-italic prefixes from MiMo/Cline thinking tags", () => {
+			const input =
+				"<\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>\nLet me read the file.\n</\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>";
+			const result = __test__.normalizeDecoratedXmlTags(input);
+			expect(result).toContain("<thinking>");
+			expect(result).toContain("</thinking>");
+			expect(result).not.toContain("\u{1D41A}");
+		});
+
+		it("strips Unicode math-italic prefixes from MiMo/Cline tool tags", () => {
+			const input =
+				"<\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:read_file>\n<path>README.md</path>\n</\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:read_file>";
+			const result = __test__.normalizeDecoratedXmlTags(input);
+			expect(result).toContain("<read_file>");
+			expect(result).toContain("</read_file>");
+			expect(result).not.toContain("\u{1D41A}");
+		});
+
+		it("leaves normal ASCII XML tags unchanged", () => {
+			const input =
+				"<thinking>\nLet me read the file.\n</thinking>\n<read_file>\n<path>README.md</path>\n</read_file>";
+			expect(__test__.normalizeDecoratedXmlTags(input)).toBe(input);
+		});
+
+		it("handles mixed decorated and plain tags", () => {
+			const input = "<\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>plan</\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>\n<read_file>\n<path>x</path>\n</read_file>";
+			const result = __test__.normalizeDecoratedXmlTags(input);
+			expect(result).toContain("<thinking>");
+			expect(result).toContain("<read_file>");
+			expect(result).not.toContain("\u{1D41A}");
+		});
+	});
+
 	describe("buildClineXmlMessages", () => {
 		it("advertises Pi edit as Cline replace_in_file with SEARCH/REPLACE format", () => {
 			const messages = __test__.buildClineXmlMessages({


### PR DESCRIPTION
## Summary
- treat dangling Cline hidden wrappers like </summary> and </persistent_issue_checking> as hidden thinking artifacts
- avoid surfacing obvious internal planning text as visible assistant output; show a safe fallback instead
- retry generic Cline `Stream error occurred` failures once without `include_reasoning`, which may help MiMo/xiaomi streams when reasoning SSE is unstable

## Session evidence
Session `019ec7e5-ef25-7e6a-8773-7e6c632e8661` showed:
- visible internal planning ending in `</summary>`
- hidden planning ending in `</persistent_issue_checking>`
- after switching to `cline/xiaomi/mimo-v2.5`, `error: Stream error occurred`

## Validation
- `npx vitest run tests/cline-xml-bridge.test.ts --reporter=dot` (31 passed)
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files
- `git diff --check`