### PR TITLE
fix(probe): skip auto-probe when probe cache is fresh

### DIFF
--- a/lib/probe-cache.ts
+++ b/lib/probe-cache.ts
@@ -60,6 +60,14 @@ export function getModelsDueForProbe(
 	});
 }
 
+export function areAllModelsFresh(
+	providerId: string,
+	modelIds: string[],
+	ttlMs = DEFAULT_PROBE_TTL_MS,
+): boolean {
+	return getModelsDueForProbe(providerId, modelIds, ttlMs).length === 0;
+}
+
 export async function recordModelProbeResults(
 	providerId: string,
 	results: ModelProbeResult[],

--- a/lib/provider-probe.ts
+++ b/lib/provider-probe.ts
@@ -24,6 +24,7 @@ import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { updateConfig } from "../config.ts";
 import { createLogger } from "./logger.ts";
 import {
+	areAllModelsFresh,
 	getModelsDueForProbe,
 	recordModelProbeResults,
 	type ModelProbeResult,
@@ -175,6 +176,20 @@ export function createProviderProbe(
 		return () => {
 			if (done) return;
 			done = true;
+
+			// Skip scheduling entirely if every model was probed recently.
+			// Without this check the handler fires on every session_start and
+			// only then discovers the cache is fresh inside run().
+			if (
+				areAllModelsFresh(
+					providerId,
+					models.map((m) => m.id),
+				)
+			) {
+				_logger.info(`[probe] ${providerId}: auto-probe cache is fresh`);
+				return;
+			}
+
 			_logger.info(`[probe] Starting lazy auto-probe for ${providerId}...`);
 			run(apiKey, models, { useCache: true }).catch((err) => {
 				_logger.warn(`[probe] ${providerId}: auto-probe failed`, {

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -45,6 +45,7 @@ import { createLogger } from "../../lib/logger.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import {
+	areAllModelsFresh,
 	getModelsDueForProbe,
 	recordModelProbeResults,
 } from "../../lib/probe-cache.ts";
@@ -605,6 +606,17 @@ async function registerProvider(
 			wrapSessionStartHandler(`${config.providerId}-auto-probe`, async () => {
 				if (_autoProbeDone) return;
 				_autoProbeDone = true;
+				if (
+					areAllModelsFresh(
+						config.providerId,
+						stored.free.map((m) => m.id),
+					)
+				) {
+					_logger.info(
+						`[probe] ${config.providerId}: auto-probe cache is fresh`,
+					);
+					return;
+				}
 				_logger.info(
 					`Starting lazy auto-probe of ${config.providerId} free models...`,
 				);

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -43,6 +43,7 @@ import {
 } from "../../lib/provider-cache.ts";
 import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
 import {
+	areAllModelsFresh,
 	getModelsDueForProbe,
 	recordModelProbeResults,
 } from "../../lib/probe-cache.ts";
@@ -592,6 +593,18 @@ export default async function ollamaProvider(pi: ExtensionAPI) {
 	});
 
 	const runProbeInBackground = (models: ProviderModelConfig[]) => {
+		// Skip scheduling entirely if every model was probed recently.
+		// Without this check the probe runs on every session_start and
+		// only then discovers the cache is fresh inside runOllamaProbe.
+		if (
+			areAllModelsFresh(
+				PROVIDER_OLLAMA,
+				models.map((m) => m.id),
+			)
+		) {
+			_logger.info("Auto-probe: Ollama probe cache is fresh");
+			return;
+		}
 		runOllamaProbe(apiKey, models, applyModelList, { useCache: true }).catch(
 			(error) => {
 				_logger.warn("Auto-probe failed", {

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -37,6 +37,7 @@ import {
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
 import {
+	areAllModelsFresh,
 	getModelsDueForProbe,
 	recordModelProbeResults,
 } from "../../lib/probe-cache.ts";
@@ -350,6 +351,15 @@ export default async function routewayProvider(pi: ExtensionAPI) {
 		wrapSessionStartHandler("routeway", async () => {
 			if (_autoProbeDone || !apiKey) return;
 			_autoProbeDone = true;
+			if (
+				areAllModelsFresh(
+					PROVIDER_ROUTEWAY,
+					allModels.map((m) => m.id),
+				)
+			) {
+				_logger.info("Auto-probe: Routeway probe cache is fresh");
+				return;
+			}
 			_logger.info("Starting lazy auto-probe of Routeway models...");
 			runRoutewayProbe(apiKey, allModels, stored, reRegister, {
 				useCache: true,

--- a/tests/provider-probe.test.ts
+++ b/tests/provider-probe.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for `createProviderProbe` and the `autoProbeHandler` cache-skip
+ * behaviour.
+ *
+ * The fix for issue #258: auto-probe was firing on every `session_start`,
+ * and only then discovering the cache was fresh inside `run()`. Now the
+ * handler checks the cache first and short-circuits when every model is
+ * already fresh within the TTL window.
+ */
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { existsSync, mkdtempSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+
+const tempDir = mkdtempSync(
+	join(tmpdir(), "pi-free-provider-probe-test-"),
+);
+
+function makeModel(id: string): ProviderModelConfig {
+	return {
+		id,
+		name: `Test ${id}`,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8000,
+		maxTokens: 1024,
+	};
+}
+
+describe("createProviderProbe", () => {
+	beforeEach(() => {
+		// Point HOME at the temp dir so the probe cache lives in a clean
+		// location for each test.
+		process.env.HOME = tempDir;
+		process.env.USERPROFILE = tempDir;
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		delete process.env.HOME;
+		delete process.env.USERPROFILE;
+	});
+
+	it("autoProbeHandler does not invoke probeModel when cache is fresh", async () => {
+		const { createProviderProbe } = await import(
+			"../lib/provider-probe.ts"
+		);
+		const { recordModelProbeResults } = await import(
+			"../lib/probe-cache.ts"
+		);
+
+		// Pre-populate the cache so every model is already fresh.
+		await recordModelProbeResults("test-provider", [
+			{ modelId: "a", status: "ok" },
+			{ modelId: "b", status: "ok" },
+		]);
+
+		const probeModel = vi.fn(async () => "ok" as const);
+		const probe = createProviderProbe({
+			providerId: "test-provider",
+			probeModel,
+		});
+
+		const trigger = probe.autoProbeHandler("test-key", [
+			makeModel("a"),
+			makeModel("b"),
+		]);
+
+		// Fire the handler — should short-circuit.
+		trigger();
+
+		// Give any stray async work a chance to run.
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(probeModel).not.toHaveBeenCalled();
+	});
+
+	it("autoProbeHandler invokes probeModel when cache is missing", async () => {
+		const { createProviderProbe } = await import(
+			"../lib/provider-probe.ts"
+		);
+
+		const probeModel = vi.fn(async () => "ok" as const);
+		const probe = createProviderProbe({
+			providerId: "test-provider-empty",
+			probeModel,
+		});
+
+		const trigger = probe.autoProbeHandler("test-key", [
+			makeModel("a"),
+			makeModel("b"),
+		]);
+
+		trigger();
+
+		// Wait for the async run() to complete.
+		await vi.waitFor(() => {
+			expect(probeModel).toHaveBeenCalled();
+		});
+
+		expect(probeModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("autoProbeHandler invokes probeModel when some models are stale", async () => {
+		const { createProviderProbe } = await import(
+			"../lib/provider-probe.ts"
+		);
+		const { recordModelProbeResults } = await import(
+			"../lib/probe-cache.ts"
+		);
+
+		// Mark "a" fresh, leave "b" uncached.
+		await recordModelProbeResults("test-provider-stale", [
+			{ modelId: "a", status: "ok" },
+		]);
+
+		const probeModel = vi.fn(async () => "ok" as const);
+		const probe = createProviderProbe({
+			providerId: "test-provider-stale",
+			probeModel,
+		});
+
+		const trigger = probe.autoProbeHandler("test-key", [
+			makeModel("a"),
+			makeModel("b"),
+		]);
+
+		trigger();
+
+		await vi.waitFor(() => {
+			expect(probeModel).toHaveBeenCalled();
+		});
+
+		// Only the stale model is probed.
+		expect(probeModel).toHaveBeenCalledTimes(1);
+		expect(probeModel).toHaveBeenCalledWith("test-key", "b");
+	});
+
+	it("autoProbeHandler only fires once per process (idempotent)", async () => {
+		const { createProviderProbe } = await import(
+			"../lib/provider-probe.ts"
+		);
+
+		const probeModel = vi.fn(async () => "ok" as const);
+		const probe = createProviderProbe({
+			providerId: "test-provider-once",
+			probeModel,
+		});
+
+		const trigger = probe.autoProbeHandler("test-key", [makeModel("a")]);
+
+		trigger();
+		trigger();
+		trigger();
+
+		await vi.waitFor(() => {
+			expect(probeModel).toHaveBeenCalled();
+		});
+
+		// Multiple fires of the same trigger collapse to one run().
+		expect(probeModel).toHaveBeenCalledTimes(1);
+	});
+
+	it("run() respects useCache=false even when cache is fresh", async () => {
+		const { createProviderProbe } = await import(
+			"../lib/provider-probe.ts"
+		);
+		const { recordModelProbeResults } = await import(
+			"../lib/probe-cache.ts"
+		);
+
+		await recordModelProbeResults("test-provider-force", [
+			{ modelId: "a", status: "ok" },
+		]);
+
+		const probeModel = vi.fn(async () => "ok" as const);
+		const probe = createProviderProbe({
+			providerId: "test-provider-force",
+			probeModel,
+		});
+
+		// Direct call with useCache: false should probe anyway
+		// (e.g. when invoked by the /probe-{provider} command).
+		await probe.run("test-key", [makeModel("a")], { useCache: false });
+
+		expect(probeModel).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("areAllModelsFresh", () => {
+	beforeEach(() => {
+		process.env.HOME = tempDir;
+		process.env.USERPROFILE = tempDir;
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		delete process.env.HOME;
+		delete process.env.USERPROFILE;
+	});
+
+	it("returns true when all models are fresh in cache", async () => {
+		const { areAllModelsFresh, recordModelProbeResults } = await import(
+			"../lib/probe-cache.ts"
+		);
+
+		await recordModelProbeResults("test-fresh", [
+			{ modelId: "a", status: "ok" },
+			{ modelId: "b", status: "ok" },
+		]);
+
+		expect(areAllModelsFresh("test-fresh", ["a", "b"])).toBe(true);
+	});
+
+	it("returns false when a model is missing from cache", async () => {
+		const { areAllModelsFresh } = await import(
+			"../lib/probe-cache.ts"
+		);
+
+		expect(areAllModelsFresh("test-empty-provider", ["a"])).toBe(false);
+	});
+
+	it("returns false when a model is cached as broken", async () => {
+		const { areAllModelsFresh, recordModelProbeResults } = await import(
+			"../lib/probe-cache.ts"
+		);
+
+		await recordModelProbeResults("test-broken", [
+			{ modelId: "a", status: "broken" },
+		]);
+
+		expect(areAllModelsFresh("test-broken", ["a"])).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #258

## Problem
Auto-probe was firing on every `session_start` and only then discovering the cache was fresh inside `run()`. The user noticed that probe was running too often.

## Fix
The `autoProbeHandler` now checks the probe cache up-front. If every model was probed within the 24h TTL window, the handler short-circuits without scheduling any work.

## Changes
- **lib/probe-cache.ts**: Added `areAllModelsFresh(providerId, modelIds, ttlMs?)` helper for the common freshness check.
- **lib/provider-probe.ts**: `autoProbeHandler` now calls `areAllModelsFresh` before scheduling `run()`.
- **providers/ollama/ollama.ts**: `runProbeInBackground` short-circuits when cache is fresh.
- **providers/routeway/routeway.ts**: `session_start` handler short-circuits when cache is fresh.
- **providers/dynamic-built-in/index.ts**: `session_start` handler short-circuits when cache is fresh.

## Tests
New `tests/provider-probe.test.ts` with 8 tests covering:
- Fresh cache → handler does not invoke `probeModel`
- Missing cache → handler invokes `probeModel`
- Partial cache → only stale models are probed
- Handler idempotency (multiple fires → one run)
- `run({useCache: false})` still bypasses cache
- `areAllModelsFresh` returns correct values for fresh, missing, and broken entries

All 404 tests pass; 8 new tests added.