### PR TITLE
release: 2.2.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
       should_release: ${{ steps.meta.outputs.should_release }}
-      has_npm_token: ${{ steps.meta.outputs.has_npm_token }}
+      needs_npm_publish: ${{ steps.meta.outputs.needs_npm_publish }}
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -31,32 +31,36 @@ jobs:
 
       - name: Compute release metadata
         id: meta
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
 
+          # Create a GitHub release if the version tag doesn't exist yet.
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             SHOULD_RELEASE=false
           else
             SHOULD_RELEASE=true
           fi
 
-          if [ -n "$NPM_TOKEN" ]; then
-            HAS_NPM_TOKEN=true
+          # Publish to npm if this version is not on the registry yet. Checked
+          # independently of the tag so a re-run (workflow_dispatch) can
+          # publish a version whose tag/release already exists.
+          if npm view "pi-free@$VERSION" version >/dev/null 2>&1; then
+            NEEDS_NPM_PUBLISH=false
           else
-            HAS_NPM_TOKEN=false
+            NEEDS_NPM_PUBLISH=true
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "has_npm_token=$HAS_NPM_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "needs_npm_publish=$NEEDS_NPM_PUBLISH" >> "$GITHUB_OUTPUT"
 
       - name: Verify changelog entry exists
-        if: steps.meta.outputs.should_release == 'true'
+        if: >
+          steps.meta.outputs.should_release == 'true' ||
+          steps.meta.outputs.needs_npm_publish == 'true'
         shell: bash
         env:
           VERSION: ${{ steps.meta.outputs.version }}
@@ -67,71 +71,49 @@ jobs:
           fi
 
       # yamllint disable-line rule:line-length
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
-        run: npm install --no-audit --no-fund
+        if: steps.meta.outputs.needs_npm_publish == 'true'
+        run: npm ci --no-audit --no-fund
 
       - name: Lockfile in sync with package.json
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run check:lockfile
 
       - name: Audit production dependencies
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run audit:prod
 
       - name: Type-check
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run lint
 
       - name: Run tests
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run test:run
 
-      - name: Dry-run publish (validates tarball + registry auth)
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Dry-run publish (validates tarball)
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm publish --dry-run
 
       - name: Pack tarball for verification
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm pack
 
       - name: Verify tarball contents
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         shell: bash
         run: |
           TARBALL=$(ls pi-free-*.tgz)
           node scripts/check-tarball.mjs "$TARBALL"
 
       - name: Smoke-load source entry
-        if: >-
-          steps.meta.outputs.should_release == 'true' &&
-          steps.meta.outputs.has_npm_token == 'true'
+        if: steps.meta.outputs.needs_npm_publish == 'true'
         shell: bash
         run: |
           ENTRY=$(node -p "require('./package.json').pi.extensions[0]")
@@ -177,14 +159,24 @@ jobs:
           gh release create "$TAG" --title "$TAG"
           --notes-file "$RUNNER_TEMP/release-notes.md"
 
+  # Publishes via npm trusted publishing (OIDC) — no NPM_TOKEN secret. The
+  # trusted publisher must be configured on npmjs.com for pi-free, pointing
+  # at this repo and this workflow file. npm >= 11.5.1 (bundled with Node 24)
+  # detects the GitHub Actions OIDC token automatically during `npm publish`.
   publish-npm:
     runs-on: ubuntu-latest
     needs: [prepare, release]
-    if: >-
-      needs.prepare.outputs.should_release == 'true' &&
-      needs.prepare.outputs.has_npm_token == 'true'
+    # `release` is skipped when the tag already exists; still publish as long
+    # as the version is missing from the registry and release didn't FAIL.
+    if: >
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.needs_npm_publish == 'true' &&
+      needs.release.result != 'failure' &&
+      needs.release.result != 'cancelled'
     permissions:
       contents: read
+      id-token: write
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -192,15 +184,13 @@ jobs:
           persist-credentials: false
 
       # yamllint disable-line rule:line-length
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (trusted publishing)
         run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.meta.outputs.needs_npm_publish == 'true'
-        run: npm ci --no-audit --no-fund --ignore-scripts
+        run: npm ci --no-audit --no-fund
 
       - name: Lockfile in sync with package.json
         if: steps.meta.outputs.needs_npm_publish == 'true'
@@ -190,7 +190,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund --ignore-scripts
+        run: npm ci --no-audit --no-fund
 
       - name: Publish to npm (trusted publishing)
         run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.meta.outputs.needs_npm_publish == 'true'
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --ignore-scripts
 
       - name: Lockfile in sync with package.json
         if: steps.meta.outputs.needs_npm_publish == 'true'
@@ -190,7 +190,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --ignore-scripts
 
       - name: Publish to npm (trusted publishing)
         run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.8] - 2026-07-21
+
 ### Changed
 
 - **Lazy benchmark loading** — replaced ~10k lines of eagerly-imported `benchmarks-chunk-*.ts` files with a lazily-loaded `benchmarks.json` catalog, reducing module parse cost at startup (#315, #316, #320).
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Benchmark regexes hoisted** — regexes previously compiled inside hot loops in `benchmark-lookup.ts` are now compiled once at module level (#318).
 - **Ollama capabilities cached** — `/api/show` is now only fetched for models not already in the provider cache, avoiding redundant per-model capability probes (#327).
 - **CI uses `npm ci`** — switched CI install step from `npm install` to `npm ci` for deterministic builds and correct lockfile-pinned dependency resolution.
+- **Dead export cleanup** — removed 10 unused exports from `constants.ts` and `lib/types.ts` (leftover from provider removals).
 
 ### Fixed
 
@@ -26,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Handler duplication on reload** — global event handlers (`setupTelemetry`, `setupQuotaMonitoring`) are now guarded against duplicate registration when the extension is reloaded (#325).
 - **Empty provider warning** — `loadCachedOrFetchModels` now logs at `warn` level when a provider registers with 0 models due to fetch failure and empty cache (#323).
 - **Atomic probe config writes** — Ollama and Routeway probes now use `updateConfig()` instead of the non-atomic `loadConfigFile()` + `saveConfig()` pattern, preventing concurrent probes from overwriting each other's `hidden_models` updates (#319).
+- **Guarded JSON.parse calls** — `benchmarks.json` load and SSE chunk parsing now catch and log malformed data instead of crashing (#339).
 - **npm audit vulnerabilities** — pinned `brace-expansion@5.0.7` and `protobufjs@7.6.5` to fix GHSA-3jxr-9vmj-r5cp and GHSA-j3f2-48v5-ccww from peer-dep transitive dependencies.
 
 ## [2.2.7] - 2026-07-10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.2.7",
+	"version": "2.2.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.2.7",
+			"version": "2.2.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.2.7",
+	"version": "2.2.8",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## v2.2.8 — Reliability and performance pass

Version bump, changelog update, and release workflow migrated to npm trusted publishing (OIDC).

See [CHANGELOG.md](CHANGELOG.md#228---2026-07-21) for the full list of changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)