### PR TITLE
fix: back up corrupt config files and serialise saveConfig writes

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -11,6 +11,7 @@
 
 import {
 	chmodSync,
+	copyFileSync,
 	existsSync,
 	readFileSync,
 	statSync,
@@ -170,10 +171,18 @@ function ensureConfigFile(): void {
 					readFileSync(CONFIG_PATH, "utf8"),
 				) as PiFreeConfig;
 			} catch (_parseErr) {
-				// File exists but is corrupt — DO NOT overwrite it.
-				// The user needs to fix or delete it manually.
-				_logger.error(
-					"Config file exists but is corrupt — refusing to overwrite. Fix or delete ~/.pi/free.json.",
+				// File exists but is corrupt — back it up and write a fresh
+				// template so the extension can start. The original bytes are
+				// preserved in the timestamped backup for recovery.
+				backupCorruptConfigFile();
+				writeFileSync(
+					CONFIG_PATH,
+					`${JSON.stringify(CONFIG_TEMPLATE, null, 2)}\n`,
+					"utf8",
+				);
+				restrictConfigFilePermissions();
+				_logger.warn(
+					"Config file was corrupt and has been reset from template; backup preserved",
 					{ path: CONFIG_PATH },
 				);
 				return;
@@ -225,6 +234,35 @@ function restrictConfigFilePermissions(): void {
 	}
 }
 
+function backupCorruptConfigFile(): void {
+	try {
+		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+		const backupPath = `${CONFIG_PATH}.bak-${timestamp}`;
+		copyFileSync(CONFIG_PATH, backupPath);
+		restrictConfigFilePermissionsForPath(backupPath);
+		_logger.warn(
+			"Config file is corrupt; a backup was created before the next write.",
+			{ path: CONFIG_PATH, backupPath },
+		);
+	} catch (err) {
+		_logger.warn("Could not back up corrupt config file", {
+			path: CONFIG_PATH,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
+function restrictConfigFilePermissionsForPath(path: string): void {
+	try {
+		chmodSync(path, 0o600);
+	} catch (err) {
+		_logger.warn("Could not restrict config backup permissions to 0600", {
+			path,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
 export function loadConfigFile(): PiFreeConfig {
 	// Return the memoized parse when the file hasn't changed on disk.
 	// Use a single stat result for both the hit check and the cached mtime to
@@ -253,8 +291,9 @@ export function loadConfigFile(): PiFreeConfig {
 		cachedConfig = null;
 		cachedConfigMtime = -1;
 		if (err instanceof SyntaxError) {
-			_logger.error(
-				"Config file is corrupt (invalid JSON) — returning empty config",
+			backupCorruptConfigFile();
+			_logger.warn(
+				"Config file is corrupt (invalid JSON) — returning empty config; a backup was created",
 				{
 					path: CONFIG_PATH,
 					error: err.message,
@@ -676,7 +715,10 @@ export function applyHidden<T extends { id: string }>(
 // Persistence
 // =============================================================================
 
-export function saveConfig(updates: Partial<PiFreeConfig>): void {
+export async function saveConfig(
+	updates: Partial<PiFreeConfig>,
+): Promise<void> {
+	const release = await _configLock.acquire();
 	try {
 		// Read the raw file content — never use loadConfigFile() here because
 		// if the file is unparsable, loadConfigFile() returns {} which would
@@ -690,6 +732,7 @@ export function saveConfig(updates: Partial<PiFreeConfig>): void {
 				`${JSON.stringify(merged, null, 2)}\n`,
 				"utf8",
 			);
+			restrictConfigFilePermissions();
 			_logger.info("Config saved (new file)", {
 				path: CONFIG_PATH,
 				keys: Object.keys(updates),
@@ -697,25 +740,27 @@ export function saveConfig(updates: Partial<PiFreeConfig>): void {
 			return;
 		}
 
-		let existing: PiFreeConfig;
+		let base: PiFreeConfig;
 		try {
-			existing = JSON.parse(raw, safeJsonReviver) as PiFreeConfig;
+			base = JSON.parse(raw, safeJsonReviver) as PiFreeConfig;
 		} catch (parseErr) {
-			// File exists but is corrupt. REFUSE to overwrite it with a partial
-			// config — that would permanently destroy the user's keys.
-			_logger.error(
-				"REFUSING to save config — existing file is corrupt. Fix or delete ~/.pi/free.json manually.",
+			// File exists but is corrupt. Back it up first, then write a fresh
+			// config so the user's original bytes are preserved for recovery.
+			backupCorruptConfigFile();
+			base = { ...CONFIG_TEMPLATE };
+			_logger.warn(
+				"Config file was corrupt; a backup was created and the next save will overwrite it",
 				{
 					path: CONFIG_PATH,
 					error:
 						parseErr instanceof Error ? parseErr.message : String(parseErr),
 				},
 			);
-			return;
 		}
 
-		const merged = { ...existing, ...updates };
+		const merged = { ...base, ...updates };
 		writeFileSync(CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+		restrictConfigFilePermissions();
 		_logger.info("Config saved", {
 			path: CONFIG_PATH,
 			keys: Object.keys(updates),
@@ -725,6 +770,8 @@ export function saveConfig(updates: Partial<PiFreeConfig>): void {
 			path: CONFIG_PATH,
 			error: err instanceof Error ? err.message : String(err),
 		});
+	} finally {
+		release();
 	}
 }
 
@@ -755,8 +802,9 @@ const _configLock = new ConfigLock();
  * receives the current parsed config and returns the partial updates to
  * merge. Concurrent calls are serialised by an internal lock.
  *
- * If the config file is corrupt, the updater is NOT called and the file
- * is left untouched (matches saveConfig's safety behaviour).
+ * If the config file is corrupt, a backup is created first and the updater
+ * is applied to a fresh template (the original bytes are preserved for
+ * recovery).
  */
 export async function updateConfig(
 	updater: (current: PiFreeConfig) => Partial<PiFreeConfig>,
@@ -773,6 +821,7 @@ export async function updateConfig(
 				`${JSON.stringify(merged, null, 2)}\n`,
 				"utf8",
 			);
+			restrictConfigFilePermissions();
 			_logger.info("Config updated (new file)", {
 				path: CONFIG_PATH,
 				keys: Object.keys(updated),
@@ -784,20 +833,24 @@ export async function updateConfig(
 		try {
 			existing = JSON.parse(raw, safeJsonReviver) as PiFreeConfig;
 		} catch (parseErr) {
-			_logger.error(
-				"REFUSING to update config — existing file is corrupt. Fix or delete ~/.pi/free.json manually.",
+			// File exists but is corrupt. Back it up first, then continue with
+			// the template as the base so the requested update can proceed.
+			backupCorruptConfigFile();
+			existing = { ...CONFIG_TEMPLATE };
+			_logger.warn(
+				"Config file was corrupt; a backup was created and the update will overwrite it",
 				{
 					path: CONFIG_PATH,
 					error:
 						parseErr instanceof Error ? parseErr.message : String(parseErr),
 				},
 			);
-			return;
 		}
 
 		const updated = updater(existing);
 		const merged = { ...existing, ...updated };
 		writeFileSync(CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+		restrictConfigFilePermissions();
 		_logger.info("Config updated", {
 			path: CONFIG_PATH,
 			keys: Object.keys(updated),

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -222,7 +222,7 @@ export function applyGlobalFilter(
 	options: { force?: boolean } = {},
 ): void {
 	globalFreeOnly = freeOnly;
-	saveConfig({ free_only: freeOnly });
+	void saveConfig({ free_only: freeOnly });
 
 	for (const [providerId, entry] of providerRegistry) {
 		try {

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -151,11 +151,7 @@ export async function loadCachedOrFetchModels(
 	const ttlMs = options?.ttlMs ?? DEFAULT_PROVIDER_CACHE_TTL_MS;
 	const cached = loadProviderCache(providerId);
 
-	if (
-		cached &&
-		cached.length > 0 &&
-		isProviderCacheFresh(providerId, ttlMs)
-	) {
+	if (cached && cached.length > 0 && isProviderCacheFresh(providerId, ttlMs)) {
 		return cached;
 	}
 
@@ -304,7 +300,7 @@ export function setupProvider(
 
 				// Persist to config file
 				const configKey = getShowPaidConfigKey(providerId);
-				saveConfig({ [configKey]: currentShowPaid });
+				await saveConfig({ [configKey]: currentShowPaid });
 
 				// Re-register with appropriate model set
 				if (currentShowPaid) {

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -12,7 +12,11 @@
  *   # Free models visible immediately; /login kilo for paid access
  */
 
-import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai/compat";
+import type {
+	Api,
+	Model,
+	OAuthCredentials,
+} from "@earendil-works/pi-ai/compat";
 import {
 	readStoredCredential,
 	type ExtensionAPI,
@@ -312,7 +316,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		description: "Toggle between free and all Kilo models",
 		handler: async (_args, ctx) => {
 			showPaidModels = !showPaidModels;
-			saveConfig({ kilo_show_paid: showPaidModels });
+			await saveConfig({ kilo_show_paid: showPaidModels });
 
 			// Determine which models to show
 			const modelsToShow =

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -442,7 +442,7 @@ async function runOllamaProbe(
 	const config = loadConfigFile();
 	const existingHidden = new Set(config.hidden_models ?? []);
 	for (const id of notFound) existingHidden.add(`${PROVIDER_OLLAMA}/${id}`);
-	saveConfig({
+	await saveConfig({
 		hidden_models: Array.from(existingHidden),
 	});
 

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -279,7 +279,7 @@ async function runRoutewayProbe(
 	const cfg = loadConfigFile();
 	const existingHidden = new Set(cfg.hidden_models ?? []);
 	for (const id of broken) existingHidden.add(`${PROVIDER_ROUTEWAY}/${id}`);
-	saveConfig({ hidden_models: Array.from(existingHidden) });
+	await saveConfig({ hidden_models: Array.from(existingHidden) });
 
 	// Re-register so hidden models disappear immediately
 	const filtered = await fetchRoutewayModels(apiKey);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -20,6 +20,10 @@ vi.mock("node:fs", () => {
 	const mockData = new Map<string, string>();
 	return {
 		appendFileSync: vi.fn(),
+		chmodSync: vi.fn(),
+		copyFileSync: vi.fn((src: string, dest: string) => {
+			mockData.set(dest, mockData.get(src) ?? "");
+		}),
 		existsSync: vi.fn((path: string) => mockData.has(path)),
 		mkdirSync: vi.fn(),
 		readFileSync: vi.fn((path: string) => mockData.get(path) ?? ""),
@@ -283,7 +287,7 @@ describe("config persistence", () => {
 		);
 
 		const { saveConfig } = await import("../config.ts");
-		saveConfig({ free_only: false });
+		await saveConfig({ free_only: false });
 
 		const lastCall =
 			writeFileSync.mock.calls[writeFileSync.mock.calls.length - 1];
@@ -299,7 +303,7 @@ describe("config persistence", () => {
 		__mockData.set(configPath(), JSON.stringify({ free_only: true }));
 
 		const { saveConfig } = await import("../config.ts");
-		saveConfig({ nvidia_api_key: "new-key" });
+		await saveConfig({ nvidia_api_key: "new-key" });
 
 		const lastCall =
 			writeFileSync.mock.calls[writeFileSync.mock.calls.length - 1];
@@ -361,21 +365,25 @@ describe("updateConfig", () => {
 		expect(final.hidden_models).toHaveLength(3);
 	});
 
-	it("refuses to update a corrupt config file", async () => {
+	it("backs up a corrupt config file and applies the update to a fresh template", async () => {
 		vi.stubEnv("HOME", "/tmp");
 		const fs = await import("node:fs");
-		const { __mockData, writeFileSync } = fs as any;
+		const { __mockData, copyFileSync } = fs as any;
 		__mockData.set(configPath(), "not json {{{");
 
 		const { updateConfig } = await import("../config.ts");
-		await updateConfig(() => ({ nvidia_api_key: "should-not-write" }));
+		await updateConfig(() => ({ nvidia_api_key: "recovered-write" }));
 
-		// writeFileSync should not have been called (file is corrupt)
-		const lastCall = writeFileSync.mock.calls.at(-1);
-		if (lastCall) {
-			const written = parseMockJson(lastCall[1]);
-			expect(written.nvidia_api_key).not.toBe("should-not-write");
-		}
+		// Original bytes preserved in a timestamped backup
+		const backupCall = copyFileSync.mock.calls.at(-1);
+		expect(backupCall).toBeDefined();
+		expect(backupCall[0]).toBe(configPath());
+		expect(String(backupCall[1])).toContain(".bak-");
+		expect(__mockData.get(backupCall[1])).toBe("not json {{{");
+
+		// The update proceeds against a fresh template
+		const written = parseMockJson(__mockData.get(configPath()));
+		expect(written.nvidia_api_key).toBe("recovered-write");
 	});
 });
 


### PR DESCRIPTION
## Summary
- A corrupt `~/.pi/free.json` no longer permanently blocks config writes: the original bytes are preserved in a timestamped `free.json.bak-*` backup (chmod 0600) and the file is reset from the template so the extension keeps working
- `saveConfig` is now async and serialised through the config lock, preventing concurrent writes from clobbering each other; all callers updated (`registry`, `provider-helper`, `kilo`, `ollama`, `routeway`)
- File permissions are re-restricted to 0600 after every config write
- Updated the corrupt-config test to assert the new backup-then-proceed contract and extended the fs mock with `copyFileSync`/`chmodSync`

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (474 tests, including new backup assertions)
- [ ] Manual: corrupt `~/.pi/free.json`, trigger a config write, verify backup file appears and config resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)