### PR TITLE
chore: suppress ts-weak-hash on COSY MD5 calls

### DIFF
--- a/providers/qoder/cosy.ts
+++ b/providers/qoder/cosy.ts
@@ -201,10 +201,12 @@ export function buildAuthHeaders(
 	const bodyStr = bodyToUtf8(body);
 	const sigInput = `${payloadB64}\n${cosyKey}\n${timestamp}\n${bodyStr}\n${sigPath}`;
 	// sonar-security: MD5 is protocol-mandatory for COSY signature (reverse-engineered from Qoder CLI)
+	// pi-lens-ignore: ts-weak-hash
 	const sig = crypto.createHash("md5").update(sigInput).digest("hex");
 
 	// sonar-security: MD5 is protocol-mandatory for COSY body hash (reverse-engineered from Qoder CLI)
 	const bodyHash = crypto
+		// pi-lens-ignore: ts-weak-hash
 		.createHash("md5")
 		.update(body || "")
 		.digest("hex");


### PR DESCRIPTION
## Summary

Suppress the `ts-weak-hash` lens finding on the two MD5 calls in `providers/qoder/cosy.ts`.

## Context

MD5 is **protocol-mandatory** for the COSY signature scheme reverse-engineered from the Qoder CLI. The existing `// sonar-security:` comments already document this. The new `// pi-lens-ignore: ts-weak-hash` directives sit next to those comments for the lens scanner to pick up.

## Why we can't upgrade

- The signature scheme is dictated by the upstream Qoder API. Changing the hash function will produce signatures the server rejects with a 401/403.
- The Qoder CLI is the source of truth here — the `auth.ts` handlers reconstruct what the CLI sends.
- Upgrading to SHA-256 would break OAuth entirely for Qoder users.

## Diff

```diff
   const sigInput = `${payloadB64}\n${cosyKey}\n${timestamp}\n${bodyStr}\n${sigPath}`;
   // sonar-security: MD5 is protocol-mandatory for COSY signature (reverse-engineered from Qoder CLI)
+  // pi-lens-ignore: ts-weak-hash
   const sig = crypto.createHash("md5").update(sigInput).digest("hex");

   // sonar-security: MD5 is protocol-mandatory for COSY body hash (reverse-engineered from Qoder CLI)
   const bodyHash = crypto
+      // pi-lens-ignore: ts-weak-hash
       .createHash("md5")
       .update(body || "")
       .digest("hex");
```

## False positives also dismissed in this scan (not in this PR)

These were marked as `false-positive` in the local lens state only — no repo change needed:

- `scripts/smoke-cline-xml-bridge.ts` L23, L27, L30, L59 — `AUTH_PATH` is hardcoded to `~/.pi/agent/auth.json`, no user input. Dev-only script not shipped in the tarball.
- `providers/cline/cline-auth.ts` L224 — SSRF false positive, fetches to hardcoded `BASE_URL_CLINE` / `USERINFO_URL`.
- `providers/qoder/auth.ts` L148, L255 — SSRF false positive, same reasoning.

## Test plan

- [x] Diff is two added comment lines, no behavioral change
- [ ] CI passes (no logic changed; should be green)
