### PR TITLE
chore: prepare v2.2.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.7] - 2026-07-10
+
+### Added
+
+- **AnyAPI provider** — add AnyAPI's OpenAI-compatible gateway with dynamic model discovery, free-model filtering, a 100K-token daily free plan, and `/toggle-anyapi` for switching to the full catalog.
+
 ### Changed
 
 - **Pi 0.80 compatibility** — update the Pi SDK peer requirements to `>=0.80.0` and refresh the development toolchain dependencies.
-- **AnyAPI provider** — add AnyAPI's OpenAI-compatible gateway with dynamic model discovery, free-model filtering, a 100K-token daily free plan, and `/toggle-anyapi` for switching to the full catalog.
+
+### Fixed
+
+- **AnyAPI model limits** — enrich context and output limits from models.dev when AnyAPI omits them, avoiding incorrect 4K defaults and migrating existing caches once.
+- **TokenRouter Pi AI compatibility** — use the supported lazy OpenAI completions API path for Pi 0.80.
 
 ## [2.2.6] - 2026-07-09
 

--- a/agents.md
+++ b/agents.md
@@ -6,7 +6,7 @@
 
 A **Pi extension** (`@earendil-works/pi-coding-agent`) that registers free and paid AI model providers with Pi's model picker. It shows free models by default and lets users toggle per-provider between free-only and all-models view via `/toggle-{provider}` commands.
 
-**Package:** `pi-free` v2.2.4  
+**Package:** `pi-free` v2.2.7
 **Author:** Apostolos Mantzaris  
 **License:** MIT  
 **Repo:** `github.com/apmantza/pi-free`  
@@ -216,7 +216,7 @@ Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DE
 
 ## Testing
 
-- **Framework:** Vitest (`vitest` v4.1.5)
+- **Framework:** Vitest (`vitest` v4.1.10)
 - **Run:** `npm test` (watch), `npm run test:run` (once)
 - **Tests:** `tests/*.test.ts` — covers registry, toggle state, config, model detection, provider compat
 - Tests use `vi.fn()` mocks for ExtensionAPI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.2.6",
+	"version": "2.2.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.2.6",
+			"version": "2.2.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.2.6",
+	"version": "2.2.7",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## Release 2.2.7

- Add the AnyAPI provider and `/toggle-anyapi`.
- Update peer dependencies and Pi 0.80 compatibility.
- Fix AnyAPI model context/output metadata so models do not default to 4K limits.
- Fix TokenRouter's Pi AI lazy completions import.

## Validation

- `npm run lint`
- `npm run test:run` — 471 tests passed
- `npm run check:lockfile`
- `npm run check`
- `npm run audit:prod` — 0 vulnerabilities
- `npm publish --dry-run --ignore-scripts`
- `npm pack --ignore-scripts` + `npm run check:tarball`
