### PR TITLE
fix: address SonarCloud code smell findings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -188,7 +188,12 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 
 			const lines = ["📊 Model Telemetry:", ""];
 			lines.push(
-				`${`Model`.padEnd(40)} ${`Calls`.padEnd(6)} ${`OK%`.padEnd(6)} ${`Lat`.padEnd(7)} ${`tok/s`.padEnd(7)} ${`Cost`}`,
+				"Model".padEnd(40) + " " +
+				"Calls".padEnd(6) + " " +
+				"OK%".padEnd(6) + " " +
+				"Lat".padEnd(7) + " " +
+				"tok/s".padEnd(7) + " " +
+				"Cost",
 			);
 			lines.push(`─`.repeat(75));
 

--- a/index.ts
+++ b/index.ts
@@ -188,12 +188,17 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 
 			const lines = ["📊 Model Telemetry:", ""];
 			lines.push(
-				"Model".padEnd(40) + " " +
-				"Calls".padEnd(6) + " " +
-				"OK%".padEnd(6) + " " +
-				"Lat".padEnd(7) + " " +
-				"tok/s".padEnd(7) + " " +
-				"Cost",
+				"Model".padEnd(40) +
+					" " +
+					"Calls".padEnd(6) +
+					" " +
+					"OK%".padEnd(6) +
+					" " +
+					"Lat".padEnd(7) +
+					" " +
+					"tok/s".padEnd(7) +
+					" " +
+					"Cost",
 			);
 			lines.push(`─`.repeat(75));
 

--- a/lib/model-metadata.ts
+++ b/lib/model-metadata.ts
@@ -45,7 +45,9 @@ function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-async function fetchModelsDevCatalog(): Promise<Record<string, ModelsDevProvider>> {
+async function fetchModelsDevCatalog(): Promise<
+	Record<string, ModelsDevProvider>
+> {
 	let lastError: unknown;
 
 	for (let attempt = 1; attempt <= MODELS_DEV_RETRIES; attempt++) {
@@ -291,7 +293,9 @@ function enrichModel<T extends ProviderModelConfig>(
 			? (["text", "image"] as const)
 			: model.input;
 	const reasoning =
-		ctx.enrichReasoning && modelMeta.reasoning === true ? true : model.reasoning;
+		ctx.enrichReasoning && modelMeta.reasoning === true
+			? true
+			: model.reasoning;
 	const thinkingLevelMap =
 		ctx.enrichReasoning && model.thinkingLevelMap === undefined
 			? thinkingMapFromReasoningOptions(modelMeta.reasoning_options)
@@ -301,7 +305,10 @@ function enrichModel<T extends ProviderModelConfig>(
 			? (costFromModelsDev(modelMeta.cost) ?? model.cost)
 			: model.cost;
 	const compat = ctx.enrichCompat
-		? mergeCompat(model.compat, getProxyModelCompat(identityFromMeta(model, modelMeta)))
+		? mergeCompat(
+				model.compat,
+				getProxyModelCompat(identityFromMeta(model, modelMeta)),
+			)
 		: model.compat;
 
 	const modelsDevMetadata: ModelMatchHints = {

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -156,16 +156,16 @@ function deriveModelTelemetry(
 				: 0,
 		avgTokensPerSecond:
 			totalLatencyFromSuccessful > 0
-				? parseFloat(
+				? Number.parseFloat(
 						(
 							totalTokensFromSuccessful /
 							(totalLatencyFromSuccessful / 1000)
 						).toFixed(1),
-					)
+				)
 				: 0,
 		successRate:
 			totalCalls > 0
-				? parseFloat(((successCalls / totalCalls) * 100).toFixed(1))
+				? Number.parseFloat(((successCalls / totalCalls) * 100).toFixed(1))
 				: 0,
 		recentCalls: recent,
 	};
@@ -310,7 +310,7 @@ export async function recordModelCall(
 	const totalTokens = usage.totalTokens || usage.input + usage.output;
 	const tokensPerSecond =
 		latencyMs > 0
-			? parseFloat((totalTokens / (latencyMs / 1000)).toFixed(1))
+			? Number.parseFloat((totalTokens / (latencyMs / 1000)).toFixed(1))
 			: 0;
 
 	const entry: TelemetryEntry = {

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -105,54 +105,46 @@ const _store = createJSONStore<TelemetryStore>(TELEMETRY_FILE, {
 // =============================================================================
 
 function deriveModelTelemetry(
-	_modelKey: string,
 	entries: TelemetryEntry[],
 ): ModelTelemetry {
 	const recent = entries.slice(-MAX_RECENT_CALLS);
+
+	let successCalls = 0;
+	let totalTokensFromSuccessful = 0;
+	let totalLatencyFromSuccessful = 0;
+	let totalTokens = 0;
+	let totalPromptTokens = 0;
+	let totalCompletionTokens = 0;
+	let totalLatencyMs = 0;
+	let totalCost = 0;
+
+	for (const e of entries) {
+		totalTokens += e.totalTokens;
+		totalPromptTokens += e.promptTokens;
+		totalCompletionTokens += e.completionTokens;
+		totalLatencyMs += e.latencyMs;
+		totalCost += e.cost;
+		if (e.success) {
+			successCalls++;
+			totalTokensFromSuccessful += e.totalTokens;
+			totalLatencyFromSuccessful += e.latencyMs;
+		}
+	}
+
 	const totalCalls = entries.length;
-	const successCalls = entries.filter((e) => e.success).length;
-	const errorCalls = totalCalls - successCalls;
-
-	const stats = entries.reduce(
-		(acc, e) => {
-			acc.totalTokens += e.totalTokens;
-			acc.totalPromptTokens += e.promptTokens;
-			acc.totalCompletionTokens += e.completionTokens;
-			acc.totalLatencyMs += e.latencyMs;
-			acc.totalCost += e.cost;
-			return acc;
-		},
-		{
-			totalTokens: 0,
-			totalPromptTokens: 0,
-			totalCompletionTokens: 0,
-			totalLatencyMs: 0,
-			totalCost: 0,
-		},
-	);
-
-	const totalSuccessEntries = entries.filter((e) => e.success);
-	const totalTokensFromSuccessful = totalSuccessEntries.reduce(
-		(s, e) => s + e.totalTokens,
-		0,
-	);
-	const totalLatencyFromSuccessful = totalSuccessEntries.reduce(
-		(s, e) => s + e.latencyMs,
-		0,
-	);
 
 	return {
 		totalCalls,
 		successCalls,
-		errorCalls,
-		totalTokens: stats.totalTokens,
-		totalPromptTokens: stats.totalPromptTokens,
-		totalCompletionTokens: stats.totalCompletionTokens,
-		totalLatencyMs: stats.totalLatencyMs,
-		totalCost: stats.totalCost,
+		errorCalls: totalCalls - successCalls,
+		totalTokens,
+		totalPromptTokens,
+		totalCompletionTokens,
+		totalLatencyMs,
+		totalCost,
 		avgLatencyMs:
-			totalSuccessEntries.length > 0
-				? Math.round(totalLatencyFromSuccessful / totalSuccessEntries.length)
+			successCalls > 0
+				? Math.round(totalLatencyFromSuccessful / successCalls)
 				: 0,
 		avgTokensPerSecond:
 			totalLatencyFromSuccessful > 0
@@ -186,7 +178,7 @@ async function addEntry(entry: TelemetryEntry): Promise<void> {
 			...store,
 			models: {
 				...store.models,
-				[modelKey]: deriveModelTelemetry(modelKey, pruned),
+				[modelKey]: deriveModelTelemetry(pruned),
 			},
 			lastUpdated: Date.now(),
 		};

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -645,19 +645,19 @@ function buildToolInstructions(tools: Tool[] | undefined): string {
 		let params: string;
 		if (bridge.remoteName === "replace_in_file") {
 			params = [
-					"  <path>path/to/file</path>",
-					"  <diff>",
-					"------- SEARCH",
-					"exact text to replace",
-					"=======",
-					"new text",
-					"+++++++ REPLACE",
-					"  </diff>",
-				].join("\n");
+				"  <path>path/to/file</path>",
+				"  <diff>",
+				"------- SEARCH",
+				"exact text to replace",
+				"=======",
+				"new text",
+				"+++++++ REPLACE",
+				"  </diff>",
+			].join("\n");
 		} else if (bridge.parameters.length) {
 			params = bridge.parameters
-					.map((name) => `  <${name}>value</${name}>`)
-					.join("\n");
+				.map((name) => `  <${name}>value</${name}>`)
+				.join("\n");
 		} else {
 			params = "  <arguments>{}</arguments>";
 		}

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -170,7 +170,9 @@ const CORE_CLINE_TOOL_NAMES = [
 
 function stringArg(args: Record<string, unknown>, key: string): string {
 	const value = args[key];
-	return typeof value === "string" ? value : value == null ? "" : String(value);
+	if (typeof value === "string") return value;
+	if (value == null) return "";
+	return String(value);
 }
 
 function booleanArg(args: Record<string, unknown>, key: string): boolean {
@@ -178,7 +180,8 @@ function booleanArg(args: Record<string, unknown>, key: string): boolean {
 }
 
 function shellQuote(value: string): string {
-	return `'${value.replaceAll("'", `'"'"'`)}'`;
+	const escaped = value.replaceAll("'", `'"'"'`);
+	return `'${escaped}'`;
 }
 
 function buildListFilesCommand(args: Record<string, unknown>): string {
@@ -639,23 +642,25 @@ function buildToolInstructions(tools: Tool[] | undefined): string {
 	if (bridges.length === 0) return "";
 
 	const sections = bridges.map((bridge) => {
-		const params =
-			bridge.remoteName === "replace_in_file"
-				? [
-						"  <path>path/to/file</path>",
-						"  <diff>",
-						"------- SEARCH",
-						"exact text to replace",
-						"=======",
-						"new text",
-						"+++++++ REPLACE",
-						"  </diff>",
-					].join("\n")
-				: bridge.parameters.length
-					? bridge.parameters
-							.map((name) => `  <${name}>value</${name}>`)
-							.join("\n")
-					: "  <arguments>{}</arguments>";
+		let params: string;
+		if (bridge.remoteName === "replace_in_file") {
+			params = [
+					"  <path>path/to/file</path>",
+					"  <diff>",
+					"------- SEARCH",
+					"exact text to replace",
+					"=======",
+					"new text",
+					"+++++++ REPLACE",
+					"  </diff>",
+				].join("\n");
+		} else if (bridge.parameters.length) {
+			params = bridge.parameters
+					.map((name) => `  <${name}>value</${name}>`)
+					.join("\n");
+		} else {
+			params = "  <arguments>{}</arguments>";
+		}
 		return [
 			`Tool: ${bridge.remoteName}`,
 			`Description: ${bridge.description ?? bridge.runtimeName}`,
@@ -1461,12 +1466,13 @@ export function streamClineXml(
 				pushToolCall(assistant, toolCall, stream);
 			}
 
-			assistant.stopReason =
-				toolCalls.length > 0
-					? "toolUse"
-					: finishReason === "length"
-						? "length"
-						: "stop";
+			if (toolCalls.length > 0) {
+				assistant.stopReason = "toolUse";
+			} else if (finishReason === "length") {
+				assistant.stopReason = "length";
+			} else {
+				assistant.stopReason = "stop";
+			}
 			stream.push({
 				type: "done",
 				reason: assistant.stopReason as "stop" | "length" | "toolUse",

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -138,7 +138,7 @@ export async function fetchOpenRouterModelsWithFree(
 
 	const free = all.filter((m) => {
 		const cost = m.cost;
-		return cost?.input === 0 && cost.output === 0;
+		return cost != null && cost.input === 0 && cost.output === 0;
 	});
 
 	return { free, all };

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -138,7 +138,7 @@ export async function fetchOpenRouterModelsWithFree(
 
 	const free = all.filter((m) => {
 		const cost = m.cost;
-		return cost && cost.input === 0 && cost.output === 0;
+		return cost?.input === 0 && cost.output === 0;
 	});
 
 	return { free, all };

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -226,8 +226,8 @@ function resolvePiAiSubpathFromPackage(specifier: string): string | undefined {
 }
 
 class DeferredAssistantMessageEventStream {
-	private queue: AssistantMessageEvent[] = [];
-	private waiting: Array<
+	private readonly queue: AssistantMessageEvent[] = [];
+	private readonly waiting: Array<
 		(result: IteratorResult<AssistantMessageEvent>) => void
 	> = [];
 	private done = false;


### PR DESCRIPTION
## Summary

Fixes 8 legitimate SonarCloud MEDIUM-severity code smell issues (25 of the 31 flagged items are false positives — see analysis below).

All 404 tests pass ✅.

### Changes

- **lib/telemetry.ts**: Replace global `parseFloat` with `Number.parseFloat` (3 instances)
- **providers/opencode-session.ts**: Mark `queue`/`waiting` class members as `readonly`
- **providers/model-fetcher.ts**: Use optional chain `cost?.input` instead of redundant null check
- **providers/cline/cline-xml-bridge.ts**:
  - Extract nested ternary in `stringArg` → if/return chain
  - Extract nested ternary for `params` → if/else if/else
  - Extract nested ternary for `stopReason` → if/else if/else
  - Extract nested template literal in `shellQuote` → intermediate variable
- **index.ts**: Replace nested template literals (header row) → concatenated `padEnd` calls

### False Positives (not changed)

| Issue | Reason |
|-------|--------|
| Move helper functions to outer scope (4 files) | Test helpers and closures intentionally scoped |
| Top-level await in scripts (4 files) | Scripts use `.catch()` for proper error handling |
| Use `startsWith` in `lib/util.ts` | Character range checks, not string prefixes |
| Split `freeOnly` param in `lib/registry.ts` | Core toggle logic — splitting adds no clarity |
| Use `toSorted` in `lib/model-detection.ts` | Requires ES2023; `sort()` on fresh array is fine |
| Nested ternary in `lib/model-metadata.ts` | Compact object literal — extracting hurts readability |
| Regex complexity in `benchmark-lookup.ts` | Literal prefix list, not a complex pattern |

**SonarCloud link:** https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&issueStatuses=OPEN%2CCONFIRMED&id=apmantza_pi-free