### PR TITLE
Use Pi's built-in OpenRouter provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed pi-free's duplicate OpenRouter model provider; Pi's built-in OpenRouter provider is now used, including Pi-managed OAuth. `/toggle-openrouter` preserves Pi's authentication while filtering models.
+
 ## [2.2.8] - 2026-07-21
 
 ### Changed

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -19,7 +19,6 @@ import type {
 import {
 	getOpencodeApiKey,
 	getOpencodeShowPaid,
-	getOpenrouterApiKey,
 	getOpenrouterShowPaid,
 } from "../config.ts";
 import { createLogger } from "./logger.ts";
@@ -62,7 +61,7 @@ interface BuiltInToggleConfig {
 	getShowPaid: () => boolean;
 	baseUrl: string;
 	api: Api;
-	getApiKey: () => string | undefined;
+	getApiKey?: () => string | undefined;
 }
 
 const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
@@ -85,7 +84,6 @@ const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
 		getShowPaid: getOpenrouterShowPaid,
 		baseUrl: "https://openrouter.ai/api/v1",
 		api: "openai-completions",
-		getApiKey: getOpenrouterApiKey,
 	},
 ];
 
@@ -197,8 +195,18 @@ function tryCaptureProvider(
 async function tryDiscoverProvider(
 	pi: ExtensionAPI,
 	config: BuiltInToggleConfig,
+	ctx: {
+		modelRegistry?: {
+			getApiKeyForProvider?: (
+				providerId: string,
+			) => Promise<string | undefined>;
+		};
+	},
 ): Promise<BuiltInProviderState | undefined> {
-	const apiKey = config.getApiKey();
+	const apiKey =
+		config.id === "openrouter"
+			? await ctx.modelRegistry?.getApiKeyForProvider?.(config.id)
+			: config.getApiKey?.();
 	if (!apiKey) return undefined;
 
 	try {
@@ -223,8 +231,9 @@ async function tryDiscoverProvider(
 		const rawModels = Array.isArray(body) ? body : (body.data ?? []);
 		const mappedModels = rawModels
 			.map((m) => rawModelToProviderConfig(m, config))
-			.filter((m): m is ProviderModelConfig & { _pricingKnown?: boolean } =>
-				m !== undefined,
+			.filter(
+				(m): m is ProviderModelConfig & { _pricingKnown?: boolean } =>
+					m !== undefined,
 			);
 		const allModels = applyAuthoritativeFreeFlags(mappedModels, config.id);
 
@@ -234,7 +243,8 @@ async function tryDiscoverProvider(
 			allModels,
 			baseUrl: config.baseUrl,
 			api: config.api,
-			apiKey,
+			// Keep Pi-managed OpenRouter OAuth intact after discovery.
+			apiKey: config.id === "openrouter" ? undefined : apiKey,
 			source: "discovered",
 		});
 	} catch (err) {
@@ -252,7 +262,7 @@ function createProviderState(
 		allModels: ProviderModelConfig[];
 		baseUrl: string;
 		api: Api;
-		apiKey: string;
+		apiKey?: string;
 		source: "captured" | "discovered";
 	},
 ): BuiltInProviderState {
@@ -269,7 +279,7 @@ function createProviderState(
 		}
 		pi.registerProvider(config.id, {
 			baseUrl,
-			apiKey,
+			...(apiKey !== undefined ? { apiKey } : {}),
 			api: isOpenCodeProvider(config.id) ? OPENCODE_DYNAMIC_API : api,
 			...(isOpenCodeProvider(config.id)
 				? { streamSimple: createOpenCodeStreamSimple(getOpenCodeSession()) }
@@ -318,7 +328,7 @@ function registerToggleCommand(
 				// If Pi has not exposed built-in models yet, fetch the provider's
 				// /models endpoint directly so /toggle-opencode works before the
 				// first chat session has populated the model registry.
-				state = await tryDiscoverProvider(pi, config);
+				state = await tryDiscoverProvider(pi, config, ctx);
 			}
 			if (!state) {
 				ctx.ui.notify(
@@ -422,11 +432,13 @@ function applyAuthoritativeFreeFlags(
 	});
 }
 
-function getApiKeyEnvForProvider(providerId: string): string {
+function getApiKeyEnvForProvider(providerId: string): string | undefined {
+	// OpenRouter is Pi's built-in provider. Do not supply an apiKey here:
+	// re-registerProvider merges only defined fields, so omitting it preserves
+	// Pi-managed OAuth credentials from /login openrouter (and refresh support).
 	const envMap: Record<string, string> = {
 		opencode: "$OPENCODE_API_KEY",
 		"opencode-go": "$OPENCODE_API_KEY",
-		openrouter: "$OPENROUTER_API_KEY",
 	};
-	return envMap[providerId] || `$${providerId.toUpperCase()}_API_KEY`;
+	return envMap[providerId];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^4.1.10",
-				"brace-expansion": "^5.0.7",
+				"brace-expansion": "^5.0.8",
 				"protobufjs": "^7.6.5",
 				"tsx": "^4.23.0",
 				"typescript": "^7.0.2",
@@ -20,9 +20,9 @@
 				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-ai": ">=0.82.0",
-				"@earendil-works/pi-coding-agent": ">=0.82.0",
-				"@earendil-works/pi-tui": ">=0.82.0"
+				"@earendil-works/pi-ai": ">=0.80.8",
+				"@earendil-works/pi-coding-agent": ">=0.80.8",
+				"@earendil-works/pi-tui": ">=0.80.8"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -516,9 +516,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
-			"integrity": "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw==",
+			"version": "0.80.10",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+			"integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -542,16 +542,16 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
-			"integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
+			"version": "0.80.10",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+			"integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.82.0",
-				"@earendil-works/pi-ai": "^0.82.0",
-				"@earendil-works/pi-tui": "^0.82.0",
+				"@earendil-works/pi-agent-core": "^0.80.10",
+				"@earendil-works/pi-ai": "^0.80.10",
+				"@earendil-works/pi-tui": "^0.80.10",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -1041,13 +1041,12 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
+			"version": "0.80.10",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.82.0",
-				"diff": "8.0.4",
+				"@earendil-works/pi-ai": "^0.80.10",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -1057,8 +1056,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
+			"version": "0.80.10",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1075,15 +1074,15 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "./dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
+			"version": "0.80.10",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1197,6 +1196,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1213,6 +1215,9 @@
 			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1231,6 +1236,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1248,6 +1256,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1264,6 +1275,9 @@
 			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1634,9 +1648,9 @@
 			"peer": true
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2501,9 +2515,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.82.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
-			"integrity": "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ==",
+			"version": "0.80.10",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+			"integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4169,16 +4183,16 @@
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/buffer-equal-constant-time": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
 				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-ai": ">=0.80.8",
-				"@earendil-works/pi-coding-agent": ">=0.80.8",
-				"@earendil-works/pi-tui": ">=0.80.8"
+				"@earendil-works/pi-ai": ">=0.82.0",
+				"@earendil-works/pi-coding-agent": ">=0.82.0",
+				"@earendil-works/pi-tui": ">=0.82.0"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -516,9 +516,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.10",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
-			"integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
+			"integrity": "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -542,16 +542,16 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.80.10",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
-			"integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.0.tgz",
+			"integrity": "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.80.10",
-				"@earendil-works/pi-ai": "^0.80.10",
-				"@earendil-works/pi-tui": "^0.80.10",
+				"@earendil-works/pi-agent-core": "^0.82.0",
+				"@earendil-works/pi-ai": "^0.82.0",
+				"@earendil-works/pi-tui": "^0.82.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -1041,12 +1041,13 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.10",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.10",
+				"@earendil-works/pi-ai": "^0.82.0",
+				"diff": "8.0.4",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -1056,8 +1057,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.10",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1074,15 +1075,15 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.10",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1196,9 +1197,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1215,9 +1213,6 @@
 			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1236,9 +1231,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1256,9 +1248,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1275,9 +1264,6 @@
 			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2515,9 +2501,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.10",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
-			"integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
+			"version": "0.82.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
+			"integrity": "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
 		"protobufjs": "^7.6.5"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-ai": ">=0.80.8",
-		"@earendil-works/pi-coding-agent": ">=0.80.8",
-		"@earendil-works/pi-tui": ">=0.80.8"
+		"@earendil-works/pi-ai": ">=0.82.0",
+		"@earendil-works/pi-coding-agent": ">=0.82.0",
+		"@earendil-works/pi-tui": ">=0.82.0"
 	},
 	"devDependencies": {
 		"@vitest/ui": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -57,17 +57,23 @@
 		"smoke:openmodel": "tsx scripts/smoke-openmodel-wire-format.ts"
 	},
 	"overrides": {
-		"brace-expansion": "^5.0.7",
+		"brace-expansion": "^5.0.8",
+		"@earendil-works/pi-coding-agent": {
+			"brace-expansion": "^5.0.8",
+			"minimatch": {
+				"brace-expansion": "^5.0.8"
+			}
+		},
 		"protobufjs": "^7.6.5"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-ai": ">=0.82.0",
-		"@earendil-works/pi-coding-agent": ">=0.82.0",
-		"@earendil-works/pi-tui": ">=0.82.0"
+		"@earendil-works/pi-ai": ">=0.80.8",
+		"@earendil-works/pi-coding-agent": ">=0.80.8",
+		"@earendil-works/pi-tui": ">=0.80.8"
 	},
 	"devDependencies": {
 		"@vitest/ui": "^4.1.10",
-		"brace-expansion": "^5.0.7",
+		"brace-expansion": "^5.0.8",
 		"protobufjs": "^7.6.5",
 		"tsx": "^4.23.0",
 		"typescript": "^7.0.2",

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -15,7 +15,6 @@
  * - cerebras (CEREBRAS_API_KEY)
  * - xai (XAI_API_KEY)
  * - opencode (OPENCODE_API_KEY from auth.json)
- * - openrouter (OPENROUTER_API_KEY from auth.json)
  * - fastrouter (always discovered, FASTROUTER_API_KEY)
  * - huggingface (HF_TOKEN - optional, special-cased API shape)
  *
@@ -36,8 +35,6 @@ import {
 	getMistralApiKey,
 	getOpencodeApiKey,
 	getOpencodeShowPaid,
-	getOpenrouterApiKey,
-	getOpenrouterShowPaid,
 	getXaiApiKey,
 } from "../../config.ts";
 import { DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
@@ -55,7 +52,10 @@ import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
 import { fetchWithTimeout } from "../../lib/util.ts";
 import { fetchOpenRouterCompatibleModels } from "../model-fetcher.ts";
 import { createToggleState } from "../../lib/toggle-state.ts";
-import { enhanceWithCI, loadCachedOrFetchModels } from "../../provider-helper.ts";
+import {
+	enhanceWithCI,
+	loadCachedOrFetchModels,
+} from "../../provider-helper.ts";
 import {
 	OPENCODE_DYNAMIC_API,
 	createOpenCodeSessionTracker,
@@ -286,21 +286,6 @@ const DYNAMIC_PROVIDERS: DynamicProviderDef[] = [
 				),
 		},
 	},
-	{
-		providerId: "openrouter",
-		getApiKey: getOpenrouterApiKey,
-		baseUrl: "https://openrouter.ai/api/v1",
-		api: "openai-completions",
-		defaultShowPaid: getOpenrouterShowPaid,
-		// OpenRouter returns full pricing — use its dedicated fetcher
-		fetchModels: (apiKey) =>
-			fetchOpenRouterCompatibleModels({
-				providerId: "openrouter",
-				baseUrl: "https://openrouter.ai/api/v1",
-				apiKey,
-				freeOnly: false,
-			}),
-	},
 ];
 
 // =============================================================================
@@ -316,34 +301,29 @@ async function discoverAndRegister(
 	// FastRouter) don't block startup on a network fetch. The helper serves a fresh
 	// cache, falls back to stale cache on failure/empty fetch, and persists the
 	// result for next startup.
-	const models = await loadCachedOrFetchModels(
-		config.providerId,
-		async () => {
-			let allModels: ProviderModelConfig[];
-			if (config.fetchModels) {
-				allModels = await config.fetchModels(apiKey);
-			} else {
-				allModels = await fetchModelsFromEndpoint({
-					providerId: config.providerId,
-					baseUrl: config.baseUrl,
-					apiKey,
-					compat: config.compat,
-					modelDefaults: config.modelDefaults,
-					timeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
-				});
-			}
+	const models = await loadCachedOrFetchModels(config.providerId, async () => {
+		let allModels: ProviderModelConfig[];
+		if (config.fetchModels) {
+			allModels = await config.fetchModels(apiKey);
+		} else {
+			allModels = await fetchModelsFromEndpoint({
+				providerId: config.providerId,
+				baseUrl: config.baseUrl,
+				apiKey,
+				compat: config.compat,
+				modelDefaults: config.modelDefaults,
+				timeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
+			});
+		}
 
-			// Apply DeepSeek proxy compat to matching models. OpenCode headers are
-			// injected per request by createOpenCodeStreamSimple(), not stored here.
-			return allModels.map((m) => ({
-				...m,
-				api: isOpenCodeProvider(config.providerId)
-					? OPENCODE_DYNAMIC_API
-					: m.api,
-				compat: getProxyModelCompat(m) ?? m.compat,
-			}));
-		},
-	);
+		// Apply DeepSeek proxy compat to matching models. OpenCode headers are
+		// injected per request by createOpenCodeStreamSimple(), not stored here.
+		return allModels.map((m) => ({
+			...m,
+			api: isOpenCodeProvider(config.providerId) ? OPENCODE_DYNAMIC_API : m.api,
+			compat: getProxyModelCompat(m) ?? m.compat,
+		}));
+	});
 
 	if (models.length === 0) {
 		// No usable models and no fallback cache: leave Pi's built-in defaults.

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -144,6 +144,48 @@ describe("built-in provider toggles", () => {
 		);
 	});
 
+	it("preserves Pi-managed OpenRouter OAuth when toggling captured models", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		const models = [
+			{
+				provider: "openrouter",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://openrouter.ai/api/v1",
+			},
+			{
+				provider: "openrouter",
+				id: "paid-model",
+				name: "Paid Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://openrouter.ai/api/v1",
+			},
+		];
+
+		await handlers.session_start(
+			{},
+			{ modelRegistry: { getAvailable: () => models } },
+		);
+		await commands["toggle-openrouter"]({}, { ui: { notify: vi.fn() } });
+
+		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
+			"openrouter",
+			expect.not.objectContaining({ apiKey: expect.anything() }),
+		);
+	});
+
 	it("skips fallback capture for providers already registered dynamically", () => {
 		mockProviderRegistry.set("opencode", {});
 		mockProviderRegistry.set("opencode-go", {});


### PR DESCRIPTION
# Pull Request

## Summary

Use Pi's built-in OpenRouter provider instead of registering a duplicate provider, while keeping pi-free's free/paid model toggle compatible with Pi-managed OpenRouter authentication.

## Problem

Pi now provides OpenRouter directly, including OAuth authentication through `/login openrouter`. pi-free was also dynamically discovering and registering an `openrouter` provider. That duplicate registration could replace Pi's provider configuration and interfere with Pi-managed credentials when `/toggle-openrouter` re-registered filtered models.

## Root Cause

1. **Duplicate provider registration**: `providers/dynamic-built-in/index.ts` independently fetched and registered OpenRouter models.
2. **Authentication replacement during toggles**: `lib/built-in-toggle.ts` supplied pi-free's API-key value when re-registering OpenRouter models instead of preserving Pi's existing provider authentication.

## Changes

### 1. Remove duplicate OpenRouter discovery

Removed OpenRouter from pi-free's dynamic built-in provider list. Pi remains the sole owner of the built-in `openrouter` provider and its authentication lifecycle.

### 2. Preserve Pi authentication during toggles

The built-in toggle now re-registers only the filtered model list for OpenRouter. Undefined fields are omitted, allowing Pi's provider registration merge behavior to preserve API-key and OAuth configuration, including credentials created by `/login openrouter`.

On-demand discovery obtains the current provider key through Pi's `modelRegistry.getApiKeyForProvider()` but does not write that key back into the provider registration.

### 3. Dependency audit compatibility

Updated dependency metadata and lockfile entries for the latest security fixes required by CI's production audit.

## Testing

- [x] TypeScript compilation passes with no errors (`npm run lint`)
- [x] All 478 tests pass (`npm run test:run`)
- [x] Production dependency audit passes (`npm run audit:prod`)
