### PR TITLE
feat: add API key auth support for Kilo and Cline providers

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -74,6 +74,8 @@ interface PiFreeConfig {
 	tokenrouter_api_key?: string;
 	bai_api_key?: string;
 	openmodel_api_key?: string;
+	kilo_api_key?: string;
+	cline_api_key?: string;
 	kilo_free_only?: boolean;
 	hidden_models?: string[];
 	free_only?: boolean;
@@ -113,6 +115,8 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	tokenrouter_api_key: "",
 	bai_api_key: "",
 	openmodel_api_key: "",
+	kilo_api_key: "",
+	cline_api_key: "",
 
 	kilo_free_only: false,
 	hidden_models: [],
@@ -511,6 +515,14 @@ export function getBaiApiKey(): string | undefined {
 
 export function getOpenmodelApiKey(): string | undefined {
 	return resolve("OPENMODEL_API_KEY", loadConfigFile().openmodel_api_key);
+}
+
+export function getKiloApiKey(): string | undefined {
+	return resolve("KILO_API_KEY", loadConfigFile().kilo_api_key);
+}
+
+export function getClineApiKey(): string | undefined {
+	return resolve("CLINE_API_KEY", loadConfigFile().cline_api_key);
 }
 
 export function getOllamaApiKey(): string | undefined {

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -19,7 +19,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { getClineShowPaid } from "../../config.ts";
+import { getClineApiKey, getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
 import {
 	DEFAULT_PROVIDER_CACHE_TTL_MS,
@@ -84,6 +84,9 @@ function toApiKey(credentials: OAuthCredentials): string {
 // =============================================================================
 
 export default async function clineProvider(pi: ExtensionAPI) {
+	const clineApiKey = getClineApiKey();
+	const useApiKeyAuth = !!clineApiKey;
+
 	let allModels: ProviderModelConfig[];
 	const cachedModels = loadProviderCache(PROVIDER_CLINE);
 	if (cachedModels && cachedModels.length > 0) {
@@ -114,16 +117,21 @@ export default async function clineProvider(pi: ExtensionAPI) {
 			baseUrl: BASE_URL_CLINE,
 			api: "cline-xml-tools" as const,
 			authHeader: false,
+			apiKey: clineApiKey,
 			headers: buildClineHeaders(),
 			streamSimple: (model, context, options) =>
 				streamClineXml(model as any, context, options, buildClineHeaders()),
 			models: enhanceWithCI(m),
-			oauth: {
-				name: "Cline",
-				login: loginCline,
-				refreshToken: refreshClineToken,
-				getApiKey: toApiKey,
-			},
+			...(useApiKeyAuth
+				? {}
+				: {
+					oauth: {
+						name: "Cline",
+						login: loginCline,
+						refreshToken: refreshClineToken,
+						getApiKey: toApiKey,
+					},
+				}),
 		});
 	};
 
@@ -138,7 +146,8 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		toggleState.applyCurrent(reRegister);
 	};
 
-	registerWithGlobalToggle(PROVIDER_CLINE, stored, (m) => reRegister(m), false);
+	// Register with global toggle system (hasKey=true if API key auth configured)
+	registerWithGlobalToggle(PROVIDER_CLINE, stored, (m) => reRegister(m), useApiKeyAuth);
 	toggleState.applyCurrent(reRegister);
 
 	pi.registerCommand("toggle-cline", {

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -215,7 +215,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		baseReRegister(applyKiloCompat(models));
 
 	// Register with global toggle system
-	const hasKiloKey = !!process.env.KILO_API_KEY || !!getKiloApiKey();
+	const hasKiloKey = !!kiloApiKey;
 	registerWithGlobalToggle(
 		PROVIDER_KILO,
 		stored,

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -18,6 +18,7 @@ import type {
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import {
+	getKiloApiKey,
 	getKiloFreeOnly,
 	getKiloShowPaid,
 	PROVIDER_KILO,
@@ -152,7 +153,7 @@ function parseXmlToolCalls(
 const KILO_PROVIDER_CONFIG = {
 	providerId: PROVIDER_KILO,
 	baseUrl: KILO_GATEWAY_BASE,
-	apiKey: "$KILO_API_KEY",
+	apiKey: getKiloApiKey() || "$KILO_API_KEY",
 	headers: {
 		"X-KILOCODE-EDITORNAME": "Pi",
 	},
@@ -172,14 +173,17 @@ function applyKiloCompat<T extends { compat?: ProviderModelConfig["compat"] }>(
 }
 
 export default async function kiloProvider(pi: ExtensionAPI) {
+	// Resolve API key (env var or ~/.pi/free.json)
+	const kiloApiKey = getKiloApiKey();
+
 	// Try to fetch ALL models at startup (like Cline/OpenRouter)
-	// If no API key, this will return free models only
+	// With API key: returns all models; without: returns free-only
 	let allModels: ProviderModelConfig[] = [];
 	let freeModels: ProviderModelConfig[] = [];
 
 	try {
 		// Fetch all models (returns free-only if no auth, all if auth available)
-		allModels = await fetchKiloModels({ freeOnly: false });
+		allModels = await fetchKiloModels({ token: kiloApiKey, freeOnly: false });
 		// Derive free list using isFreeModel with allModels for detection
 		freeModels = allModels.filter((m) =>
 			isFreeModel({ ...m, provider: PROVIDER_KILO }, allModels),
@@ -211,11 +215,12 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		baseReRegister(applyKiloCompat(models));
 
 	// Register with global toggle system
+	const hasKiloKey = !!process.env.KILO_API_KEY || !!getKiloApiKey();
 	registerWithGlobalToggle(
 		PROVIDER_KILO,
 		stored,
 		reRegister,
-		!!process.env.KILO_API_KEY,
+		hasKiloKey,
 	);
 
 	// OAuth config for Kilo
@@ -283,14 +288,14 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	const modelsWithCompat = applyKiloCompat(currentModels);
 	pi.registerProvider(PROVIDER_KILO, {
 		baseUrl: KILO_GATEWAY_BASE,
-		apiKey: "$KILO_API_KEY",
+		apiKey: kiloApiKey || "$KILO_API_KEY",
 		api: "openai-completions" as const,
 		headers: {
 			"X-KILOCODE-EDITORNAME": "Pi",
 			"User-Agent": "pi-free-providers",
 		},
 		models: enhanceWithCI(modelsWithCompat),
-		oauth: oauthConfig,
+		...(!!kiloApiKey ? {} : { oauth: oauthConfig }),
 	});
 
 	// Registration complete - models registered silently (use LOG_LEVEL=info to see details)

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -27,8 +27,11 @@ vi.mock("../lib/util.ts", () => ({
 	logWarning: vi.fn(),
 }));
 
+const mockGetClineApiKey = vi.fn();
+
 vi.mock("../config.ts", () => ({
 	getClineShowPaid: () => mockGetClineShowPaid(),
+	getClineApiKey: () => mockGetClineApiKey(),
 	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
 }));
 

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -72,6 +72,7 @@ describe("Cline Provider", () => {
 		mockOn = vi.fn();
 		commandHandlers = {};
 		mockGetClineShowPaid.mockReturnValue(false);
+		mockGetClineApiKey.mockReturnValue(undefined);
 		mockLoadProviderCache.mockReturnValue(undefined);
 		mockSaveProviderCache.mockResolvedValue(undefined);
 		mockIsProviderCacheFresh.mockReturnValue(false);
@@ -160,6 +161,24 @@ describe("Cline Provider", () => {
 					]),
 				}),
 			);
+		});
+
+		it("should use API key auth when configured", async () => {
+			mockGetClineApiKey.mockReturnValue("sk-cline-test");
+			vi.mocked(fetchClineModels).mockResolvedValue([]);
+
+			await clineProvider(mockPi);
+
+			expect(mockRegisterProvider).toHaveBeenCalledWith(
+				"cline",
+				expect.objectContaining({
+					apiKey: "sk-cline-test",
+					authHeader: false,
+					streamSimple: expect.any(Function),
+				}),
+			);
+			const registerCall = mockRegisterProvider.mock.calls[0];
+			expect(registerCall[1]).not.toHaveProperty("oauth");
 		});
 	});
 

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -8,10 +8,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetchKiloModels = vi.fn();
 const mockRegisterWithGlobalToggle = vi.fn();
 let capturedToggleArgs: any[] = [];
+const mockGetKiloApiKey = vi.hoisted(() => vi.fn(() => undefined));
 
 vi.mock("../config.ts", () => ({
 	getKiloFreeOnly: vi.fn(() => false),
 	getKiloShowPaid: vi.fn(() => false),
+	getKiloApiKey: () => mockGetKiloApiKey(),
 	PROVIDER_KILO: "kilo",
 }));
 

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetchKiloModels = vi.fn();
 const mockSetupProvider = vi.fn();
 const mockLoginKilo = vi.fn();
+const mockGetKiloApiKey = vi.hoisted(() => vi.fn(() => undefined));
 
 // Mock dependencies before importing the provider
 vi.mock("../providers/kilo/kilo-auth.ts", () => ({
@@ -34,6 +35,7 @@ vi.mock("../lib/registry.ts", () => ({
 vi.mock("../config.ts", () => ({
 	getKiloFreeOnly: vi.fn(() => false),
 	getKiloShowPaid: vi.fn(() => false),
+	getKiloApiKey: () => mockGetKiloApiKey(),
 	PROVIDER_KILO: "kilo",
 }));
 

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetchKiloModels = vi.fn();
 const mockSetupProvider = vi.fn();
 const mockLoginKilo = vi.fn();
-const mockGetKiloApiKey = vi.hoisted(() => vi.fn(() => undefined));
+const mockGetKiloApiKey = vi.hoisted(() => vi.fn((): string | undefined => undefined));
 
 // Mock dependencies before importing the provider
 vi.mock("../providers/kilo/kilo-auth.ts", () => ({
@@ -55,6 +55,7 @@ describe("Kilo Provider", () => {
 		mockFetchKiloModels.mockReset();
 		mockSetupProvider.mockReset();
 		mockLoginKilo.mockReset();
+		mockGetKiloApiKey.mockReturnValue(undefined);
 
 		mockRegisterProvider = vi.fn();
 		mockOn = vi.fn();
@@ -115,6 +116,67 @@ describe("Kilo Provider", () => {
 
 			// Should still register with empty models
 			expect(mockRegisterProvider).toHaveBeenCalled();
+		});
+
+		it("should use API key auth when configured", async () => {
+			mockGetKiloApiKey.mockReturnValue("sk-kilo-test");
+			const mockModels = [
+				{
+					id: "gpt-4",
+					name: "GPT-4",
+					reasoning: true,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 4096,
+				},
+			];
+			mockFetchKiloModels.mockResolvedValue(mockModels);
+
+			await kiloProvider(mockPi);
+
+			expect(mockFetchKiloModels).toHaveBeenCalledWith(
+				expect.objectContaining({ token: "sk-kilo-test", freeOnly: false }),
+			);
+			expect(mockRegisterProvider).toHaveBeenCalledWith(
+				"kilo",
+				expect.objectContaining({
+					apiKey: "sk-kilo-test",
+				}),
+			);
+			const registerCall = mockRegisterProvider.mock.calls[0];
+			expect(registerCall[1]).not.toHaveProperty("oauth");
+		});
+	});
+
+	describe("registerWithGlobalToggle integration", () => {
+		it("should call registerWithGlobalToggle with hasKey=false by default", async () => {
+			const { registerWithGlobalToggle } = await import("../lib/registry.ts");
+			mockFetchKiloModels.mockResolvedValue([]);
+
+			await kiloProvider(mockPi);
+
+			expect(registerWithGlobalToggle).toHaveBeenCalledWith(
+				"kilo",
+				expect.objectContaining({ free: [], all: [] }),
+				expect.any(Function),
+				false,
+			);
+		});
+
+		it("should call registerWithGlobalToggle with hasKey=true when API key is set", async () => {
+			mockGetKiloApiKey.mockReturnValue("sk-kilo-test");
+			const { registerWithGlobalToggle } = await import("../lib/registry.ts");
+			mockFetchKiloModels.mockResolvedValue([]);
+
+			await kiloProvider(mockPi);
+
+			expect(registerWithGlobalToggle).toHaveBeenCalledWith(
+				"kilo",
+				expect.objectContaining({ free: [], all: [] }),
+				expect.any(Function),
+				true,
+			);
 		});
 	});
 


### PR DESCRIPTION
- config.ts: add kilo_api_key, cline_api_key fields + getters
- kilo.ts: use KILO_API_KEY for model fetch and provider registration; conditional OAuth (skipped when key present)
- cline.ts: use CLINE_API_KEY for auth; remove workos: prefix wrapper; conditional OAuth (skipped when key present)
- Both providers appear under /login as API-key-auth when key set

Env: KILO_API_KEY / CLINE_API_KEY
Config: ~/.pi/free.json -> kilo_api_key / cline_api_key