### PR TITLE
fix: opencode-dynamic API not registered in compat registry

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -678,7 +678,12 @@ export function getOpenrouterApiKey(): string | undefined {
 
 /** OpenCode key — pi's built-in provider. Read from env or auth.json. */
 export function getOpencodeApiKey(): string | undefined {
-	return readAuthJsonKey("opencode", "OPENCODE_API_KEY");
+	// Try "opencode" key first, then "opencode-go" — Pi may store OpenCode Go
+	// credentials under "opencode-go" (e.g. when logging in with /login opencode-go).
+	return (
+		readAuthJsonKey("opencode", "OPENCODE_API_KEY") ??
+		readAuthJsonKey("opencode-go", "OPENCODE_API_KEY")
+	);
 }
 
 // =============================================================================

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -35,6 +35,7 @@ import {
 	OPENCODE_DYNAMIC_API,
 	createOpenCodeSessionTracker,
 	createOpenCodeStreamSimple,
+	ensureOpenCodeApiProviderRegistered,
 	isOpenCodeProvider,
 } from "../providers/opencode-session.ts";
 
@@ -261,6 +262,11 @@ function createProviderState(
 	);
 
 	const reRegister = (models: ProviderModelConfig[]) => {
+		// Ensure the opencode-dynamic API is registered in compat's global
+		// registry so fallback code paths (compat streamSimple) can resolve it.
+		if (isOpenCodeProvider(config.id)) {
+			ensureOpenCodeApiProviderRegistered(getOpenCodeSession());
+		}
 		pi.registerProvider(config.id, {
 			baseUrl,
 			apiKey,

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -60,6 +60,7 @@ import {
 	OPENCODE_DYNAMIC_API,
 	createOpenCodeSessionTracker,
 	createOpenCodeStreamSimple,
+	ensureOpenCodeApiProviderRegistered,
 	isOpenCodeProvider,
 } from "../opencode-session.ts";
 
@@ -502,6 +503,11 @@ async function registerProvider(
 
 	// Re-register function: called by toggle and initial apply
 	const reRegister = (models: ProviderModelConfig[]) => {
+		// Ensure the opencode-dynamic API is registered in compat's global
+		// registry so fallback code paths (compat streamSimple) can resolve it.
+		if (isOpenCodeProvider(config.providerId)) {
+			ensureOpenCodeApiProviderRegistered(_opencodeSession);
+		}
 		pi.registerProvider(config.providerId, {
 			baseUrl: config.baseUrl,
 			apiKey,

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -481,7 +481,7 @@ export function ensureOpenCodeApiProviderRegistered(
 	if (_apiProviderRegistrationSourceId) return;
 
 	const streamFn = createOpenCodeStreamSimple(tracker);
-	const sourceId = `pi-free-opencode-${Math.random().toString(36).slice(2, 8)}`;
+	const sourceId = `pi-free-opencode-${randomBytes(4).toString("hex")}`;
 
 	// registerApiProvider expects { api, stream, streamSimple }. Both
 	// stream and streamSimple return async-iterable streams; using the

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -13,6 +13,7 @@ import type {
 	ProviderHeaders,
 	SimpleStreamOptions,
 } from "@earendil-works/pi-ai/compat";
+import { registerApiProvider } from "@earendil-works/pi-ai/compat";
 import type { ProviderConfig } from "@earendil-works/pi-coding-agent";
 
 export const OPENCODE_DYNAMIC_API = "opencode-dynamic" as const;
@@ -458,6 +459,45 @@ export function createOpenCodeStreamSimple(
 
 		return stream as unknown as AssistantMessageEventStream;
 	};
+}
+
+// ── Compat API registry safety net ─────────────────────────────────────────
+// The opencode-dynamic API is not a pi-ai built-in. If compat.js's
+// streamSimple() is ever called directly with a model using this API
+// (e.g. as a default-stream fallback after reload), it throws
+// "No API provider registered for api: opencode-dynamic".
+// Registering the API here ensures the compat path also works.
+
+let _apiProviderRegistrationSourceId: string | undefined;
+
+/**
+ * Register the opencode-dynamic API in compat's global API registry
+ * so that fallback code paths (compat streamSimple) can resolve it.
+ * Safe to call multiple times — registers once per tracker instance.
+ */
+export function ensureOpenCodeApiProviderRegistered(
+	tracker: OpenCodeSessionTracker,
+): void {
+	if (_apiProviderRegistrationSourceId) return;
+
+	const streamFn = createOpenCodeStreamSimple(tracker);
+	const sourceId = `pi-free-opencode-${Math.random().toString(36).slice(2, 8)}`;
+
+	// registerApiProvider expects { api, stream, streamSimple }. Both
+	// stream and streamSimple return async-iterable streams; using the
+	// same implementation for both is safe — the compat wrappers only
+	// validate model.api and forward the call.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	registerApiProvider(
+		{
+			api: OPENCODE_DYNAMIC_API,
+			stream: streamFn as any,
+			streamSimple: streamFn,
+		},
+		sourceId,
+	);
+
+	_apiProviderRegistrationSourceId = sourceId;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Summary

Fix `No API provider registered for api: opencode-dynamic` crash when using `opencode-go` as the default provider after authenticating via `/login opencode-go`.

## Problem

When a user logs into `opencode-go` via `/login opencode-go`, Pi stores the credential in `~/.pi/agent/auth.json` under the key `"opencode-go"`. However, `getOpencodeApiKey()` only reads the `"opencode"` key, causing the function to return `undefined`. This prevents the dynamic built-in provider discovery from fetching OpenCode Go models, which forces the system to fall back on less reliable code paths.

Additionally, the `opencode-dynamic` API identifier is not one of pi-ai's built-in APIs. If compat.js's `streamSimple()` is ever invoked directly with a model using this API (e.g., as the default stream fallback after `/reload`), it throws:

```
Error: No API provider registered for api: opencode-dynamic
    at resolveApiProvider (compat.js:165)
    at streamSimple (compat.js:192)
```

This crash terminates the entire pi session.

## Root Cause

1. **`config.ts`**: `getOpencodeApiKey()` uses `readAuthJsonKey("opencode", ...)` but Pi may store credentials under `"opencode-go"` (e.g., when using `/login opencode-go`). The `"opencode-go"` key is never checked.

2. **Compat API registry**: `opencode-dynamic` is not a pi-ai built-in API. The pi-free extension registers providers through `ModelRuntime` (which uses a composed provider with a custom `streamSimple`), but does not register the API in compat's global `apiProviderRegistry`. This means compat fallback paths cannot resolve it.

## Changes

### 1. `config.ts` — Fix API key lookup

`getOpencodeApiKey()` now falls back to `"opencode-go"` when `"opencode"` is not found in `auth.json`:

```ts
export function getOpencodeApiKey(): string | undefined {
    return (
        readAuthJsonKey("opencode", "OPENCODE_API_KEY") ??
        readAuthJsonKey("opencode-go", "OPENCODE_API_KEY")
    );
}
```

This ensures `dynamic-built-in` can discover OpenCode Go models when the user has authenticated with `/login opencode-go`.

### 2. `providers/opencode-session.ts` — Register compat API safety net

Added `ensureOpenCodeApiProviderRegistered()` which registers the `opencode-dynamic` API in compat's global `apiProviderRegistry` using the existing `createOpenCodeStreamSimple()` implementation. This is guarded by a module-level flag so it runs at most once.

### 3. `providers/dynamic-built-in/index.ts` & `lib/built-in-toggle.ts` — Wire up the safety net

Both registration points now call `ensureOpenCodeApiProviderRegistered()` before registering an OpenCode provider, ensuring the compat API is always available as a fallback.

## Testing

- [x] TypeScript compilation passes with no errors (`tsc --noEmit`)
- [x] All 477 existing tests pass (`vitest run`)
- [x] Manual end-to-end test: grep on large SQL file with opencode-go provider — no crash
- [x] `/reload` followed by same test — no crash
- [x] Confirmed via `free.log` that `dynamic-built-in` successfully discovers and registers opencode-go models