### PR TITLE
fix: remove MiniMax-M3 as hardcoded free model from b.ai and tokenrouter

### DIFF
--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -47,16 +47,11 @@ const _logger = createLogger("bai");
 // =============================================================================
 // Known Free Models
 // B.AI doesn't expose pricing via /v1/models, so known-free models are
-// hardcoded. The site currently advertises `MiniMax-M3` as a limited-time
-// free promotional model; we hardcode that alias and any future `:free`
-// suffixed IDs (catches dynamic promotional additions).
+// detected by name suffix. Catches `:free`-tagged models the gateway
+// advertises as promotional.
 // =============================================================================
 
-const BAI_KNOWN_FREE_MODELS = new Set(["minimax-m3", "MiniMax-M3"]);
-
 function isBaiKnownFree(modelId: string): boolean {
-	if (BAI_KNOWN_FREE_MODELS.has(modelId)) return true;
-	// Catch any future `:free` suffixed model the gateway advertises
 	return modelId.toLowerCase().endsWith(":free");
 }
 

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -112,12 +112,9 @@ function isTokenRouterModel(model: { provider?: string }): boolean {
 
 // =============================================================================
 // Known Free Models
-// TokenRouter doesn't expose pricing via /v1/models, so known-free models
-// are hardcoded. Detected via name suffix also catches `:free`-tagged models.
+// TokenRouter doesn't expose pricing via /v1/models.
+// Known-free detection uses `:free` name suffix for promotional models.
 // =============================================================================
-
-const MINIMAX_M3_ID = "MiniMax-M3";
-const KNOWN_FREE_MODELS = new Set([MINIMAX_M3_ID]);
 const TOKENROUTER_OPENAI_API = "tokenrouter-openai-completions" as const;
 const TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS = 30_000;
 const MINIMAX_ADAPTIVE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
@@ -482,7 +479,7 @@ export function mapTokenRouterModel(
 	const reasoning = isMinimax || isLikelyReasoningModel({ id: model.id, name });
 	const isResponseApi =
 		model.supported_endpoint_types.includes("openai-response");
-	const isKnownFree = KNOWN_FREE_MODELS.has(model.id);
+	const isKnownFree = model.id.toLowerCase().endsWith(":free");
 
 	return {
 		id: model.id,


### PR DESCRIPTION
MiniMax-M3 is no longer a guaranteed free promotional model on these gateways.

Known-free detection now relies solely on ` :free` name suffix which catches any future promotional additions dynamically.

**Not touched:** MiniMax thinking/compat patching logic in tokenrouter (handles `<thinking>` tag reshaping, unrelated to free model detection).