### PR TITLE
fix: OAuth retry, persistence failure escalation, XML parse warning

### DIFF
--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -24,6 +24,9 @@ import { enhanceModelNameWithCodingIndex } from "./provider-failover/benchmark-l
 
 const _logger = createLogger("provider-helper");
 
+/** Tracks consecutive persistence failures per provider for escalation logging. */
+const _persistFailCount = new Map<string, number>();
+
 interface ContextWithOAuthStatus {
 	model?: unknown;
 	modelRegistry?: {
@@ -175,11 +178,29 @@ export async function loadCachedOrFetchModels(
 	// transiently-shrunk response (poisoning guard, centralized in provider-cache),
 	// so a flaky API can't wipe a good cached list for the TTL window.
 	if (fetched.length > 0) {
-		saveProviderCacheGuarded(providerId, fetched).catch((err) => {
-			_logger.error(`[${providerId}] failed to persist provider cache`, {
-				error: err instanceof Error ? err.message : String(err),
+		saveProviderCacheGuarded(providerId, fetched)
+			.then(() => {
+				_persistFailCount.delete(providerId);
+			})
+			.catch((err) => {
+				const count = (_persistFailCount.get(providerId) ?? 0) + 1;
+				_persistFailCount.set(providerId, count);
+				const logData = {
+					error: err instanceof Error ? err.message : String(err),
+					consecutiveFailures: count,
+				};
+				if (count >= 3) {
+					_logger.error(
+						`[${providerId}] failed to persist provider cache (${count} consecutive failures)`,
+						logData,
+					);
+				} else {
+					_logger.warn(
+						`[${providerId}] failed to persist provider cache`,
+						logData,
+					);
+				}
 			});
-		});
 	} else if (cached && cached.length > 0) {
 		// Empty fetch but we have a cache: keep serving cache.
 		return cached;

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -436,11 +436,9 @@ export async function loginCline(
 	}
 }
 
-export async function refreshClineToken(
+async function attemptClineTokenRefresh(
 	credentials: OAuthCredentials,
 ): Promise<OAuthCredentials> {
-	if (credentials.expires > Date.now()) return credentials;
-
 	const res = await fetch(`${BASE_URL_CLINE}/auth/refresh`, {
 		method: "POST",
 		headers: buildClineHeaders(),
@@ -451,9 +449,8 @@ export async function refreshClineToken(
 	});
 
 	if (!res.ok) {
-		logger.warn("Cline token refresh failed", { status: res.status });
 		throw new Error(
-			"Cline token refresh failed. Run /login cline to re-authenticate.",
+			`Cline token refresh failed with status ${res.status}`,
 		);
 	}
 
@@ -463,11 +460,9 @@ export async function refreshClineToken(
 	};
 
 	if (!data?.success || !data.data) {
-		logger.warn("Invalid Cline refresh response", {
-			success: data?.success,
-			hasData: !!data?.data,
-		});
-		throw new Error("Invalid refresh response");
+		throw new Error(
+			`Invalid Cline refresh response (success=${data?.success}, hasData=${!!data?.data})`,
+		);
 	}
 
 	return {
@@ -475,4 +470,32 @@ export async function refreshClineToken(
 		refresh: data.data.refreshToken ?? credentials.refresh,
 		expires: parseExpiresAt(data.data.expiresAt),
 	};
+}
+
+export async function refreshClineToken(
+	credentials: OAuthCredentials,
+): Promise<OAuthCredentials> {
+	if (credentials.expires > Date.now()) return credentials;
+
+	try {
+		return await attemptClineTokenRefresh(credentials);
+	} catch (firstErr) {
+		logger.warn("Cline token refresh failed, retrying in 1 s", {
+			error: firstErr instanceof Error ? firstErr.message : String(firstErr),
+		});
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		try {
+			return await attemptClineTokenRefresh(credentials);
+		} catch (secondErr) {
+			logger.warn("Cline token refresh failed after retry", {
+				error:
+					secondErr instanceof Error
+						? secondErr.message
+						: String(secondErr),
+			});
+			throw new Error(
+				"Cline token refresh failed. Run /login cline to re-authenticate.",
+			);
+		}
+	}
 }

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -1037,9 +1037,24 @@ function parseXmlToolCalls(
 	}
 
 	pushTextFragment(textParts, sourceText.slice(cursor));
+	const allToolCalls = [...fnResult.toolCalls, ...toolCalls];
+
+	// Warn if the raw text appears to contain tool XML tags but no tool calls
+	// were parsed — this can indicate a model using an unrecognised tag variant.
+	if (allToolCalls.length === 0) {
+		const TOOL_XML_RE =
+			/<(read_file|write_to_file|replace_in_file|execute_command|list_files|search_files|browser_action|ask_followup_question|attempt_completion)\b/;
+		if (TOOL_XML_RE.test(rawText)) {
+			_logger.warn(
+				"parseXmlToolCalls: raw text contains tool XML tags but no tool calls were parsed",
+				{ preview: rawText.slice(0, 200) },
+			);
+		}
+	}
+
 	return {
 		text: textParts.join("\n\n").trim(),
-		toolCalls: [...fnResult.toolCalls, ...toolCalls],
+		toolCalls: allToolCalls,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Add single bounded retry (1s delay) to `refreshClineToken` before throwing, with structured logging on both attempts
- Track consecutive persistence failures per provider in `loadCachedOrFetchModels`; escalate from `warn` to `error` after 3+ consecutive failures
- Warn when `parseXmlToolCalls` finds tool XML tags in raw text but parses 0 tool calls

Closes #326

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (477 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)