### PR TITLE
style(cline): apply prettier formatting

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -971,10 +971,12 @@ function parseXmlToolCalls(
 	// Some Cline/MiMo variants use the Pi runtime tool name (e.g. <edit>,
 	// <write>) instead of the Cline XML name (<replace_in_file>, <write_to_file>).
 	// Register runtime names as aliases so both forms are recognised.
-	const bridgeByName = new Map(bridges.flatMap((bridge) => [
-		[bridge.remoteName, bridge],
-		[bridge.runtimeName, bridge],
-	]));
+	const bridgeByName = new Map(
+		bridges.flatMap((bridge) => [
+			[bridge.remoteName, bridge],
+			[bridge.runtimeName, bridge],
+		]),
+	);
 	const toolNames = new Set(bridgeByName.keys());
 
 	// Extract <function=name> Pi SDK tool calls directly (no Cline XML intermediate)
@@ -1027,7 +1029,10 @@ function parseXmlToolCalls(
 	}
 
 	pushTextFragment(textParts, sourceText.slice(cursor));
-	return { text: textParts.join("\n\n").trim(), toolCalls: [...fnResult.toolCalls, ...toolCalls] };
+	return {
+		text: textParts.join("\n\n").trim(),
+		toolCalls: [...fnResult.toolCalls, ...toolCalls],
+	};
 }
 
 function parseReasoningHiddenToolCalls(
@@ -1417,7 +1422,10 @@ export function streamClineXml(
 					thinking,
 					currentContext.tools,
 				);
-				const parsed = parseXmlToolCalls(extractedThinking.text, currentContext.tools);
+				const parsed = parseXmlToolCalls(
+					extractedThinking.text,
+					currentContext.tools,
+				);
 				output = prepareClineXmlOutput(
 					parsed.text,
 					extractedThinking.thinking,
@@ -1428,10 +1436,7 @@ export function streamClineXml(
 				// Reasoning-only response: MiMo stopped without producing visible
 				// text or tool calls. Auto-retry once with a "continue" nudge
 				// instead of showing a dead-end error to the user.
-				if (
-					output.visibleText === INTERNAL_ONLY_RESPONSE &&
-					attempt === 0
-				) {
+				if (output.visibleText === INTERNAL_ONLY_RESPONSE && attempt === 0) {
 					currentContext = {
 						...context,
 						messages: [

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -504,7 +504,7 @@ describe("Cline XML bridge", () => {
 				[
 					"<edit>",
 					"  <path>CHANGELOG.md</path>",
-					"  <edits>[{\"oldText\":\"before\",\"newText\":\"after\"}]</edits>",
+					'  <edits>[{"oldText":"before","newText":"after"}]</edits>',
 					"</edit>",
 				].join("\n"),
 				[tool("edit")],
@@ -794,11 +794,15 @@ describe("Cline XML bridge", () => {
 			expect(result.toolCalls[0].name).toBe("read_file");
 			expect(result.toolCalls[0].arguments).toEqual({ path: "a.txt" });
 			expect(result.toolCalls[1].name).toBe("write_to_file");
-			expect(result.toolCalls[1].arguments).toEqual({ path: "b.txt", content: "hello" });
+			expect(result.toolCalls[1].arguments).toEqual({
+				path: "b.txt",
+				content: "hello",
+			});
 		});
 
 		it("preserves surrounding text", () => {
-			const input = "Let me read the file.\n<function=read_file>\n<param name=\"path\">x.txt</param>\n</function>\nDone.";
+			const input =
+				'Let me read the file.\n<function=read_file>\n<param name="path">x.txt</param>\n</function>\nDone.';
 			const result = __test__.extractFunctionTagToolCalls(input, new Map());
 			expect(result.toolCalls).toHaveLength(1);
 			expect(result.text).toContain("Let me read the file.");


### PR DESCRIPTION
Auto-formatted long lines in providers/cline/cline-xml-bridge.ts and tests/cline-xml-bridge.test.ts. No functional changes.