### PR TITLE
chore(release): 2.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,13 +147,20 @@ jobs:
           git tag "${{ needs.prepare.outputs.tag }}"
           git push origin "${{ needs.prepare.outputs.tag }}"
 
+      - name: Extract release notes from CHANGELOG
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: >-
+          node scripts/changelog-extract.mjs "$VERSION" --summary
+          -o "$RUNNER_TEMP/release-notes.md"
+
       - name: Create GitHub release
         uses: >-
           softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: ${{ needs.prepare.outputs.tag }}
-          generate_release_notes: true
+          body_path: ${{ runner.temp }}/release-notes.md
 
   publish-npm:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4] - 2026-06-27
+
 ### Added
 
 - **OpenModel AI provider** — Anthropic-compatible LLM gateway at `api.openmodel.ai` (24 models). Merges the public `/web/v1/models` catalog (real per-token pricing via `price_multiplier`, supports flags, max tokens) with the authed `/v1/models` protocol list. Registers only messages-protocol models. The current **DeepSeek V4 Flash Free Event** is automatically detected: `deepseek-v4-flash` has `price_multiplier=0` → free via Route A (no hardcoding required). 6 free models surface under `free_only`: `deepseek-v4-flash` (1M context, MoE), plus 5 DashScope Qwen models whose catalog entries have no per-token pricing. Set `OPENMODEL_API_KEY` or add `openmodel_api_key` to `~/.pi/free.json`. Toggle with `/toggle-openmodel` ([#269](https://github.com/apmantza/pi-free/pull/269)).
 
 - `npm run smoke:openmodel` — Live end-to-end check for the OpenModel Anthropic-Messages wire format. Reads `OPENMODEL_API_KEY` from env or `~/.pi/free.json`; skips with exit 0 when neither is set, exits 1 on any non-200 or malformed response.
+
+- **Kilo and Cline API key authentication** — Both providers now support direct API key auth alongside OAuth. Set `KILO_API_KEY` / `CLINE_API_KEY` (or `kilo_api_key` / `cline_api_key` in `~/.pi/free.json`) to skip the OAuth flow. When a key is configured, the provider registers without OAuth and uses the key for model fetching and chat requests ([#282](https://github.com/apmantza/pi-free/pull/282)).
 
 ### Removed
 

--- a/agents.md
+++ b/agents.md
@@ -6,7 +6,7 @@
 
 A **Pi extension** (`@earendil-works/pi-coding-agent`) that registers free and paid AI model providers with Pi's model picker. It shows free models by default and lets users toggle per-provider between free-only and all-models view via `/toggle-{provider}` commands.
 
-**Package:** `pi-free` v2.0.9  
+**Package:** `pi-free` v2.2.4  
 **Author:** Apostolos Mantzaris  
 **License:** MIT  
 **Repo:** `github.com/apmantza/pi-free`  
@@ -154,7 +154,7 @@ Debug logging writes to `~/.pi/modelmatch.log`.
 
 | Category    | Providers                                          | Auth              | Notes                            |
 | ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
-| ✅ Free     | kilo, cline, openrouter, opencode, llm7            | OAuth or none     | Toggle between free/paid         |
+| ✅ Free     | kilo, cline, openrouter, opencode, llm7            | OAuth, API key, or none | Toggle between free/paid         |
 | 🔄 Freemium | ollama-cloud, sambanova, codestral, tokenrouter    | API key           | Free tier with limits            |
 | 💳 Paid     | zenmux, crofai, deepinfra, together, novita, routeway | API key + credits | Trial credits or pay-per-token   |
 | 🔧 Dynamic  | mistral, groq, cerebras, xai, huggingface, fastrouter | API key        | Fetched when key configured      |
@@ -205,6 +205,10 @@ Debug logging writes to `~/.pi/modelmatch.log`.
 | `/logout kilo`       | Kilo         | Clear OAuth credentials                   |
 | `/logout cline`      | Cline        | Clear OAuth credentials                   |
 
+**Authentication notes:**
+
+- **Kilo** and **Cline** support both OAuth (`/login`) and direct API keys. Set `KILO_API_KEY` / `CLINE_API_KEY` (or `kilo_api_key` / `cline_api_key` in `~/.pi/free.json`) to skip OAuth and authenticate directly. When an API key is configured, the provider registers without OAuth and uses the key for model fetching and chat requests.
+
 ---
 
 ## Testing
@@ -226,6 +230,44 @@ Debug logging writes to `~/.pi/modelmatch.log`.
 6. Add tests to `tests/` if there's provider-specific logic worth testing
 
 ---
+
+## Release Workflow
+
+Releases are automated via `.github/workflows/release.yml`.
+
+1. **Update version** in `package.json` (semver: patch for fixes, minor for features, major for breaking changes).
+2. **Update `CHANGELOG.md`** — move content from `[Unreleased]` to a new `## [X.Y.Z] - YYYY-MM-DD` section.
+3. **Update `AGENTS.md`** if architecture, commands, or conventions changed.
+4. **Commit and push to `master`**.
+5. The CI workflow will:
+   - Read the version from `package.json`.
+   - Verify a matching `CHANGELOG.md` entry exists.
+   - Run `check:lockfile`, `audit:prod`, `lint`, `test:run`, `npm publish --dry-run`, tarball verification, and entry smoke-load.
+   - Create and push the `vX.Y.Z` tag.
+   - Extract the curated section from `CHANGELOG.md` via `scripts/changelog-extract.mjs --summary` and use it as the GitHub release body.
+   - Publish the package to npm (only if `NPM_TOKEN` is configured).
+
+Do **not** create the Git tag manually — the workflow creates it automatically on push to `master`.
+
+### Backfilling release notes
+
+To retroactively update existing GitHub releases with curated notes from `CHANGELOG.md`:
+
+```bash
+# dry run
+node scripts/backfill-github-releases.mjs
+
+# actually edit releases
+node scripts/backfill-github-releases.mjs --apply
+
+# full prose instead of summary
+node scripts/backfill-github-releases.mjs --apply --full
+
+# only specific releases
+node scripts/backfill-github-releases.mjs --apply --only v2.2.4,v2.1.1
+```
+
+Requires the `gh` CLI authenticated.
 
 ## Pi Extension API (Key Methods)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.2.3",
+	"version": "2.2.4",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [

--- a/scripts/backfill-github-releases.mjs
+++ b/scripts/backfill-github-releases.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Retroactively set every GitHub release body to its curated CHANGELOG section.
+//
+// The release history may have been created with auto-generated notes, so each
+// body is a thin PR-title list. The curated prose already lives in
+// CHANGELOG.md; this pushes it into the release bodies so the whole history
+// reads meaningfully.
+//
+//   node scripts/backfill-github-releases.mjs            # DRY RUN (default)
+//   node scripts/backfill-github-releases.mjs --apply    # actually edit releases
+//   node scripts/backfill-github-releases.mjs --apply --only v2.2.4,v2.1.1
+//   node scripts/backfill-github-releases.mjs --apply --full   # full prose
+//   node scripts/backfill-github-releases.mjs --repo owner/name --apply
+//
+// By default the release body is the scannable summary; `--full` writes the
+// whole CHANGELOG section instead. Requires the `gh` CLI authenticated.
+// Releases without a CHANGELOG section are skipped, never blanked.
+
+import { readFileSync, writeFileSync, mkdtempSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+	extractSection,
+	summarizeSection,
+	normalizeVersion,
+} from "./lib/changelog.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHANGELOG_PATH = join(__dirname, "..", "CHANGELOG.md");
+
+function parseArgs(argv) {
+	const args = { apply: false, full: false, repo: undefined, only: undefined };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--apply") args.apply = true;
+		else if (a === "--full") args.full = true;
+		else if (a === "--repo") args.repo = argv[++i];
+		else if (a === "--only")
+			args.only = new Set(
+				argv[++i].split(",").map((s) => normalizeVersion(s.trim())),
+			);
+	}
+	return args;
+}
+
+function gh(args) {
+	return execFileSync("gh", args, { encoding: "utf8" });
+}
+
+function listReleases(repo) {
+	const args = ["release", "list", "--limit", "200", "--json", "tagName"];
+	if (repo) args.push("--repo", repo);
+	const output = gh(args);
+	let parsed;
+	try {
+		parsed = JSON.parse(output);
+	} catch (err) {
+		throw new Error(`Failed to parse 'gh release list' output: ${String(err)}`);
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error("Unexpected 'gh release list' output: expected JSON array");
+	}
+	return parsed.map((r) => r.tagName);
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const changelog = readFileSync(CHANGELOG_PATH, "utf8");
+
+	let tags;
+	try {
+		tags = listReleases(args.repo);
+	} catch (err) {
+		console.error("Failed to list releases via `gh`. Is it installed/authed?");
+		console.error(String(err.message || err));
+		process.exit(1);
+	}
+
+	const tmp = mkdtempSync(join(tmpdir(), "pifree-relnotes-"));
+	const plan = [];
+	for (const tag of tags) {
+		if (args.only && !args.only.has(normalizeVersion(tag))) continue;
+		const full = extractSection(changelog, tag);
+		if (full === null || full.trim().length === 0) {
+			plan.push({ tag, action: "skip", reason: "no CHANGELOG section" });
+			continue;
+		}
+		const body = args.full ? full : summarizeSection(full);
+		plan.push({ tag, action: "update", body });
+	}
+
+	const updates = plan.filter((p) => p.action === "update");
+	const skips = plan.filter((p) => p.action === "skip");
+
+	console.log(
+		`${args.apply ? "APPLYING" : "DRY RUN"} — ${updates.length} release(s) to update, ${skips.length} skipped.\n`,
+	);
+	for (const p of skips) console.log(`  skip   ${p.tag}  (${p.reason})`);
+	for (const p of updates) {
+		const firstLine = p.body.split("\n").find((l) => l.trim()) ?? "";
+		console.log(`  update ${p.tag}  ${firstLine.slice(0, 70)}`);
+	}
+
+	if (!args.apply) {
+		console.log("\nRe-run with --apply to write these release bodies.");
+		return;
+	}
+
+	let ok = 0;
+	for (const p of updates) {
+		const notesFile = join(tmp, `${normalizeVersion(p.tag)}.md`);
+		writeFileSync(notesFile, p.body + "\n", "utf8");
+		const editArgs = ["release", "edit", p.tag, "--notes-file", notesFile];
+		if (args.repo) editArgs.push("--repo", args.repo);
+		try {
+			gh(editArgs);
+			ok++;
+			console.log(`  ok     ${p.tag}`);
+		} catch (err) {
+			console.error(`  FAIL   ${p.tag}: ${String(err.message || err)}`);
+		}
+	}
+	console.log(`\nUpdated ${ok}/${updates.length} release bodies.`);
+}
+
+main();

--- a/scripts/changelog-extract.mjs
+++ b/scripts/changelog-extract.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Print the curated CHANGELOG.md section body for a version.
+//
+//   node scripts/changelog-extract.mjs 2.2.4          # to stdout
+//   node scripts/changelog-extract.mjs v2.2.4 -o out  # to a file
+//
+// Used by .github/workflows/release.yml to feed `gh release create
+// --notes-file`, so the GitHub release body IS the curated section (single
+// source of truth). Exits non-zero with a clear message if the section is
+// missing or empty, which fails the release before it tags anything.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { extractSection, summarizeSection } from "./lib/changelog.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHANGELOG_PATH = join(__dirname, "..", "CHANGELOG.md");
+
+function parseArgs(argv) {
+	const args = { version: undefined, out: undefined, summary: false };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "-o" || a === "--out") args.out = argv[++i];
+		else if (a === "--summary") args.summary = true;
+		else if (!args.version) args.version = a;
+	}
+	return args;
+}
+
+function main() {
+	const { version, out, summary } = parseArgs(process.argv.slice(2));
+	if (!version) {
+		console.error(
+			"usage: changelog-extract.mjs <version> [--summary] [-o <file>]",
+		);
+		process.exit(2);
+	}
+	const text = readFileSync(CHANGELOG_PATH, "utf8");
+	const full = extractSection(text, version);
+	if (full === null || full.trim().length === 0) {
+		console.error(`No CHANGELOG section for version "${version}".`);
+		process.exit(1);
+	}
+	const body = summary ? summarizeSection(full) : full;
+	if (out) writeFileSync(out, body + "\n", "utf8");
+	else process.stdout.write(body + "\n");
+}
+
+main();

--- a/scripts/lib/changelog.mjs
+++ b/scripts/lib/changelog.mjs
@@ -1,0 +1,125 @@
+// Shared CHANGELOG.md parsing/extraction helpers (Keep a Changelog format).
+//
+// One source of truth: the curated CHANGELOG section for a version IS the body
+// of its GitHub release. `changelog-extract.mjs` (release workflow) builds on
+// these pure functions so the parsing rules stay identical everywhere.
+
+/** A version heading looks like `## [2.2.4] - 2026-06-27` or `## [Unreleased]`. */
+const VERSION_HEADING = /^## \[([^\]]+)\]/;
+
+/**
+ * Split a CHANGELOG into ordered sections. Each entry is the bracketed label
+ * (e.g. `2.2.4`, `Unreleased`) plus the raw body between this heading and the
+ * next `## ` heading (heading line excluded, surrounding blank lines trimmed).
+ *
+ * @param {string} text full CHANGELOG.md contents
+ * @returns {Array<{ label: string, heading: string, body: string }>}
+ */
+export function parseSections(text) {
+	const lines = text.split(/\r?\n/);
+	const sections = [];
+	let current = null;
+	for (const line of lines) {
+		const m = line.match(VERSION_HEADING);
+		if (m) {
+			if (current) sections.push(finalize(current));
+			current = { label: m[1].trim(), heading: line, bodyLines: [] };
+			continue;
+		}
+		if (current) current.bodyLines.push(line);
+	}
+	if (current) sections.push(finalize(current));
+	return sections;
+}
+
+function finalize(current) {
+	return {
+		label: current.label,
+		heading: current.heading,
+		body: current.bodyLines
+			.join("\n")
+			.replace(/^\n+/, "")
+			.replace(/\s+$/, ""),
+	};
+}
+
+/**
+ * Condense a section body into scannable release notes: keep the `### Added/
+ * Changed/Fixed` subheadings and each entry's bold title, but trim the entry to
+ * a single short gist (first sentence, length-capped). The full prose stays in
+ * CHANGELOG.md; this is what the GitHub release body shows.
+ *
+ * @param {string} body a section body from extractSection()
+ * @param {{ maxGist?: number }} [opts]
+ * @returns {string}
+ */
+export function summarizeSection(body, opts = {}) {
+	const maxGist = opts.maxGist ?? 130;
+	const order = [];
+	const buckets = new Map();
+	let heading = null;
+	for (const raw of body.split(/\r?\n/)) {
+		const line = raw.trimEnd();
+		const h = line.match(/^#{2,4}\s+(.*)$/);
+		if (h) {
+			heading = h[1].trim();
+			if (!buckets.has(heading)) {
+				buckets.set(heading, []);
+				order.push(heading);
+			}
+			continue;
+		}
+		const m = line.match(/^- (\*\*.+?\*\*)\s*(.*)$/);
+		if (!m || heading === null) continue;
+		const gist = cleanGist(m[2], maxGist);
+		buckets.get(heading).push(gist ? `- ${m[1]} — ${gist}` : `- ${m[1]}`);
+	}
+	const out = [];
+	for (const h of order) {
+		const items = buckets.get(h);
+		if (!items.length) continue;
+		out.push(`### ${h}`, "", ...items, "");
+	}
+	return out.join("\n").replace(/^\n+/, "").replace(/\s+$/, "");
+}
+
+function cleanGist(rest, maxGist) {
+	const text = rest
+		.replace(/^\s*\((?:refs?|closes?|fixes?)?\s*#\d+\)\s*/i, "")
+		.replace(/^\s*[—–:-]\s*/, "")
+		.trim();
+	if (!text) return "";
+	const period = text.search(/\.\s/);
+	const first = period >= 0 ? text.slice(0, period) : text;
+	return first.length > 0 && first.length <= maxGist ? first : "";
+}
+
+/**
+ * Normalize a tag/version to its bare semver form: `v2.2.4` -> `2.2.4`.
+ * @param {string} version
+ */
+export function normalizeVersion(version) {
+	return String(version).trim().replace(/^v/i, "");
+}
+
+/**
+ * Return the curated release-notes body for a version (heading excluded), or
+ * `null` if no matching `## [version]` section exists.
+ *
+ * @param {string} text full CHANGELOG.md contents
+ * @param {string} version e.g. "2.2.4" or "v2.2.4"
+ * @returns {string | null}
+ */
+export function extractSection(text, version) {
+	const want = normalizeVersion(version);
+	const section = parseSections(text).find(
+		(s) => normalizeVersion(s.label) === want,
+	);
+	return section ? section.body : null;
+}
+
+/** True if the CHANGELOG has a non-empty section for this version. */
+export function hasSection(text, version) {
+	const body = extractSection(text, version);
+	return typeof body === "string" && body.trim().length > 0;
+}


### PR DESCRIPTION
Release 2.2.4.

### Changes

- **Added**: Kilo and Cline API key authentication (skip OAuth when `KILO_API_KEY` / `CLINE_API_KEY` or config keys are set).
- **Added**: OpenModel AI provider — Anthropic-compatible gateway with 6 free models.
- **Added**: `scripts/changelog-extract.mjs` and `scripts/backfill-github-releases.mjs` for curated release notes.
- **Removed**: Broken AgentRouter and Naraya AI Router providers.
- **Fixed**: OpenModel 404 `route not found` by threading the correct `api` wire protocol through `provider-helper.ts`.
- **Changed**: Release workflow now posts the curated CHANGELOG summary as the GitHub release body instead of auto-generated notes.

Merging this will trigger the release workflow, which will create tag `v2.2.4`, create the GitHub release, and publish to npm.
