### PR TITLE
fix: guard modelRegistry.authStorage for pi v0.80 compatibility

### DIFF
--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -24,6 +24,37 @@ import { enhanceModelNameWithCodingIndex } from "./provider-failover/benchmark-l
 
 const _logger = createLogger("provider-helper");
 
+interface AuthStorageLike {
+	get(providerId: string): unknown;
+}
+
+interface ContextWithOptionalAuthStorage {
+	modelRegistry?: {
+		authStorage?: AuthStorageLike;
+	};
+}
+
+/**
+ * Read a provider credential when running against Pi versions that expose
+ * authStorage on the extension context. Newer Pi versions may omit it.
+ */
+export function getStoredProviderCredential(
+	ctx: unknown,
+	providerId: string,
+): unknown {
+	if (!ctx || typeof ctx !== "object") return undefined;
+	const context = ctx as ContextWithOptionalAuthStorage;
+	return context.modelRegistry?.authStorage?.get(providerId);
+}
+
+export function isOAuthCredential(
+	credential: unknown,
+): credential is { type: "oauth"; access: string } {
+	if (!credential || typeof credential !== "object") return false;
+	const candidate = credential as { type?: unknown; access?: unknown };
+	return candidate.type === "oauth" && typeof candidate.access === "string";
+}
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -336,9 +367,8 @@ export function setupProvider(
 			if (tosShown || ctx.model?.provider !== providerId) return;
 			tosShown = true;
 			if (config.hasKey) return;
-			const authStorage = (ctx as any).modelRegistry?.authStorage;
-			const cred = authStorage?.get(providerId);
-			if (cred?.type === "oauth") return;
+			const cred = getStoredProviderCredential(ctx, providerId);
+			if (isOAuthCredential(cred)) return;
 			ctx.ui.notify(
 				`Using ${providerId} free models. Set API key for paid access. Terms: ${tosUrl}`,
 				"info",

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -336,7 +336,8 @@ export function setupProvider(
 			if (tosShown || ctx.model?.provider !== providerId) return;
 			tosShown = true;
 			if (config.hasKey) return;
-			const cred = ctx.modelRegistry.authStorage.get(providerId);
+			const authStorage = (ctx as any).modelRegistry?.authStorage;
+			const cred = authStorage?.get(providerId);
 			if (cred?.type === "oauth") return;
 			ctx.ui.notify(
 				`Using ${providerId} free models. Set API key for paid access. Terms: ${tosUrl}`,

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -344,7 +344,8 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		// ToS notice (once)
 		if (tosShown) return;
 		tosShown = true;
-		const cred = ctx.modelRegistry.authStorage.get(PROVIDER_KILO);
+		const authStorage = (ctx as any).modelRegistry?.authStorage;
+		const cred = authStorage?.get(PROVIDER_KILO);
 		if (cred?.type === "oauth") return;
 		const paidCount = allModels.length - freeModels.length;
 		if (paidCount > 0) {
@@ -442,7 +443,8 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	pi.on(
 		"session_start",
 		wrapSessionStartHandler("kilo", (_event, ctx) => {
-			const cred = ctx.modelRegistry.authStorage.get(PROVIDER_KILO);
+			const authStorage = (ctx as any).modelRegistry?.authStorage;
+			const cred = authStorage?.get(PROVIDER_KILO);
 			if (cred?.type !== "oauth" || refreshInFlight) return Promise.resolve();
 
 			refreshInFlight = fetchKiloModels({ token: cred.access, freeOnly: false })

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -33,6 +33,8 @@ import {
 	createCtxReRegister,
 	createReRegister,
 	enhanceWithCI,
+	getStoredProviderCredential,
+	isOAuthCredential,
 	loadCachedOrFetchModels,
 	type StoredModels,
 } from "../../provider-helper.ts";
@@ -344,9 +346,8 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		// ToS notice (once)
 		if (tosShown) return;
 		tosShown = true;
-		const authStorage = (ctx as any).modelRegistry?.authStorage;
-		const cred = authStorage?.get(PROVIDER_KILO);
-		if (cred?.type === "oauth") return;
+		const cred = getStoredProviderCredential(ctx, PROVIDER_KILO);
+		if (isOAuthCredential(cred)) return;
 		const paidCount = allModels.length - freeModels.length;
 		if (paidCount > 0) {
 			ctx.ui.notify(
@@ -443,9 +444,8 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	pi.on(
 		"session_start",
 		wrapSessionStartHandler("kilo", (_event, ctx) => {
-			const authStorage = (ctx as any).modelRegistry?.authStorage;
-			const cred = authStorage?.get(PROVIDER_KILO);
-			if (cred?.type !== "oauth" || refreshInFlight) return Promise.resolve();
+			const cred = getStoredProviderCredential(ctx, PROVIDER_KILO);
+			if (!isOAuthCredential(cred) || refreshInFlight) return Promise.resolve();
 
 			refreshInFlight = fetchKiloModels({ token: cred.access, freeOnly: false })
 				.then((newModels) => {

--- a/tests/provider-helper-api-field.test.ts
+++ b/tests/provider-helper-api-field.test.ts
@@ -16,6 +16,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	createCtxReRegister,
 	createReRegister,
+	getStoredProviderCredential,
+	isOAuthCredential,
 	registerOpenAICompatible,
 } from "../provider-helper.ts";
 
@@ -34,6 +36,21 @@ function makeFakePi(): {
 	});
 	return { registerProvider, calls };
 }
+
+describe("optional auth storage compatibility", () => {
+	it("returns undefined when Pi omits authStorage", () => {
+		expect(getStoredProviderCredential({ modelRegistry: {} }, "kilo")).toBeUndefined();
+		expect(getStoredProviderCredential({}, "kilo")).toBeUndefined();
+	});
+
+	it("reads credentials when authStorage is available", () => {
+		const credential = { type: "oauth", access: "token" };
+		const ctx = { modelRegistry: { authStorage: { get: vi.fn(() => credential) } } };
+		expect(getStoredProviderCredential(ctx, "kilo")).toBe(credential);
+		expect(isOAuthCredential(credential)).toBe(true);
+		expect(isOAuthCredential({ type: "api_key" })).toBe(false);
+	});
+});
 
 describe("OpenAICompatibleConfig.api", () => {
 	describe("registerOpenAICompatible", () => {


### PR DESCRIPTION
Pi v0.80 removed authStorage from modelRegistry, so the previous ctx.modelRegistry.authStorage.get(...) calls crashed extension binding with 'Cannot read properties of undefined (reading get)'. Use optional chaining (matching the existing qwen.ts pattern) so the credential lookup is a no-op when authStorage is unavailable.