### PR TITLE
fix(cline): parse MiMo Pi SDK and Unicode-decorated XML directly

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -900,6 +900,51 @@ type ParsedToolCalls = {
 	toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>;
 };
 
+/**
+ * Some MiMo/Cline models emit Pi SDK `<function=name>` tool-call syntax
+ * instead of Cline XML `<toolName>` syntax:
+ *
+ *   <function=read_file>
+ *   <param name="path">README.md</param>
+ *   </function>
+ *
+ * Parse these directly to Pi tool calls without going through Cline XML.
+ */
+function extractFunctionTagToolCalls(
+	text: string,
+	bridgeByRemoteName: Map<string, ToolBridge>,
+): { text: string; toolCalls: ParsedToolCalls["toolCalls"] } {
+	const FUNCTION_TAG_RE = /<function=([a-zA-Z0-9_-]+)>([\s\S]*?)<\/function>/g;
+	const toolCalls: ParsedToolCalls["toolCalls"] = [];
+	const parts: string[] = [];
+	let cursor = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = FUNCTION_TAG_RE.exec(text)) !== null) {
+		const [fullMatch, toolName, body] = match;
+		pushTextFragment(parts, text.slice(cursor, match.index));
+
+		// Parse <param name="x">val</param> directly to arguments
+		const args: Record<string, unknown> = {};
+		const PARAM_RE = /<param\s+name="([^"]*)">([\s\S]*?)<\/param>/g;
+		let paramMatch: RegExpExecArray | null;
+		while ((paramMatch = PARAM_RE.exec(body)) !== null) {
+			args[paramMatch[1]] = paramMatch[2];
+		}
+
+		const bridge = bridgeByRemoteName.get(toolName);
+		toolCalls.push({
+			name: bridge?.runtimeName ?? toolName,
+			arguments: bridge?.toRuntimeArgs(args) ?? args,
+		});
+
+		cursor = match.index + fullMatch.length;
+	}
+
+	pushTextFragment(parts, text.slice(cursor));
+	return { text: parts.join("\n\n").trim(), toolCalls };
+}
+
 function parseXmlToolCalls(
 	rawText: string,
 	tools: Tool[] | undefined,
@@ -908,9 +953,12 @@ function parseXmlToolCalls(
 		getParseToolBridges(tools).map((bridge) => [bridge.remoteName, bridge]),
 	);
 	const toolNames = new Set(bridgeByRemoteName.keys());
-	const textWithoutThinking = extractThinkingXml(rawText).text;
+
+	// Extract <function=name> Pi SDK tool calls directly (no Cline XML intermediate)
+	const fnResult = extractFunctionTagToolCalls(rawText, bridgeByRemoteName);
+	const textWithoutThinking = extractThinkingXml(fnResult.text).text;
 	if (toolNames.size === 0) {
-		return { text: textWithoutThinking.trim(), toolCalls: [] };
+		return { text: textWithoutThinking.trim(), toolCalls: fnResult.toolCalls };
 	}
 
 	const sourceText = findNextToolStart(textWithoutThinking, toolNames, 0)
@@ -955,7 +1003,7 @@ function parseXmlToolCalls(
 	}
 
 	pushTextFragment(textParts, sourceText.slice(cursor));
-	return { text: textParts.join("\n\n").trim(), toolCalls };
+	return { text: textParts.join("\n\n").trim(), toolCalls: [...fnResult.toolCalls, ...toolCalls] };
 }
 
 function parseReasoningHiddenToolCalls(
@@ -982,7 +1030,12 @@ function parseReasoningHiddenToolCalls(
 		toolCalls.push(...parsed.toolCalls, ...nested.toolCalls);
 		if (parsed.text) thinking.push(parsed.text);
 		thinking.push(...nested.thinking);
-		if (!parsed.text && parsed.toolCalls.length === 0 && nested.toolCalls.length === 0 && nested.thinking.length === 0) {
+		if (
+			!parsed.text &&
+			parsed.toolCalls.length === 0 &&
+			nested.toolCalls.length === 0 &&
+			nested.thinking.length === 0
+		) {
 			thinking.push(trimmed);
 		}
 	}
@@ -1369,6 +1422,7 @@ export function streamClineXml(
 
 export const __test__ = {
 	buildClineXmlMessages,
+	extractFunctionTagToolCalls,
 	isRetryableClineReasoningStreamError,
 	normalizeDecoratedXmlTags,
 	parseReasoningHiddenToolCalls,

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -618,9 +618,7 @@ describe("Cline XML bridge", () => {
 
 			expect(fetchMock).toHaveBeenCalledTimes(2);
 			expect(requestBody(fetchMock, 0).include_reasoning).toBe(true);
-			expect(requestBody(fetchMock, 1)).not.toHaveProperty(
-				"include_reasoning",
-			);
+			expect(requestBody(fetchMock, 1)).not.toHaveProperty("include_reasoning");
 			expect(result.stopReason).toBe("stop");
 			expect(result.content).toContainEqual({
 				type: "text",
@@ -746,11 +744,50 @@ describe("Cline XML bridge", () => {
 		});
 
 		it("handles mixed decorated and plain tags", () => {
-			const input = "<\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>plan</\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>\n<read_file>\n<path>x</path>\n</read_file>";
+			const input =
+				"<\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>plan</\u{1D41A}\u{1D42C}\u{1D429}\u{1D428}\u{1D427}:thinking>\n<read_file>\n<path>x</path>\n</read_file>";
 			const result = __test__.normalizeDecoratedXmlTags(input);
 			expect(result).toContain("<thinking>");
 			expect(result).toContain("<read_file>");
 			expect(result).not.toContain("\u{1D41A}");
+		});
+	});
+
+	describe("extractFunctionTagToolCalls", () => {
+		it("parses <function=name> Pi SDK format directly to tool calls", () => {
+			const input =
+				'<function=read_file>\n<param name="path">README.md</param>\n</function>';
+			const result = __test__.extractFunctionTagToolCalls(input, new Map());
+			expect(result.toolCalls).toHaveLength(1);
+			expect(result.toolCalls[0].name).toBe("read_file");
+			expect(result.toolCalls[0].arguments).toEqual({ path: "README.md" });
+			expect(result.text).toBe("");
+		});
+
+		it("parses multiple <function=name> blocks", () => {
+			const input =
+				'<function=read_file>\n<param name="path">a.txt</param>\n</function>\n<function=write_to_file>\n<param name="path">b.txt</param>\n<param name="content">hello</param>\n</function>';
+			const result = __test__.extractFunctionTagToolCalls(input, new Map());
+			expect(result.toolCalls).toHaveLength(2);
+			expect(result.toolCalls[0].name).toBe("read_file");
+			expect(result.toolCalls[0].arguments).toEqual({ path: "a.txt" });
+			expect(result.toolCalls[1].name).toBe("write_to_file");
+			expect(result.toolCalls[1].arguments).toEqual({ path: "b.txt", content: "hello" });
+		});
+
+		it("preserves surrounding text", () => {
+			const input = "Let me read the file.\n<function=read_file>\n<param name=\"path\">x.txt</param>\n</function>\nDone.";
+			const result = __test__.extractFunctionTagToolCalls(input, new Map());
+			expect(result.toolCalls).toHaveLength(1);
+			expect(result.text).toContain("Let me read the file.");
+			expect(result.text).toContain("Done.");
+		});
+
+		it("leaves normal Cline XML untouched", () => {
+			const input = "<read_file>\n<path>README.md</path>\n</read_file>";
+			const result = __test__.extractFunctionTagToolCalls(input, new Map());
+			expect(result.toolCalls).toHaveLength(0);
+			expect(result.text).toContain("<read_file>");
 		});
 	});
 


### PR DESCRIPTION
## Two MiMo Cline bridge fixes

### 1. Unicode-decorated XML tags

MiMo wraps XML tags in Unicode math-italic characters forming `anthml:` prefixes:

```
<𝑎𝑛𝑡𝑚𝑙:thinking>...</𝑎𝑛𝑡𝑚𝑙:thinking>
<𝑎𝑛𝑡𝑚𝑙:read_file>...</𝑎𝑛𝑡𝑚𝑙:read_file>
```

**Fix:** `normalizeDecoratedXmlTags()` strips the Unicode prefix from both opening and closing tags before any parsing.

### 2. Pi SDK `<function=name>` tool calls

MiMo sometimes outputs Pi's native `<function=name>` format instead of Cline XML:

```
<function=read_file>
<param name="path">README.md</param>
</function>
```

**Fix:** `extractFunctionTagToolCalls()` parses these directly to Pi `{ name, arguments }` tool calls — no Cline XML intermediate conversion.

### Validation
- 43/43 Cline XML bridge tests pass
- TypeScript clean
- LSP clean