### PR TITLE
fix(release): authenticate tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,9 +155,13 @@ jobs:
 
       - name: Create and push tag
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git tag "$TAG"
-          git push origin "$TAG"
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com"
+          REMOTE="$REMOTE/${GITHUB_REPOSITORY}.git"
+          git push "$REMOTE" "$TAG"
 
       - name: Extract release notes from CHANGELOG
         env:


### PR DESCRIPTION
## Summary
- Push release tags using GITHUB_TOKEN because checkout disables persisted credentials
- Fixes the failed 2.2.5 release job at the Create and push tag step

## Validation
- Workflow YAML syntax checked by pi-lens