### PR TITLE
chore(release): 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.6] - 2026-07-09
+
 ### Changed
 
-- **Faster startup (cache-first provider loading)** — extends the cache-first pattern (already used by Cline) to kilo, fastrouter, and all OpenAI-compatible fetchers (tokenrouter, zenmux, crofai, deepinfra, sambanova, together, novita, routeway, bai, openmodel). Providers register from a fresh (1-hour TTL) disk cache and only hit the network on cold/stale cache; the dynamic built-in phase now runs concurrently with the static providers. Measured pi-free warm-cache load cost dropped from ~2.1s to ~70ms.
+- **Faster startup (~30x)** — warm-cache load dropped from ~2.1s to ~70ms: providers now serve from a 1-hour disk cache and fetch live only on cold/stale cache. Extends the cache-first pattern (already used by Cline) to kilo, fastrouter, and all OpenAI-compatible fetchers (tokenrouter, zenmux, crofai, deepinfra, sambanova, together, novita, routeway, bai, openmodel); the dynamic built-in phase runs concurrently with the static providers.
 - **Coding-Index debug logging is now opt-in** — `~/.pi/modelmatch.log` previously received one synchronous `appendFileSync` per model per match attempt at startup. Now off by default; set `PI_FREE_BENCHMARK_DEBUG=1` to re-enable.
 - **Config reads are memoized** — `~/.pi/free.json` is parsed once and reused while its mtime is unchanged.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.2.5",
+	"version": "2.2.6",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## Summary
Release **2.2.6** (patch).

- Removes the **Codestral** provider (its free tier is gone — see #293 / #296). Mistral remains available via pi's built-in dynamic provider (`MISTRAL_API_KEY`).
- Ships the cache-first provider loading work: **warm-cache startup dropped from ~2.1s to ~70ms (~30x)**.
- Memoized config reads; Coding-Index debug logging now opt-in; cache-poisoning guard.

Version bumped to `2.2.6` and CHANGELOG `[Unreleased]` promoted to a dated `2.2.6` section.

## Test plan
- `npm run lint` (tsc --noEmit) passes.
- `npm run test:run` — 466 tests pass.
- `node scripts/changelog-extract.mjs 2.2.6 --summary` surfaces the perf win.

🤖 Generated with [Pi](https://github.com/apmantza/pi-free)