### PR TITLE
feat: add AnyAPI free model provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Pi 0.80 compatibility** — update the Pi SDK peer requirements to `>=0.80.0` and refresh the development toolchain dependencies.
+- **AnyAPI provider** — add AnyAPI's OpenAI-compatible gateway with dynamic model discovery, free-model filtering, a 100K-token daily free plan, and `/toggle-anyapi` for switching to the full catalog.
 
 ## [2.2.6] - 2026-07-09
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Free and paid AI model providers for [Pi](https://pi.dev). Access **free and pai
 
 When you install pi-free, it:
 
-1. **Registers free-tier providers** — Kilo, Cline, LLM7, OpenModel, TokenRouter, and more
+1. **Registers free-tier providers** — Kilo, Cline, LLM7, OpenModel, TokenRouter, AnyAPI, and more
 2. **Captures Pi's built-in providers** with free/paid toggles — OpenCode, OpenRouter
 3. **Fetches models dynamically** — ZenMux, CrofAI, Mistral, Groq, Cerebras, xAI, Hugging Face when API keys are configured
 4. **Filters to show only free models by default** — paid models hidden until explicitly toggled on
@@ -62,6 +62,7 @@ First run creates `~/.pi/free.json` automatically. Add keys there or use environ
 ```json
 {
   "ollama_api_key": "...",
+  "anyapi_api_key": "...",
   "sambanova_api_key": "...",
   "deepinfra_api_key": "..."
 }
@@ -74,7 +75,7 @@ First run creates `~/.pi/free.json` automatically. Add keys there or use environ
 | Category | Providers |
 |---|---|
 | ✅ **Free** | Kilo, Cline, OpenRouter, OpenCode, LLM7, OpenModel, TokenRouter (1 free) |
-| 🔄 **Freemium** | Ollama Cloud, SambaNova, AgentRouter |
+| 🔄 **Freemium** | AnyAPI, Ollama Cloud, SambaNova |
 | 💳 **Paid** | ZenMux, CrofAI, DeepInfra, Together, Novita, Routeway, b.ai |
 | 🔧 **Dynamic** | Mistral, Groq, Cerebras, xAI, Hugging Face, FastRouter |
 

--- a/agents.md
+++ b/agents.md
@@ -52,6 +52,7 @@ index.ts                          ← Extension entry point (piFreeEntry)
       ├─ deepinfra/deepinfra.ts   ← DeepInfra ($5 trial credit)
       ├─ together/together.ts     ← Together AI (paid credits)
       ├─ tokenrouter/tokenrouter.ts ← TokenRouter API gateway (paid + free models)
+      ├─ anyapi/anyapi.ts         ← AnyAPI gateway (free plan + free models)
       ├─ qwen/qwen.ts             ← Qwen (deprecated, free tier removed)
       ├─ model-fetcher.ts         ← Shared OpenRouter-compatible model fetching
       ├─ opencode-session.ts      ← OpenCode session handling
@@ -156,7 +157,7 @@ Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DE
 | Category    | Providers                                          | Auth              | Notes                            |
 | ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
 | ✅ Free     | kilo, cline, openrouter, opencode, llm7            | OAuth, API key, or none | Toggle between free/paid         |
-| 🔄 Freemium | ollama-cloud, sambanova, tokenrouter    | API key           | Free tier with limits            |
+| 🔄 Freemium | anyapi, ollama-cloud, sambanova, tokenrouter | API key           | Free tier with limits            |
 | 💳 Paid     | zenmux, crofai, deepinfra, together, novita, routeway | API key + credits | Trial credits or pay-per-token   |
 | 🔧 Dynamic  | mistral, groq, cerebras, xai, huggingface, fastrouter | API key        | Fetched when key configured      |
 

--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import {
+	PROVIDER_ANYAPI,
 	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_FASTROUTER,
@@ -38,6 +39,7 @@ import {
 	PROVIDER_NOVITA,
 } from "./constants.ts";
 export {
+	PROVIDER_ANYAPI,
 	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_FASTROUTER,
@@ -78,6 +80,7 @@ interface PiFreeConfig {
 	routeway_api_key?: string;
 	fastrouter_api_key?: string;
 	tokenrouter_api_key?: string;
+	anyapi_api_key?: string;
 	bai_api_key?: string;
 	openmodel_api_key?: string;
 	kilo_api_key?: string;
@@ -98,6 +101,7 @@ interface PiFreeConfig {
 	routeway_show_paid?: boolean;
 	fastrouter_show_paid?: boolean;
 	tokenrouter_show_paid?: boolean;
+	anyapi_show_paid?: boolean;
 	bai_show_paid?: boolean;
 	openmodel_show_paid?: boolean;
 	openrouter_show_paid?: boolean;
@@ -118,6 +122,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_api_key: "",
 	fastrouter_api_key: "",
 	tokenrouter_api_key: "",
+	anyapi_api_key: "",
 	bai_api_key: "",
 	openmodel_api_key: "",
 	kilo_api_key: "",
@@ -139,6 +144,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_show_paid: false,
 	fastrouter_show_paid: false,
 	tokenrouter_show_paid: false,
+	anyapi_show_paid: false,
 	bai_show_paid: false,
 	openmodel_show_paid: false,
 	openrouter_show_paid: false,
@@ -345,6 +351,7 @@ const PROVIDER_META: readonly ProviderMeta[] = [
 		prefix: "TOKENROUTER",
 		showPaidKey: "tokenrouter_show_paid",
 	},
+	{ id: PROVIDER_ANYAPI, prefix: "ANYAPI", showPaidKey: "anyapi_show_paid" },
 	{ id: PROVIDER_BAI, prefix: "BAI", showPaidKey: "bai_show_paid" },
 	{
 		id: PROVIDER_OPENMODEL,
@@ -444,6 +451,10 @@ export function getTokenrouterShowPaid(): boolean {
 	);
 }
 
+export function getAnyapiShowPaid(): boolean {
+	return resolveBool("ANYAPI_SHOW_PAID", loadConfigFile().anyapi_show_paid);
+}
+
 export function getBaiShowPaid(): boolean {
 	return resolveBool("BAI_SHOW_PAID", loadConfigFile().bai_show_paid);
 }
@@ -539,6 +550,10 @@ export function getFastrouterApiKey(): string | undefined {
 
 export function getTokenrouterApiKey(): string | undefined {
 	return resolve("TOKENROUTER_API_KEY", loadConfigFile().tokenrouter_api_key);
+}
+
+export function getAnyapiApiKey(): string | undefined {
+	return resolve("ANYAPI_API_KEY", loadConfigFile().anyapi_api_key);
 }
 
 export function getBaiApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -23,6 +23,7 @@ export const PROVIDER_TOGETHER = "together";
 export const PROVIDER_NOVITA = "novita";
 export const PROVIDER_ROUTEWAY = "routeway";
 export const PROVIDER_TOKENROUTER = "tokenrouter";
+export const PROVIDER_ANYAPI = "anyapi";
 export const PROVIDER_BAI = "bai";
 export const PROVIDER_OPENMODEL = "openmodel";
 export const PROVIDER_QODER = "qoder";
@@ -48,6 +49,7 @@ export const ALL_UNIQUE_PROVIDERS = [
 	PROVIDER_NOVITA,
 	PROVIDER_ROUTEWAY,
 	PROVIDER_TOKENROUTER,
+	PROVIDER_ANYAPI,
 	PROVIDER_BAI,
 	PROVIDER_OPENMODEL,
 	PROVIDER_QODER,
@@ -73,6 +75,7 @@ export const BASE_URL_TOGETHER = "https://api.together.xyz/v1";
 export const BASE_URL_NOVITA = "https://api.novita.ai/openai/v1";
 export const BASE_URL_ROUTEWAY = "https://api.routeway.ai/v1";
 export const BASE_URL_TOKENROUTER = "https://api.tokenrouter.com/v1";
+export const BASE_URL_ANYAPI = "https://api.anyapi.ai/v1";
 export const BASE_URL_BAI = "https://api.b.ai/v1";
 /**
  * OpenModel is registered with `api: "anthropic-messages"`. The pi-ai

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,9 +30,9 @@ Run `/toggle-{provider}` to switch between free-only and all models. Your prefer
 | `/toggle-llm7` | LLM7 | ✅ free |
 | `/toggle-novita` | Novita AI | 💳 paid |
 | `/toggle-routeway` | Routeway AI | 💳 paid |
-| `/toggle-tokenrouter` | TokenRouter | 💳 paid |
+| `/toggle-tokenrouter` | TokenRouter | 🔄 freemium |
+| `/toggle-anyapi` | AnyAPI | 🔄 freemium |
 | `/toggle-openmodel` | OpenModel | ✅ free |
-| `/toggle-agentrouter` | AgentRouter | 🔄 freemium |
 | `/toggle-zenmux` | ZenMux | 💳 paid |
 | `/toggle-crofai` | CrofAI | 💳 paid |
 | `/toggle-deepinfra` | DeepInfra | 💳 trial |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ pi-free reads settings from `~/.pi/free.json` (auto-created on first run).
   "crofai_api_key": "YOUR_KEY",
   "routeway_api_key": "sk-...",
   "tokenrouter_api_key": "YOUR_KEY",
+  "anyapi_api_key": "YOUR_KEY",
   "bai_api_key": "YOUR_KEY",
   "openmodel_api_key": "YOUR_KEY",
   "novita_api_key": "YOUR_KEY",

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -87,6 +87,16 @@ export TOKENROUTER_API_KEY="..."
 
 ## 🔄 Freemium Providers
 
+### AnyAPI
+
+Free plan with 100K ANY tokens per day and no credit card. AnyAPI is an OpenAI-compatible gateway with explicitly free models plus paid models.
+
+```bash
+export ANYAPI_API_KEY="..."
+```
+
+Use `/toggle-anyapi` to switch between free models and the full catalog. Details: [anyapi.ai/pricing](https://anyapi.ai/pricing).
+
 ### Ollama Cloud
 
 Usage-based free tier, resets every 5 hours + 7 days.
@@ -110,14 +120,6 @@ Free tier: 20-480 RPM, 400-9600 RPD (no credit card). Models include Llama 3.3 7
 
 ```bash
 export SAMBANOVA_API_KEY="..."
-```
-
-### AgentRouter
-
-Free public-welfare gateway with 5 Claude models (Anthropic-compatible access). Requires API key.
-
-```bash
-export AGENTROUTER_API_KEY="..."
 ```
 
 ---

--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,7 @@ import tokenRouter from "./providers/tokenrouter/tokenrouter.ts";
 import ollama from "./providers/ollama/ollama.ts";
 import zenmux from "./providers/zenmux/zenmux.ts";
 import bai from "./providers/bai/bai.ts";
+import anyapi from "./providers/anyapi/anyapi.ts";
 import openmodel from "./providers/openmodel/openmodel.ts";
 import qoder from "./providers/qoder/qoder.ts";
 
@@ -67,6 +68,7 @@ const UNIQUE_PROVIDERS: ReadonlyArray<(pi: ExtensionAPI) => Promise<void>> = [
 	novita,
 	routeway,
 	tokenRouter,
+	anyapi,
 	bai,
 	openmodel,
 	qoder,

--- a/providers/anyapi/anyapi.ts
+++ b/providers/anyapi/anyapi.ts
@@ -1,0 +1,247 @@
+/**
+ * AnyAPI provider extension.
+ *
+ * AnyAPI is an OpenAI-compatible gateway with a free plan and a catalog of
+ * explicitly free models. It exposes the catalog at /v1/models and routes
+ * chat requests through /v1/chat/completions.
+ *
+ * Setup:
+ *   ANYAPI_API_KEY=...
+ *   # or add anyapi_api_key to ~/.pi/free.json
+ */
+
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import {
+	applyHidden,
+	getAnyapiApiKey,
+	getAnyapiShowPaid,
+} from "../../config.ts";
+import {
+	BASE_URL_ANYAPI,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_ANYAPI,
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
+import { fetchWithRetry, mapOpenRouterModel } from "../../lib/util.ts";
+import {
+	createReRegister,
+	loadCachedOrFetchModels,
+	setupProvider,
+} from "../../provider-helper.ts";
+
+const _logger = createLogger("anyapi");
+
+interface AnyApiModel {
+	id: string;
+	name?: string;
+	context_length?: number;
+	max_completion_tokens?: number | null;
+	top_provider?: {
+		context_length?: number | null;
+		max_completion_tokens?: number | null;
+	};
+	pricing?: {
+		prompt?: string | number | null;
+		completion?: string | number | null;
+		input_cache_read?: string | number | null;
+		input_cache_write?: string | number | null;
+	};
+	architecture?: {
+		input_modalities?: string[] | null;
+		output_modalities?: string[] | null;
+	};
+	supported_parameters?: string[] | null;
+	tags?: string[];
+	isFree?: boolean;
+}
+
+type AnyApiProviderModel = ProviderModelConfig & {
+	_pricingKnown?: boolean;
+	_freeKnown?: boolean;
+	_isFree?: boolean;
+};
+
+function hasPricing(model: AnyApiModel): boolean {
+	return (
+		(model.pricing?.prompt !== null && model.pricing?.prompt !== undefined) ||
+		(model.pricing?.completion !== null &&
+			model.pricing?.completion !== undefined) ||
+		(model.pricing?.input_cache_read !== null &&
+			model.pricing?.input_cache_read !== undefined) ||
+		(model.pricing?.input_cache_write !== null &&
+			model.pricing?.input_cache_write !== undefined)
+	);
+}
+
+function normalizePrice(
+	value: string | number | null | undefined,
+): string | null {
+	return value === null || value === undefined ? null : String(value);
+}
+
+/**
+ * Detect AnyAPI's explicitly free model labels without treating every model
+ * with omitted pricing as free. The API may also expose an authoritative flag
+ * or zero pricing, both of which are handled here.
+ */
+export function isAnyApiFreeModel(model: AnyApiModel): boolean {
+	if (typeof model.isFree === "boolean") return model.isFree;
+
+	const label = `${model.id} ${model.name ?? ""}`.toLowerCase();
+	if (/\bfree\b/.test(label)) return true;
+
+	if (!hasPricing(model)) return false;
+	const input = Number(model.pricing?.prompt);
+	const output = Number(model.pricing?.completion);
+	return input === 0 && output === 0;
+}
+
+export function mapAnyApiModel(model: AnyApiModel): AnyApiProviderModel {
+	const name = model.name ?? model.id;
+	const pricingKnown = hasPricing(model);
+	const freeKnown =
+		typeof model.isFree === "boolean" ||
+		/\bfree\b/i.test(`${model.id} ${name}`) ||
+		(pricingKnown && isAnyApiFreeModel(model));
+
+	const tags = model.tags ?? [];
+	const supportsReasoning =
+		tags.includes("reasoning") || tags.includes("chat_completions:reasoning");
+	const supportsVision =
+		tags.includes("vision") || tags.includes("chat_completions:vision");
+
+	const mapped = mapOpenRouterModel({
+		...model,
+		name,
+		supported_parameters:
+			model.supported_parameters ?? (supportsReasoning ? ["reasoning"] : []),
+		architecture: model.architecture ?? {
+			input_modalities: supportsVision ? ["text", "image"] : ["text"],
+			output_modalities: ["text"],
+		},
+		pricing: model.pricing
+			? {
+					prompt: normalizePrice(model.pricing.prompt),
+					completion: normalizePrice(model.pricing.completion),
+					input_cache_read: normalizePrice(model.pricing.input_cache_read),
+					input_cache_write: normalizePrice(model.pricing.input_cache_write),
+				}
+			: undefined,
+	});
+
+	return {
+		...mapped,
+		_pricingKnown: pricingKnown,
+		...(freeKnown && {
+			_freeKnown: true,
+			_isFree: isAnyApiFreeModel(model),
+		}),
+	};
+}
+
+function isTextModel(model: AnyApiModel): boolean {
+	const outputModalities = model.architecture?.output_modalities ?? [];
+	if (outputModalities.length > 0 && !outputModalities.includes("text")) {
+		return false;
+	}
+
+	const tags = model.tags;
+	if (!tags || tags.length === 0) return true;
+	return tags.some((tag) => tag.startsWith("chat_completions:"));
+}
+
+async function fetchAnyApiModels(
+	apiKey: string,
+): Promise<AnyApiProviderModel[]> {
+	const response = await fetchWithRetry(
+		`${BASE_URL_ANYAPI}/models`,
+		{
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				Accept: "application/json",
+				"Content-Type": "application/json",
+			},
+		},
+		3,
+		1000,
+		DEFAULT_FETCH_TIMEOUT_MS,
+	);
+
+	if (!response.ok) {
+		throw new Error(
+			`AnyAPI API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const json = (await response.json()) as { data?: AnyApiModel[] };
+	const models = (json.data ?? []).flatMap((model) => {
+		if (!model.id || !isTextModel(model)) return [];
+		return [mapAnyApiModel(model)];
+	});
+
+	_logger.info(`[anyapi] Fetched ${models.length} text models`);
+
+	const enriched = await safeEnrichModelsWithModelsDev(models, {
+		providerId: PROVIDER_ANYAPI,
+	});
+	return applyHidden(enriched, PROVIDER_ANYAPI) as AnyApiProviderModel[];
+}
+
+export default async function anyapiProvider(pi: ExtensionAPI) {
+	const apiKey = getAnyapiApiKey();
+	if (!apiKey) {
+		_logger.info("[anyapi] Skipping — ANYAPI_API_KEY not set.");
+		return;
+	}
+
+	const allModels = await loadCachedOrFetchModels(PROVIDER_ANYAPI, () =>
+		fetchAnyApiModels(apiKey),
+	);
+	if (allModels.length === 0) {
+		_logger.warn("[anyapi] No text models available");
+		return;
+	}
+
+	const freeModels = allModels.filter((model) =>
+		isFreeModel({ ...model, provider: PROVIDER_ANYAPI }, allModels),
+	);
+	const stored = { free: freeModels, all: allModels };
+
+	_logger.info(
+		`[anyapi] Registered ${allModels.length} models (${freeModels.length} free)`,
+	);
+
+	const reRegister = createReRegister(pi, {
+		providerId: PROVIDER_ANYAPI,
+		baseUrl: BASE_URL_ANYAPI,
+		apiKey,
+	});
+
+	registerWithGlobalToggle(PROVIDER_ANYAPI, stored, reRegister, true);
+
+	setupProvider(
+		pi,
+		{
+			providerId: PROVIDER_ANYAPI,
+			initialShowPaid: getAnyapiShowPaid(),
+			hasKey: true,
+			tosUrl: "https://anyapi.ai/terms-of-service",
+			reRegister: (models, current) => {
+				if (current) {
+					stored.free = current.free;
+					stored.all = current.all;
+				}
+				reRegister(models);
+			},
+		},
+		stored,
+	);
+
+	const showPaid = getAnyapiShowPaid();
+	reRegister(showPaid ? stored.all : stored.free);
+}

--- a/tests/anyapi.test.ts
+++ b/tests/anyapi.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+	isAnyApiFreeModel,
+	mapAnyApiModel,
+} from "../providers/anyapi/anyapi.ts";
+
+describe("AnyAPI free model detection", () => {
+	it("recognizes the provider's explicit free flag", () => {
+		expect(
+			isAnyApiFreeModel({ id: "provider/model", isFree: true }),
+		).toBe(true);
+		expect(
+			isAnyApiFreeModel({ id: "provider/model", isFree: false }),
+		).toBe(false);
+	});
+
+	it("recognizes free labels in model ids or names", () => {
+		expect(
+			isAnyApiFreeModel({ id: "provider/model-free", name: "Model" }),
+		).toBe(true);
+		expect(
+			isAnyApiFreeModel({ id: "provider/model", name: "Model (free)" }),
+		).toBe(true);
+	});
+
+	it("uses zero pricing when the API exposes it", () => {
+		expect(
+			isAnyApiFreeModel({
+				id: "provider/model",
+				pricing: { prompt: "0", completion: "0" },
+			}),
+		).toBe(true);
+	});
+
+	it("does not treat missing pricing as free", () => {
+		expect(isAnyApiFreeModel({ id: "provider/model" })).toBe(false);
+	});
+
+	it("marks mapped free models as authoritative", () => {
+		const model = mapAnyApiModel({
+			id: "provider/model-free",
+			name: "Model (free)",
+			context_length: 32_000,
+			max_completion_tokens: 4_096,
+			tags: ["chat_completions:reasoning", "chat_completions:vision"],
+		});
+
+		expect(model).toMatchObject({
+			id: "provider/model-free",
+			contextWindow: 32_000,
+			maxTokens: 4_096,
+			_freeKnown: true,
+			_isFree: true,
+			_pricingKnown: false,
+			reasoning: true,
+			input: ["text", "image"],
+		});
+	});
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -35,6 +35,27 @@ function configPath(): string {
 	return join(home, ".pi", "free.json");
 }
 
+function parseMockJson(value: unknown): Record<string, unknown> {
+	try {
+		if (typeof value !== "string") {
+			throw new TypeError("mock JSON value is not a string");
+		}
+		const parsed: unknown = JSON.parse(value);
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			throw new TypeError("mock JSON value is not an object");
+		}
+		return parsed as Record<string, unknown>;
+	} catch (error) {
+		throw new Error(
+			`Invalid mock JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
 // Fresh modules, env, and mock fs state for each test
 beforeEach(async () => {
 	vi.unstubAllEnvs();
@@ -266,7 +287,7 @@ describe("config persistence", () => {
 
 		const lastCall =
 			writeFileSync.mock.calls[writeFileSync.mock.calls.length - 1];
-		const written = JSON.parse(lastCall[1]);
+		const written = parseMockJson(lastCall[1]);
 		expect(written.free_only).toBe(false);
 		expect(written.nvidia_api_key).toBe("existing");
 	});
@@ -282,7 +303,7 @@ describe("config persistence", () => {
 
 		const lastCall =
 			writeFileSync.mock.calls[writeFileSync.mock.calls.length - 1];
-		const written = JSON.parse(lastCall[1]);
+		const written = parseMockJson(lastCall[1]);
 		expect(written.free_only).toBe(true);
 		expect(written.nvidia_api_key).toBe("new-key");
 	});
@@ -305,7 +326,7 @@ describe("updateConfig", () => {
 
 		const lastCall =
 			writeFileSync.mock.calls[writeFileSync.mock.calls.length - 1];
-		const written = JSON.parse(lastCall[1]);
+		const written = parseMockJson(lastCall[1]);
 		expect(written.hidden_models).toEqual(["a/b", "c/d"]);
 		expect(written.nvidia_api_key).toBe("keep");
 	});
@@ -332,7 +353,7 @@ describe("updateConfig", () => {
 
 		// Read the final state of the file
 		const finalRaw = __mockData.get(configPath());
-		const final = JSON.parse(finalRaw);
+		const final = parseMockJson(finalRaw);
 		// Both updates must be present, in some order
 		expect(final.hidden_models).toContain("initial");
 		expect(final.hidden_models).toContain("deepinfra/x");
@@ -352,7 +373,7 @@ describe("updateConfig", () => {
 		// writeFileSync should not have been called (file is corrupt)
 		const lastCall = writeFileSync.mock.calls.at(-1);
 		if (lastCall) {
-			const written = JSON.parse(lastCall[1]);
+			const written = parseMockJson(lastCall[1]);
 			expect(written.nvidia_api_key).not.toBe("should-not-write");
 		}
 	});


### PR DESCRIPTION
## Summary

- Add AnyAPI as a dynamic OpenAI-compatible provider.
- Discover AnyAPI's live catalog and filter explicitly free models (`:free`, free flags, or zero pricing).
- Detect AnyAPI tags for reasoning, vision, and chat-completions support.
- Add `/toggle-anyapi`, `ANYAPI_API_KEY`, and `anyapi_api_key` configuration.
- Document the provider and add model/configuration tests.

## Live validation

- AnyAPI `/v1/models` returned 295 models, including 14 free text models.
- The configured key is stored locally in `~/.pi/free.json` and is not committed.
- A live chat probe reached AnyAPI but returned HTTP 429 due to the account's current rate limit.

## Tests

- `npm run lint`
- `npm run test:run` (471 tests)
- `npm run check:lockfile`
- `npm run check`
- `npm audit --omit=dev --audit-level=high`
