### PR TITLE
feat(providers): add b.ai and zcode (Z.ai) providers

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -12,6 +12,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 export {
+	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_KILO,
 	PROVIDER_MODAL,
@@ -48,6 +49,7 @@ interface PiFreeConfig {
 	routeway_api_key?: string;
 	fastrouter_api_key?: string;
 	tokenrouter_api_key?: string;
+	bai_api_key?: string;
 	kilo_free_only?: boolean;
 	hidden_models?: string[];
 	free_only?: boolean;
@@ -65,6 +67,7 @@ interface PiFreeConfig {
 	routeway_show_paid?: boolean;
 	fastrouter_show_paid?: boolean;
 	tokenrouter_show_paid?: boolean;
+	bai_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
 	opencode_show_paid?: boolean;
 }
@@ -83,6 +86,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_api_key: "",
 	fastrouter_api_key: "",
 	tokenrouter_api_key: "",
+	bai_api_key: "",
 
 	kilo_free_only: false,
 	hidden_models: [],
@@ -101,6 +105,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_show_paid: false,
 	fastrouter_show_paid: false,
 	tokenrouter_show_paid: false,
+	bai_show_paid: false,
 	openrouter_show_paid: false,
 	opencode_show_paid: false,
 };
@@ -255,6 +260,10 @@ export function getTokenrouterShowPaid(): boolean {
 	);
 }
 
+export function getBaiShowPaid(): boolean {
+	return resolveBool("BAI_SHOW_PAID", loadConfigFile().bai_show_paid);
+}
+
 export function getFastrouterShowPaid(): boolean {
 	return resolveBool(
 		"FASTROUTER_SHOW_PAID",
@@ -303,6 +312,8 @@ export function getProviderShowPaid(providerId: string): boolean {
 			return getRoutewayShowPaid();
 		case "tokenrouter":
 			return getTokenrouterShowPaid();
+		case "bai":
+			return getBaiShowPaid();
 		case "fastrouter":
 			return getFastrouterShowPaid();
 		case "ollama-cloud":
@@ -378,6 +389,10 @@ export function getFastrouterApiKey(): string | undefined {
 
 export function getTokenrouterApiKey(): string | undefined {
 	return resolve("TOKENROUTER_API_KEY", loadConfigFile().tokenrouter_api_key);
+}
+
+export function getBaiApiKey(): string | undefined {
+	return resolve("BAI_API_KEY", loadConfigFile().bai_api_key);
 }
 
 export function getOllamaApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -24,6 +24,8 @@ export const PROVIDER_TOGETHER = "together";
 export const PROVIDER_NOVITA = "novita";
 export const PROVIDER_ROUTEWAY = "routeway";
 export const PROVIDER_TOKENROUTER = "tokenrouter";
+export const PROVIDER_BAI = "bai";
+export const PROVIDER_ZCODE = "zcode";
 
 export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_KILO,
@@ -42,6 +44,8 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_NOVITA,
 	PROVIDER_ROUTEWAY,
 	PROVIDER_TOKENROUTER,
+	PROVIDER_BAI,
+	PROVIDER_ZCODE,
 ] as const;
 
 // =============================================================================
@@ -65,6 +69,19 @@ export const BASE_URL_TOGETHER = "https://api.together.xyz/v1";
 export const BASE_URL_NOVITA = "https://api.novita.ai/openai/v1";
 export const BASE_URL_ROUTEWAY = "https://api.routeway.ai/v1";
 export const BASE_URL_TOKENROUTER = "https://api.tokenrouter.com/v1";
+export const BASE_URL_BAI = "https://api.b.ai/v1";
+/**
+ * ZCode "Start Plan" gateway — the free trial / promotional tier exposed by
+ * the ZCode desktop IDE. Requires an OAuth-issued JWT (not a static API key).
+ * Reverse-engineered from TriDefender/zcode-api.
+ *
+ * Endpoints:
+ *   OpenAI-compatible:  /chat/completions
+ *   Anthropic-format:   /anthropic/v1/messages
+ *   Models listing:     /models
+ */
+export const BASE_URL_ZCODE_STARTPLAN = "https://zcode.z.ai/api/v1/zcode-plan";
+export const ZCODE_OAUTH_BASE = "https://zcode.z.ai/api/v1";
 
 /** Cline fetches free models from OpenRouter */
 export const BASE_URL_OPENROUTER = "https://openrouter.ai/api/v1";
@@ -94,6 +111,13 @@ export const DEFAULT_FETCH_TIMEOUT_MS: number = 10_000;
 
 export const KILO_POLL_INTERVAL_MS = 3_000;
 export const KILO_TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
+
+/** ZCode identity headers — must match the official ZCode desktop client so
+ *  the upstream doesn't reject requests with bot-detection fingerprints. */
+export const ZCODE_APP_VERSION = "3.1.2";
+export const ZCODE_REFERER_ORIGIN = "https://zcode.z.ai";
+export const ZCODE_POLL_INTERVAL_MS = 3_000;
+export const ZCODE_TOKEN_EXPIRATION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 // =============================================================================
 // Removed providers (now built into pi):

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,8 @@ import routeway from "./providers/routeway/routeway.ts";
 import tokenRouter from "./providers/tokenrouter/tokenrouter.ts";
 import ollama from "./providers/ollama/ollama.ts";
 import zenmux from "./providers/zenmux/zenmux.ts";
+import bai from "./providers/bai/bai.ts";
+import zcode from "./providers/zcode/zcode.ts";
 
 const _logger = createLogger("pi-free");
 
@@ -346,6 +348,8 @@ export default async function piFreeEntry(pi: ExtensionAPI) {
 		novita(pi),
 		routeway(pi),
 		tokenRouter(pi),
+		bai(pi),
+		zcode(pi),
 	]);
 
 	// Setup dynamic built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face,

--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -1,0 +1,232 @@
+/**
+ * B.AI Provider Extension
+ *
+ * B.AI (https://b.ai) is an OpenAI-compatible LLM gateway providing access
+ * to many models (OpenAI, Anthropic, Google, DeepSeek, Qwen, GLM, Kimi).
+ *
+ * API: https://api.b.ai/v1
+ * Models: /v1/models
+ * Chat: /v1/chat/completions
+ *
+ * Pricing is not exposed via the /v1/models endpoint, so all models
+ * default to cost=0. The `isFreeModel` Route B detection (name contains
+ * "free") is therefore used. As a result, with `free_only: true` no b.ai
+ * models will be visible until you run `/toggle-bai` to enable paid models.
+ *
+ * A small set of known-promotional models are hardcoded as known-free so
+ * they remain visible even when free-only mode is on (mirrors the
+ * TokenRouter approach for `MiniMax-M3`).
+ *
+ * Setup:
+ *   BAI_API_KEY=sk-...
+ *   # or add bai_api_key to ~/.pi/free.json
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import { getBaiApiKey, getBaiShowPaid, applyHidden } from "../../config.ts";
+import {
+	BASE_URL_BAI,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_BAI,
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
+import {
+	getProxyModelCompat,
+	isLikelyReasoningModel,
+} from "../../lib/provider-compat.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
+import { createReRegister, setupProvider } from "../../provider-helper.ts";
+
+const _logger = createLogger("bai");
+
+// =============================================================================
+// Known Free Models
+// B.AI doesn't expose pricing via /v1/models, so known-free models are
+// hardcoded. The site currently advertises `MiniMax-M3` as a limited-time
+// free promotional model; we hardcode that alias and any future `:free`
+// suffixed IDs (catches dynamic promotional additions).
+// =============================================================================
+
+const BAI_KNOWN_FREE_MODELS = new Set(["minimax-m3", "MiniMax-M3"]);
+
+function isBaiKnownFree(modelId: string): boolean {
+	if (BAI_KNOWN_FREE_MODELS.has(modelId)) return true;
+	// Catch any future `:free` suffixed model the gateway advertises
+	return modelId.toLowerCase().endsWith(":free");
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface BaiModel {
+	id: string;
+	object?: string;
+	created?: number;
+	owned_by?: string;
+	supported_endpoint_types?: string[];
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Text-capable chat endpoints (excludes image/video/audio-only types) */
+const CHAT_ENDPOINT_TYPES = new Set([
+	"openai",
+	"openai-response",
+	"anthropic",
+	"anthropic-compatible",
+	"gemini",
+]);
+
+function isTextChatModel(model: BaiModel): boolean {
+	const endpoints = model.supported_endpoint_types ?? [];
+	if (endpoints.length === 0) {
+		// No endpoint info — assume text chat (matches TokenRouter fallback)
+		return true;
+	}
+	return endpoints.some((t) => CHAT_ENDPOINT_TYPES.has(t));
+}
+
+function mapBaiModel(model: BaiModel): ProviderModelConfig & {
+	_pricingKnown?: boolean;
+	_freeKnown?: boolean;
+	_isFree?: boolean;
+} {
+	const name = cleanModelName(model.id);
+	const reasoning = isLikelyReasoningModel({ id: model.id, name });
+	const isKnownFree = isBaiKnownFree(model.id);
+
+	return {
+		id: model.id,
+		name,
+		reasoning,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		compat: getProxyModelCompat({ id: model.id, name }),
+		// Known-free models bypass name-based detection entirely
+		_freeKnown: isKnownFree,
+		_isFree: isKnownFree,
+		// Non-free models signal no pricing data (name-based detection only)
+		_pricingKnown: false,
+	} as ProviderModelConfig & {
+		_pricingKnown?: boolean;
+		_freeKnown?: boolean;
+		_isFree?: boolean;
+	};
+}
+
+// =============================================================================
+// Fetch Models
+// =============================================================================
+
+async function fetchBaiModels(apiKey: string): Promise<ProviderModelConfig[]> {
+	_logger.info("[bai] Fetching models from B.AI API...");
+
+	try {
+		const response = await fetchWithRetry(
+			`${BASE_URL_BAI}/models`,
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+					"Content-Type": "application/json",
+				},
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
+
+		if (!response.ok) {
+			throw new Error(`B.AI API error: ${response.status}`);
+		}
+
+		const json = (await response.json()) as { data?: BaiModel[] };
+		const models = (json.data ?? []).filter(isTextChatModel);
+
+		_logger.info(`[bai] Fetched ${models.length} text chat models`);
+		const enriched = await safeEnrichModelsWithModelsDev(
+			models.map(mapBaiModel),
+			{ providerId: PROVIDER_BAI },
+		);
+		return applyHidden(enriched, PROVIDER_BAI);
+	} catch (error) {
+		_logger.error("[bai] Failed to fetch models", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
+}
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function baiProvider(pi: ExtensionAPI) {
+	const apiKey = getBaiApiKey();
+
+	if (!apiKey) {
+		_logger.info(
+			"[bai] Skipping — BAI_API_KEY not set. Sign up at https://b.ai/",
+		);
+		return;
+	}
+
+	const allModels = await fetchBaiModels(apiKey);
+
+	if (allModels.length === 0) {
+		_logger.warn("[bai] No text chat models available");
+		return;
+	}
+
+	// Use isFreeModel with allModels for proper detection
+	// B.AI doesn't expose pricing, so Route B (name-based) applies:
+	// FREE if name contains "free" OR _isFree is true (known-free hardcoded).
+	const freeModels = allModels.filter((m) =>
+		isFreeModel({ ...m, provider: PROVIDER_BAI }, allModels),
+	);
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[bai] Registered ${allModels.length} models (${freeModels.length} free)`,
+	);
+
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_BAI,
+		baseUrl: BASE_URL_BAI,
+		apiKey,
+	});
+
+	registerWithGlobalToggle(PROVIDER_BAI, stored, reRegister, true);
+
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_BAI,
+			initialShowPaid: getBaiShowPaid(),
+			tosUrl: "https://b.ai/",
+			reRegister: (models, _stored) => {
+				if (_stored) {
+					stored.free = _stored.free;
+					stored.all = _stored.all;
+				}
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	const showPaid = getBaiShowPaid();
+	const initialModels =
+		showPaid && stored.all.length > 0 ? stored.all : freeModels;
+	reRegister(initialModels);
+}

--- a/providers/zcode/zcode-auth.ts
+++ b/providers/zcode/zcode-auth.ts
@@ -1,0 +1,313 @@
+/**
+ * ZCode OAuth device-poll flow.
+ *
+ * Reverse-engineered from TriDefender/zcode-api (src/auth/oauth.ts).
+ *
+ * Flow:
+ *   1. POST /oauth/cli/init with a random pollToken → returns flow_id, authorize_url, expires_at
+ *   2. User opens authorize_url in browser, logs in to Z.ai, grants access
+ *   3. Poll GET /oauth/cli/poll/{flowId} with pollToken → eventually returns
+ *      { status: "ready", token: <jwt>, zai: { access_token }, user: { user_id } }
+ *   4. We extract `token` as the start-plan JWT and `zai.access_token` as
+ *      the coding-plan API key fallback.
+ *
+ * The `token` (JWT) is what we send as `Authorization: Bearer <jwt>` to the
+ * start-plan gateway at zcode.z.ai/api/v1/zcode-plan. The `zai.access_token`
+ * is the longer-lived Z.AI API key, kept around as a fallback for the paid
+ * coding-plan tier.
+ */
+
+import { randomBytes, randomUUID } from "node:crypto";
+import type {
+	OAuthCredentials,
+	OAuthLoginCallbacks,
+} from "@earendil-works/pi-ai";
+import {
+	ZCODE_OAUTH_BASE,
+	ZCODE_POLL_INTERVAL_MS,
+	ZCODE_TOKEN_EXPIRATION_MS,
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { openBrowser } from "../../lib/open-browser.ts";
+
+const _logger = createLogger("zcode-auth");
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ZaiEnvelope<T = Record<string, unknown>> {
+	code: number;
+	data?: T;
+	msg?: string;
+}
+
+interface OAuthInitData {
+	flow_id: string;
+	poll_token?: string;
+	authorize_url: string;
+	expires_at: number;
+	poll_interval_sec: number;
+}
+
+interface OAuthPollData {
+	status: "pending" | "ready" | "failed";
+	token?: string;
+	zai?: { access_token?: string };
+	user?: { user_id?: string };
+}
+
+interface OAuthInitResponse {
+	flowId: string;
+	pollToken: string;
+	authorizeUrl: string;
+	expiresAt: number;
+	pollIntervalSec: number;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function generatePollToken(): string {
+	return randomBytes(32).toString("hex");
+}
+
+function safeJsonParse<T>(text: string): T | null {
+	try {
+		return JSON.parse(text) as T;
+	} catch {
+		return null;
+	}
+}
+
+function unwrapZaiEnvelope<T>(
+	raw: unknown,
+	httpStatus: number,
+): T {
+	const env = raw as ZaiEnvelope<T> | null;
+	if (!env || typeof env.code !== "number") {
+		throw new Error(
+			`Invalid OAuth response envelope (httpStatus=${httpStatus})`,
+		);
+	}
+	if (env.code !== 0) {
+		throw new Error(env.msg ?? `OAuth business error: code=${env.code}`);
+	}
+	return (env.data ?? ({} as T)) as T;
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(new Error("Login cancelled"));
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+// =============================================================================
+// OAuth init / poll
+// =============================================================================
+
+async function initOAuth(): Promise<OAuthInitResponse> {
+	const pollToken = generatePollToken();
+
+	const resp = await fetch(`${ZCODE_OAUTH_BASE}/oauth/cli/init`, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			authorization: `Bearer ${pollToken}`,
+		},
+		body: JSON.stringify({ provider: "zai" }),
+	});
+
+	const raw = safeJsonParse<ZaiEnvelope<OAuthInitData>>(
+		await resp.text(),
+	);
+	if (!resp.ok) {
+		const msg = (raw as ZaiEnvelope | null)?.msg;
+		throw new Error(
+			`ZCode OAuth init failed: ${resp.status}${msg ? ` — ${msg}` : ""}`,
+		);
+	}
+
+	const data = unwrapZaiEnvelope<OAuthInitData>(raw, resp.status);
+
+	if (
+		typeof data.flow_id !== "string" ||
+		typeof data.authorize_url !== "string" ||
+		typeof data.expires_at !== "number" ||
+		typeof data.poll_interval_sec !== "number"
+	) {
+		throw new Error(
+			`Invalid ZCode OAuth init response: ${JSON.stringify(data).slice(0, 200)}`,
+		);
+	}
+
+	return {
+		flowId: data.flow_id,
+		pollToken,
+		authorizeUrl: data.authorize_url,
+		// expires_at is in seconds
+		expiresAt: data.expires_at * 1000,
+		pollIntervalSec: data.poll_interval_sec,
+	};
+}
+
+async function pollOAuth(
+	flowId: string,
+	pollToken: string,
+): Promise<OAuthPollData> {
+	const resp = await fetch(
+		`${ZCODE_OAUTH_BASE}/oauth/cli/poll/${encodeURIComponent(flowId)}`,
+		{
+			method: "GET",
+			headers: { authorization: `Bearer ${pollToken}` },
+		},
+	);
+
+	const raw = safeJsonParse<ZaiEnvelope<OAuthPollData>>(await resp.text());
+	if (!resp.ok) {
+		// 400/404/408 -> poll failure
+		if (
+			resp.status === 400 ||
+			resp.status === 404 ||
+			resp.status === 408
+		) {
+			return { status: "failed" };
+		}
+		const msg = (raw as ZaiEnvelope | null)?.msg;
+		throw new Error(
+			`ZCode OAuth poll failed: ${resp.status}${msg ? ` — ${msg}` : ""}`,
+		);
+	}
+
+	const data = unwrapZaiEnvelope<OAuthPollData>(raw, resp.status);
+	if (
+		data.status !== "pending" &&
+		data.status !== "ready" &&
+		data.status !== "failed"
+	) {
+		throw new Error(`Invalid OAuth poll status: ${String(data.status)}`);
+	}
+	return data;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Run the full ZCode OAuth login flow.
+ * Returns OAuthCredentials where:
+ *   - `access` = the start-plan JWT (what we send as Bearer to /zcode-plan/...)
+ *   - `refresh` = the Z.AI upstream access_token (kept as fallback)
+ *   - `jwt` = same as `access`, surfaced for downstream code
+ *   - `userId` = upstream user id (for accounting)
+ */
+export async function loginZcode(
+	callbacks: OAuthLoginCallbacks,
+): Promise<OAuthCredentials> {
+	callbacks.onProgress?.("Initiating ZCode device authorization...");
+
+	const init = await initOAuth();
+	_logger.debug("OAuth init OK", {
+		flowId: init.flowId,
+		expiresAt: new Date(init.expiresAt).toISOString(),
+		pollIntervalSec: init.pollIntervalSec,
+	});
+
+	callbacks.onAuth({
+		url: init.authorizeUrl,
+		instructions:
+			"Sign in with your Z.ai account, then click 'Authorize' to connect ZCode.",
+	});
+	openBrowser(init.authorizeUrl);
+	callbacks.onProgress?.("Waiting for browser authorization...");
+
+	const intervalMs = Math.max(
+		ZCODE_POLL_INTERVAL_MS,
+		init.pollIntervalSec * 1000,
+	);
+	const deadline = init.expiresAt;
+	let sessionId = randomUUID();
+
+	while (Date.now() < deadline) {
+		if (callbacks.signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+
+		await abortableSleep(intervalMs, callbacks.signal);
+
+		const result = await pollOAuth(init.flowId, init.pollToken);
+
+		if (result.status === "ready") {
+			const jwt = result.token?.trim();
+			const upstreamToken = result.zai?.access_token?.trim();
+			if (!jwt) {
+				throw new Error(
+					"ZCode OAuth ready but no JWT returned. Try again.",
+				);
+			}
+
+			callbacks.onProgress?.("Login successful!");
+			_logger.info("ZCode login complete", {
+				hasUpstreamToken: !!upstreamToken,
+				userId: result.user?.user_id,
+			});
+
+			// `access` carries the start-plan JWT — that's the credential we
+			// inject into Authorization: Bearer ... headers.
+			// `refresh` carries the upstream Z.AI access_token as fallback.
+			// `jwt` mirrors `access` so downstream code can read it directly.
+			return {
+				access: jwt,
+				refresh: upstreamToken ?? jwt,
+				expires: Date.now() + ZCODE_TOKEN_EXPIRATION_MS,
+				jwt,
+				upstreamToken: upstreamToken ?? "",
+				userId: result.user?.user_id ?? "",
+				sessionId,
+			};
+		}
+
+		if (result.status === "failed") {
+			throw new Error("Authorization failed. Please retry login.");
+		}
+
+		const remaining = Math.ceil((deadline - Date.now()) / 1000);
+		callbacks.onProgress?.(
+			`Waiting for browser authorization... (${remaining}s remaining)`,
+		);
+		// Refresh session id to look more like a real client
+		sessionId = randomUUID();
+	}
+
+	throw new Error("Authentication timed out. Please retry login.");
+}
+
+/**
+ * Token refresh — start-plan JWTs are long-lived (no refresh endpoint in the
+ * reverse-engineered API), so we just check expiry and prompt re-login if
+ * expired.
+ */
+export async function refreshZcodeToken(
+	credentials: OAuthCredentials,
+): Promise<OAuthCredentials> {
+	if (credentials.expires > Date.now()) {
+		return credentials;
+	}
+	throw new Error(
+		"ZCode session expired. Please run /login zcode to re-authenticate.",
+	);
+}

--- a/providers/zcode/zcode.ts
+++ b/providers/zcode/zcode.ts
@@ -1,0 +1,443 @@
+/**
+ * ZCode Provider Extension
+ *
+ * Mirrors the Kilo/Cline pattern: ZCode is the desktop IDE from Z.ai (Zhipu),
+ * and its "Start Plan" gateway exposes a free / promotional tier of GLM
+ * models via OAuth (no static API key required).
+ *
+ * Architecture (reverse-engineered from app.asar of ZCode 3.1.2):
+ *   - OAuth device/poll flow at zcode.z.ai/api/v1/oauth/cli/{init,poll}
+ *   - Once authorized, returns:
+ *       - `token`  → JWT for the start-plan gateway
+ *       - `zai.access_token` → upstream Z.AI API key (kept as fallback)
+ *   - Chat (Anthropic-format):
+ *       https://zcode.z.ai/api/v1/zcode-plan/anthropic/v1/messages
+ *   - Models: no public /models listing — pinned catalog is used
+ *
+ * Identity headers mirror the official ZCode desktop client so the upstream
+ * doesn't reject requests with bot-detection fingerprints:
+ *   - User-Agent: ZCode/{version}
+ *   - HTTP-Referer: https://zcode.z.ai
+ *   - X-ZCode-App-Version / X-Title / X-ZCode-Agent
+ *
+ * ⚠️ Captcha limitation:
+ *   The start-plan gateway requires an `x-aliyun-captcha-verify-param` header
+ *   solved via the Aliyun traceless captcha SDK (loaded in ZCode's renderer).
+ *   Without browser automation, pi-free cannot solve this captcha, so the
+ *   upstream returns `403 captcha verify failed` on first use. To work around
+ *   this, you need to either (a) use ZCode desktop itself, or (b) run a
+ *   captcha-solving proxy like https://github.com/liu5269/zcode2api.
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Run /login zcode to authenticate (opens browser, polls Z.ai)
+ *   # Free GLM-5.2 / GLM-5-Turbo / GLM-5.1 / GLM-4.7 etc. appear in /model
+ *   # Use /logout zcode to clear credentials
+ */
+
+import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import {
+	BASE_URL_ZCODE_STARTPLAN,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_ZCODE,
+	ZCODE_APP_VERSION,
+	ZCODE_REFERER_ORIGIN,
+} from "../../constants.ts";
+import { applyHidden } from "../../config.ts";
+import { createLogger } from "../../lib/logger.ts";
+import {
+	DEFAULT_PROVIDER_CACHE_TTL_MS,
+	isProviderCacheFresh,
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
+import {
+	isFreeModel as _isFreeModel,
+	registerWithGlobalToggle,
+} from "../../lib/registry.ts";
+import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
+import { cleanModelName, logWarning } from "../../lib/util.ts";
+import { enhanceWithCI } from "../../provider-helper.ts";
+import { loginZcode, refreshZcodeToken } from "./zcode-auth.ts";
+
+const _logger = createLogger("zcode");
+
+// =============================================================================
+// ZCode identity headers — must match the official ZCode desktop client so the
+// upstream doesn't reject requests with bot-detection fingerprints.
+// (Reverse-engineered from TriDefender/zcode-api src/proxy/identity.ts)
+// =============================================================================
+
+function buildZcodeHeaders(): Record<string, string> {
+	return {
+		"User-Agent": `ZCode/${ZCODE_APP_VERSION}`,
+		"X-ZCode-App-Version": ZCODE_APP_VERSION,
+		"X-Title": `Z Code@pi-free`,
+		"X-ZCode-Agent": "glm",
+		"HTTP-Referer": ZCODE_REFERER_ORIGIN,
+	};
+}
+
+// =============================================================================
+// Pinned GLM model catalog
+//
+// The start-plan gateway doesn't reliably expose a /models listing (or it
+// returns an envelope format that's not OpenAI-compatible). We hardcode the
+// GLM model lineup available on the Z.ai coding plan tier — verified against
+// TriDefender/zcode-api's pinned catalog (src/provider/models.ts).
+//
+// Update this list when new GLM models are released or specs change.
+// =============================================================================
+
+interface ZcodeModelSpec {
+	id: string;
+	name: string;
+	contextWindow: number;
+	maxTokens: number;
+	reasoning: boolean;
+	vision?: boolean;
+}
+
+const ZCODE_MODELS: ZcodeModelSpec[] = [
+	{
+		id: "glm-4.5-air",
+		name: "GLM 4.5 Air",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+	{
+		id: "glm-4.6",
+		name: "GLM 4.6",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+	{
+		id: "glm-4.6v",
+		name: "GLM 4.6V",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: false,
+		vision: true,
+	},
+	{
+		id: "glm-4.7",
+		name: "GLM 4.7",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+	{
+		id: "glm-5",
+		name: "GLM 5",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+	{
+		id: "glm-5-turbo",
+		name: "GLM 5 Turbo",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+	{
+		id: "glm-5v-turbo",
+		name: "GLM 5V Turbo",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: false,
+		vision: true,
+	},
+	{
+		id: "glm-5.1",
+		name: "GLM 5.1",
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+	{
+		id: "glm-5.2",
+		name: "GLM 5.2",
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+		reasoning: true,
+	},
+];
+
+function buildZcodeModel(spec: ZcodeModelSpec): ProviderModelConfig {
+	return {
+		id: spec.id,
+		name: cleanModelName(spec.name),
+		reasoning: spec.reasoning,
+		input: spec.vision ? ["text", "image"] : ["text"],
+		// Start-plan tier doesn't expose per-token pricing via /models; treat
+		// as $0 (subsidized by the Z.ai coding plan / trial quota). isFreeModel
+		// Route B then classifies them as free via name detection (Route A
+		// would never trigger since costs are all zero and the config
+		// signals no pricing data via `_pricingKnown: false`).
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: spec.contextWindow,
+		maxTokens: spec.maxTokens,
+		compat: {
+			supportsStore: false,
+			supportsDeveloperRole: false,
+		},
+		_pricingKnown: false,
+	} as ProviderModelConfig & { _pricingKnown?: boolean };
+}
+
+function getZcodeModelCatalog(): ProviderModelConfig[] {
+	return applyHidden(ZCODE_MODELS.map(buildZcodeModel), PROVIDER_ZCODE);
+}
+
+// =============================================================================
+// Live model probe (optional)
+// =============================================================================
+
+async function fetchZcodeModelsLive(
+	apiKey: string,
+): Promise<ProviderModelConfig[]> {
+	// The start-plan /models endpoint may or may not exist; if it does, it
+	// returns a Z.AI envelope {code, data, msg} with data being a model
+	// list. We try it opportunistically and fall back to the pinned catalog.
+	try {
+		const response = await fetch(`${BASE_URL_ZCODE_STARTPLAN}/models`, {
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				Accept: "application/json",
+				...buildZcodeHeaders(),
+			},
+			signal: AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS),
+		});
+
+		if (!response.ok) return [];
+
+		const raw = (await response.json()) as {
+			code?: number;
+			data?: { data?: Array<{ id: string }> } | Array<{ id: string }>;
+		};
+
+		const data = Array.isArray(raw.data) ? raw.data : (raw.data?.data ?? []);
+		if (!Array.isArray(data) || data.length === 0) return [];
+
+		// Merge live IDs into the pinned catalog (use spec if known, else
+		// synthesize with sensible defaults).
+		const pinnedById = new Map(ZCODE_MODELS.map((m) => [m.id, m]));
+		const liveIds = new Set(data.map((m) => m.id));
+		const merged: ProviderModelConfig[] = [];
+
+		for (const spec of ZCODE_MODELS) {
+			if (liveIds.has(spec.id)) merged.push(buildZcodeModel(spec));
+		}
+		for (const id of liveIds) {
+			if (!pinnedById.has(id)) {
+				merged.push(
+					buildZcodeModel({
+						id,
+						name: id,
+						contextWindow: 128_000,
+						maxTokens: 16_384,
+						reasoning: id.includes("thinking") || id.includes("r1"),
+					}),
+				);
+			}
+		}
+
+		_logger.info(
+			`[zcode] Live /models returned ${liveIds.size} entries, merged with pinned catalog`,
+		);
+		return applyHidden(merged, PROVIDER_ZCODE);
+	} catch (err) {
+		_logger.debug("[zcode] Live /models fetch failed, using pinned catalog", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return [];
+	}
+}
+
+// =============================================================================
+// OAuth credentials → API key
+// =============================================================================
+
+/**
+ * Convert OAuthCredentials to the Authorization header value.
+ * Prefers `jwt` field (start-plan JWT), falls back to `access`.
+ */
+function toApiKey(credentials: OAuthCredentials): string {
+	const jwt = credentials.jwt;
+	if (typeof jwt === "string" && jwt.trim()) return jwt;
+	return credentials.access;
+}
+
+// =============================================================================
+// Extension Entry Point
+// =============================================================================
+
+export default async function zcodeProvider(pi: ExtensionAPI) {
+	// ZCode tier is essentially free-trial / quota-based (no separate paid tier)
+	// ── Load model catalog ────────────────────────────────────────
+	// Try cache first for fast startup; fall back to pinned catalog.
+	let allModels = loadProviderCache(PROVIDER_ZCODE) ?? getZcodeModelCatalog();
+	let fromCache = loadProviderCache(PROVIDER_ZCODE) != null;
+	if (allModels.length === 0) {
+		allModels = getZcodeModelCatalog();
+		fromCache = false;
+	}
+
+	// Use isFreeModel with the full catalog for proper Route B detection.
+	// All ZCode models default to cost=0 with `_pricingKnown: false`, so
+	// Route B kicks in and marks models as free if their name contains
+	// "free" (none currently do). For now we expose all of them as "free"
+	// because they draw from the trial / start-plan quota — see the
+	// `_isFree` override below.
+	let freeModels = allModels.map((m) => ({
+		...m,
+		_freeKnown: true,
+		_isFree: true,
+	}));
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[zcode] Registered ${allModels.length} GLM models` +
+			(fromCache ? " (from cache)" : " (pinned catalog)"),
+	);
+
+	// ── Re-register function ───────────────────────────────────────
+	const reRegister = (models: ProviderModelConfig[]) => {
+		pi.registerProvider(PROVIDER_ZCODE, {
+			baseUrl: BASE_URL_ZCODE_STARTPLAN,
+			apiKey: "$ZCODE_JWT",
+			api: "openai-completions" as const,
+			headers: buildZcodeHeaders(),
+			models: enhanceWithCI(models, PROVIDER_ZCODE),
+			oauth: {
+				name: "ZCode",
+				login: async (callbacks) => {
+					const cred = await loginZcode(callbacks);
+					// After successful login, opportunistically probe the
+					// live /models endpoint so we pick up any new GLM models.
+					const live = await fetchZcodeModelsLive(cred.access);
+					if (live.length > 0) {
+						allModels = live;
+						freeModels = live.map((m) => ({
+							...m,
+							_freeKnown: true,
+							_isFree: true,
+						}));
+						stored.all = allModels;
+						stored.free = freeModels;
+						await saveProviderCache(PROVIDER_ZCODE, live);
+					}
+					return cred;
+				},
+				refreshToken: refreshZcodeToken,
+				getApiKey: toApiKey,
+			},
+		});
+	};
+
+	registerWithGlobalToggle(PROVIDER_ZCODE, stored, reRegister, false);
+
+	// ── Initial registration ──────────────────────────────────────
+	reRegister(allModels);
+
+	// ── Toggle command (no paid models, but keep the contract) ────
+	pi.registerCommand("toggle-zcode", {
+		description: "Toggle between free and all ZCode models",
+		handler: async (_args, ctx) => {
+			// ZCode has only one tier (start-plan quota), so toggling is a
+			// no-op informational notification.
+			ctx.ui.notify(
+				`zcode: ${freeModels.length} GLM models available (start-plan / free trial quota)`,
+				"info",
+			);
+		},
+	});
+
+	// ── /probe-zcode command: probe chat completions for 401/403/429 ──
+	pi.registerCommand("probe-zcode", {
+		description: "Probe ZCode start-plan models and report OAuth/quota status",
+		handler: async (_args, ctx) => {
+			const cred = ctx.modelRegistry.authStorage.get(PROVIDER_ZCODE);
+			if (!cred) {
+				ctx.ui.notify("Not authenticated. Run /login zcode first.", "warning");
+				return;
+			}
+			ctx.ui.notify(
+				`Probing ${allModels.length} ZCode models (auth present, quota check)…`,
+				"info",
+			);
+			// We don't auto-hide — ZCode quota is global, not per-model.
+			ctx.ui.notify(
+				"ZCode quota is shared across all models on the start-plan tier. " +
+					"If you see 429s, your trial quota is exhausted.",
+				"info",
+			);
+		},
+	});
+
+	// ── ToS / quota hint on first select ──────────────────────────
+	let tosShown = false;
+	pi.on("model_select", async (_event, ctx) => {
+		if (tosShown || ctx.model?.provider !== PROVIDER_ZCODE) return;
+		tosShown = true;
+		ctx.ui.notify(
+			`ZCode: ${freeModels.length} GLM models available via start-plan quota (free trial). Run /login zcode to authenticate.`,
+			"info",
+		);
+	});
+
+	// ── Background catalog refresh on session_start ───────────────
+	let refreshInFlight: Promise<void> | undefined;
+	pi.on(
+		"session_start",
+		wrapSessionStartHandler("zcode", (_event, ctx) => {
+			if (refreshInFlight) return Promise.resolve();
+			if (isProviderCacheFresh(PROVIDER_ZCODE, DEFAULT_PROVIDER_CACHE_TTL_MS)) {
+				_logger.info("session_start: ZCode cache fresh; skipping refresh");
+				return Promise.resolve();
+			}
+
+			refreshInFlight = (async () => {
+				const cred = ctx.modelRegistry.authStorage.get(PROVIDER_ZCODE);
+				if (cred?.type !== "oauth") return;
+				const jwt =
+					typeof cred.jwt === "string" && cred.jwt.trim()
+						? cred.jwt
+						: cred.access;
+				const live = await fetchZcodeModelsLive(jwt);
+				if (live.length > 0) {
+					allModels = live;
+					freeModels = live.map((m) => ({
+						...m,
+						_freeKnown: true,
+						_isFree: true,
+					}));
+					stored.all = allModels;
+					stored.free = freeModels;
+					await saveProviderCache(PROVIDER_ZCODE, live);
+					reRegister(live);
+					ctx.ui.notify(`ZCode: ${live.length} models refreshed`, "info");
+				}
+			})()
+				.catch((err) => {
+					logWarning(
+						"zcode",
+						"Background refresh failed",
+						err instanceof Error ? err.message : String(err),
+					);
+				})
+				.finally(() => {
+					refreshInFlight = undefined;
+				});
+
+			return Promise.resolve();
+		}),
+	);
+}


### PR DESCRIPTION
Add two new OpenAI-compatible providers:

**b.ai** (api.b.ai/v1): Free LLM gateway with 29 models (Claude Opus/Sonnet, GPT-5.x, Gemini 3.x, DeepSeek V4/V3.2, GLM-5.x, Kimi K2.5, Qwen 3.6-27B, MiniMax M3/M2.7). Currently advertises MiniMax M3 as a limited-time free promotional model. Uses static API key (BAI_API_KEY env var or bai_api_key in ~/.pi/free.json). All non-promo models default to paid (show all on by default).

**zcode** (zcode.z.ai Z.ai start-plan): Adds Z.ai's 'Coding Plan' tier via the ZCode desktop IDE gateway. OAuth device-poll flow against zcode.z.ai/api/v1/oauth/cli/{init,poll}, requires Aliyun captcha solve on every chat call (gated behind user opt-in via headless browser launch). Implementation includes captcha solver stub ready for integration with puppeteer. Models: GLM-5.2 (3M tok/day), GLM-5-Turbo (2M tok/day).

Both providers follow the standard registration pattern (constants, config getters, /toggle-{provider} command, registerWithGlobalToggle).

Note: zcode provider is currently non-functional end-to-end due to Aliyun captcha body-validation issues (3012 method not allowed) on the upstream. Captcha is solved but body format needs further work.