### PR TITLE
fix(tokenrouter): resolve pi-ai lazy import that broke extension load

### DIFF
--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -27,7 +27,7 @@ import type {
 	ThinkingContent,
 } from "@earendil-works/pi-ai";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
 import {
 	getTokenrouterApiKey,
 	getTokenrouterShowPaid,


### PR DESCRIPTION
## Summary
- `providers/tokenrouter/tokenrouter.ts` statically imports `@earendil-works/pi-ai/api/openai-completions.lazy` (added in #299/#300). Pi's extension host resolves extension imports via jiti aliases that only cover `@earendil-works/pi-ai`, `@earendil-works/pi-ai/compat`, and `@earendil-works/pi-ai/oauth` — any other subpath gets prefix-substituted into the resolved `compat.js` file path plus the literal remaining suffix, producing an unresolvable path and failing to load the extension entirely: `Cannot find module '.../pi-ai/dist/compat.js/api/openai-completions.lazy'`.
- Fix: import `openAICompletionsApi` from `@earendil-works/pi-ai/compat` instead, which already re-exports it (`compat.js` does `export * from "./api/openai-completions.lazy.js"`) and is correctly aliased by both the pi extension host and plain npm `exports` resolution.

## Test plan
- [x] `npx vitest run tests/tokenrouter-free.test.ts` — 17 passed
- [x] `npx vitest run` — full suite, 471 passed
- [x] `npx tsc --noEmit` — clean
- [x] Verified the failure reproduces with plain Node ESM resolution succeeding on the `.lazy` subpath (ruling out a pi-ai packaging bug) and traced the exact alias-substitution bug in `@earendil-works/pi-coding-agent`'s `loader.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)