### PR TITLE
fix(tokenrouter): retry high-load 2064 errors

### DIFF
--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -19,13 +19,17 @@ import type {
 import type {
 	Api,
 	AssistantMessage,
+	AssistantMessageEvent,
 	AssistantMessageEventStream,
 	Context,
 	Model,
 	SimpleStreamOptions,
 	ThinkingContent,
 } from "@earendil-works/pi-ai";
-import { streamSimpleOpenAICompletions } from "@earendil-works/pi-ai";
+import {
+	createAssistantMessageEventStream,
+	streamSimpleOpenAICompletions,
+} from "@earendil-works/pi-ai";
 import {
 	getTokenrouterApiKey,
 	getTokenrouterShowPaid,
@@ -115,6 +119,7 @@ function isTokenRouterModel(model: { provider?: string }): boolean {
 const MINIMAX_M3_ID = "MiniMax-M3";
 const KNOWN_FREE_MODELS = new Set([MINIMAX_M3_ID]);
 const TOKENROUTER_OPENAI_API = "tokenrouter-openai-completions" as const;
+const TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS = 30_000;
 const MINIMAX_ADAPTIVE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
 	...DEEPSEEK_PROXY_COMPAT,
 	thinkingFormat: "deepseek",
@@ -282,10 +287,50 @@ export function patchTokenRouterMinimaxThinkingPayload(
 	return result.changed ? result.value : payload;
 }
 
-export function streamSimpleTokenRouter(
+function isTokenRouterHighLoadError(message: string | undefined): boolean {
+	const lower = (message ?? "").toLowerCase();
+	return (
+		lower.includes("(2064)") ||
+		lower.includes("server cluster is currently under high load")
+	);
+}
+
+function isOutputEvent(event: AssistantMessageEvent): boolean {
+	return (
+		event.type === "text_start" ||
+		event.type === "text_delta" ||
+		event.type === "text_end" ||
+		event.type === "thinking_start" ||
+		event.type === "thinking_delta" ||
+		event.type === "thinking_end" ||
+		event.type === "toolcall_start" ||
+		event.type === "toolcall_delta" ||
+		event.type === "toolcall_end"
+	);
+}
+
+function waitForTokenRouterRetry(
+	ms: number,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	if (signal?.aborted) return Promise.reject(new Error("aborted"));
+	return new Promise((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timeout);
+			reject(new Error("aborted"));
+		};
+		const timeout = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+function createTokenRouterOpenAIStream(
 	model: Model<Api>,
 	context: Context,
-	options?: SimpleStreamOptions,
+	options: SimpleStreamOptions | undefined,
 ): AssistantMessageEventStream {
 	const forcePatch = isTokenRouterMinimaxModel(model.id);
 	return streamSimpleOpenAICompletions(
@@ -310,6 +355,120 @@ export function streamSimpleTokenRouter(
 		},
 	);
 }
+
+function createTokenRouterRetryErrorMessage(
+	model: Model<Api>,
+	options: SimpleStreamOptions | undefined,
+	error: unknown,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: options?.signal?.aborted ? "aborted" : "error",
+		errorMessage: error instanceof Error ? error.message : String(error),
+		timestamp: Date.now(),
+	};
+}
+
+function streamWithTokenRouterHighLoadRetry(
+	model: Model<Api>,
+	createAttempt: () => AssistantMessageEventStream,
+	options: SimpleStreamOptions | undefined,
+): AssistantMessageEventStream {
+	const output = createAssistantMessageEventStream();
+
+	void (async () => {
+		const buffer: AssistantMessageEvent[] = [];
+		let flushed = false;
+		let sawOutput = false;
+
+		function flushBuffer(): void {
+			if (flushed) return;
+			flushed = true;
+			for (const event of buffer) output.push(event);
+			buffer.length = 0;
+		}
+
+		try {
+			const first = createAttempt();
+			let retryAfterHighLoad = false;
+			for await (const event of first) {
+				if (isOutputEvent(event)) {
+					sawOutput = true;
+					flushBuffer();
+					output.push(event);
+					continue;
+				}
+
+				if (
+					event.type === "error" &&
+					!sawOutput &&
+					isTokenRouterHighLoadError(event.error.errorMessage)
+				) {
+					retryAfterHighLoad = true;
+					break;
+				}
+
+				if (flushed) output.push(event);
+				else buffer.push(event);
+			}
+
+			if (!retryAfterHighLoad) {
+				flushBuffer();
+				return;
+			}
+
+			_logger.warn(
+				"[tokenrouter] Server cluster high load (2064); retrying once after 30s",
+			);
+			await waitForTokenRouterRetry(
+				TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS,
+				options?.signal,
+			);
+			for await (const event of createAttempt()) output.push(event);
+		} catch (error) {
+			flushBuffer();
+			const message = createTokenRouterRetryErrorMessage(model, options, error);
+			output.push({
+				type: "error",
+				reason: message.stopReason as "error" | "aborted",
+				error: message,
+			});
+		}
+	})();
+
+	return output;
+}
+
+export function streamSimpleTokenRouter(
+	model: Model<Api>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	return streamWithTokenRouterHighLoadRetry(
+		model,
+		() => createTokenRouterOpenAIStream(model, context, options),
+		options,
+	);
+}
+
+export const __test__ = {
+	TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS,
+	isTokenRouterHighLoadError,
+	streamWithTokenRouterHighLoadRetry,
+	waitForTokenRouterRetry,
+};
 
 export function mapTokenRouterModel(
 	model: TokenRouterModel,

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -1,12 +1,76 @@
-import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { isFreeModel } from "../lib/registry.ts";
 import {
+	__test__,
 	finalizeTokenRouterModel,
 	mapTokenRouterModel,
 	normalizeAssistantMessage,
 	patchTokenRouterMinimaxThinkingPayload,
 	streamSimpleTokenRouter,
 } from "../providers/tokenrouter/tokenrouter.ts";
+
+function tokenRouterTestModel(): Model<string> {
+	return {
+		id: "MiniMax-M3",
+		name: "MiniMax-M3",
+		provider: "tokenrouter",
+		api: "tokenrouter-openai-completions",
+	} as Model<string>;
+}
+
+function assistantMessage(
+	stopReason: AssistantMessage["stopReason"],
+	errorMessage?: string,
+	content: AssistantMessage["content"] = [],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "tokenrouter-openai-completions",
+		provider: "tokenrouter",
+		model: "MiniMax-M3",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+function errorAttempt(message: string) {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const error = assistantMessage("error", message);
+		stream.push({ type: "start", partial: error });
+		stream.push({ type: "error", reason: "error", error });
+	});
+	return stream;
+}
+
+function textAttempt(text: string) {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message = assistantMessage("stop", undefined, [{ type: "text", text }]);
+		stream.push({ type: "start", partial: { ...message, content: [] } });
+		stream.push({ type: "text_start", contentIndex: 0, partial: message });
+		stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: message });
+		stream.push({ type: "text_end", contentIndex: 0, content: text, partial: message });
+		stream.push({ type: "done", reason: "stop", message });
+	});
+	return stream;
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("TokenRouter free model detection", () => {
 	const freeModel = {
@@ -204,6 +268,75 @@ describe("TokenRouter free model detection", () => {
 			reasoning_effort: "high",
 		});
 		expect(JSON.stringify(capturedPayload)).not.toContain('"enabled"');
+	});
+
+	it("retries TokenRouter high-load 2064 errors once after 30 seconds", async () => {
+		vi.useFakeTimers();
+		let attempts = 0;
+		const stream = __test__.streamWithTokenRouterHighLoadRetry(
+			tokenRouterTestModel(),
+			() => {
+				attempts += 1;
+				return attempts === 1
+					? errorAttempt(
+							"The server cluster is currently under high load. Please retry after a short wait and thank you for your patience. (2064)",
+						)
+					: textAttempt("retried successfully");
+			},
+			{},
+		);
+
+		const resultPromise = stream.result();
+		await vi.advanceTimersByTimeAsync(
+			__test__.TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS - 1,
+		);
+		expect(attempts).toBe(1);
+		await vi.advanceTimersByTimeAsync(1);
+
+		const result = await resultPromise;
+		expect(attempts).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([
+			{ type: "text", text: "retried successfully" },
+		]);
+	});
+
+	it("does not retry TokenRouter high-load errors after output started", async () => {
+		let attempts = 0;
+		const stream = __test__.streamWithTokenRouterHighLoadRetry(
+			tokenRouterTestModel(),
+			() => {
+				attempts += 1;
+				const attempt = createAssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial = assistantMessage("error", undefined, [
+						{ type: "text", text: "partial" },
+					]);
+					attempt.push({ type: "start", partial: { ...partial, content: [] } });
+					attempt.push({ type: "text_start", contentIndex: 0, partial });
+					attempt.push({
+						type: "text_delta",
+						contentIndex: 0,
+						delta: "partial",
+						partial,
+					});
+					attempt.push({
+						type: "error",
+						reason: "error",
+						error: assistantMessage("error", "high load (2064)", [
+							{ type: "text", text: "partial" },
+						]),
+					});
+				});
+				return attempt;
+			},
+			{},
+		);
+
+		const result = await stream.result();
+		expect(attempts).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("high load (2064)");
 	});
 
 	it("leaves non-MiniMax and disabled thinking payloads unchanged", () => {


### PR DESCRIPTION
## Summary
- retry TokenRouter high-load cluster errors once when the provider returns code/message 2064
- wait 30 seconds before retrying, as requested by the provider message
- only retry if the first attempt fails before output/tool streaming starts
- preserve existing MiniMax payload patching in the TokenRouter stream wrapper

## Validation
- `npx vitest run tests/tokenrouter-free.test.ts --reporter=dot` (17 passed)
- `npx tsc --noEmit --pretty false`
- LSP diagnostics clean for edited files
- `git diff --check`

Per request: did not run DRYKISS after this fix.