### PR TITLE
release: 2.2.9

### DIFF
--- a/.github/workflows/update-benchmarks.yml
+++ b/.github/workflows/update-benchmarks.yml
@@ -20,12 +20,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Update benchmark data
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.9] - 2026-07-25
+
 ### Changed
 
 - Removed pi-free's duplicate OpenRouter model provider; Pi's built-in OpenRouter provider is now used, including Pi-managed OAuth. `/toggle-openrouter` preserves Pi's authentication while filtering models.
+- Updated dependency lockfile overrides for the latest security fixes required by CI audits.
+
+### Fixed
+
+- Fixed the OpenRouter toggle so re-registering filtered models does not replace Pi-managed API-key or OAuth credentials.
+
+### Contributors
+
+- [@kuuhaku-00](https://github.com/kuuhaku-00) — contributed fixes for the `opencode-dynamic` compatibility registry and cryptographically secure source IDs in [PR #341](https://github.com/apmantza/pi-free/pull/341).
 
 ## [2.2.8] - 2026-07-21
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -52,6 +52,12 @@ function shouldLog(level: LogLevel, minLevel: LogLevel): boolean {
 	return LOG_LEVELS[level] >= LOG_LEVELS[minLevel];
 }
 
+function sanitizeLogText(value: string): string {
+	return value.replace(/[\u0000-\u001f\u007f]/g, (character) =>
+		`\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+	);
+}
+
 function formatMessage(entry: LogEntry): string {
 	let data = "";
 	if (entry.data) {
@@ -61,7 +67,7 @@ function formatMessage(entry: LogEntry): string {
 			data = " [unserializable-data]";
 		}
 	}
-	return `[${entry.timestamp}] [${entry.level.toUpperCase()}] [${entry.namespace}] ${entry.message}${data}`;
+	return `[${entry.timestamp}] [${entry.level.toUpperCase()}] [${sanitizeLogText(entry.namespace)}] ${sanitizeLogText(entry.message)}${data}`;
 }
 
 const LOG_PATH = resolveSafeDataFile(process.env.PI_FREE_LOG_PATH, "free.log");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.2.8",
+	"version": "2.2.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.2.8",
+			"version": "2.2.9",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/ui": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.2.8",
+	"version": "2.2.9",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## v2.2.9

Release pi-free 2.2.9 with the OpenRouter provider integration update and contributor credits.

### Included

- Use Pi's built-in OpenRouter provider and preserve Pi-managed OAuth during `/toggle-openrouter`.
- Remove duplicate OpenRouter discovery from pi-free.
- Include contributor credit for @kuuhaku-00's fixes from PR #341.

See [CHANGELOG.md](CHANGELOG.md#229---2026-07-25) for the full release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
