### PR TITLE
chore: align with Pi 0.80.7 compatibility API

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -679,7 +679,7 @@ export function applyHidden<T extends { id: string }>(
 export function saveConfig(updates: Partial<PiFreeConfig>): void {
 	try {
 		// Read the raw file content — never use loadConfigFile() here because
-		// if the file is unparseable, loadConfigFile() returns {} which would
+		// if the file is unparsable, loadConfigFile() returns {} which would
 		// cause us to write a partial config and WIPE all existing keys.
 		const raw = readRawConfigFile();
 		if (raw === undefined) {
@@ -737,14 +737,14 @@ class ConfigLock {
 	private promise: Promise<void> = Promise.resolve();
 
 	async acquire(): Promise<() => void> {
-		let release: () => void;
+		let release: () => void = () => {};
 		const newPromise = new Promise<void>((resolve) => {
 			release = resolve;
 		});
 		const previous = this.promise;
 		this.promise = previous.then(() => newPromise);
 		await previous;
-		return release!;
+		return release;
 	}
 }
 

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -11,7 +11,7 @@
  * Usage: /toggle-opencode
  */
 
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/lib/model-detection.ts
+++ b/lib/model-detection.ts
@@ -4,7 +4,7 @@
  * Used for failover when providers hit rate limits.
  */
 
-import type { Model } from "@earendil-works/pi-ai";
+import type { Model } from "@earendil-works/pi-ai/compat";
 import type { ProviderModelConfig } from "./types.ts";
 
 export interface ModelInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,19 +23,25 @@
 				"@earendil-works/pi-tui": ">=0.80.0"
 			}
 		},
-		"node_modules/@aws-crypto/crc32": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-			"license": "Apache-2.0",
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@aws-crypto/util": "^5.2.0",
-				"@aws-sdk/types": "^3.222.0",
-				"tslib": "^2.6.2"
+				"json-schema-to-ts": "^3.1.1"
 			},
-			"engines": {
-				"node": ">=16.0.0"
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
@@ -118,18 +124,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
-			"integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
+			"version": "3.975.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+			"integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@aws-sdk/xml-builder": "^3.972.30",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.24.6",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/xml-builder": "^3.972.36",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.29.4",
+				"@smithy/signature-v4": "^5.6.5",
+				"@smithy/types": "^4.16.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -138,16 +144,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.48",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
-			"integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
+			"version": "3.972.59",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+			"integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -155,18 +161,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.50",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
-			"integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
+			"version": "3.972.61",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+			"integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/node-http-handler": "^4.7.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -174,14 +180,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
-			"integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
+			"version": "4.9.6",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
+			"integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.25.1",
-				"@smithy/types": "^4.15.0",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -189,24 +195,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
-			"integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
+			"version": "3.973.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.3.tgz",
+			"integrity": "sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/credential-provider-env": "^3.972.48",
-				"@aws-sdk/credential-provider-http": "^3.972.50",
-				"@aws-sdk/credential-provider-login": "^3.972.54",
-				"@aws-sdk/credential-provider-process": "^3.972.48",
-				"@aws-sdk/credential-provider-sso": "^3.972.54",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.54",
-				"@aws-sdk/nested-clients": "^3.997.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/credential-provider-imds": "^4.3.7",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/credential-provider-env": "^3.972.59",
+				"@aws-sdk/credential-provider-http": "^3.972.61",
+				"@aws-sdk/credential-provider-login": "^3.972.65",
+				"@aws-sdk/credential-provider-process": "^3.972.59",
+				"@aws-sdk/credential-provider-sso": "^3.973.3",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.65",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/credential-provider-imds": "^4.4.9",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -214,17 +220,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.54",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
-			"integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
+			"version": "3.972.65",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.65.tgz",
+			"integrity": "sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/nested-clients": "^3.997.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -232,22 +238,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.57",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
-			"integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
+			"version": "3.972.69",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
+			"integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.48",
-				"@aws-sdk/credential-provider-http": "^3.972.50",
-				"@aws-sdk/credential-provider-ini": "^3.972.55",
-				"@aws-sdk/credential-provider-process": "^3.972.48",
-				"@aws-sdk/credential-provider-sso": "^3.972.54",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.54",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/credential-provider-imds": "^4.3.7",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/credential-provider-env": "^3.972.59",
+				"@aws-sdk/credential-provider-http": "^3.972.61",
+				"@aws-sdk/credential-provider-ini": "^3.973.3",
+				"@aws-sdk/credential-provider-process": "^3.972.59",
+				"@aws-sdk/credential-provider-sso": "^3.973.3",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.65",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/credential-provider-imds": "^4.4.9",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -255,16 +261,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.48",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
-			"integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
+			"version": "3.972.59",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+			"integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -272,18 +278,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.54",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
-			"integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
+			"version": "3.973.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+			"integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/nested-clients": "^3.997.22",
-				"@aws-sdk/token-providers": "3.1071.0",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/token-providers": "3.1088.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -291,17 +297,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1071.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
-			"integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
+			"version": "3.1088.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+			"integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/nested-clients": "^3.997.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -309,17 +315,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.54",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
-			"integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
+			"version": "3.972.65",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+			"integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/nested-clients": "^3.997.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -327,15 +333,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
-			"integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.28.tgz",
+			"integrity": "sha512-XV5sEH1xH5oydNgvUH87CR8BA2SBZXltckteS17D7ZT2k2THIBiExO9TEBYcgqUU31WAIfBH2hmx+fhFMiTL4Q==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -343,15 +349,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.18",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
-			"integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
+			"integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -359,18 +365,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.30",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.30.tgz",
-			"integrity": "sha512-kH6N4f/Fzi9r/dYap8EQ+Zk4NOz8pl4AtWKhzAoG2C1/4YkIHok9APp/e+75woreWQq264n+LkrJsJVZ0Q+M1Q==",
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.41.tgz",
+			"integrity": "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/signature-v4": "^5.6.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -378,21 +384,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
-			"integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
+			"version": "3.997.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+			"integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.22",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.35",
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/core": "^3.24.6",
-				"@smithy/fetch-http-handler": "^5.4.6",
-				"@smithy/node-http-handler": "^4.7.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -400,14 +404,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
-			"integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
+			"version": "4.9.6",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
+			"integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.25.1",
-				"@smithy/types": "^4.15.0",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -415,15 +419,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.35",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-			"integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+			"version": "3.996.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+			"integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.13",
-				"@smithy/signature-v4": "^5.4.6",
-				"@smithy/types": "^4.14.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/signature-v4": "^5.6.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -449,13 +453,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-			"integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+			"version": "3.974.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.14.3",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -476,14 +480,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.30",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
-			"integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+			"integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.14.3",
-				"fast-xml-parser": "5.7.3",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -491,9 +494,9 @@
 			}
 		},
 		"node_modules/@aws/lambda-invoke-store": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
@@ -501,9 +504,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -511,9 +514,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-			"integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+			"version": "0.80.7",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
+			"integrity": "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -536,38 +539,17 @@
 				"node": ">=22.19.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
-			"version": "0.91.1",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
-			},
-			"bin": {
-				"anthropic-ai-sdk": "bin/cli"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.0 || ^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"zod": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-			"integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+			"version": "0.80.7",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
+			"integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.80.6",
-				"@earendil-works/pi-ai": "^0.80.6",
-				"@earendil-works/pi-tui": "^0.80.6",
+				"@earendil-works/pi-agent-core": "^0.80.7",
+				"@earendil-works/pi-ai": "^0.80.7",
+				"@earendil-works/pi-tui": "^0.80.7",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -1057,12 +1039,12 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+			"version": "0.80.7",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.6",
+				"@earendil-works/pi-ai": "^0.80.7",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -1072,8 +1054,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+			"version": "0.80.7",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1090,15 +1072,15 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "./dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+			"version": "0.80.7",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2516,9 +2498,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-			"integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+			"version": "0.80.7",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+			"integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -3077,19 +3059,6 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
-		"node_modules/@nodable/entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/nodable"
-				}
-			],
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -3101,9 +3070,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
@@ -3111,9 +3080,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.138.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-			"integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3187,16 +3156,16 @@
 			"peer": true
 		},
 		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-			"integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3211,9 +3180,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-			"integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3228,9 +3197,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-			"integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
 			"cpu": [
 				"x64"
 			],
@@ -3245,9 +3214,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-			"integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
 			"cpu": [
 				"x64"
 			],
@@ -3262,9 +3231,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-			"integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
 			"cpu": [
 				"arm"
 			],
@@ -3279,9 +3248,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-			"integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3296,9 +3265,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-			"integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3313,9 +3282,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-			"integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3330,9 +3299,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-			"integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
 			"cpu": [
 				"s390x"
 			],
@@ -3347,9 +3316,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-			"integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3364,9 +3333,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-			"integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
 			"cpu": [
 				"x64"
 			],
@@ -3381,9 +3350,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-			"integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3398,9 +3367,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-			"integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
 			"cpu": [
 				"wasm32"
 			],
@@ -3417,9 +3386,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-			"integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3434,9 +3403,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-			"integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
 			"cpu": [
 				"x64"
 			],
@@ -3458,14 +3427,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
-			"integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
+			"version": "3.29.4",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
+			"integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.15.0",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3473,14 +3441,14 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
-			"integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
+			"integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.25.1",
-				"@smithy/types": "^4.15.0",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3488,14 +3456,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
-			"integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
+			"version": "5.6.6",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
+			"integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.25.1",
-				"@smithy/types": "^4.15.0",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3531,14 +3499,14 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
-			"integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
+			"version": "5.6.5",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
+			"integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.25.1",
-				"@smithy/types": "^4.15.0",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3546,9 +3514,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.15.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3630,13 +3598,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.5.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-			"integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/retry": {
@@ -3791,19 +3759,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/anynum": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
-			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3925,9 +3880,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3984,9 +3939,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -3999,45 +3954,6 @@
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/fast-xml-builder": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"path-expression-matcher": "^1.5.0",
-				"xml-naming": "^0.1.0"
-			}
-		},
-		"node_modules/fast-xml-parser": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.7",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.2.3"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
-			}
 		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
@@ -4082,9 +3998,9 @@
 			}
 		},
 		"node_modules/fflate": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4124,9 +4040,9 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
-			"integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+			"integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4167,9 +4083,9 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.7.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
-			"integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+			"integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4578,9 +4494,9 @@
 			"peer": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4637,15 +4553,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/openai": {
 			"version": "6.26.0",
@@ -4690,22 +4609,6 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/path-expression-matcher": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4721,9 +4624,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4734,9 +4637,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4763,9 +4666,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
@@ -4797,13 +4700,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-			"integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.138.0",
+				"@oxc-project/types": "=0.139.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -4813,21 +4716,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.1.4",
-				"@rolldown/binding-darwin-arm64": "1.1.4",
-				"@rolldown/binding-darwin-x64": "1.1.4",
-				"@rolldown/binding-freebsd-x64": "1.1.4",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-				"@rolldown/binding-linux-arm64-gnu": "1.1.4",
-				"@rolldown/binding-linux-arm64-musl": "1.1.4",
-				"@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-				"@rolldown/binding-linux-s390x-gnu": "1.1.4",
-				"@rolldown/binding-linux-x64-gnu": "1.1.4",
-				"@rolldown/binding-linux-x64-musl": "1.1.4",
-				"@rolldown/binding-openharmony-arm64": "1.1.4",
-				"@rolldown/binding-wasm32-wasi": "1.1.4",
-				"@rolldown/binding-win32-arm64-msvc": "1.1.4",
-				"@rolldown/binding-win32-x64-msvc": "1.1.4"
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -4890,21 +4793,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/strnum": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
-			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"anynum": "^1.0.1"
-			}
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -4914,9 +4808,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4974,9 +4868,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5014,23 +4908,23 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/vite": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.16",
-				"rolldown": "~1.1.3",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.17",
+				"rolldown": "~1.1.5",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
@@ -5188,13 +5082,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/std-env": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5223,9 +5110,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -5244,26 +5131,10 @@
 				}
 			}
 		},
-		"node_modules/xml-naming": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/zod": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"peer": true,
 			"funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,7 +1072,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -14,7 +14,7 @@ import { URL as NodeURL } from "node:url";
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import { BASE_URL_CLINE, CLINE_AUTH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -8,8 +8,8 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 	Usage,
-} from "@earendil-works/pi-ai";
-import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
 
 const DEFAULT_USAGE: Usage = {

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -14,7 +14,7 @@
  *   # Models appear immediately; run /login cline to start chatting
  */
 
-import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type { OAuthCredentials } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -22,7 +22,7 @@
  * OpenAI is intentionally skipped per user request.
  */
 
-import type { Api } from "@earendil-works/pi-ai";
+import type { Api } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/kilo/kilo-auth.ts
+++ b/providers/kilo/kilo-auth.ts
@@ -5,7 +5,7 @@
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import {
 	KILO_POLL_INTERVAL_MS,
 	KILO_TOKEN_EXPIRATION_MS,

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -12,7 +12,7 @@
  *   # Free models visible immediately; /login kilo for paid access
  */
 
-import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai";
+import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -12,7 +12,7 @@ import type {
 	Model,
 	ProviderHeaders,
 	SimpleStreamOptions,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import type { ProviderConfig } from "@earendil-works/pi-coding-agent";
 
 export const OPENCODE_DYNAMIC_API = "opencode-dynamic" as const;

--- a/providers/qoder/auth.ts
+++ b/providers/qoder/auth.ts
@@ -18,7 +18,7 @@ import { join } from "node:path";
 import type {
 	OAuthCredentials,
 	OAuthLoginCallbacks,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import { getMachineId } from "./cosy.ts";
 
 // ─── Constants ───────────────────────────────────────────────────────────────

--- a/providers/qoder/qoder.ts
+++ b/providers/qoder/qoder.ts
@@ -20,7 +20,7 @@
  *   QODER_PAT                   — Alias for above
  */
 
-import type { Api, OAuthCredentials } from "@earendil-works/pi-ai";
+import type { Api, OAuthCredentials } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/qoder/stream.ts
+++ b/providers/qoder/stream.ts
@@ -21,8 +21,8 @@ import type {
 	TextContent,
 	ThinkingContent,
 	ToolCall,
-} from "@earendil-works/pi-ai";
-import * as PiAi from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
+import * as PiAi from "@earendil-works/pi-ai/compat";
 import { BASE_URL_QODER } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getCachedModelConfig, staticModels } from "./models.ts";

--- a/providers/qoder/thinking-parser.ts
+++ b/providers/qoder/thinking-parser.ts
@@ -15,7 +15,7 @@ import type {
 	AssistantMessageEventStream,
 	TextContent,
 	ThinkingContent,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 
 const THINKING_TAG_VARIANTS: Array<{ open: string; close: string }> = [
 	{ open: "<thinking>", close: "</thinking>" },

--- a/providers/qoder/transform.ts
+++ b/providers/qoder/transform.ts
@@ -16,7 +16,7 @@ import type {
 	Tool,
 	ToolCall,
 	ToolResultMessage,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 
 /** OpenAI-style tool definition sent to the Qoder API. */
 interface QoderTool {

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -25,8 +25,8 @@ import type {
 	Model,
 	SimpleStreamOptions,
 	ThinkingContent,
-} from "@earendil-works/pi-ai";
-import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
 import {
 	getTokenrouterApiKey,

--- a/scripts/smoke-cline-xml-bridge.ts
+++ b/scripts/smoke-cline-xml-bridge.ts
@@ -14,8 +14,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { Model, OAuthCredentials, ToolCall } from "@earendil-works/pi-ai";
-import { Type } from "@earendil-works/pi-ai";
+import type { Model, OAuthCredentials, ToolCall } from "@earendil-works/pi-ai/compat";
+import { Type } from "@earendil-works/pi-ai/compat";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../constants.ts";
 import { refreshClineToken } from "../providers/cline/cline-auth.ts";
 import { streamClineXml } from "../providers/cline/cline-xml-bridge.ts";

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -1,4 +1,4 @@
-import type { Context, Model, Tool } from "@earendil-works/pi-ai";
+import type { Context, Model, Tool } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	__test__,

--- a/tests/opencode-session-integration.test.ts
+++ b/tests/opencode-session-integration.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
-import type { Model, Api, Context } from "@earendil-works/pi-ai";
+import type { Model, Api, Context } from "@earendil-works/pi-ai/compat";
 import {
 	createOpenCodeStreamSimple,
 	createOpenCodeSessionTracker,
@@ -150,7 +150,18 @@ ${testScript}
 			encoding: "utf-8",
 		});
 
-		const results = JSON.parse(output.trim());
+		let results: Array<{
+			subpath: string;
+			resolved: string | null;
+			fallbackOk: boolean;
+		}>;
+		try {
+			results = JSON.parse(output.trim()) as typeof results;
+		} catch (error) {
+			throw new Error("Invalid JSON from Pi AI subpath probe", {
+				cause: error,
+			});
+		}
 		for (const r of results) {
 			// The direct import may resolve when the test runner exposes the project
 			// node_modules; the package-relative fallback must work either way.
@@ -233,7 +244,17 @@ console.log(JSON.stringify({
 			cwd: tempDir,
 			encoding: "utf-8",
 		});
-		const result = JSON.parse(output.trim());
+		let result: {
+			direct: { ok: boolean; message: string };
+			fallbackOk: boolean;
+		};
+		try {
+			result = JSON.parse(output.trim()) as typeof result;
+		} catch (error) {
+			throw new Error("Invalid JSON from Pi AI fallback probe", {
+				cause: error,
+			});
+		}
 		expect(result.direct.ok).toBe(false);
 		expect(result.fallbackOk).toBe(true);
 	});

--- a/tests/qoder-stream.test.ts
+++ b/tests/qoder-stream.test.ts
@@ -5,7 +5,7 @@
 import type {
 	AssistantMessage,
 	AssistantMessageEvent,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 interface MockStreamShape {
@@ -25,7 +25,7 @@ const mockLogger = vi.hoisted(() => ({
 
 const mockGetCachedModelConfig = vi.hoisted(() => vi.fn());
 
-vi.mock("@earendil-works/pi-ai", async () => {
+vi.mock("@earendil-works/pi-ai/compat", async () => {
 	class MockStream implements MockStreamShape {
 		events: AssistantMessageEvent[] = [];
 		ended = false;

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -1,5 +1,5 @@
-import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
-import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Model } from "@earendil-works/pi-ai/compat";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isFreeModel } from "../lib/registry.ts";
 import {


### PR DESCRIPTION
## Summary
- migrate pi-ai imports to the published `/compat` entrypoint
- retain the intentional root-import fallback for pre-0.80 Pi AI packages
- update the lockfile to Pi 0.80.7

## Validation
- `npm run test:run` (471 tests passed)
- `npx tsc --noEmit` passed

Tracking issues:
- #308 for ModelRuntime/authStorage migration
- #307 for evaluating refreshModels adoption
