### PR TITLE
refactor: migrate auth checks to Pi runtime APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
 				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-ai": ">=0.80.0",
-				"@earendil-works/pi-coding-agent": ">=0.80.0",
-				"@earendil-works/pi-tui": ">=0.80.0"
+				"@earendil-works/pi-ai": ">=0.80.8",
+				"@earendil-works/pi-coding-agent": ">=0.80.8",
+				"@earendil-works/pi-tui": ">=0.80.8"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -180,13 +180,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-			"version": "4.9.6",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-			"integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+			"version": "4.9.7",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+			"integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.4",
+				"@smithy/core": "^3.29.5",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -404,13 +404,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.9.6",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
-			"integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+			"version": "4.9.7",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+			"integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.4",
+				"@smithy/core": "^3.29.5",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -514,9 +514,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.7",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
-			"integrity": "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ==",
+			"version": "0.80.9",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.9.tgz",
+			"integrity": "sha512-kHsH5nO4FU7mbKnskK0BVPVuWzNb2DrZtiN1fb6LamP+6BMI8xEZiAOw2fqs4VudvlMQgOLjtbgErv+kNJRPIg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -540,16 +540,16 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.80.7",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
-			"integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
+			"version": "0.80.9",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.9.tgz",
+			"integrity": "sha512-Clgx2Bg5NbMcCpGxusSDQwE+GC0g/d6sCBluE9aypPgSgtJ6n8VmZIIT6auXObMskpRgkr+XZ77wG5hf+cSDtg==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.80.7",
-				"@earendil-works/pi-ai": "^0.80.7",
-				"@earendil-works/pi-tui": "^0.80.7",
+				"@earendil-works/pi-agent-core": "^0.80.9",
+				"@earendil-works/pi-ai": "^0.80.9",
+				"@earendil-works/pi-tui": "^0.80.9",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -1039,12 +1039,12 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.7",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
+			"version": "0.80.9",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.9.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.7",
+				"@earendil-works/pi-ai": "^0.80.9",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -1054,8 +1054,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.7",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
+			"version": "0.80.9",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.9.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1079,8 +1079,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.7",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+			"version": "0.80.9",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.9.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2498,9 +2498,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.7",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
-			"integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
+			"version": "0.80.9",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.9.tgz",
+			"integrity": "sha512-unPTW8hRgIHEGjV8mJJ2jqm+fzgnRubes6V2FPk9ay1W9ZLofcpYQ3NDfrODXSci+oKbBpX9JyYUMfQV6jCA/A==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -3427,9 +3427,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.29.4",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-			"integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+			"version": "3.29.5",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+			"integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3441,13 +3441,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.9",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-			"integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+			"integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.4",
+				"@smithy/core": "^3.29.5",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -3456,13 +3456,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.6.6",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
-			"integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+			"version": "5.6.7",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+			"integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.4",
+				"@smithy/core": "^3.29.5",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -3499,13 +3499,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.6.5",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
-			"integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+			"version": "5.6.6",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+			"integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.4",
+				"@smithy/core": "^3.29.5",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -4893,9 +4893,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
 		"smoke:openmodel": "tsx scripts/smoke-openmodel-wire-format.ts"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-ai": ">=0.80.0",
-		"@earendil-works/pi-coding-agent": ">=0.80.0",
-		"@earendil-works/pi-tui": ">=0.80.0"
+		"@earendil-works/pi-ai": ">=0.80.8",
+		"@earendil-works/pi-coding-agent": ">=0.80.8",
+		"@earendil-works/pi-tui": ">=0.80.8"
 	},
 	"devDependencies": {
 		"@vitest/ui": "^4.1.10",

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -24,27 +24,23 @@ import { enhanceModelNameWithCodingIndex } from "./provider-failover/benchmark-l
 
 const _logger = createLogger("provider-helper");
 
-interface AuthStorageLike {
-	get(providerId: string): unknown;
-}
-
-interface ContextWithOptionalAuthStorage {
+interface ContextWithOAuthStatus {
+	model?: unknown;
 	modelRegistry?: {
-		authStorage?: AuthStorageLike;
+		isUsingOAuth?: (model: unknown) => boolean;
 	};
 }
 
 /**
- * Read a provider credential when running against Pi versions that expose
- * authStorage on the extension context. Newer Pi versions may omit it.
+ * Check OAuth status through Pi's ModelRegistry compatibility facade.
+ * Newer Pi versions no longer expose authStorage on the context.
  */
-export function getStoredProviderCredential(
-	ctx: unknown,
-	providerId: string,
-): unknown {
-	if (!ctx || typeof ctx !== "object") return undefined;
-	const context = ctx as ContextWithOptionalAuthStorage;
-	return context.modelRegistry?.authStorage?.get(providerId);
+export function isCurrentModelOAuth(ctx: unknown): boolean {
+	if (!ctx || typeof ctx !== "object") return false;
+	const context = ctx as ContextWithOAuthStatus;
+	return Boolean(
+		context.model && context.modelRegistry?.isUsingOAuth?.(context.model),
+	);
 }
 
 export function isOAuthCredential(
@@ -367,8 +363,7 @@ export function setupProvider(
 			if (tosShown || ctx.model?.provider !== providerId) return;
 			tosShown = true;
 			if (config.hasKey) return;
-			const cred = getStoredProviderCredential(ctx, providerId);
-			if (isOAuthCredential(cred)) return;
+			if (isCurrentModelOAuth(ctx)) return;
 			ctx.ui.notify(
 				`Using ${providerId} free models. Set API key for paid access. Terms: ${tosUrl}`,
 				"info",

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -13,9 +13,10 @@
  */
 
 import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai/compat";
-import type {
-	ExtensionAPI,
-	ProviderModelConfig,
+import {
+	readStoredCredential,
+	type ExtensionAPI,
+	type ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import {
 	getKiloApiKey,
@@ -33,7 +34,6 @@ import {
 	createCtxReRegister,
 	createReRegister,
 	enhanceWithCI,
-	getStoredProviderCredential,
 	isOAuthCredential,
 	loadCachedOrFetchModels,
 	type StoredModels,
@@ -346,7 +346,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		// ToS notice (once)
 		if (tosShown) return;
 		tosShown = true;
-		const cred = getStoredProviderCredential(ctx, PROVIDER_KILO);
+		const cred = readStoredCredential(PROVIDER_KILO);
 		if (isOAuthCredential(cred)) return;
 		const paidCount = allModels.length - freeModels.length;
 		if (paidCount > 0) {
@@ -444,7 +444,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	pi.on(
 		"session_start",
 		wrapSessionStartHandler("kilo", (_event, ctx) => {
-			const cred = getStoredProviderCredential(ctx, PROVIDER_KILO);
+			const cred = readStoredCredential(PROVIDER_KILO);
 			if (!isOAuthCredential(cred) || refreshInFlight) return Promise.resolve();
 
 			refreshInFlight = fetchKiloModels({ token: cred.access, freeOnly: false })

--- a/tests/provider-helper-api-field.test.ts
+++ b/tests/provider-helper-api-field.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	createCtxReRegister,
 	createReRegister,
-	getStoredProviderCredential,
+	isCurrentModelOAuth,
 	isOAuthCredential,
 	registerOpenAICompatible,
 } from "../provider-helper.ts";
@@ -37,17 +37,22 @@ function makeFakePi(): {
 	return { registerProvider, calls };
 }
 
-describe("optional auth storage compatibility", () => {
-	it("returns undefined when Pi omits authStorage", () => {
-		expect(getStoredProviderCredential({ modelRegistry: {} }, "kilo")).toBeUndefined();
-		expect(getStoredProviderCredential({}, "kilo")).toBeUndefined();
+describe("ModelRegistry OAuth compatibility", () => {
+	it("returns false when Pi omits OAuth status APIs", () => {
+		expect(isCurrentModelOAuth({ modelRegistry: {} })).toBe(false);
+		expect(isCurrentModelOAuth({})).toBe(false);
 	});
 
-	it("reads credentials when authStorage is available", () => {
-		const credential = { type: "oauth", access: "token" };
-		const ctx = { modelRegistry: { authStorage: { get: vi.fn(() => credential) } } };
-		expect(getStoredProviderCredential(ctx, "kilo")).toBe(credential);
-		expect(isOAuthCredential(credential)).toBe(true);
+	it("uses ModelRegistry.isUsingOAuth when available", () => {
+		const model = { provider: "kilo", id: "free-model" };
+		const isUsingOAuth = vi.fn(() => true);
+		const ctx = { model, modelRegistry: { isUsingOAuth } };
+		expect(isCurrentModelOAuth(ctx)).toBe(true);
+		expect(isUsingOAuth).toHaveBeenCalledWith(model);
+	});
+
+	it("validates stored OAuth credentials", () => {
+		expect(isOAuthCredential({ type: "oauth", access: "token" })).toBe(true);
 		expect(isOAuthCredential({ type: "api_key" })).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- migrate OAuth status checks from removed `ctx.modelRegistry.authStorage`
- use `ModelRegistry.isUsingOAuth()` for ToS decisions
- use Pi's `readStoredCredential()` for Kilo OAuth refresh access
- add regression coverage for missing and available OAuth APIs
- update Pi peer dependencies and lockfile to the 0.80.9-compatible range

## Validation
- `npx tsc --noEmit`
- `npm run test:run` (474 tests passed)

This is the first step of the ModelRuntime compatibility migration; provider-owned `refreshModels()` adoption remains separate.
