### PR TITLE
fix(bench): handle malformed provider caches clearly

### DIFF
--- a/scripts/bench-startup-cache.ts
+++ b/scripts/bench-startup-cache.ts
@@ -1,0 +1,45 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Copy a provider cache while refreshing timestamps for a warm-start benchmark.
+ *
+ * The benchmark intentionally fails with a path-specific error when the source
+ * cache is malformed instead of hiding the parse or shape error behind a raw
+ * JSON exception or a later provider failure.
+ */
+export function freshenProviderCache(src: string, dest: string): number {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(src, "utf-8")) as unknown;
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed to parse provider cache ${src}: ${detail}`, {
+			cause: error,
+		});
+	}
+
+	if (!isRecord(raw) || !isRecord(raw.providers)) {
+		throw new Error(
+			`Invalid provider cache ${src}: expected an object with a providers object`,
+		);
+	}
+
+	const now = new Date().toISOString();
+	let count = 0;
+	for (const [providerId, value] of Object.entries(raw.providers)) {
+		if (!isRecord(value)) {
+			throw new Error(
+				`Invalid provider cache ${src}: entry ${JSON.stringify(providerId)} must be an object`,
+			);
+		}
+		value.fetchedAt = now;
+		count++;
+	}
+
+	writeFileSync(dest, JSON.stringify(raw));
+	return count;
+}

--- a/scripts/bench-startup.ts
+++ b/scripts/bench-startup.ts
@@ -39,12 +39,12 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
-	readFileSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { freshenProviderCache } from "./bench-startup-cache.ts";
 
 const mode = process.argv[2] ?? "warm";
 if (!["warm", "cold", "fastcold"].includes(mode)) {
@@ -81,23 +81,14 @@ const MINIMAL_CONFIG = JSON.stringify(
 	2,
 );
 
-function freshenCache(src: string, dest: string): number {
-	const raw = JSON.parse(readFileSync(src, "utf-8"));
-	const now = new Date().toISOString();
-	let n = 0;
-	for (const v of Object.values<any>(raw.providers ?? {})) {
-		v.fetchedAt = now;
-		n++;
-	}
-	writeFileSync(dest, JSON.stringify(raw));
-	return n;
-}
-
 let seededProviders = 0;
 if (mode === "warm") {
 	const cacheSrc = join(REAL_PI, "provider-cache.json");
 	if (existsSync(cacheSrc)) {
-		seededProviders = freshenCache(cacheSrc, join(piDir, "provider-cache.json"));
+		seededProviders = freshenProviderCache(
+			cacheSrc,
+			join(piDir, "provider-cache.json"),
+		);
 	}
 	const cfgSrc = join(REAL_PI, "free.json");
 	if (existsSync(cfgSrc)) copyFileSync(cfgSrc, join(piDir, "free.json"));

--- a/tests/bench-startup-cache.test.ts
+++ b/tests/bench-startup-cache.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { freshenProviderCache } from "../scripts/bench-startup-cache.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function cachePaths(): { src: string; dest: string } {
+	const dir = mkdtempSync(join(tmpdir(), "pi-free-bench-cache-test-"));
+	tempDirs.push(dir);
+	return { src: join(dir, "source.json"), dest: join(dir, "fresh.json") };
+}
+
+describe("freshenProviderCache", () => {
+	it("reports malformed JSON with the source path", () => {
+		const { src, dest } = cachePaths();
+		writeFileSync(src, "{not-json");
+
+		expect(() => freshenProviderCache(src, dest)).toThrow(
+			`Failed to parse provider cache ${src}`,
+		);
+	});
+
+	it("rejects a cache without a providers object", () => {
+		const { src, dest } = cachePaths();
+		writeFileSync(src, JSON.stringify({ providers: [] }));
+
+		expect(() => freshenProviderCache(src, dest)).toThrow(
+			`Invalid provider cache ${src}: expected an object with a providers object`,
+		);
+	});
+
+	it("refreshes each provider timestamp while copying the cache", () => {
+		const { src, dest } = cachePaths();
+		writeFileSync(
+			src,
+			JSON.stringify({
+				providers: {
+					alpha: { fetchedAt: "old", models: [] },
+					beta: { fetchedAt: "old", models: [] },
+				},
+			}),
+		);
+
+		expect(freshenProviderCache(src, dest)).toBe(2);
+		const fresh = JSON.parse(readFileSync(dest, "utf-8")) as {
+			providers: Record<string, { fetchedAt: string }>;
+		};
+		for (const provider of Object.values(fresh.providers)) {
+			expect(provider.fetchedAt).not.toBe("old");
+			expect(Number.isNaN(Date.parse(provider.fetchedAt))).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Handle malformed JSON in the warm-start provider-cache fixture with a path-specific error.
- Validate the cache root, `providers` object, and provider entries before refreshing timestamps.
- Extract the cache freshening helper so its failure and success paths can be tested directly.

## Why

A corrupt `~/.pi/provider-cache.json` previously caused the benchmark to fail with an uncontextualized `JSON.parse` exception. The benchmark now reports which cache is invalid and why, instead of failing later with an unrelated provider error.

## Validation

- `npm run lint`
- `npx vitest run tests/bench-startup-cache.test.ts` — 3 tests passed
- `npx tsx scripts/bench-startup.ts fastcold`
