### PR TITLE
docs: restructure README, add docs/ folder, contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,336 @@
+# Contributing to pi-free
+
+Thanks for wanting to contribute! This guide covers how to add a new provider — the most common and valuable contribution.
+
+---
+
+## What makes a good provider?
+
+pi-free is about **unlocking free and low-cost models** for Pi users. Prioritize:
+
+1. **Free-tier providers** — models that cost $0 to use (even with limits)
+2. **Trial-credit providers** — one-time free credits on signup (no credit card)
+3. **Freemium providers** — free tier with rate limits, paid after
+4. **Paid providers** — only if they offer something unique not available elsewhere
+
+**Avoid:** Providers that duplicate models already available through existing providers (e.g., another OpenAI-compatible gateway that only offers GPT-4o).
+
+---
+
+## Quick Start: Adding a New Provider
+
+### 1. Add provider constants
+
+In [`constants.ts`](constants.ts), add a provider ID and base URL:
+
+```typescript
+// Provider names (near top)
+export const PROVIDER_MYPROVIDER = "myprovider";
+
+// Add to ALL_UNIQUE_PROVIDERS array
+export const ALL_UNIQUE_PROVIDERS = [
+    // ... existing providers
+    PROVIDER_MYPROVIDER,
+];
+
+// Base URLs
+export const BASE_URL_MYPROVIDER = "https://api.myprovider.com/v1";
+```
+
+### 2. Add config support
+
+In [`config.ts`](config.ts):
+
+- Add the API key field to `PiFreeConfig` interface
+- Add the getter function (env var + file resolution)
+- Add to `CONFIG_TEMPLATE` so first-run users see it
+
+```typescript
+interface PiFreeConfig {
+    // ... existing fields
+    myprovider_api_key?: string;
+}
+
+// Add getter (uses resolve() helper)
+export function getMyproviderApiKey(): string | undefined {
+    return resolve("MYPROVIDER_API_KEY", config.myprovider_api_key);
+}
+
+// Add to CONFIG_TEMPLATE
+const CONFIG_TEMPLATE = {
+    // ... existing keys
+    myprovider_api_key: undefined,
+};
+```
+
+### 3. Create the provider file
+
+Create `providers/myprovider/myprovider.ts` following this pattern:
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createLogger } from "../../lib/logger.ts";
+import {
+    isFreeModel,
+    registerWithGlobalToggle,
+} from "../../lib/registry.ts";
+import { createReRegister, setupProvider, enhanceWithCI } from "../../provider-helper.ts";
+import { PROVIDER_MYPROVIDER, BASE_URL_MYPROVIDER } from "../../constants.ts";
+import { getMyproviderApiKey } from "../../config.ts";
+
+const _logger = createLogger("myprovider");
+
+// --- Model fetching ---
+
+interface MyProviderModel {
+    id: string;
+    name: string;
+    // ... provider-specific fields
+}
+
+async function fetchMyProviderModels(
+    apiKey: string,
+): Promise<Array<{ id: string; name: string; cost: Record<string, number> }>> {
+    const response = await fetch(`${BASE_URL_MYPROVIDER}/models`, {
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+        },
+    });
+
+    if (!response.ok) return [];
+
+    const data = (await response.json()) as { data: MyProviderModel[] };
+    return data.data.map((m) => ({
+        id: m.id,
+        name: m.name,
+        cost: { input: 0, output: 0 }, // adjust if pricing is available
+    }));
+}
+
+// --- Provider registration ---
+
+export default async function myproviderProvider(pi: ExtensionAPI) {
+    const apiKey = getMyproviderApiKey();
+
+    if (!apiKey) {
+        _logger.info(
+            "[myprovider] Skipping — MYPROVIDER_API_KEY not set.",
+        );
+        return;
+    }
+
+    // Fetch models
+    const allModels = await fetchMyProviderModels(apiKey);
+
+    if (allModels.length === 0) {
+        _logger.warn("[myprovider] No models available");
+        return;
+    }
+
+    // Detect free models
+    const freeModels = allModels.filter((m) =>
+        isFreeModel({ ...m, provider: PROVIDER_MYPROVIDER }, allModels),
+    );
+    const stored = { free: freeModels, all: allModels };
+
+    _logger.info(
+        `[myprovider] Registered ${allModels.length} models (${freeModels.length} free)`,
+    );
+
+    // Create re-register function (used by toggles)
+    const reRegister = createReRegister(pi, {
+        providerId: PROVIDER_MYPROVIDER,
+        baseUrl: BASE_URL_MYPROVIDER,
+        apiKey,
+    });
+
+    // Register with global toggle system
+    registerWithGlobalToggle(PROVIDER_MYPROVIDER, stored, reRegister, true);
+
+    // Setup provider with toggle command
+    setupProvider(
+        pi,
+        {
+            providerId: PROVIDER_MYPROVIDER,
+            initialShowPaid: false, // true if provider is trial-credit or paid
+            reRegister: (models, newStored) => {
+                if (newStored) {
+                    stored.free = newStored.free;
+                    stored.all = newStored.all;
+                }
+                reRegister(enhanceWithCI(models));
+            },
+        },
+        stored,
+    );
+
+    // Initial registration
+    reRegister(enhanceWithCI(freeModels));
+
+    // Refresh models on session start
+    pi.on("session_start", async () => {
+        const refreshed = await fetchMyProviderModels(apiKey);
+        if (refreshed.length > 0) {
+            const refreshedFree = refreshed.filter((m) =>
+                isFreeModel({ ...m, provider: PROVIDER_MYPROVIDER }, refreshed),
+            );
+            stored.free = refreshedFree;
+            stored.all = refreshed;
+            reRegister(enhanceWithCI(refreshedFree));
+        }
+    });
+}
+```
+
+### 4. Register in index.ts
+
+In [`index.ts`](index.ts):
+
+```typescript
+// Add import
+import myprovider from "./providers/myprovider/myprovider.ts";
+
+// Add to UNIQUE_PROVIDERS array
+const UNIQUE_PROVIDERS = [
+    // ... existing providers
+    myprovider,
+];
+```
+
+### 5. Update README.md
+
+Add your provider to the appropriate section in [`README.md`](README.md):
+
+- List it under the correct category (✅ Free, 🔄 Freemium, 💳 Paid, 🔧 Dynamic)
+- Add setup instructions if it needs an API key
+- Add the `/toggle-{provider}` command to the commands table
+
+---
+
+## Provider Categories
+
+| Category | Description | `initialShowPaid` |
+|---|---|---|
+| ✅ **Free** | Models cost $0, no payment required | `false` |
+| 🔄 **Freemium** | Free tier with limits, paid after | `false` |
+| 💳 **Paid / Trial** | Requires credits or payment | `true` |
+| 🔧 **Dynamic** | Fetched only when API key configured | `true` |
+
+---
+
+## Non-OpenAI-Compatible Providers
+
+Most providers use OpenAI-compatible APIs. If your provider uses a different protocol (custom headers, non-standard streaming, etc.), you'll need a custom `streamSimple` handler.
+
+**Reference:** The [qoder provider](providers/qoder/) is the most complete example of a non-OpenAI-compatible provider. It implements:
+
+- Custom cryptographic auth headers ([`cosy.ts`](providers/qoder/cosy.ts))
+- Custom streaming handler ([`stream.ts`](providers/qoder/stream.ts))
+- OAuth device flow authentication ([`auth.ts`](providers/qoder/auth.ts))
+- Message format transformation ([`transform.ts`](providers/qoder/transform.ts))
+- Model fetching from proprietary API ([`models.ts`](providers/qoder/models.ts))
+
+For simpler custom protocols, look at the [cline provider](providers/cline/) which adds message reshaping without full custom streaming.
+
+---
+
+## Helper Functions
+
+The following utilities are available and should be used instead of reimplementing:
+
+| Helper | Location | Purpose |
+|---|---|---|
+| `isFreeModel()` | `lib/registry.ts` | Detect free models (adaptive pricing/name detection) |
+| `registerWithGlobalToggle()` | `lib/registry.ts` | Register provider with free/all toggle system |
+| `createReRegister()` | `provider-helper.ts` | Create re-register function for toggles |
+| `setupProvider()` | `provider-helper.ts` | Register provider + toggle command in one call |
+| `enhanceWithCI()` | `provider-helper.ts` | Append Coding Index benchmark scores to model names |
+| `createLogger()` | `lib/logger.ts` | Structured logging (console + file) |
+| `fetchWithTimeout()` | `lib/util.ts` | Fetch with configurable timeout |
+| `createProviderProbe()` | `lib/provider-probe.ts` | Model availability probing + auto-hide |
+| `wrapSessionStartHandler()` | `lib/session-start-metrics.ts` | Wrap handlers with session start metrics |
+
+---
+
+## Code Quality Requirements
+
+All new providers must pass the CI checks:
+
+1. **TypeScript** — no type errors (`npm run lint`)
+2. **Tests** — existing tests still pass (`npm run test:run`)
+3. **SonarCloud** — Cognitive Complexity ≤ 15 per function, no security violations
+4. **CodeQL** — no security alerts (protocol-mandatory crypto must be documented with comments)
+
+### Cognitive Complexity
+
+SonarCloud requires cognitive complexity ≤ 15 per function. Keep functions small:
+
+- Extract SSE/delta processing into separate functions
+- Extract request building into helpers
+- Extract setup/initialization into separate functions
+- Use early returns instead of deep nesting
+
+### Security
+
+If your provider requires non-standard cryptographic primitives (MD5, AES-CBC with unusual IV, etc.):
+
+1. Document **why** with inline comments referencing the protocol source
+2. Example: `// sonar-security: MD5 is protocol-mandatory for COSY signature`
+
+---
+
+## Testing
+
+Add tests for any provider-specific logic:
+
+```typescript
+// tests/myprovider.test.ts
+import { describe, it, expect, vi } from "vitest";
+
+describe("myprovider", () => {
+    it("detects free models correctly", () => {
+        // ...
+    });
+});
+```
+
+Run tests locally:
+
+```bash
+npm test          # watch mode
+npm run test:run  # single run
+```
+
+---
+
+## Development Workflow
+
+```bash
+# Clone and setup
+git clone https://github.com/apmantza/pi-free.git
+cd pi-free
+npm install
+
+# Develop on a feature branch
+git checkout -b feat/my-provider
+
+# Test locally
+npm run lint
+npm run test:run
+
+# Commit and push
+git add -A
+git commit -m "feat: add myprovider with free models"
+git push origin feat/my-provider
+
+# Open PR against master
+```
+
+---
+
+## Questions?
+
+- Check existing providers in [`providers/`](providers/) for reference
+- Read the [AGENTS.md](AGENTS.md) for architecture details
+- [Open an issue](https://github.com/apmantza/pi-free/issues) if you need help

--- a/README.md
+++ b/README.md
@@ -14,552 +14,83 @@ Free and paid AI model providers for [Pi](https://pi.dev). Access **free and pai
 
 When you install pi-free, it:
 
-1. **Registers free-tier providers** with Pi's model picker — Kilo (free), Cline (free), LLM7 (free), TokenRouter (1 free model), OpenModel (6 free models including DeepSeek V4 Flash event), ZenMux (paid), CrofAI (paid), Ollama Cloud (freemium), SambaNova (freemium), Codestral (freemium), DeepInfra (trial credit), Together AI (trial credit), Novita (paid), Routeway (paid), b.ai (paid), and more
-
-2. **Captures Pi's built-in OpenCode and OpenRouter providers** with a free/paid toggle — OpenCode and OpenRouter are now built into Pi; pi-free adds `/toggle-opencode` and `/toggle-openrouter` so you can switch between free-only and all models without restart
-
-3. **Fetches models dynamically** from provider APIs — ZenMux, CrofAI, and Pi's built-in providers (Mistral, Groq, Cerebras, xAI, Hugging Face, OpenRouter) when API keys are configured
-
-4. **Filters to show only free models by default** for providers that expose pricing — You see only the models that cost $0 to use. Paid models are hidden until you explicitly toggle them on.
-
-5. **Provides per-provider toggle commands** — Run `/toggle-{provider}` (e.g., `/toggle-kilo`) to switch between free-only mode and showing all models including paid ones. Changes apply immediately and your preference is saved for the next Pi restart.
-
-6. **Handles authentication for you** — OAuth flows (Kilo, Cline) open your browser automatically; API keys are read from `~/.pi/free.json` or environment variables
-
-7. **Adds Coding Index scores** — Model names include a coding benchmark score (CI: 45.2) to help you pick capable coding models at a glance
-
-8. **Persists your preferences** — Your toggle choices (free vs all models) are saved to `~/.pi/free.json` and remembered across Pi restarts
+1. **Registers free-tier providers** — Kilo, Cline, LLM7, OpenModel, TokenRouter, and more
+2. **Captures Pi's built-in providers** with free/paid toggles — OpenCode, OpenRouter
+3. **Fetches models dynamically** — ZenMux, CrofAI, Mistral, Groq, Cerebras, xAI, Hugging Face when API keys are configured
+4. **Filters to show only free models by default** — paid models hidden until explicitly toggled on
+5. **Provides per-provider toggle commands** — `/toggle-{provider}` switches free ↔ all immediately
+6. **Handles authentication** — OAuth flows open your browser; API keys from `~/.pi/free.json` or env vars
+7. **Adds Coding Index scores** — model names include benchmark scores (`CI: 45.2`) for quick comparison
+8. **Auto-probes and hides broken models** — expired free tiers and decommissioned models detected automatically
 
 ---
 
-## How to use
-
-### 1. Install the extension
+## Install
 
 ```bash
 pi install git:github.com/apmantza/pi-free
 ```
 
-### 2. Open the model picker
+Press `Ctrl+L` to open the model picker. Free models are shown by default.
 
-Start Pi and press `Ctrl+L` to open the model picker.
+---
 
-Free models are shown by default — look for the provider prefixes:
+## Quick Start
 
-**✅ Free Models (no payment required):**
+### 1. Use free models (no setup)
 
-- `kilo/` — Kilo models (free models available immediately, more after `/login kilo`)
-- `openrouter/` — OpenRouter models (free account required)
-- `cline/` — Cline models (run `/login cline` to use)
-- `llm7/` — LLM7 gateway models (free tier: default/fast selectors, 100 req/hr)
-- `tokenrouter/` — TokenRouter gateway (1 free model: `MiniMax-M3`; requires API key with credits for the rest)
-- `openmodel/` — OpenModel AI gateway (6 free models including `deepseek-v4-flash` during the current free event — 1M context, MoE; 10 RPM / 100K TPM daily quota)
-
-**🔄 Freemium (free tier with limits, then paid):**
-
-- `ollama-cloud/` — Ollama Cloud models (usage-based free tier, resets every 5 hours + 7 days)
-- `sambanova/` — SambaNova Cloud models (20-480 RPM free, no credit card required)
-- `codestral/` — Codestral via Mistral (free Experiment plan: 2 req/min, 1B tokens/month)
-- `naraya/` — ~~Naraya AI Router~~ (removed: Naraya's `/v1/*` gateway is down as of 2026-06-23; see CHANGELOG)
-- `agentrouter/` — AgentRouter free public-welfare gateway (5 Claude models with Anthropic-compatible access; requires API key)
-
-**💳 Paid Providers (API key with credits required):**
-
-- `zenmux/` — ZenMux AI gateway (200+ models from OpenAI, Anthropic, Google, etc.)
-- `crofai/` — CrofAI OpenAI-compatible API (streaming, reasoning models)
-- `deepinfra/` — DeepInfra inference cloud ($5 one-time trial credit, no credit card)
-- `novita/` — Novita AI (100+ open-source models, OpenAI-compatible, 3 free models)
-- `routeway/` — Routeway AI gateway (OpenAI-compatible, `:free` models)
-- `together/` — Together AI ($1 one-time trial credit, 200+ open-source models)
-
-> **Note:** Paid providers may occasionally offer free models or promotional credits. The `isFreeModel` helper automatically detects free models based on provider pricing data or model names containing "free". For providers that don't expose pricing (like CrofAI), only models with "free" in their names are marked as free.
-
-**🔧 Dynamic API Providers (fetched when API key configured):**
-
-- `mistral/` — Mistral models (when `MISTRAL_API_KEY` set)
-- `groq/` — Groq models (when `GROQ_API_KEY` set)
-- `cerebras/` — Cerebras models (when `CEREBRAS_API_KEY` set)
-- `xai/` — xAI models (when `XAI_API_KEY` set)
-- `huggingface/` — Hugging Face models (when `HF_TOKEN` set)
-- `openrouter/` — OpenRouter models (fetched from openrouter.ai, when `OPENROUTER_API_KEY` set)
-- `fastrouter/` — FastRouter models (always discovered, 170+ models, no auth for listing)
-
-**Note:** Fireworks and NVIDIA NIM are now [built-in Pi providers](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md#0681---2026-04-22) — no extension needed. Set `FIREWORKS_API_KEY` or `NVIDIA_API_KEY` to use them directly.
-
-### 3. Toggle between free and paid models
-
-Want to see paid models too? Run the toggle command for your provider:
+Kilo and Cline models appear immediately. To unlock all models:
 
 ```
-/toggle-kilo       # Toggle Kilo (✅ offers free models)
-/toggle-openrouter # Toggle OpenRouter (✅ offers free models)
-/toggle-opencode   # Toggle OpenCode (✅ offers free models)
-/toggle-cline      # Toggle Cline (✅ offers free models)
-/toggle-ollama     # Toggle Ollama Cloud (🔄 freemium)
-/toggle-mistral    # Toggle Mistral (🔧 dynamic - needs API key)
-/toggle-groq       # Toggle Groq (🔧 dynamic - needs API key)
-/toggle-cerebras   # Toggle Cerebras (🔧 dynamic - needs API key)
-/toggle-xai        # Toggle xAI (🔧 dynamic - needs API key)
-/toggle-huggingface # Toggle Hugging Face (🔧 dynamic - needs HF_TOKEN)
-/toggle-zenmux    # Toggle ZenMux (💳 paid - needs API key with credits)
-/toggle-crofai    # Toggle CrofAI (💳 paid - needs API key with credits)
-/toggle-codestral # Toggle Codestral (🔄 free Experiment plan)
-/toggle-deepinfra # Toggle DeepInfra (💳 trial credit provider)
-/toggle-together  # Toggle Together AI (💳 trial credit provider)
-/toggle-sambanova # Toggle SambaNova (🔄 freemium)
-/toggle-llm7      # Toggle LLM7 (✅ free gateway)
-/toggle-novita    # Toggle Novita AI (💳 paid — 3 free models)
-/toggle-routeway  # Toggle Routeway AI (💳 paid — has :free models)
-/toggle-fastrouter # Toggle FastRouter (🔧 dynamic — always discovered)
-/toggle-tokenrouter # Toggle TokenRouter (💳 paid — 1 free model)
-/toggle-openmodel   # Toggle OpenModel (✅ 6 free models — deepseek-v4-flash free event)
-/toggle-agentrouter # Toggle AgentRouter (🔄 freemium — free public-welfare gateway)
+/login kilo      # Kilo free OAuth
+/login cline     # Cline free OAuth
 ```
 
-**Notes:**
+### 2. Toggle between free and paid
 
-- **Toggle commands are mainly for ✅ and 🔄 providers** — to switch between "free models only" vs "show paid models too"
-- **🔧 Dynamic providers** show all fetched models by default — the toggle filters the list when you have an API key configured
-- **Freemium providers** show all models by default; you manage your usage limits via their dashboards
+```
+/toggle-kilo       # Kilo free ↔ all
+/toggle-openrouter # OpenRouter free ↔ all
+/toggle-free       # global free-only mode
+/free-providers    # show model counts
+```
 
-### 4. Add API keys for more providers (optional)
+### 3. Add API keys (optional)
 
-Some providers require a free account or API key.
-
-**The first time you run Pi after installing this extension, a config file is automatically created:**
-
-- **Linux/Mac:** `~/.pi/free.json`
-- **Windows:** `%USERPROFILE%\.pi\free.json`
-
-Add your API keys to this file:
+First run creates `~/.pi/free.json` automatically. Add keys there or use environment variables:
 
 ```json
 {
   "ollama_api_key": "...",
-  "mistral_api_key": "...",
-  "codestral_api_key": "...",
-  "deepinfra_api_key": "...",
   "sambanova_api_key": "...",
-  "llm7_api_key": "...",
-  "zenmux_api_key": "...",
-  "crofai_api_key": "...",
-  "routeway_api_key": "sk-..."
+  "deepinfra_api_key": "..."
 }
 ```
 
-Or set environment variables instead (same names, uppercase: `OPENROUTER_API_KEY`, `OLLAMA_API_KEY`, etc.)
+---
 
-If `~/.pi/free.json` contains invalid JSON, pi-free now logs the parse error to `~/.pi/free.log` so you can fix the file quickly.
+## Provider Catalog
 
-See the [Providers That Need Authentication](#providers-that-need-authentication) section below for detailed setup instructions per provider.
+| Category | Providers |
+|---|---|
+| ✅ **Free** | Kilo, Cline, OpenRouter, OpenCode, LLM7, OpenModel, TokenRouter (1 free) |
+| 🔄 **Freemium** | Ollama Cloud, SambaNova, Codestral, AgentRouter |
+| 💳 **Paid** | ZenMux, CrofAI, DeepInfra, Together, Novita, Routeway, b.ai |
+| 🔧 **Dynamic** | Mistral, Groq, Cerebras, xAI, Hugging Face, FastRouter |
 
-### 5. Quick commands reference
-
-| Command                    | What it does                                              |
-| -------------------------- | --------------------------------------------------------- |
-| `/toggle-{provider}`       | Switch between free-only and all models for that provider |
-| `/toggle-free`             | Toggle global free-only mode for ALL providers            |
-| `/free-providers`          | Show free/paid model counts for all providers             |
-| `/free-telemetry`          | Show real-world performance data (tokens/s, latency, success rate) for free models |
-| `/clear-free-telemetry`    | Clear all stored telemetry data                           |
-| `/login kilo`              | Start OAuth flow for Kilo                                 |
-| `/login cline`             | Start OAuth flow for Cline                                |
-| `/logout kilo`             | Clear Kilo OAuth credentials                              |
-| `/logout cline`            | Clear Cline OAuth credentials                             |
+**Full catalog and setup instructions:** [docs/providers.md](docs/providers.md)
 
 ---
 
-## Features
-
-### 🔍 Model Availability Probing
-
-Some provider APIs list models that return errors when you try to use them (expired free promotions, decommissioned models, server spin-down). pi-free automatically detects and hides broken models:
-
-- **Ollama Cloud**: `/probe-ollama` — probes for 403 errors, auto-hides inaccessible models
-- **Routeway**: `/probe-routeway` — probes for 5xx/404 errors, auto-hides broken models
-- **OpenCode**: `/probe-opencode`, `/probe-opencode-go` — probes for expired free promotions (reports only, no auto-hide)
-- **DeepInfra**: `/probe-deepinfra` — probes for 404/5xx errors, auto-hides broken models
-- **SambaNova**: `/probe-sambanova` — probes for 404/5xx errors, auto-hides broken models
-- **Together AI**: `/probe-together` — probes for 404/5xx errors, auto-hides broken models
-- **Novita AI**: `/probe-novita` — probes for 404/5xx errors, auto-hides broken models
-
-All probes use a **24-hour probe cache** to avoid re-checking recently-verified models. Run any probe command manually to force a full re-check, or let the lazy auto-probe on first `session_start` handle it.
-
-### 🎯 Coding Index (CI) Scores
-
-Every model shows a **Coding Index score** (e.g., `CI: 52.3`) in the model picker:
-
-- **Benchmark-based** — Scores derived from Artificial Analysis coding benchmarks (HumanEval, MBPP, etc.)
-- **Quality indicator** — Higher scores = better coding performance
-- **All providers** — Applied to every model from every provider (Mistral, Groq, Cerebras, etc.)
-
-**Missing CI scores?** Provider model IDs often don't match benchmark database keys exactly. pi-free applies provider-specific normalization to improve matching:
-
-| Provider     | Normalization Applied                                              |
-| ------------ | ------------------------------------------------------------------ |
-| **Fireworks**   | Strips vendor prefixes (`meta/`, `mistralai/`, `microsoft/`, etc.) |
-| **Groq**     | Removes `-versatile` and numeric suffixes (`-32768`)               |
-| **Cerebras** | Normalizes `llama3.1` → `llama-3.1`, adds `instruct` suffix        |
-| **Mistral**  | Strips `-latest` suffix                                            |
-| **Ollama**   | Converts `model:tag` → `model-tag`                                 |
-
-**Debug missing scores:** Check `~/.pi/modelmatch.log` to see which models matched/didn't match and what normalization was applied.
-
-### 🔄 Free/Paid Model Toggling
-
-Providers have different pricing models. pi-free handles them all:
-
-- **Free-only by default** — Shows only zero-cost models initially
-- **Auto-probe on session_start** — Lazy background probes detect broken models automatically on your first session; no manual command needed
-- **Per-provider toggles** — Run `/toggle-{provider}` to switch between "free only" vs "all models"
-- **Persists across sessions** — Your preference is saved to `~/.pi/free.json`
-- **Instant updates** — Changes apply immediately; no Pi restart needed
-
-**Provider types:**
-
-- ✅ **Free providers** (Kilo, Cline) — Toggle between free-only vs paid models
-- 🔄 **Freemium** (Ollama, SambaNova) — Free tier with limits, toggle shows all
-- 🔧 **Dynamic API** (Mistral, Groq, Cerebras, xAI) — Fetched when API key configured, toggle filters the list
-
-### 🔐 OAuth + API Key Handling
-
-Authentication is handled automatically:
-
-- **OAuth flows** — `/login kilo` and `/login cline` open your browser, wait for authorization, and complete automatically
-- **Multiple auth sources** — API keys read from `~/.pi/free.json`, environment variables, or standard Pi auth files (`~/.pi/agent/auth.json`)
-
----
-
-## Using Free Models (No Setup Required)
-
-### Kilo (free models, more after login)
-
-Kilo shows free models immediately. To unlock all models, authenticate with Kilo's free OAuth:
-
-```
-/login kilo
-```
-
-This command will:
-
-1. Open your browser to Kilo's authorization page
-2. Show a device code in Pi's UI
-3. Wait for you to authorize in the browser
-4. Automatically complete login once approved
-
-- No credit card required
-- Free tier: 200 requests/hour
-- After login, run `/toggle-kilo` to switch between free-only and all models
-
-### Cline (free account)
-
-Cline models appear immediately in the model picker. To use them, authenticate with Cline's free account:
-
-```
-/login cline
-```
-
-This command will:
-
-1. Open your browser to Cline's sign-in page
-2. Wait for you to complete sign-in
-3. Automatically complete login once approved
-
-- Free account required (no credit card)
-- Uses local ports 48801-48811 for OAuth callback
-
----
-
-## Providers That Need Authentication
-
-Some providers require a free account or API key to access their free tiers.
-
----
-
-### 🆓 Free Providers
-
-### OpenRouter (free models available)
-
-Get a free API key at [openrouter.ai/keys](https://openrouter.ai/keys), then either:
-
-**Option A: Environment variable**
-
-```bash
-export OPENROUTER_API_KEY="sk-or-v1-..."
-```
-
-**Option B: Pi's auth file** (`~/.pi/agent/auth.json`)
-
-OpenRouter reads its key from Pi's built-in auth storage. Set it via:
-
-```bash
-export OPENROUTER_API_KEY="sk-or-v1-..."
-```
-
-Then use `/toggle-openrouter` to switch between free-only and all models.
-
-**Note:** `openrouter_api_key` in `~/.pi/free.json` is ignored. OpenRouter always reads from Pi's auth system to avoid stale keys.
-
-### NVIDIA NIM (now built-in)
-
-NVIDIA NIM is now a **built-in Pi provider** — no extension needed. Set `NVIDIA_API_KEY` to use it directly with Pi's built-in model picker.
-
-### Ollama Cloud
-
-Get an API key from [ollama.com/settings/keys](https://ollama.com/settings/keys), then:
-
-**Option A: Environment variable**
-
-```bash
-export OLLAMA_API_KEY="..."
-export OLLAMA_SHOW_PAID=true
-```
-
-**Option B: Config file** (`~/.pi/free.json`)
-
-```json
-{
-  "ollama_api_key": "YOUR_KEY",
-  "ollama_show_paid": true
-}
-```
-
-**Note:** Ollama requires `OLLAMA_SHOW_PAID=true` because they have usage limits on their cloud API.
-
-Free tier resets every 5 hours + 7 days.
-
-### Mistral (free API key)
-
-Add API key to `~/.pi/free.json` or environment variables:
-
-```bash
-export MISTRAL_API_KEY="..."
-```
-
----
-
-### 💳 Paid Providers
-
-### Codestral (free Experiment plan)
-
-Codestral is Mistral's code-focused model via `codestral.mistral.ai`:
-
-- Free tier (Experiment plan): 2 req/min, 500K tokens/min, 1B tokens/month
-- No credit card — phone verification only
-- Sign up at <https://console.mistral.ai/codestral>
-
-```bash
-export CODESTRAL_API_KEY="..."
-```
-
-Or add to `~/.pi/free.json`:
-
-```json
-{
-  "codestral_api_key": "YOUR_KEY"
-}
-```
-
-**Note:** Codestral uses Mistral's SDK (`mistral-conversations` API type), not OpenAI-completions.
-
-### LLM7.io (free gateway)
-
-LLM7 routes across multiple providers through a single OpenAI-compatible endpoint:
-
-- Free tier: default/fast selectors, 100 req/hr, 20 req/min
-- No credit card required
-- Get free token at <https://token.llm7.io/>
-
-```bash
-export LLM7_API_KEY="..."
-```
-
-### DeepInfra ($5 trial credit)
-
-AI inference cloud with 100+ open-source models:
-
-- $5 one-time credit on signup (no credit card)
-- ~5M tokens, expires after 90 days
-- 60 RPM (varies by model)
-
-```bash
-export DEEPINFRA_TOKEN="..."
-```
-
-### Together AI ($1 trial credit)
-
-Fast inference on 200+ open-source models:
-
-- $1 one-time credit on signup (no credit card)
-- 138 chat models (Llama, DeepSeek, Qwen, Mixtral, etc.)
-- 60 RPM, 600 RPD (varies by model)
-
-```bash
-export TOGETHER_AI_API_KEY="..."
-```
-
-### SambaNova Cloud (free tier)
-
-Fast inference on custom RDU hardware:
-
-- Free tier: 20-480 RPM, 400-9600 RPD (no credit card)
-- Models include Llama 3.3 70B, DeepSeek-V3/R1, Llama 4 Maverick
-
-```bash
-export SAMBANOVA_API_KEY="..."
-```
-
----
-
-## Slash Commands
-
-Each provider has toggle commands to switch between free and all models:
-
-| Command                 | Action                                                   |
-| ----------------------- | -------------------------------------------------------- |
-| `/toggle-kilo`          | Toggle between free/all Kilo models                      |
-| `/toggle-openrouter`    | Toggle between free/all OpenRouter models                |
-| `/toggle-opencode`      | Toggle between free/all OpenCode models                  |
-| `/toggle-cline`         | Toggle between free/all Cline models                     |
-| `/toggle-ollama`        | Toggle between free/all Ollama Cloud models              |
-| `/toggle-mistral`       | Toggle between free/all Mistral models (🔧 dynamic)      |
-| `/toggle-groq`          | Toggle between free/all Groq models (🔧 dynamic)         |
-| `/toggle-cerebras`      | Toggle between free/all Cerebras models (🔧 dynamic)     |
-| `/toggle-xai`           | Toggle between free/all xAI models (🔧 dynamic)          |
-| `/toggle-huggingface`   | Toggle between free/all Hugging Face models (🔧 dynamic)  |
-| `/toggle-codestral`     | Toggle Codestral (🔄 freemium)                           |
-| `/toggle-deepinfra`     | Toggle DeepInfra (💳 trial credit)                       |
-| `/toggle-together`      | Toggle Together AI (💳 trial credit)                     |
-| `/toggle-sambanova`     | Toggle SambaNova (🔄 freemium)                           |
-| `/toggle-llm7`          | Toggle LLM7 (✅ free gateway)                            |
-| `/toggle-zenmux`        | Toggle ZenMux (💳 paid)                                  |
-| `/toggle-crofai`        | Toggle CrofAI (💳 paid)                                  |
-| `/toggle-novita`        | Toggle Novita AI (💳 paid)                               |
-| `/toggle-routeway`      | Toggle Routeway AI (💳 paid)                             |
-| `/toggle-fastrouter`    | Toggle FastRouter (🔧 dynamic)                           |
-| `/toggle-tokenrouter`   | Toggle TokenRouter (💳 paid — 1 free model)              |
-| `/toggle-openmodel`     | Toggle OpenModel (✅ free gateway — deepseek-v4-flash event) |
-| `/toggle-agentrouter`   | Toggle AgentRouter (🔄 freemium — free public-welfare)    |
-| `/ollama-cloud-refresh` | Re-fetch Ollama Cloud models live (no restart needed)    |
-| `/probe-ollama`         | Test Ollama Cloud models for 403 errors (auto-hide)      |
-
-**The toggle command:**
-
-- **For ✅ free providers**: Switches between showing only free models vs. all available models (including paid)
-- **For 🔄 freemium providers**: Shows all models by default; toggle switches between filtered and full list
-- **For 🔧 dynamic API providers**: Filters the model list when you have an API key configured
-- **Persists your preference** to `~/.pi/free.json` for next startup
-
-### Probe Commands (Health Check)
-
-Test models for errors and auto-hide broken ones:
-
-| Command                | What it does                                                |
-| ---------------------- | ----------------------------------------------------------- |
-| `/probe-ollama`        | Test all Ollama Cloud models, auto-hide 403s                 |
-| `/probe-routeway`      | Test all Routeway models, auto-hide 5xx/404s                |
-| `/probe-opencode`      | Test all OpenCode free models for expired promotions        |
-| `/probe-opencode-go`   | Test all OpenCode Go free models for expired promotions     |
-| `/probe-deepinfra`     | Test all DeepInfra models for availability, auto-hide broken|
-| `/probe-sambanova`     | Test all SambaNova models for availability, auto-hide broken|
-| `/probe-together`      | Test all Together AI models for availability, auto-hide broken|
-| `/probe-novita`        | Test all Novita AI models for availability, auto-hide broken|
-
-**How it works:**
-
-1. Sends a minimal test request to every model
-2. Identifies broken models (404/403 responses)
-3. **Auto-hides** broken models in your config (provider-scoped: `"ollama/kimi-k2.6"`)
-4. Re-registers the provider so broken models disappear immediately
-5. Hidden models persist across Pi restarts
-
-Use these when you see models that appear in the picker but fail when you try to use them.
-
----
-
-## Configuration
-
-Create `~/.pi/free.json` in your home directory:
-
-```json
-{
-  "mistral_api_key": "YOUR_MISTRAL_KEY",
-  "ollama_api_key": "YOUR_OLLAMA_KEY",
-  "ollama_show_paid": true,
-  "hidden_models": ["model-id-to-hide"]
-}
-```
-
-Or use environment variables (same names, uppercase):
-
-```bash
-export MISTRAL_API_KEY="..."
-export OLLAMA_API_KEY="..."
-```
-
----
-
-## Logging & Debugging
-
-pi-free writes extension logs to:
-
-- **Windows:** `%USERPROFILE%\.pi\free.log`
-- **Linux/macOS:** `~/.pi/free.log`
-
-If the extension fails to read `~/.pi/free.json`, check this log first — config parse errors are written here.
-
-```bash
-# Console log verbosity (default: error)
-LOG_LEVEL=debug
-
-# File log verbosity (default: debug)
-PI_FREE_LOG_LEVEL=debug
-
-# Custom log path (optional)
-PI_FREE_LOG_PATH=/tmp/pi-free.log
-
-# Disable file logging
-PI_FREE_FILE_LOG=false
-```
-
-### Model Matching Debug Log
-
-To diagnose why some models don't show Coding Index scores, pi-free writes detailed matching diagnostics to:
-
-- **Windows:** `%USERPROFILE%\.pi\modelmatch.log`
-- **Linux/macOS:** `~/.pi/modelmatch.log`
-
-**Log format:**
-
-```
-timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details
-```
-
-**Example entries:**
-
-```
-2026-04-26T10:30:00Z|nvidia|meta/llama-3.1-405b-instruct|Llama 3.1 405B|match|provider-normalized:strip-nvidia-prefix|llama-3.1-405b-instruct|llama-3.1-instruct-405b|52.3|
-2026-04-26T10:30:01Z|groq|llama-3.1-70b-versatile|Llama 3.1 70B Versatile|match|strip-groq-versatile|llama-3.1-70b|llama-3.1-instruct-70b|48.5|
-2026-04-26T10:30:02Z|groq|mixtral-8x7b-instruct|Mixtral 8x7B|miss|all-strategies-failed|mixtral-8x7b-instruct|||
-```
-
-**Common mismatch patterns:**
-
-- `miss` + `all-strategies-failed` = Model not in benchmark database or ID format not recognized
-- Check `normalizedId` column to see what the lookup tried against
-
-**View the log:**
-
-```bash
-# Pretty-print with column alignment
-cat ~/.pi/modelmatch.log | column -t -s '|'
-
-# See only misses (models without CI scores)
-grep '|miss|' ~/.pi/modelmatch.log
-
-# See stats for specific provider
-grep '|nvidia|' ~/.pi/modelmatch.log | grep -c '|match|'
-```
+## Docs
+
+| Topic | Link |
+|---|---|
+| Provider catalog & auth | [docs/providers.md](docs/providers.md) |
+| Slash commands | [docs/commands.md](docs/commands.md) |
+| Configuration & logging | [docs/configuration.md](docs/configuration.md) |
+| Features deep dive | [docs/features.md](docs/features.md) |
+| Adding new providers | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,89 @@
+# Commands
+
+All slash commands provided by pi-free.
+
+---
+
+## Global Commands
+
+| Command | Description |
+|---|---|
+| `/toggle-free` | Toggle global free-only mode for ALL providers |
+| `/free-providers` | Show free/paid model counts for all providers |
+| `/free-telemetry` | Show real-world performance data (tokens/s, latency, success rate) for free models |
+| `/clear-free-telemetry` | Clear all stored telemetry data |
+
+---
+
+## Per-Provider Toggles
+
+Run `/toggle-{provider}` to switch between free-only and all models. Your preference is saved to `~/.pi/free.json` and remembered across Pi restarts.
+
+| Command | Provider | Type |
+|---|---|---|
+| `/toggle-kilo` | Kilo | ✅ free |
+| `/toggle-openrouter` | OpenRouter | ✅ free |
+| `/toggle-opencode` | OpenCode | ✅ free |
+| `/toggle-cline` | Cline | ✅ free |
+| `/toggle-ollama` | Ollama Cloud | 🔄 freemium |
+| `/toggle-sambanova` | SambaNova | 🔄 freemium |
+| `/toggle-codestral` | Codestral | 🔄 freemium |
+| `/toggle-llm7` | LLM7 | ✅ free |
+| `/toggle-novita` | Novita AI | 💳 paid |
+| `/toggle-routeway` | Routeway AI | 💳 paid |
+| `/toggle-tokenrouter` | TokenRouter | 💳 paid |
+| `/toggle-openmodel` | OpenModel | ✅ free |
+| `/toggle-agentrouter` | AgentRouter | 🔄 freemium |
+| `/toggle-zenmux` | ZenMux | 💳 paid |
+| `/toggle-crofai` | CrofAI | 💳 paid |
+| `/toggle-deepinfra` | DeepInfra | 💳 trial |
+| `/toggle-together` | Together AI | 💳 trial |
+| `/toggle-fastrouter` | FastRouter | 🔧 dynamic |
+| `/toggle-mistral` | Mistral | 🔧 dynamic |
+| `/toggle-groq` | Groq | 🔧 dynamic |
+| `/toggle-cerebras` | Cerebras | 🔧 dynamic |
+| `/toggle-xai` | xAI | 🔧 dynamic |
+| `/toggle-huggingface` | Hugging Face | 🔧 dynamic |
+
+**Notes:**
+
+- **✅ Free providers** — toggle switches between free-only vs all models (including paid)
+- **🔄 Freemium** — shows all models by default; toggle switches between filtered and full list
+- **🔧 Dynamic** — filters the model list when you have an API key configured
+- **💳 Paid** — shows all models by default
+
+---
+
+## OAuth Commands
+
+| Command | Description |
+|---|---|
+| `/login kilo` | Start OAuth flow for Kilo |
+| `/logout kilo` | Clear Kilo OAuth credentials |
+| `/login cline` | Start OAuth flow for Cline |
+| `/logout cline` | Clear Cline OAuth credentials |
+
+---
+
+## Probe Commands
+
+Test models for errors and auto-hide broken ones. All probes use a **24-hour cache** to avoid re-checking recently-verified models. Run any probe manually to force a full re-check.
+
+| Command | Provider | What it does |
+|---|---|---|
+| `/probe-ollama` | Ollama Cloud | Test for 403 errors, auto-hide |
+| `/probe-routeway` | Routeway | Test for 5xx/404 errors, auto-hide |
+| `/probe-opencode` | OpenCode | Test for expired free promotions (report only) |
+| `/probe-opencode-go` | OpenCode Go | Test for expired free promotions (report only) |
+| `/probe-deepinfra` | DeepInfra | Test for 404/5xx errors, auto-hide |
+| `/probe-sambanova` | SambaNova | Test for 404/5xx errors, auto-hide |
+| `/probe-together` | Together AI | Test for 404/5xx errors, auto-hide |
+| `/probe-novita` | Novita AI | Test for 404/5xx errors, auto-hide |
+
+**How probes work:**
+
+1. Sends a minimal test request to every model
+2. Identifies broken models (404/403/5xx responses)
+3. **Auto-hides** broken models in your config (provider-scoped: `"ollama/kimi-k2.6"`)
+4. Re-registers the provider so broken models disappear immediately
+5. Hidden models persist across Pi restarts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,132 @@
+# Configuration & Logging
+
+---
+
+## Config File
+
+pi-free reads settings from `~/.pi/free.json` (auto-created on first run).
+
+**Resolution order** (first wins):
+
+1. Environment variable
+2. `~/.pi/free.json`
+
+### API Keys
+
+```json
+{
+  "ollama_api_key": "YOUR_KEY",
+  "mistral_api_key": "YOUR_KEY",
+  "codestral_api_key": "YOUR_KEY",
+  "deepinfra_api_key": "YOUR_KEY",
+  "sambanova_api_key": "YOUR_KEY",
+  "llm7_api_key": "YOUR_KEY",
+  "zenmux_api_key": "YOUR_KEY",
+  "crofai_api_key": "YOUR_KEY",
+  "routeway_api_key": "sk-...",
+  "tokenrouter_api_key": "YOUR_KEY",
+  "bai_api_key": "YOUR_KEY",
+  "openmodel_api_key": "YOUR_KEY",
+  "novita_api_key": "YOUR_KEY",
+  "together_api_key": "YOUR_KEY"
+}
+```
+
+Or use environment variables (same names, uppercase):
+
+```bash
+export MISTRAL_API_KEY="..."
+export OLLAMA_API_KEY="..."
+```
+
+### Boolean Flags
+
+```json
+{
+  "free_only": true,
+  "ollama_show_paid": true,
+  "kilo_show_paid": true
+}
+```
+
+### Hidden Models
+
+Hide specific models per-provider:
+
+```json
+{
+  "hidden_models": [
+    "ollama/kimi-k2.6",
+    "deepinfra/meta-llama/Llama-3.3-70B-Instruct"
+  ]
+}
+```
+
+Use `"provider/model-id"` format for provider-scoped hiding. A bare `"model-id"` hides across all providers.
+
+---
+
+## Logging
+
+### Extension Log
+
+- **Windows:** `%USERPROFILE%\.pi\free.log`
+- **Linux/macOS:** `~/.pi/free.log`
+
+Config parse errors and provider startup messages are written here.
+
+### Model Match Log
+
+Diagnostic log for Coding Index score matching:
+
+- **Windows:** `%USERPROFILE%\.pi\modelmatch.log`
+- **Linux/macOS:** `~/.pi/modelmatch.log`
+
+**Log format:**
+
+```
+timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details
+```
+
+**View the log:**
+
+```bash
+# Pretty-print with column alignment
+cat ~/.pi/modelmatch.log | column -t -s '|'
+
+# See only misses (models without CI scores)
+grep '|miss|' ~/.pi/modelmatch.log
+```
+
+### Provider Cache
+
+Fetched model lists are cached on disk to avoid re-fetching on every session:
+
+- **Path:** `~/.pi/provider-cache.json`
+
+### Log Verbosity
+
+```bash
+# Console log verbosity (default: error)
+LOG_LEVEL=debug
+
+# File log verbosity (default: debug)
+PI_FREE_LOG_LEVEL=debug
+
+# Custom log path (optional)
+PI_FREE_LOG_PATH=/tmp/pi-free.log
+
+# Disable file logging
+PI_FREE_FILE_LOG=false
+```
+
+---
+
+## File Locations
+
+| File | Purpose |
+|---|---|
+| `~/.pi/free.json` | Config (API keys, flags, hidden models) |
+| `~/.pi/free.log` | Extension log |
+| `~/.pi/modelmatch.log` | Model match diagnostics |
+| `~/.pi/provider-cache.json` | Cached model lists |

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,68 @@
+# Features
+
+---
+
+## Free Model Detection
+
+pi-free uses **adaptive Route A/B detection** to identify free models:
+
+- **Route A** (pricing-exposed): If ANY model has cost > 0, use cost-based detection. Free = both input AND output cost are 0 (OR name contains "free").
+- **Route B** (non-pricing-exposed): If ALL models have cost === 0, use name-based detection only. Free = name contains "free" (case-insensitive).
+
+This avoids false positives where providers default all costs to 0 without exposing real pricing.
+
+---
+
+## Coding Index (CI) Scores
+
+Every model shows a **Coding Index score** (e.g., `CI: 52.3`) in the model picker:
+
+- **Benchmark-based** — scores from Artificial Analysis coding benchmarks (HumanEval, MBPP, etc.)
+- **Applied to all providers** — every model from every provider gets a CI score
+- **Multi-strategy matching** — direct match, variant alias, provider normalization, prefix fallback
+
+**Debug missing scores:** Check `~/.pi/modelmatch.log` to see which models matched or didn't match.
+
+---
+
+## Model Availability Probing
+
+Provider APIs often list models that return errors when actually used (expired free promotions, decommissioned models, server spin-down). pi-free automatically detects and hides broken models:
+
+- **Lazy auto-probe** — runs on first `session_start`, no manual command needed
+- **24-hour probe cache** — avoids re-checking recently-verified models
+- **Provider-scoped hiding** — broken models hidden in `~/.pi/free.json` as `"provider/model-id"`
+
+See [Commands](commands.md#probe-commands) for the full list of probe commands.
+
+---
+
+## Free/Paid Model Toggling
+
+- **Free-only by default** — shows only zero-cost models initially
+- **Per-provider toggles** — `/toggle-{provider}` switches between free-only and all models
+- **Global toggle** — `/toggle-free` applies to all providers at once
+- **Persists across sessions** — preference saved to `~/.pi/free.json`
+- **Instant updates** — changes apply immediately, no Pi restart needed
+
+---
+
+## Telemetry
+
+pi-free collects optional real-world performance data for free models:
+
+| Command | Description |
+|---|---|
+| `/free-telemetry` | Show tokens/s, latency, success rate |
+| `/clear-free-telemetry` | Clear all stored telemetry data |
+
+---
+
+## Non-OpenAI-Compatible Providers
+
+Most providers use OpenAI-compatible APIs. Some use custom protocols:
+
+- **Qoder** — proprietary COSY auth headers, WAF-encoded bodies, custom SSE streaming, PKCE OAuth device flow
+- **Cline** — OpenAI-compatible API with message reshaping for Cline's bot protocol
+
+These providers implement the full `streamSimple` interface that Pi expects, bridging their proprietary streaming to Pi's `AssistantMessageEventStream`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,231 @@
+# Providers
+
+Full catalog of providers registered by pi-free, how to authenticate, and per-provider setup.
+
+---
+
+## Provider Categories
+
+| Category | Emoji | Description |
+|---|---|---|
+| **Free** | ✅ | Models cost $0, no payment required |
+| **Freemium** | 🔄 | Free tier with limits, paid after |
+| **Paid** | 💳 | Requires credits or payment |
+| **Dynamic** | 🔧 | Fetched only when API key configured |
+
+---
+
+## ✅ Free Providers
+
+### Kilo
+
+Free models available immediately. More models after `/login kilo`.
+
+- No credit card required
+- Free tier: 200 requests/hour
+
+```
+/login kilo
+```
+
+This opens your browser to Kilo's authorization page, shows a device code, and completes automatically once approved.
+
+After login, run `/toggle-kilo` to switch between free-only and all models.
+
+### Cline
+
+Free account required (no credit card). Uses local ports 48801-48811 for OAuth callback.
+
+```
+/login cline
+```
+
+### OpenRouter
+
+Free models available with a free API key. Get one at [openrouter.ai/keys](https://openrouter.ai/keys).
+
+Set via environment variable:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-v1-..."
+```
+
+OpenRouter reads its key from Pi's built-in auth storage. Run `/toggle-openrouter` to switch between free-only and all models.
+
+### OpenModel
+
+6 free models including `deepseek-v4-flash` during the current free event (1M context, MoE; 10 RPM / 100K TPM daily quota).
+
+Requires API key — add to `~/.pi/free.json`:
+
+```json
+{
+  "openmodel_api_key": "YOUR_KEY"
+}
+```
+
+### LLM7
+
+Free gateway routing across multiple providers through a single OpenAI-compatible endpoint.
+
+- Free tier: default/fast selectors, 100 req/hr, 20 req/min
+- Get free token at [token.llm7.io](https://token.llm7.io/)
+
+```bash
+export LLM7_API_KEY="..."
+```
+
+### TokenRouter
+
+1 free model (`MiniMax-M3`); requires API key with credits for the rest.
+
+```bash
+export TOKENROUTER_API_KEY="..."
+```
+
+---
+
+## 🔄 Freemium Providers
+
+### Ollama Cloud
+
+Usage-based free tier, resets every 5 hours + 7 days.
+
+```bash
+export OLLAMA_API_KEY="..."
+```
+
+Or in `~/.pi/free.json`:
+
+```json
+{
+  "ollama_api_key": "YOUR_KEY",
+  "ollama_show_paid": true
+}
+```
+
+### SambaNova
+
+Free tier: 20-480 RPM, 400-9600 RPD (no credit card). Models include Llama 3.3 70B, DeepSeek-V3/R1, Llama 4 Maverick.
+
+```bash
+export SAMBANOVA_API_KEY="..."
+```
+
+### Codestral
+
+Mistral's code-focused model via `codestral.mistral.ai`.
+
+- Free Experiment plan: 2 req/min, 500K tokens/min, 1B tokens/month
+- No credit card — phone verification only
+- Sign up at [console.mistral.ai/codestral](https://console.mistral.ai/codestral)
+
+```bash
+export CODESTRAL_API_KEY="..."
+```
+
+**Note:** Codestral uses Mistral's SDK (`mistral-conversations` API type), not OpenAI-completions.
+
+### AgentRouter
+
+Free public-welfare gateway with 5 Claude models (Anthropic-compatible access). Requires API key.
+
+```bash
+export AGENTROUTER_API_KEY="..."
+```
+
+---
+
+## 💳 Paid Providers
+
+### ZenMux
+
+200+ models from OpenAI, Anthropic, Google, etc.
+
+```bash
+export ZENMUX_API_KEY="..."
+```
+
+### CrofAI
+
+OpenAI-compatible API with streaming and reasoning models.
+
+```bash
+export CROFAI_API_KEY="..."
+```
+
+### DeepInfra
+
+$5 one-time trial credit, no credit card. ~5M tokens, expires after 90 days. 60 RPM.
+
+```bash
+export DEEPINFRA_TOKEN="..."
+```
+
+### Together AI
+
+$1 one-time trial credit, no credit card. 200+ open-source models. 60 RPM.
+
+```bash
+export TOGETHER_AI_API_KEY="..."
+```
+
+### Novita
+
+100+ open-source models, OpenAI-compatible, 3 free models.
+
+```bash
+export NOVITA_API_KEY="..."
+```
+
+### Routeway
+
+OpenAI-compatible gateway with `:free` models.
+
+```bash
+export ROUTEWAY_API_KEY="sk-..."
+```
+
+### b.ai
+
+Paid provider.
+
+```bash
+export BAI_API_KEY="..."
+```
+
+---
+
+## 🔧 Dynamic API Providers
+
+Fetched only when the corresponding API key is configured.
+
+| Provider | Env Var | Config Key |
+|---|---|---|
+| Mistral | `MISTRAL_API_KEY` | `mistral_api_key` |
+| Groq | `GROQ_API_KEY` | `groq_api_key` |
+| Cerebras | `CEREBRAS_API_KEY` | `cerebras_api_key` |
+| xAI | `XAI_API_KEY` | `xai_api_key` |
+| Hugging Face | `HF_TOKEN` | `huggingface_api_key` |
+| OpenRouter | `OPENROUTER_API_KEY` | (uses Pi auth) |
+| FastRouter | always discovered | `fastrouter_api_key` |
+
+---
+
+## Built-in Pi Providers
+
+These are now built into Pi — no extension needed:
+
+- **Fireworks** — set `FIREWORKS_API_KEY`
+- **NVIDIA NIM** — set `NVIDIA_API_KEY`
+
+---
+
+## Removing a Provider
+
+To remove a provider that is no longer working (e.g., free tier expired):
+
+1. Open an issue describing the problem
+2. The provider will be removed in the next release and noted in [CHANGELOG.md](../CHANGELOG.md)
+
+See Naraya AI Router as an example — removed in v2.0.9 because their `/v1/*` gateway went down.

--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -47,16 +47,11 @@ const _logger = createLogger("bai");
 // =============================================================================
 // Known Free Models
 // B.AI doesn't expose pricing via /v1/models, so known-free models are
-// hardcoded. The site currently advertises `MiniMax-M3` as a limited-time
-// free promotional model; we hardcode that alias and any future `:free`
-// suffixed IDs (catches dynamic promotional additions).
+// detected by name suffix. Catches `:free`-tagged models the gateway
+// advertises as promotional.
 // =============================================================================
 
-const BAI_KNOWN_FREE_MODELS = new Set(["minimax-m3", "MiniMax-M3"]);
-
 function isBaiKnownFree(modelId: string): boolean {
-	if (BAI_KNOWN_FREE_MODELS.has(modelId)) return true;
-	// Catch any future `:free` suffixed model the gateway advertises
 	return modelId.toLowerCase().endsWith(":free");
 }
 

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -112,12 +112,9 @@ function isTokenRouterModel(model: { provider?: string }): boolean {
 
 // =============================================================================
 // Known Free Models
-// TokenRouter doesn't expose pricing via /v1/models, so known-free models
-// are hardcoded. Detected via name suffix also catches `:free`-tagged models.
+// TokenRouter doesn't expose pricing via /v1/models.
+// Known-free detection uses `:free` name suffix for promotional models.
 // =============================================================================
-
-const MINIMAX_M3_ID = "MiniMax-M3";
-const KNOWN_FREE_MODELS = new Set([MINIMAX_M3_ID]);
 const TOKENROUTER_OPENAI_API = "tokenrouter-openai-completions" as const;
 const TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS = 30_000;
 const MINIMAX_ADAPTIVE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
@@ -482,7 +479,7 @@ export function mapTokenRouterModel(
 	const reasoning = isMinimax || isLikelyReasoningModel({ id: model.id, name });
 	const isResponseApi =
 		model.supported_endpoint_types.includes("openai-response");
-	const isKnownFree = KNOWN_FREE_MODELS.has(model.id);
+	const isKnownFree = model.id.toLowerCase().endsWith(":free");
 
 	return {
 		id: model.id,


### PR DESCRIPTION
## Summary

Leaner README (570 → ~100 lines) with full documentation split into a new `docs/` folder, plus a `CONTRIBUTING.md` guide for adding new providers.

Also removes MiniMax-M3 as a hardcoded free model from b.ai and tokenrouter providers (no longer a guaranteed free promotional model).

## Changes

### Documentation
- **Slim README** — keeps quick start, provider summary, and links to docs/
- **docs/providers.md** — full provider catalog with auth setup per provider
- **docs/commands.md** — all slash commands (toggles, OAuth, probes)
- **docs/configuration.md** — config file, env vars, logging, file locations
- **docs/features.md** — free detection, CI scores, probing, non-OpenAI providers
- **CONTRIBUTING.md** — step-by-step provider addition guide

### Provider Fixes
- **b.ai** — removed `BAI_KNOWN_FREE_MODELS` set (MiniMax-M3 no longer guaranteed free)
- **tokenrouter** — removed `KNOWN_FREE_MODELS` set (same reason)
- Both providers now rely solely on ` :free` name suffix for dynamic promotional detection
- MiniMax thinking/compat patching logic preserved (unrelated to free model detection)