### PR TITLE
fix: call-id telemetry tracking and structured logging for silent failures

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -294,6 +294,11 @@ function setupQuotaMonitoring(pi: ExtensionAPI) {
 // =============================================================================
 
 function setupTelemetry(pi: ExtensionAPI) {
+	// Tracks the most recent call id per provider/model so turn_end can
+	// pair with the correct startModelCall. Calls are serialized per model
+	// in practice, so the last id is the correct one.
+	const pendingCallIds = new Map<string, string>();
+
 	// Only track telemetry for FREE models (uses same isFreeModel logic as model filtering)
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(pi as any).on("before_agent_start", (_event: any, ctx: any) => {
@@ -303,7 +308,8 @@ function setupTelemetry(pi: ExtensionAPI) {
 		const model = ctx.model?.id;
 		if (provider && model) {
 			try {
-				startModelCall(provider, model);
+				const callId = startModelCall(provider, model);
+				pendingCallIds.set(`${provider}/${model}`, callId);
 			} catch (err) {
 				// Telemetry is best-effort — never break the agent flow
 				_logger.warn("telemetry startModelCall failed", {
@@ -341,6 +347,10 @@ function setupTelemetry(pi: ExtensionAPI) {
 		const model = msg.model || ctx.model?.id;
 		if (!provider || !model) return;
 
+		const callKey = `${provider}/${model}`;
+		const callId = pendingCallIds.get(callKey);
+		pendingCallIds.delete(callKey);
+
 		const usage = msg.usage;
 		const inputTokens = usage?.input ?? 0;
 		const outputTokens = usage?.output ?? 0;
@@ -350,6 +360,7 @@ function setupTelemetry(pi: ExtensionAPI) {
 
 		try {
 			await recordModelCall(
+				callId,
 				provider,
 				model,
 				{ input: inputTokens, output: outputTokens, totalTokens },

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -76,19 +76,41 @@ const TELEMETRY_FILE = resolveSafeDataFile(
 );
 const MAX_RECENT_CALLS = 50;
 
-// In-flight tracking: keyed by "provider/model", value is start timestamp.
-// TTL: 1 hour — anything older is stale (the matching recordModelCall
-// never fired, e.g. the agent was killed mid-call) and gets reaped
-// on the next startModelCall/recordModelCall.
-const _inFlight = new Map<string, number>();
+/** Latency samples above this threshold are discarded as implausible. */
+const MAX_SANE_LATENCY_MS = 10 * 60 * 1000; // 10 minutes
+
+// In-flight tracking: keyed by a unique call id, value is
+// { key: "provider/model", startTime: timestamp }.
+// Entries are reaped after 1 hour (the matching recordModelCall never fired,
+// e.g. the agent was killed mid-call).
+interface InFlightEntry {
+	key: string;
+	startTime: number;
+}
+const _inFlight = new Map<string, InFlightEntry>();
 const _IN_FLIGHT_TTL_MS = 60 * 60 * 1000;
 
+let _callIdCounter = 0;
+
 function reapStaleInFlight(now: number): void {
-	for (const [key, start] of _inFlight) {
-		if (now - start > _IN_FLIGHT_TTL_MS) {
-			_inFlight.delete(key);
+	for (const [id, entry] of _inFlight) {
+		if (now - entry.startTime > _IN_FLIGHT_TTL_MS) {
+			_logger.info("Reaped stale in-flight telemetry entry", {
+				callId: id,
+				key: entry.key,
+				ageMs: now - entry.startTime,
+			});
+			_inFlight.delete(id);
 		}
 	}
+}
+
+// =============================================================================
+// Key construction — single source of truth for provider/model keys
+// =============================================================================
+
+function telemetryKey(provider: string, model: string): string {
+	return `${provider}/${model}`;
 }
 
 // =============================================================================
@@ -165,7 +187,7 @@ function deriveModelTelemetry(
 
 async function addEntry(entry: TelemetryEntry): Promise<void> {
 	await _store.update((store) => {
-		const modelKey = `${entry.provider}/${entry.model}`;
+		const modelKey = telemetryKey(entry.provider, entry.model);
 
 		const existing: TelemetryEntry[] =
 			store.models[modelKey]?.recentCalls ?? [];
@@ -203,7 +225,7 @@ export function getModelTelemetry(
 	provider: string,
 	model: string,
 ): ModelTelemetry | null {
-	return _store.load().models[`${provider}/${model}`] ?? null;
+	return _store.load().models[telemetryKey(provider, model)] ?? null;
 }
 
 /**
@@ -259,14 +281,15 @@ export function getProviderTelemetry(provider: string): {
 }
 
 /**
- * Mark a model call as started (records the start timestamp).
- * Call this from before_agent_start or model_select.
+ * Mark a model call as started and return a unique call id.
+ * Pass this id to {@link recordModelCall} to pair the start/end correctly.
  */
-export function startModelCall(provider: string, model: string): void {
-	const key = `${provider}/${model}`;
+export function startModelCall(provider: string, model: string): string {
 	const now = Date.now();
 	reapStaleInFlight(now);
-	_inFlight.set(key, now);
+	const callId = `${telemetryKey(provider, model)}:${now}:${++_callIdCounter}`;
+	_inFlight.set(callId, { key: telemetryKey(provider, model), startTime: now });
+	return callId;
 }
 
 /** Options for {@link recordModelCall} */
@@ -280,6 +303,8 @@ export interface RecordModelCallOptions {
  * Record a completed model call with its usage data.
  * Call this from turn_end when the message is an AssistantMessage.
  *
+ * @param callId - The call id returned by {@link startModelCall}, or undefined
+ *   if no matching start was recorded.
  * @param provider - The provider ID
  * @param model - The model ID
  * @param usage - Token usage { input, output, totalTokens }
@@ -287,6 +312,7 @@ export interface RecordModelCallOptions {
  * @param options - Options object ({@link RecordModelCallOptions})
  */
 export async function recordModelCall(
+	callId: string | undefined,
 	provider: string,
 	model: string,
 	usage: { input: number; output: number; totalTokens: number },
@@ -294,10 +320,34 @@ export async function recordModelCall(
 	options: RecordModelCallOptions,
 ): Promise<void> {
 	const { success, stopReason, errorMessage } = options;
-	const key = `${provider}/${model}`;
-	const startTime = _inFlight.get(key) ?? Date.now();
-	const latencyMs = Date.now() - startTime;
-	_inFlight.delete(key);
+	const now = Date.now();
+
+	let latencyMs: number;
+	if (callId && _inFlight.has(callId)) {
+		const entry = _inFlight.get(callId)!;
+		latencyMs = now - entry.startTime;
+		_inFlight.delete(callId);
+	} else {
+		// No matching start — record 0 latency rather than a bogus value.
+		latencyMs = 0;
+		_logger.info("recordModelCall: no matching startModelCall", {
+			callId: callId ?? "(none)",
+			provider,
+			model,
+		});
+	}
+
+	// Discard implausibly long latency samples (e.g. system was suspended).
+	if (latencyMs > MAX_SANE_LATENCY_MS) {
+		_logger.info("Discarding implausible latency sample", {
+			callId,
+			provider,
+			model,
+			latencyMs,
+			thresholdMs: MAX_SANE_LATENCY_MS,
+		});
+		latencyMs = 0;
+	}
 
 	const totalTokens = usage.totalTokens || usage.input + usage.output;
 	const tokensPerSecond =
@@ -306,7 +356,7 @@ export async function recordModelCall(
 			: 0;
 
 	const entry: TelemetryEntry = {
-		timestamp: Date.now(),
+		timestamp: now,
 		provider,
 		model,
 		success,
@@ -322,7 +372,7 @@ export async function recordModelCall(
 
 	await addEntry(entry);
 
-	_logger.info(`Telemetry: ${provider}/${model}`, {
+	_logger.info(`Telemetry: ${telemetryKey(provider, model)}`, {
 		latencyMs,
 		totalTokens,
 		tokensPerSecond,

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -12,7 +12,10 @@
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { createLogger } from "../lib/logger.ts";
 import type { ModelMatchHints } from "../lib/types.ts";
+
+const _logger = createLogger("benchmark-lookup");
 import {
 	HARDCODED_BENCHMARKS,
 	type HardcodedBenchmark,
@@ -132,8 +135,10 @@ function logDebug(entry: {
 			.join("|");
 
 		appendFileSync(LOG_FILE, `${line}\n`);
-	} catch {
-		// Silently fail - don't break functionality for logging issues
+	} catch (err) {
+		_logger.warn("Debug log write failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
 	}
 }
 
@@ -155,8 +160,10 @@ export function clearMatchLog(): void {
 				"timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details\n",
 			);
 		}
-	} catch {
-		// Ignore errors
+	} catch (err) {
+		_logger.warn("Failed to clear match log", {
+			error: err instanceof Error ? err.message : String(err),
+		});
 	}
 }
 
@@ -881,8 +888,10 @@ export function getMatchingStats(): {
 		for (const line of content.split("\n").slice(1)) {
 			parseLogLine(stats, line);
 		}
-	} catch {
-		// Return empty stats on error
+	} catch (err) {
+		_logger.warn("Failed to read match log stats", {
+			error: err instanceof Error ? err.message : String(err),
+		});
 	}
 
 	return { ...stats, matchRate: computeMatchRate(stats) };

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -451,6 +451,7 @@ export async function refreshClineToken(
 	});
 
 	if (!res.ok) {
+		logger.warn("Cline token refresh failed", { status: res.status });
 		throw new Error(
 			"Cline token refresh failed. Run /login cline to re-authenticate.",
 		);
@@ -462,6 +463,10 @@ export async function refreshClineToken(
 	};
 
 	if (!data?.success || !data.data) {
+		logger.warn("Invalid Cline refresh response", {
+			success: data?.success,
+			hasData: !!data?.data,
+		});
 		throw new Error("Invalid refresh response");
 	}
 

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -10,7 +10,10 @@ import type {
 	Usage,
 } from "@earendil-works/pi-ai/compat";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
+import { createLogger } from "../../lib/logger.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
+
+const _logger = createLogger("cline-xml-bridge");
 
 const DEFAULT_USAGE: Usage = {
 	input: 0,
@@ -1482,6 +1485,11 @@ export function streamClineXml(
 			assistant.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			assistant.errorMessage =
 				error instanceof Error ? error.message : String(error);
+			_logger.warn("Cline XML streaming error", {
+				model: model?.id,
+				stopReason: assistant.stopReason,
+				error: assistant.errorMessage,
+			});
 			stream.push({
 				type: "error",
 				reason: assistant.stopReason,

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -30,11 +30,67 @@ describe("telemetry", () => {
 		const usage = { input: 1, output: 2, totalTokens: 3 };
 		const opts = { success: true };
 		await Promise.all([
-			recordModelCall("p", "m", usage, 0, opts),
-			recordModelCall("p", "m", usage, 0, opts),
-			recordModelCall("p", "m", usage, 0, opts),
+			recordModelCall(undefined, "p", "m", usage, 0, opts),
+			recordModelCall(undefined, "p", "m", usage, 0, opts),
+			recordModelCall(undefined, "p", "m", usage, 0, opts),
 		]);
 		const t = getModelTelemetry("p", "m");
 		expect(t?.totalCalls).toBe(3);
+	});
+
+	it("pairs start and record via call id with correct latency", async () => {
+		const { startModelCall, recordModelCall, getModelTelemetry } =
+			await import("../lib/telemetry.ts");
+
+		const callId = startModelCall("prov", "mdl");
+		expect(typeof callId).toBe("string");
+
+		const usage = { input: 10, output: 20, totalTokens: 30 };
+		await recordModelCall(callId, "prov", "mdl", usage, 0, {
+			success: true,
+		});
+
+		const t = getModelTelemetry("prov", "mdl");
+		expect(t?.totalCalls).toBe(1);
+		// Latency should be >= 0 (near-instant in test)
+		expect(t?.recentCalls[0]?.latencyMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("records 0 latency when no matching startModelCall exists", async () => {
+		const { recordModelCall, getModelTelemetry } = await import(
+			"../lib/telemetry.ts"
+		);
+		const usage = { input: 5, output: 5, totalTokens: 10 };
+		await recordModelCall(undefined, "x", "y", usage, 0, {
+			success: true,
+		});
+
+		const t = getModelTelemetry("x", "y");
+		expect(t?.recentCalls[0]?.latencyMs).toBe(0);
+	});
+
+	it("discards implausibly long latency samples", async () => {
+		const { startModelCall, recordModelCall, getModelTelemetry } =
+			await import("../lib/telemetry.ts");
+
+		const callId = startModelCall("slow", "model");
+
+		// Simulate a system suspend by faking the in-flight start time
+		// (reach into the module's internals via the returned callId structure)
+		// Instead, we use vi.spyOn to override Date.now for the record call
+		const realNow = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(realNow + 15 * 60 * 1000); // 15 min later
+
+		const usage = { input: 1, output: 1, totalTokens: 2 };
+		await recordModelCall(callId, "slow", "model", usage, 0, {
+			success: true,
+		});
+
+		vi.restoreAllMocks();
+
+		const t = getModelTelemetry("slow", "model");
+		// Latency should be clamped to 0 (discarded as implausible)
+		expect(t?.recentCalls[0]?.latencyMs).toBe(0);
+		expect(t?.recentCalls[0]?.tokensPerSecond).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary
- **Telemetry (#322)**: Replace key-based in-flight tracking with unique call ids, preventing provider-id drift and TTL reaping from corrupting latency. Discard samples over 10 minutes. Log reaped entries and unmatched calls.
- **Observability (#326)**: Add structured logging to cline-xml-bridge streaming errors, cline-auth refresh failures, and benchmark-lookup debug FS operations (previously silent `catch {}` blocks)

Closes #322

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run test:run` — 477 tests pass (3 new: call-id pairing, missing start, implausible latency discard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)