### PR TITLE
feat(observability): startup timing for pi-free entry and per-provider setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Startup observability** — New `lib/startup-timing.ts` times the phases of `piFreeEntry` and each provider's setup duration (monotonic `performance.now()`, best-effort, negligible overhead). A structured summary (total entry time, per-provider timings slowest-first, cache-vs-network counts, failures) is logged once at the end of startup and surfaced via the new `/free-startup` command.
+
 ## [2.2.10] - 2026-07-28
 
 ### Fixed

--- a/agents.md
+++ b/agents.md
@@ -22,6 +22,7 @@ index.ts                          ← Extension entry point (piFreeEntry)
   ├─ lib/toggle-state.ts          ← Generic toggle state machine (free ↔ all)
   ├─ lib/built-in-toggle.ts       ← Toggles for Pi's built-in providers (opencode, openrouter)
   ├─ lib/quota-monitor.ts         ← Rate-limit header extraction → status bar
+  ├─ lib/startup-timing.ts        ← Startup phase + per-provider timing observability
   ├─ lib/logger.ts                ← Structured logging (console + ~/.pi/free.log)
   ├─ lib/json-persistence.ts      ← Generic JSON/JSONL file stores
   ├─ lib/model-detection.ts       ← Model family grouping, name normalization
@@ -196,6 +197,7 @@ Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DE
 | -------------------- | ------------ | ----------------------------------------- |
 | `/toggle-free`       | Global       | Toggle free-only mode for ALL providers   |
 | `/free-providers`    | Global       | Show free/paid counts for all providers   |
+| `/free-startup`      | Global       | Show last startup timing breakdown        |
 | `/toggle-{provider}` | Per-provider | Toggle between free and all models        |
 | `/probe-deepinfra`   | DeepInfra    | Test all models, auto-hide broken       |
 | `/probe-novita`      | Novita       | Test all models, auto-hide broken        |

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,15 @@ import {
 	clearTelemetry,
 } from "./lib/telemetry.ts";
 import {
+	beginStartup,
+	endPhase,
+	finalizeStartup,
+	formatStartupSummary,
+	logStartupSummary,
+	startPhase,
+	timeProvider,
+} from "./lib/startup-timing.ts";
+import {
 	applyGlobalFilter,
 	getGlobalFreeOnly,
 	getProviderRegistry,
@@ -254,6 +263,15 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 			ctx.ui.notify("Telemetry data cleared", "info");
 		},
 	});
+
+	// /free-startup — Show the last startup timing breakdown
+	pi.registerCommand("free-startup", {
+		description:
+			"Show pi-free startup timing (total, slowest providers, cache/network, failures)",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(formatStartupSummary(), "info");
+		},
+	});
 }
 
 // =============================================================================
@@ -401,6 +419,9 @@ function setupTelemetry(pi: ExtensionAPI) {
 // =============================================================================
 
 export default async function piFreeEntry(pi: ExtensionAPI) {
+	// Begin timing this startup run (best-effort, negligible overhead).
+	beginStartup();
+
 	const globalFreeOnly = getGlobalFreeOnly();
 	_logger.info(`[pi-free] Initializing (global free-only: ${globalFreeOnly})`);
 
@@ -411,6 +432,7 @@ export default async function piFreeEntry(pi: ExtensionAPI) {
 	// idempotent (the runtime replaces them), but pi.on() is additive with
 	// no unsubscribe API, so we skip the registration block entirely on
 	// subsequent calls.
+	startPhase("global-handlers");
 	if (!_handlersRegistered) {
 		_handlersRegistered = true;
 
@@ -427,6 +449,7 @@ export default async function piFreeEntry(pi: ExtensionAPI) {
 			"[pi-free] Skipping global handler registration (already registered)",
 		);
 	}
+	endPhase("global-handlers");
 
 	// Load all unique providers + dynamic built-in providers CONCURRENTLY.
 	// Running the dynamic phase (e.g. FastRouter) in parallel with the static
@@ -451,19 +474,37 @@ export default async function piFreeEntry(pi: ExtensionAPI) {
 		}
 	})();
 
+	// Time each provider setup individually so slow providers are visible in
+	// the startup summary. timeProvider rethrows, so Promise.allSettled keeps
+	// its exact never-throws semantics.
+	startPhase("providers");
+	const providerSetups = UNIQUE_PROVIDERS.map((setup) => {
+		const name = (setup.name || "provider").replace(/Provider$/, "");
+		return timeProvider(name, () => setup(pi));
+	});
+
 	await Promise.allSettled([
-		...UNIQUE_PROVIDERS.map((setup) => setup(pi)),
-		dynamicSetup,
+		...providerSetups,
+		timeProvider("dynamic-built-in", () => dynamicSetup),
 	]);
+	endPhase("providers");
 
 	// Setup toggles for pi's built-in providers (e.g., OpenCode)
+	startPhase("built-in-toggles");
 	setupBuiltInProviderToggles(pi);
+	endPhase("built-in-toggles");
 
 	// Apply initial global filter if free-only mode is enabled
+	startPhase("global-filter");
 	if (globalFreeOnly) {
 		_logger.info("[pi-free] Applying initial free-only filter");
 		applyGlobalFilter(true);
 	}
+	endPhase("global-filter");
+
+	// Finalize timing and emit the observability summary (best-effort).
+	finalizeStartup();
+	logStartupSummary();
 
 	const registry = getProviderRegistry();
 	_logger.info(`[pi-free] Loaded with ${registry.size} providers`);

--- a/lib/provider-cache.ts
+++ b/lib/provider-cache.ts
@@ -12,6 +12,7 @@
 import { createJSONStore } from "./json-persistence.ts";
 import { createLogger } from "./logger.ts";
 import { resolveSafeDataFile } from "./paths.ts";
+import { recordCacheHit, recordNetworkFetch } from "./startup-timing.ts";
 import type { ProviderModelConfig } from "./types.ts";
 
 const _logger = createLogger("provider-cache");
@@ -80,6 +81,9 @@ export function loadProviderCache(
 		fetchedAt: cached.fetchedAt,
 	});
 
+	// Best-effort startup observability: a disk-cache hit avoids a network fetch.
+	recordCacheHit(providerId);
+
 	// Cached data is loaded from disk on each call. Callers must treat the
 	// returned list as read-only; save paths clone before persistence.
 	return cached.models;
@@ -128,6 +132,9 @@ export async function saveProviderCache(
 	});
 
 	_logger.debug(`Saved ${models.length} models to cache for ${providerId}`);
+
+	// Best-effort startup observability: saving follows a fresh network fetch.
+	recordNetworkFetch(providerId);
 }
 
 /**

--- a/lib/startup-timing.ts
+++ b/lib/startup-timing.ts
@@ -90,7 +90,9 @@ function monotonicNow(): number {
 }
 
 function makeRunId(): string {
-	return Math.random().toString(36).slice(2, 10);
+	// CSPRNG-backed (Sonar S2245: avoid Math.random()). The ID is only a log
+	// correlation tag, so the first 8 hex chars of a UUID are ample.
+	return crypto.randomUUID().slice(0, 8);
 }
 
 function freshState(): StartupState {
@@ -307,44 +309,54 @@ export function getStartupSummary(): StartupSummary {
  * string suitable for `ctx.ui.notify`. Mirrors the style of `/free-providers`
  * and `/free-telemetry`.
  */
+/** Render the phase block (slowest-first). Empty array when no phases. */
+function renderPhaseLines(phases: PhaseTiming[]): string[] {
+	if (phases.length === 0) {
+		return [];
+	}
+	const sorted = [...phases].sort((a, b) => b.durationMs - a.durationMs);
+	const lines = ["Phases:"];
+	for (const p of sorted) {
+		lines.push(`  ${p.name.padEnd(20)} ${String(p.durationMs).padStart(6)}ms`);
+	}
+	lines.push("");
+	return lines;
+}
+
+/** Render the per-provider block (slowest-first, capped). Empty when none. */
+function renderProviderLines(
+	providers: ProviderTiming[],
+	maxProviders: number,
+): string[] {
+	if (providers.length === 0) {
+		return [];
+	}
+	const lines = ["Providers (slowest first):"];
+	for (const p of providers.slice(0, maxProviders)) {
+		const name =
+			p.provider.length > 24 ? p.provider.slice(0, 21) + "..." : p.provider;
+		const status = p.success ? "ok" : "FAILED";
+		lines.push(
+			`  ${name.padEnd(24)} ${String(p.durationMs).padStart(6)}ms  ${status}`,
+		);
+	}
+	if (providers.length > maxProviders) {
+		lines.push(`  …and ${providers.length - maxProviders} more`);
+	}
+	lines.push("");
+	return lines;
+}
+
 export function formatStartupSummary(maxProviders = 15): string {
 	const s = getStartupSummary();
-	const lines: string[] = [];
-
-	lines.push(`⏱  Pi-Free Startup: ${s.totalMs}ms (run ${s.runId})`);
-	lines.push("");
-
-	// Phases, slowest-first for quick scanning.
-	const phases = [...s.phases].sort((a, b) => b.durationMs - a.durationMs);
-	if (phases.length > 0) {
-		lines.push("Phases:");
-		for (const p of phases) {
-			lines.push(`  ${p.name.padEnd(20)} ${String(p.durationMs).padStart(6)}ms`);
-		}
-		lines.push("");
-	}
-
-	// Per-provider timings, slowest-first.
-	if (s.providers.length > 0) {
-		lines.push("Providers (slowest first):");
-		for (const p of s.providers.slice(0, maxProviders)) {
-			const name =
-				p.provider.length > 24 ? p.provider.slice(0, 21) + "..." : p.provider;
-			const status = p.success ? "ok" : "FAILED";
-			lines.push(
-				`  ${name.padEnd(24)} ${String(p.durationMs).padStart(6)}ms  ${status}`,
-			);
-		}
-		if (s.providers.length > maxProviders) {
-			lines.push(`  …and ${s.providers.length - maxProviders} more`);
-		}
-		lines.push("");
-	}
-
-	lines.push(
+	const lines: string[] = [
+		`⏱  Pi-Free Startup: ${s.totalMs}ms (run ${s.runId})`,
+		"",
+		...renderPhaseLines(s.phases),
+		...renderProviderLines(s.providers, maxProviders),
 		`Cache: ${s.cacheHits} hits / ${s.networkFetches} network fetches` +
 			(s.networkMsTotal > 0 ? ` (${s.networkMsTotal}ms)` : ""),
-	);
+	];
 
 	if (s.failures.length > 0) {
 		lines.push(`Failures: ${s.failures.join(", ")}`);

--- a/lib/startup-timing.ts
+++ b/lib/startup-timing.ts
@@ -1,0 +1,394 @@
+/**
+ * Startup Timing — lightweight observability for pi-free's startup impact.
+ *
+ * Provides a small mark/measure API (monotonic `performance.now()` based) to
+ * time the phases of `piFreeEntry` and, importantly, per-provider setup
+ * duration. Produces a structured startup summary (total entry time,
+ * per-provider timings sorted slowest-first, cache vs network counts, and
+ * failures) that is logged once at the end of startup and surfaced via the
+ * `/free-startup` command.
+ *
+ * Design constraints:
+ * - Zero/negligible overhead: everything is in-memory arithmetic on a
+ *   monotonic clock. No I/O happens here.
+ * - Best-effort: every public entry point swallows its own errors so a timing
+ *   bug can never break or stall startup.
+ * - No new runtime deps, no build step.
+ */
+
+import { createLogger } from "./logger.ts";
+
+const _logger = createLogger("startup-timing");
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface PhaseTiming {
+	/** Phase name (e.g. "providers", "global-handlers"). */
+	name: string;
+	/** Wall-clock duration in milliseconds. */
+	durationMs: number;
+}
+
+export interface ProviderTiming {
+	/** Provider name (derived from the setup function name). */
+	provider: string;
+	/** Wall-clock setup duration in milliseconds. */
+	durationMs: number;
+	/** Whether the provider setup resolved without throwing. */
+	success: boolean;
+	/** Error message when {@link success} is false. */
+	error?: string;
+}
+
+export interface StartupSummary {
+	/** Unique id for this startup run. */
+	runId: string;
+	/** ISO timestamp of when startup began. */
+	startedAt: string;
+	/** Total wall-clock time of the timed startup, in milliseconds. */
+	totalMs: number;
+	/** Named phases in the order they completed. */
+	phases: PhaseTiming[];
+	/** Per-provider timings, sorted slowest-first. */
+	providers: ProviderTiming[];
+	/** Number of provider model lists served from the disk cache. */
+	cacheHits: number;
+	/** Number of provider model lists fetched from the network. */
+	networkFetches: number;
+	/** Total milliseconds spent in network model fetches (best-effort). */
+	networkMsTotal: number;
+	/** Names of providers whose setup failed. */
+	failures: string[];
+}
+
+interface StartupState {
+	runId: string;
+	startedAt: string;
+	/** Monotonic start timestamp (performance.now()). */
+	start: number;
+	/** Total elapsed ms, filled in on finalize. */
+	totalMs: number;
+	finalized: boolean;
+	phases: PhaseTiming[];
+	/** Open (started but not ended) phases, keyed by name. */
+	openPhases: Map<string, number>;
+	providers: ProviderTiming[];
+	cacheHits: number;
+	networkFetches: number;
+	networkMsTotal: number;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function monotonicNow(): number {
+	// performance.now() is monotonic and available on Node >= 16 globally.
+	return performance.now();
+}
+
+function makeRunId(): string {
+	return Math.random().toString(36).slice(2, 10);
+}
+
+function freshState(): StartupState {
+	return {
+		runId: makeRunId(),
+		startedAt: new Date().toISOString(),
+		start: monotonicNow(),
+		totalMs: 0,
+		finalized: false,
+		phases: [],
+		openPhases: new Map(),
+		providers: [],
+		cacheHits: 0,
+		networkFetches: 0,
+		networkMsTotal: 0,
+	};
+}
+
+// Module-level state. Always present so recording before beginStartup() is a
+// harmless no-op relative to module load rather than a crash.
+let _state: StartupState = freshState();
+
+function round(ms: number): number {
+	return Math.max(0, Math.round(ms));
+}
+
+// =============================================================================
+// Public API — lifecycle
+// =============================================================================
+
+/**
+ * Begin (or reset) a startup timing run. Call at the very top of
+ * `piFreeEntry`. Safe to call multiple times (e.g. on extension reload) —
+ * each call starts a fresh run.
+ */
+export function beginStartup(): void {
+	try {
+		_state = freshState();
+	} catch (err) {
+		_logger.warn("beginStartup failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
+/**
+ * Finalize the current run, freezing the total elapsed time. Call at the end
+ * of `piFreeEntry`. Idempotent within a run.
+ */
+export function finalizeStartup(): void {
+	try {
+		if (_state.finalized) return;
+		_state.totalMs = round(monotonicNow() - _state.start);
+		_state.finalized = true;
+	} catch (err) {
+		_logger.warn("finalizeStartup failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
+// =============================================================================
+// Public API — phases
+// =============================================================================
+
+/**
+ * Start a named phase. Pair with {@link endPhase} to time an async span.
+ */
+export function startPhase(name: string): void {
+	try {
+		_state.openPhases.set(name, monotonicNow());
+	} catch {
+		// best-effort
+	}
+}
+
+/**
+ * End a named phase started by {@link startPhase} and record its duration.
+ * Ending an unstarted phase is a no-op.
+ */
+export function endPhase(name: string): void {
+	try {
+		const start = _state.openPhases.get(name);
+		if (start === undefined) return;
+		_state.openPhases.delete(name);
+		_state.phases.push({ name, durationMs: round(monotonicNow() - start) });
+	} catch {
+		// best-effort
+	}
+}
+
+/**
+ * Time a synchronous function as a named phase and return its result.
+ * The function's return value is passed through unchanged.
+ */
+export function measurePhase<T>(name: string, fn: () => T): T {
+	startPhase(name);
+	try {
+		return fn();
+	} finally {
+		endPhase(name);
+	}
+}
+
+// =============================================================================
+// Public API — per-provider timing
+// =============================================================================
+
+/**
+ * Time an async provider setup. Records wall-clock duration and
+ * success/failure, then rethrows any error so callers (e.g.
+ * `Promise.allSettled`) observe identical behavior to an unwrapped call.
+ *
+ * @param provider - Provider name for reporting.
+ * @param work - A thunk returning the provider setup promise.
+ */
+export async function timeProvider<T>(
+	provider: string,
+	work: () => Promise<T>,
+): Promise<T> {
+	const start = monotonicNow();
+	try {
+		const result = await work();
+		recordProvider(provider, round(monotonicNow() - start), true);
+		return result;
+	} catch (err) {
+		recordProvider(provider, round(monotonicNow() - start), false, err);
+		throw err;
+	}
+}
+
+function recordProvider(
+	provider: string,
+	durationMs: number,
+	success: boolean,
+	err?: unknown,
+): void {
+	try {
+		_state.providers.push({
+			provider,
+			durationMs,
+			success,
+			...(success
+				? {}
+				: { error: err instanceof Error ? err.message : String(err) }),
+		});
+	} catch {
+		// best-effort
+	}
+}
+
+// =============================================================================
+// Public API — cache vs network (best-effort)
+// =============================================================================
+
+/**
+ * Record that a provider's model list was served from the disk cache.
+ */
+export function recordCacheHit(_provider?: string): void {
+	try {
+		_state.cacheHits += 1;
+	} catch {
+		// best-effort
+	}
+}
+
+/**
+ * Record that a provider's model list was fetched from the network.
+ * @param durationMs - Optional fetch duration in milliseconds.
+ */
+export function recordNetworkFetch(_provider?: string, durationMs?: number): void {
+	try {
+		_state.networkFetches += 1;
+		if (typeof durationMs === "number" && Number.isFinite(durationMs)) {
+			_state.networkMsTotal += Math.max(0, durationMs);
+		}
+	} catch {
+		// best-effort
+	}
+}
+
+// =============================================================================
+// Public API — summary
+// =============================================================================
+
+/**
+ * Build a structured summary of the current (or most recent) startup run.
+ * Provider timings are sorted slowest-first.
+ */
+export function getStartupSummary(): StartupSummary {
+	const totalMs = _state.finalized
+		? _state.totalMs
+		: round(monotonicNow() - _state.start);
+
+	const providers = [..._state.providers].sort(
+		(a, b) => b.durationMs - a.durationMs,
+	);
+
+	return {
+		runId: _state.runId,
+		startedAt: _state.startedAt,
+		totalMs,
+		phases: [..._state.phases],
+		providers,
+		cacheHits: _state.cacheHits,
+		networkFetches: _state.networkFetches,
+		networkMsTotal: round(_state.networkMsTotal),
+		failures: _state.providers.filter((p) => !p.success).map((p) => p.provider),
+	};
+}
+
+/**
+ * Format the current startup summary as a human-readable, column-aligned
+ * string suitable for `ctx.ui.notify`. Mirrors the style of `/free-providers`
+ * and `/free-telemetry`.
+ */
+export function formatStartupSummary(maxProviders = 15): string {
+	const s = getStartupSummary();
+	const lines: string[] = [];
+
+	lines.push(`⏱  Pi-Free Startup: ${s.totalMs}ms (run ${s.runId})`);
+	lines.push("");
+
+	// Phases, slowest-first for quick scanning.
+	const phases = [...s.phases].sort((a, b) => b.durationMs - a.durationMs);
+	if (phases.length > 0) {
+		lines.push("Phases:");
+		for (const p of phases) {
+			lines.push(`  ${p.name.padEnd(20)} ${String(p.durationMs).padStart(6)}ms`);
+		}
+		lines.push("");
+	}
+
+	// Per-provider timings, slowest-first.
+	if (s.providers.length > 0) {
+		lines.push("Providers (slowest first):");
+		for (const p of s.providers.slice(0, maxProviders)) {
+			const name =
+				p.provider.length > 24 ? p.provider.slice(0, 21) + "..." : p.provider;
+			const status = p.success ? "ok" : "FAILED";
+			lines.push(
+				`  ${name.padEnd(24)} ${String(p.durationMs).padStart(6)}ms  ${status}`,
+			);
+		}
+		if (s.providers.length > maxProviders) {
+			lines.push(`  …and ${s.providers.length - maxProviders} more`);
+		}
+		lines.push("");
+	}
+
+	lines.push(
+		`Cache: ${s.cacheHits} hits / ${s.networkFetches} network fetches` +
+			(s.networkMsTotal > 0 ? ` (${s.networkMsTotal}ms)` : ""),
+	);
+
+	if (s.failures.length > 0) {
+		lines.push(`Failures: ${s.failures.join(", ")}`);
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Log the startup summary: a single structured info line plus per-provider
+ * debug detail. Called once at the end of `piFreeEntry`.
+ */
+export function logStartupSummary(): void {
+	try {
+		const s = getStartupSummary();
+		_logger.info(
+			`[pi-free] startup complete in ${s.totalMs}ms`,
+			{
+				runId: s.runId,
+				totalMs: s.totalMs,
+				providers: s.providers.length,
+				cacheHits: s.cacheHits,
+				networkFetches: s.networkFetches,
+				networkMsTotal: s.networkMsTotal,
+				failures: s.failures,
+				slowest: s.providers.slice(0, 5).map((p) => ({
+					provider: p.provider,
+					durationMs: p.durationMs,
+					success: p.success,
+				})),
+			},
+		);
+
+		// Per-provider debug detail (only written to ~/.pi/free.log by default).
+		for (const p of s.providers) {
+			_logger.debug(`[pi-free] provider setup: ${p.provider}`, {
+				durationMs: p.durationMs,
+				success: p.success,
+				...(p.error ? { error: p.error } : {}),
+			});
+		}
+	} catch (err) {
+		_logger.warn("logStartupSummary failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}

--- a/tests/startup-timing.test.ts
+++ b/tests/startup-timing.test.ts
@@ -157,10 +157,10 @@ describe("startup-timing", () => {
 		);
 		beginStartup();
 		await timeProvider("first", () => sleep(1));
-		expect(getStartupSummary().providers.length).toBe(1);
+		expect(getStartupSummary().providers).toHaveLength(1);
 
 		beginStartup();
-		expect(getStartupSummary().providers.length).toBe(0);
+		expect(getStartupSummary().providers).toHaveLength(0);
 		expect(getStartupSummary().cacheHits).toBe(0);
 	});
 });

--- a/tests/startup-timing.test.ts
+++ b/tests/startup-timing.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempDir = mkdtempSync(join(tmpdir(), "pi-free-startup-timing-test-"));
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("startup-timing", () => {
+	beforeEach(() => {
+		// Isolate any file logging inside a temp home.
+		process.env.HOME = tempDir;
+		process.env.USERPROFILE = tempDir;
+	});
+
+	afterEach(() => {
+		delete process.env.HOME;
+		delete process.env.USERPROFILE;
+	});
+
+	it("measurePhase records a phase with a non-negative duration", async () => {
+		const { beginStartup, measurePhase, getStartupSummary } = await import(
+			"../lib/startup-timing.ts"
+		);
+		beginStartup();
+
+		const result = measurePhase("work", () => {
+			let sum = 0;
+			for (let i = 0; i < 1000; i++) sum += i;
+			return sum;
+		});
+
+		expect(result).toBe(499500);
+		const summary = getStartupSummary();
+		const phase = summary.phases.find((p) => p.name === "work");
+		expect(phase).toBeDefined();
+		expect(phase?.durationMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("startPhase/endPhase record a named phase and ignore unstarted ends", async () => {
+		const { beginStartup, startPhase, endPhase, getStartupSummary } =
+			await import("../lib/startup-timing.ts");
+		beginStartup();
+
+		// Ending an unstarted phase is a no-op (should not throw).
+		endPhase("never-started");
+
+		startPhase("span");
+		await sleep(5);
+		endPhase("span");
+
+		const summary = getStartupSummary();
+		expect(summary.phases.some((p) => p.name === "never-started")).toBe(false);
+		const span = summary.phases.find((p) => p.name === "span");
+		expect(span).toBeDefined();
+		expect(span?.durationMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("timeProvider records success and rethrows failures", async () => {
+		const { beginStartup, timeProvider, getStartupSummary } = await import(
+			"../lib/startup-timing.ts"
+		);
+		beginStartup();
+
+		const ok = await timeProvider("good", async () => 42);
+		expect(ok).toBe(42);
+
+		await expect(
+			timeProvider("bad", async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		const summary = getStartupSummary();
+		const good = summary.providers.find((p) => p.provider === "good");
+		const bad = summary.providers.find((p) => p.provider === "bad");
+		expect(good?.success).toBe(true);
+		expect(bad?.success).toBe(false);
+		expect(bad?.error).toBe("boom");
+		expect(summary.failures).toContain("bad");
+	});
+
+	it("sorts providers slowest-first in the summary", async () => {
+		const { beginStartup, timeProvider, getStartupSummary } = await import(
+			"../lib/startup-timing.ts"
+		);
+		beginStartup();
+
+		// Use well-separated delays so ordering survives OS timer jitter.
+		await Promise.all([
+			timeProvider("fast", () => sleep(1)),
+			timeProvider("slow", () => sleep(80)),
+			timeProvider("medium", () => sleep(30)),
+		]);
+
+		const summary = getStartupSummary();
+		const order = summary.providers.map((p) => p.provider);
+		// The clearly-slowest provider must come first.
+		expect(order[0]).toBe("slow");
+		// Durations are monotonically non-increasing (slowest-first invariant).
+		for (let i = 1; i < summary.providers.length; i++) {
+			expect(summary.providers[i - 1].durationMs).toBeGreaterThanOrEqual(
+				summary.providers[i].durationMs,
+			);
+		}
+	});
+
+	it("tracks cache hits and network fetch counts", async () => {
+		const {
+			beginStartup,
+			recordCacheHit,
+			recordNetworkFetch,
+			getStartupSummary,
+		} = await import("../lib/startup-timing.ts");
+		beginStartup();
+
+		recordCacheHit("a");
+		recordCacheHit("b");
+		recordNetworkFetch("c", 100);
+		recordNetworkFetch("d"); // no duration
+
+		const summary = getStartupSummary();
+		expect(summary.cacheHits).toBe(2);
+		expect(summary.networkFetches).toBe(2);
+		expect(summary.networkMsTotal).toBe(100);
+	});
+
+	it("finalizeStartup freezes totalMs and formatStartupSummary renders", async () => {
+		const {
+			beginStartup,
+			timeProvider,
+			finalizeStartup,
+			getStartupSummary,
+			formatStartupSummary,
+		} = await import("../lib/startup-timing.ts");
+		beginStartup();
+
+		await timeProvider("prov", () => sleep(3));
+		finalizeStartup();
+		const frozen = getStartupSummary().totalMs;
+		expect(frozen).toBeGreaterThanOrEqual(0);
+
+		// Total stays stable after finalize even if time passes.
+		await sleep(5);
+		expect(getStartupSummary().totalMs).toBe(frozen);
+
+		const text = formatStartupSummary();
+		expect(text).toContain("Pi-Free Startup:");
+		expect(text).toContain("prov");
+		expect(text).toContain("Cache:");
+	});
+
+	it("beginStartup resets state for a fresh run", async () => {
+		const { beginStartup, timeProvider, getStartupSummary } = await import(
+			"../lib/startup-timing.ts"
+		);
+		beginStartup();
+		await timeProvider("first", () => sleep(1));
+		expect(getStartupSummary().providers.length).toBe(1);
+
+		beginStartup();
+		expect(getStartupSummary().providers.length).toBe(0);
+		expect(getStartupSummary().cacheHits).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

Adds lightweight startup observability so we can measure (and later optimize) pi-free's impact on Pi session start.

- **`lib/startup-timing.ts`** (new): mark/measure API on monotonic `performance.now()`. Times `piFreeEntry` phases and each provider's setup duration. Best-effort by design — every public function swallows its own errors so timing can never break startup; `timeProvider` rethrows so `Promise.allSettled` keeps its exact never-throws semantics.
- **`index.ts`**: wraps the provider `Promise.allSettled` fan-out with phase marks; logs a structured summary once at end of startup (total entry time, per-provider timings slowest-first, cache-vs-network counts, failures); registers the new `/free-startup` command to surface the last summary on demand.
- **`lib/provider-cache.ts`**: cache-hit/miss marks feeding the summary's network-vs-cache counts.
- Docs: `agents.md` architecture + command table, CHANGELOG `[Unreleased]` entry.

## Why

Pi awaits async extension factories before startup continues, so pi-free's provider fan-out is on the session-start critical path. This instruments it before a performance pass.

## Verification

- `npm run test:run`: 485/485 pass (incl. new `tests/startup-timing.test.ts`, 166 lines)
- `npm run lint` (`tsc --noEmit`): clean
- No new dependencies, no I/O on the hot path beyond the existing logger