### PR TITLE
fix: use Pi's native catalog to correct context windows

### DIFF
--- a/lib/model-metadata.ts
+++ b/lib/model-metadata.ts
@@ -1,4 +1,5 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import { DEFAULT_FETCH_TIMEOUT_MS, URL_MODELS_DEV } from "../constants.ts";
 import { createLogger } from "./logger.ts";
 import { getProxyModelCompat } from "./provider-compat.ts";
@@ -407,4 +408,66 @@ export async function safeEnrichModelsWithModelsDev<
 	} catch {
 		return models;
 	}
+}
+
+// =============================================================================
+// Native catalog fallback (Pi's build-time models.dev snapshot)
+// =============================================================================
+
+const NATIVE_FALLBACK_CONTEXT_WINDOWS = new Set([DEFAULT_CONTEXT_WINDOW, 4096]);
+const NATIVE_FALLBACK_MAX_TOKENS = new Set([DEFAULT_MAX_TOKENS, 4096]);
+
+/**
+ * Fill context windows / max tokens from Pi's built-time native catalog
+ * (shipped in `@earendil-works/pi-ai`) for models still carrying a generic
+ * fallback value after the models.dev enrichment pass. Synchronous, local,
+ * always available — no network required.
+ */
+export function enrichFromNativeCatalog<T extends ProviderModelConfig>(
+	models: T[],
+	providerId: string,
+): T[] {
+	if (models.length === 0) return models;
+
+	let nativeModels: Array<{
+		id: string;
+		contextWindow: number;
+		maxTokens: number;
+	}>;
+	try {
+		// providerId is a dynamic string; the catalog lookup is safe at runtime
+		// (returns [] for unknown providers) but the type is a literal union.
+		nativeModels = getBuiltinModels(
+			providerId as Parameters<typeof getBuiltinModels>[0],
+		) as typeof nativeModels;
+	} catch {
+		return models;
+	}
+	if (nativeModels.length === 0) return models;
+
+	const nativeById = new Map(nativeModels.map((m) => [m.id, m]));
+
+	let patched = 0;
+	const result = models.map((model) => {
+		if (!NATIVE_FALLBACK_CONTEXT_WINDOWS.has(model.contextWindow)) return model;
+		const native = nativeById.get(model.id);
+		if (!native) return model;
+
+		patched++;
+		return {
+			...model,
+			contextWindow: native.contextWindow,
+			maxTokens: NATIVE_FALLBACK_MAX_TOKENS.has(model.maxTokens)
+				? native.maxTokens
+				: model.maxTokens,
+		};
+	});
+
+	if (patched > 0) {
+		_logger.info(
+			`[native-catalog] ${providerId}: patched ${patched}/${models.length} models from Pi's native catalog`,
+		);
+	}
+
+	return result;
 }

--- a/providers/dynamic-built-in/index.ts
+++ b/providers/dynamic-built-in/index.ts
@@ -39,7 +39,10 @@ import {
 } from "../../config.ts";
 import { DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
+import {
+	enrichFromNativeCatalog,
+	safeEnrichModelsWithModelsDev,
+} from "../../lib/model-metadata.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import {
 	areAllModelsFresh,
@@ -143,9 +146,14 @@ async function fetchModelsFromEndpoint(
 		} satisfies ProviderModelConfig & { _pricingKnown?: boolean };
 	});
 
-	return await safeEnrichModelsWithModelsDev(models, {
+	const enriched = await safeEnrichModelsWithModelsDev(models, {
 		providerId: opts.providerId,
 	});
+
+	// Final fallback: fill context windows from Pi's build-time native catalog
+	// for any model still carrying the generic 128K default (e.g. OpenCode's API
+	// exposes no context-length fields and models.dev may be unreachable).
+	return enrichFromNativeCatalog(enriched, opts.providerId);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Problem

Closes #347

OpenCode's `/models` endpoint returns no context-length fields, so all models fall back to a hardcoded **128K** default. The models.dev runtime enrichment that should correct this is unreliable (network failures), and pi-free's `registerProvider` overwrites Pi's native build-time catalog which has the correct values (e.g. `deepseek-v4-pro` → 1M).

## Fix

Added `enrichFromNativeCatalog()` in `lib/model-metadata.ts` — a final fallback step in the enrichment chain that patches context windows from Pi's build-time catalog (`@earendil-works/pi-ai/providers/all`). Synchronous, local, zero-network, always available.

**Enrichment priority chain:**
1. Provider API fields (`context_length`, etc.)
2. models.dev runtime fetch
3. **Pi's native catalog** ← new
4. 128K hardcoded fallback

Called at the end of `fetchModelsFromEndpoint()`, so corrected values flow through `loadCachedOrFetchModels` and get persisted to the existing provider cache (`~/.pi/provider-cache.json`, 1h TTL).

## Scope

Fixes context windows for **all** dynamic providers (opencode, opencode-go, groq, cerebras, mistral, xai, huggingface), not just opencode-go.

## Testing

- 0 LSP diagnostics
- 478/478 tests pass