### PR TITLE
feat(llm7): migrate to native Provider

### DIFF
--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -1,0 +1,110 @@
+import type {
+	Api,
+	Model,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import { saveConfig } from "../config.ts";
+import { createLogger } from "./logger.ts";
+import { wrapSessionStartHandler } from "./session-start-metrics.ts";
+
+const _logger = createLogger("native-provider");
+
+interface NativeToggleOptions {
+	providerId: string;
+	stored: {
+		free: ProviderModelConfig[];
+		all: ProviderModelConfig[];
+	};
+	getShowPaid: () => boolean;
+	reRegister: (models: ProviderModelConfig[]) => void;
+}
+
+/** Register the standard free/all toggle used by native providers. */
+export function registerNativeProviderToggle(
+	pi: ExtensionAPI,
+	options: NativeToggleOptions,
+): void {
+	const { providerId, stored, getShowPaid, reRegister } = options;
+
+	pi.registerCommand(`toggle-${providerId}`, {
+		description: `Toggle between free and all ${providerId} models`,
+		handler: async (_args, ctx) => {
+			const showPaid = !getShowPaid();
+			await saveConfig({ [`${providerId}_show_paid`]: showPaid });
+
+			const modelsToShow =
+				showPaid && stored.all.length > 0 ? stored.all : stored.free;
+			reRegister(modelsToShow);
+
+			const freeCount = stored.free.length;
+			const paidCount = stored.all.length - freeCount;
+			if (showPaid && stored.all.length > 0) {
+				ctx.ui.notify(
+					`${providerId}: showing all ${stored.all.length} models (${freeCount} free, ${paidCount} paid)`,
+					"info",
+				);
+			} else {
+				ctx.ui.notify(
+					`${providerId}: showing ${freeCount} free models (${paidCount} paid hidden)`,
+					"info",
+				);
+			}
+		},
+	});
+}
+
+/** Nudge Pi's native model refresh at session start without owning refresh state. */
+export function registerNativeProviderRefresh(
+	pi: ExtensionAPI,
+	providerId: string,
+): void {
+	pi.on(
+		"session_start",
+		wrapSessionStartHandler(providerId, (_event, ctx) => {
+			try {
+				const registry = (
+					ctx as {
+						modelRegistry?: { refresh?: (opts?: unknown) => unknown };
+					}
+				).modelRegistry;
+				const result = registry?.refresh?.({ allowNetwork: true });
+				if (result && typeof (result as Promise<void>).catch === "function") {
+					(result as Promise<void>).catch((err: unknown) =>
+						logRefreshFailure(providerId, err),
+					);
+				}
+			} catch (err) {
+				logRefreshFailure(providerId, err);
+			}
+			return Promise.resolve();
+		}),
+	);
+}
+
+function logRefreshFailure(providerId: string, error: unknown): void {
+	_logger.warn(`Model refresh nudge failed for ${providerId}`, {
+		error: error instanceof Error ? error.message : String(error),
+	});
+}
+
+/** Persist a native provider catalog while retaining the previous store on failure. */
+export async function persistNativeProviderModels(
+	providerId: string,
+	context: RefreshModelsContext,
+	models: readonly Model<Api>[],
+): Promise<void> {
+	try {
+		await context.store.write({
+			models,
+			checkedAt: Date.now(),
+		});
+	} catch (err) {
+		_logger.warn(`Failed to persist ${providerId} models to store`, {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -48,6 +48,7 @@ import { getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { persistNativeProviderModels } from "../../lib/native-provider.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { clineAuth } from "./cline-auth.ts";
 import { fetchClineCatalog, toClineModels } from "./cline-models.ts";
@@ -194,18 +195,13 @@ export function createClineProvider(): ClineNativeProvider {
 
 		ingest(all, free);
 
-		try {
-			await context.store.write({
-				// stored.all holds full Model objects at runtime (toClineModels output);
-				// the StoredModels type widens them to ProviderModelConfig for the toggle.
-				models: stored.all as unknown as readonly Model<Api>[],
-				checkedAt: Date.now(),
-			});
-		} catch (err) {
-			_logger.warn("Failed to persist models to store", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
+		await persistNativeProviderModels(
+			PROVIDER_CLINE,
+			context,
+			// stored.all holds full Model objects at runtime (toClineModels output);
+			// the StoredModels type widens them to ProviderModelConfig for the toggle.
+			stored.all as unknown as readonly Model<Api>[],
+		);
 	}
 
 	// Both entry points dispatch to the XML bridge, exactly as the legacy

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -30,12 +30,13 @@ import {
 	getClineApiKey,
 	getClineShowPaid,
 	PROVIDER_CLINE,
-	saveConfig,
 } from "../../config.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import { logWarning } from "../../lib/util.ts";
+import {
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
 import { isOAuthCredential } from "../../provider-helper.ts";
 import { createClineProvider, rotateClineTaskId } from "./cline-provider.ts";
 
@@ -138,31 +139,11 @@ export default async function clineProvider(pi: ExtensionAPI) {
 	const hasClineKey = !!getClineApiKey();
 	registerWithGlobalToggle(PROVIDER_CLINE, stored, reRegister, hasClineKey);
 
-	// Per-provider toggle command
-	pi.registerCommand("toggle-cline", {
-		description: "Toggle between free and all Cline models",
-		handler: async (_args, ctx) => {
-			const showPaid = !getClineShowPaid();
-			await saveConfig({ cline_show_paid: showPaid });
-
-			const modelsToShow =
-				showPaid && stored.all.length > 0 ? stored.all : stored.free;
-			reRegister(modelsToShow);
-
-			const freeCount = stored.free.length;
-			const paidCount = stored.all.length - freeCount;
-			if (showPaid && stored.all.length > 0) {
-				ctx.ui.notify(
-					`cline: showing all ${stored.all.length} models (${freeCount} free, ${paidCount} paid)`,
-					"info",
-				);
-			} else {
-				ctx.ui.notify(
-					`cline: showing ${freeCount} free models (${paidCount} paid hidden)`,
-					"info",
-				);
-			}
-		},
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_CLINE,
+		stored,
+		getShowPaid: getClineShowPaid,
+		reRegister,
 	});
 
 	// Rotate the Cline task id when a Cline agent starts (mirrors the legacy
@@ -173,38 +154,5 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		rotateClineTaskId();
 	});
 
-	// Refresh nudge on session start. Native refreshModels (owned by Pi) keeps the
-	// catalog fresh on its throttled cycle; this replaces the legacy hand-rolled
-	// provider-cache refresh (1h TTL) with Pi's throttled background refresh. It
-	// only nudges the model registry when it exposes a refresh hook, and is a safe
-	// no-op otherwise.
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler("cline", (_event, ctx) => {
-			try {
-				const registry = (
-					ctx as {
-						modelRegistry?: { refresh?: (opts?: unknown) => unknown };
-					}
-				).modelRegistry;
-				const result = registry?.refresh?.({ allowNetwork: true });
-				if (result && typeof (result as Promise<void>).catch === "function") {
-					(result as Promise<void>).catch((err: unknown) =>
-						logWarning(
-							"cline",
-							"Model refresh nudge failed",
-							err instanceof Error ? err.message : String(err),
-						),
-					);
-				}
-			} catch (err) {
-				logWarning(
-					"cline",
-					"Model refresh nudge failed",
-					err instanceof Error ? err.message : String(err),
-				);
-			}
-			return Promise.resolve();
-		}),
-	);
+	registerNativeProviderRefresh(pi, PROVIDER_CLINE);
 }

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -42,6 +42,7 @@ import {
 import { PROVIDER_KILO } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { persistNativeProviderModels } from "../../lib/native-provider.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { kiloAuth } from "./kilo-auth.ts";
 import {
@@ -151,18 +152,13 @@ export function createKiloProvider(): KiloNativeProvider {
 
 		ingest(all, free);
 
-		try {
-			await context.store.write({
-				// stored.all holds full Model objects at runtime (toKiloModels output);
-				// the StoredModels type widens them to ProviderModelConfig for the toggle.
-				models: stored.all as unknown as readonly Model<Api>[],
-				checkedAt: Date.now(),
-			});
-		} catch (err) {
-			_logger.warn("Failed to persist models to store", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
+		await persistNativeProviderModels(
+			PROVIDER_KILO,
+			context,
+			// stored.all holds full Model objects at runtime (toKiloModels output);
+			// the StoredModels type widens them to ProviderModelConfig for the toggle.
+			stored.all as unknown as readonly Model<Api>[],
+		);
 	}
 
 	const provider: Provider<"openai-completions"> = {

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -26,12 +26,14 @@ import {
 	getKiloApiKey,
 	getKiloShowPaid,
 	PROVIDER_KILO,
-	saveConfig,
 } from "../../config.ts";
 import { URL_KILO_TOS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
+import {
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
 import { logWarning } from "../../lib/util.ts";
 import { isOAuthCredential } from "../../provider-helper.ts";
 import { createKiloProvider } from "./kilo-provider.ts";
@@ -236,31 +238,11 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	const hasKiloKey = !!getKiloApiKey();
 	registerWithGlobalToggle(PROVIDER_KILO, stored, reRegister, hasKiloKey);
 
-	// Per-provider toggle command
-	pi.registerCommand("toggle-kilo", {
-		description: "Toggle between free and all Kilo models",
-		handler: async (_args, ctx) => {
-			const showPaid = !getKiloShowPaid();
-			await saveConfig({ kilo_show_paid: showPaid });
-
-			const modelsToShow =
-				showPaid && stored.all.length > 0 ? stored.all : stored.free;
-			reRegister(modelsToShow);
-
-			const freeCount = stored.free.length;
-			const paidCount = stored.all.length - freeCount;
-			if (showPaid && stored.all.length > 0) {
-				ctx.ui.notify(
-					`kilo: showing all ${stored.all.length} models (${freeCount} free, ${paidCount} paid)`,
-					"info",
-				);
-			} else {
-				ctx.ui.notify(
-					`kilo: showing ${freeCount} free models (${paidCount} paid hidden)`,
-					"info",
-				);
-			}
-		},
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_KILO,
+		stored,
+		getShowPaid: getKiloShowPaid,
+		reRegister,
 	});
 
 	// ToS notice on provider selection
@@ -362,37 +344,5 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		};
 	});
 
-	// Refresh nudge on session start. Native refreshModels (owned by Pi) keeps the
-	// catalog fresh on its throttled cycle and refreshes the OAuth credential
-	// before fetching; this only nudges the model registry when it exposes a
-	// refresh hook, and is a safe no-op otherwise.
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler("kilo", (_event, ctx) => {
-			try {
-				const registry = (
-					ctx as {
-						modelRegistry?: { refresh?: (opts?: unknown) => unknown };
-					}
-				).modelRegistry;
-				const result = registry?.refresh?.({ allowNetwork: true });
-				if (result && typeof (result as Promise<void>).catch === "function") {
-					(result as Promise<void>).catch((err: unknown) =>
-						logWarning(
-							"kilo",
-							"Model refresh nudge failed",
-							err instanceof Error ? err.message : String(err),
-						),
-					);
-				}
-			} catch (err) {
-				logWarning(
-					"kilo",
-					"Model refresh nudge failed",
-					err instanceof Error ? err.message : String(err),
-				);
-			}
-			return Promise.resolve();
-		}),
-	);
+	registerNativeProviderRefresh(pi, PROVIDER_KILO);
 }

--- a/providers/llm7/llm7-auth.ts
+++ b/providers/llm7/llm7-auth.ts
@@ -1,0 +1,70 @@
+/**
+ * LLM7 native provider auth (createProvider object form).
+ *
+ * LLM7 has no OAuth flow — only an API key (free token from
+ * https://token.llm7.io/ or a Pro subscription key). It is pi-free's
+ * keyless-provider proof case: the free tier works without any credential, so
+ * the public catalog must stay visible when no key is configured.
+ *
+ * To that end `apiKey.resolve` ALWAYS resolves — with an empty `auth` when no
+ * key exists — instead of returning undefined. Pi's `Models.refresh()` skips
+ * providers whose auth does not resolve, which would leave logged-out users
+ * with no models at all (no offline init, no background refresh). Always
+ * resolving keeps the catalog flowing for everyone — Pi's sanctioned keyless
+ * pattern (the pi-ai `faux` provider and pi-free's Cline port do the same) —
+ * while authenticated requests still use the ambient `LLM7_API_KEY` env var /
+ * `~/.pi/free.json` value exactly as the legacy registration did. There is
+ * intentionally no `apiKey.check`: Pi runs that check before availability
+ * filtering and would hide this intentionally public catalog when the user is
+ * logged out.
+ */
+
+import type {
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	ProviderAuth,
+} from "@earendil-works/pi-ai/compat";
+import { getLlm7ApiKey } from "../../config.ts";
+
+/**
+ * Resolve the effective LLM7 API key: a natively-stored key (from
+ * `interaction.prompt` login) wins, then the ambient `LLM7_API_KEY` env var /
+ * `~/.pi/free.json` value via the shared config getter. When NO key is
+ * configured this still resolves — with an empty `auth` — so Pi keeps the
+ * public free catalog visible (see module docstring).
+ */
+async function resolveLlm7ApiKey(input: {
+	ctx: AuthContext;
+	credential?: ApiKeyCredential;
+}): Promise<AuthResult | undefined> {
+	const key = input.credential?.key ?? getLlm7ApiKey();
+	if (!key) {
+		return { auth: {}, source: "public free tier (no account)" };
+	}
+	return {
+		auth: { apiKey: key },
+		source: input.credential?.key ? "stored API key" : "LLM7_API_KEY",
+	};
+}
+
+export const llm7ApiKeyAuth: ApiKeyAuth = {
+	name: "LLM7 API key",
+	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+		const key = await interaction.prompt({
+			type: "secret",
+			message: "LLM7 API key (free token from https://token.llm7.io/)",
+		});
+		return { type: "api_key", key };
+	},
+	resolve: resolveLlm7ApiKey,
+};
+
+/**
+ * Native auth for the LLM7 provider: API key only (LLM7 has no OAuth flow).
+ */
+export const llm7Auth: ProviderAuth = {
+	apiKey: llm7ApiKeyAuth,
+};

--- a/providers/llm7/llm7-models.ts
+++ b/providers/llm7/llm7-models.ts
@@ -1,0 +1,122 @@
+/**
+ * LLM7 model catalog and conversion.
+ *
+ * LLM7.io routes requests across multiple upstream providers through a single
+ * OpenAI-compatible endpoint. Its "models" are routing selectors, not specific
+ * model IDs:
+ *
+ *   - "default" — first available free model (free)
+ *   - "fast" — lowest latency option (free)
+ *   - "pro" — highest quality, longer reasoning (paid, $12/mo subscription)
+ *
+ * The catalog is STATIC (no network fetch): the selectors never change, so
+ * `fetchLlm7Catalog` builds them locally. The native provider's refreshModels
+ * therefore performs zero network I/O even when `allowNetwork` is true.
+ */
+
+import type { Model } from "@earendil-works/pi-ai/compat";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
+import { isFreeModel } from "../../lib/registry.ts";
+
+// =============================================================================
+// Model Definitions
+// =============================================================================
+
+const LLM7_MODELS: ProviderModelConfig[] = [
+	{
+		id: "default",
+		name: "LLM7 Default",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	},
+	{
+		id: "fast",
+		name: "LLM7 Fast",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	},
+	{
+		id: "pro",
+		name: "LLM7 Pro",
+		reasoning: false,
+		input: ["text"],
+		cost: {
+			input: 0.3, // Requires $12/mo LLM7 Pro subscription
+			output: 0.9,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	},
+];
+
+// =============================================================================
+// Catalog (static — no network)
+// =============================================================================
+
+/**
+ * Build the LLM7 catalog, split into `{ all, free }` using the shared adaptive
+ * free detection (Route A: "pro" exposes non-zero pricing, so free = zero-cost
+ * input AND output → the "default" and "fast" selectors).
+ *
+ * Purely local: no fetch, no credential, never throws. `applyHidden` lets users
+ * hide selectors via `hidden_models` (e.g. "llm7/pro"), consistent with every
+ * other pi-free provider.
+ */
+export function fetchLlm7Catalog(): {
+	all: ProviderModelConfig[];
+	free: ProviderModelConfig[];
+} {
+	const all = applyHidden(LLM7_MODELS, PROVIDER_LLM7);
+	const free = all.filter((m) =>
+		isFreeModel({ ...m, provider: PROVIDER_LLM7 }, all),
+	);
+	return { all, free };
+}
+
+// =============================================================================
+// Mapping to pi-ai Model
+// =============================================================================
+
+/**
+ * Convert a ProviderModelConfig into the concrete pi-ai
+ * `Model<"openai-completions">` shape a native provider's getModels() returns.
+ * Adds the provider id, wire api, and gateway baseUrl that the legacy
+ * registerProvider config form used to supply implicitly.
+ */
+export function toLlm7Model(
+	m: ProviderModelConfig,
+): Model<"openai-completions"> {
+	return {
+		...m,
+		api: "openai-completions",
+		provider: PROVIDER_LLM7,
+		baseUrl: m.baseUrl ?? BASE_URL_LLM7,
+	} as Model<"openai-completions">;
+}
+
+/** Convert a batch of model configs to native Model objects. */
+export function toLlm7Models(
+	models: ProviderModelConfig[],
+): Model<"openai-completions">[] {
+	return models.map(toLlm7Model);
+}

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -45,6 +45,7 @@ import { getLlm7ShowPaid } from "../../config.ts";
 import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { persistNativeProviderModels } from "../../lib/native-provider.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { llm7Auth } from "./llm7-auth.ts";
 import { fetchLlm7Catalog, toLlm7Models } from "./llm7-models.ts";
@@ -99,7 +100,10 @@ export function createLlm7Provider(): Llm7NativeProvider {
 		currentView = toLlm7Models(models);
 	}
 
-	function ingest(all: ProviderModelConfig[], free: ProviderModelConfig[]): void {
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
 		stored.all = toLlm7Models(enhanceWithCI(all));
 		stored.free = toLlm7Models(enhanceWithCI(free));
 		setView(decideView());
@@ -140,18 +144,13 @@ export function createLlm7Provider(): Llm7NativeProvider {
 
 		ingest(all, free);
 
-		try {
-			await context.store.write({
-				// stored.all holds full Model objects at runtime (toLlm7Models output);
-				// the StoredModels type widens them to ProviderModelConfig for the toggle.
-				models: stored.all as unknown as readonly Model<Api>[],
-				checkedAt: Date.now(),
-			});
-		} catch (err) {
-			_logger.warn("Failed to persist models to store", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
+		await persistNativeProviderModels(
+			PROVIDER_LLM7,
+			context,
+			// stored.all holds full Model objects at runtime (toLlm7Models output);
+			// the StoredModels type widens them to ProviderModelConfig for the toggle.
+			stored.all as unknown as readonly Model<Api>[],
+		);
 	}
 
 	const provider: Provider<"openai-completions"> = {
@@ -164,7 +163,8 @@ export function createLlm7Provider(): Llm7NativeProvider {
 		auth: llm7Auth,
 		getModels: () => currentView,
 		refreshModels,
-		stream: (model, context, options) => streams.stream(model, context, options),
+		stream: (model, context, options) =>
+			streams.stream(model, context, options),
 		streamSimple: (model, context, options) =>
 			streams.streamSimple(model, context, options),
 	};

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -1,0 +1,173 @@
+/**
+ * LLM7 native provider — the createProvider object form.
+ *
+ * Builds a pi-ai `Provider` object that pi-free registers via
+ * `pi.registerProvider(provider)` (the >=0.81 single-argument overload). Pi then
+ * owns credential resolution, background model refresh (4h throttle, abortable),
+ * and offline initialization:
+ *
+ *   - native `auth` (apiKey only — LLM7 has no OAuth flow) persisted to
+ *     ~/.pi/agent/auth.json; always resolves so the keyless public catalog
+ *     stays visible (see llm7-auth.ts)
+ *   - sync `getModels()` returning the catalog pi-free chose to show
+ *   - `refreshModels(context)`:
+ *       allowNetwork:false → restore from context.store only (fast offline init)
+ *       allowNetwork:true  → build the STATIC selector catalog locally (no
+ *                            network I/O, no credential needed), persist via
+ *                            context.store.write, honor context.signal
+ *
+ * LLM7 differs from Kilo/Cline in that its "catalog" is three static routing
+ * selectors (default/fast/pro), so the online refresh path is purely local —
+ * the poisoning guard and store contract are kept identical to the reference
+ * ports anyway, so a future fetched catalog drops in without reshaping this.
+ *
+ * The object is assembled directly against the public `Provider` interface (the
+ * exact shape `createProvider()` returns) rather than through the `createProvider`
+ * helper: that helper unconditionally merges its stored dynamic overlay on top of
+ * the static baseline on every refresh, which would clobber pi-free's
+ * re-registration based free/paid toggle. Assembling directly keeps `getModels()`
+ * returning precisely the view pi-free selected while still using the native
+ * store and auth.
+ *
+ * Pi owns refresh throttling and the `force` flag (`pi update --models`); this
+ * module performs no freshness gating of its own so the two never double-throttle.
+ */
+
+import type {
+	Api,
+	Model,
+	Provider,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { getLlm7ShowPaid } from "../../config.ts";
+import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
+import { llm7Auth } from "./llm7-auth.ts";
+import { fetchLlm7Catalog, toLlm7Models } from "./llm7-models.ts";
+
+const _logger = createLogger("llm7");
+
+type Llm7Model = Model<"openai-completions">;
+
+/** Handle returned to the extension factory for toggle wiring. */
+export interface Llm7NativeProvider {
+	/** The native provider object to register via registerProvider(provider). */
+	provider: Provider<"openai-completions">;
+	/** Mutable catalogs shared with registerWithGlobalToggle / /free-providers. */
+	stored: StoredModels;
+	/** Set the visible catalog (toggle / global-toggle re-registration target). */
+	setView: (models: ProviderModelConfig[]) => void;
+	/** Ingest a fresh catalog: update stored + view, per toggle state. */
+	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
+}
+
+/**
+ * Build the LLM7 native provider. All mutable catalog state lives in the
+ * returned closure so the extension factory can wire toggles against a single
+ * source of truth.
+ */
+export function createLlm7Provider(): Llm7NativeProvider {
+	const streams = openAICompletionsApi();
+
+	// Display-ready catalogs (CI-enhanced + converted to Model). Typed as
+	// StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle; the
+	// runtime values are full Model objects, which are assignable.
+	const stored: StoredModels = { free: [], all: [] };
+	let currentView: Llm7Model[] = [];
+
+	/**
+	 * Which catalog the current toggle state wants to show. Mirrors
+	 * applyGlobalFilter's decision so the offline-init initial view matches what
+	 * the global free/paid toggle would select. LLM7 has no per-provider
+	 * free-only override — only the persisted show_paid flag.
+	 */
+	function decideView(): ProviderModelConfig[] {
+		// Global free-only off → show everything.
+		if (!getGlobalFreeOnly()) {
+			return stored.all.length > 0 ? stored.all : stored.free;
+		}
+		// Global free-only on → free, unless per-provider show_paid is persisted.
+		const showPaid = getLlm7ShowPaid();
+		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
+	}
+
+	function setView(models: ProviderModelConfig[]): void {
+		currentView = toLlm7Models(models);
+	}
+
+	function ingest(all: ProviderModelConfig[], free: ProviderModelConfig[]): void {
+		stored.all = toLlm7Models(enhanceWithCI(all));
+		stored.free = toLlm7Models(enhanceWithCI(free));
+		setView(decideView());
+	}
+
+	async function refreshModels(context: RefreshModelsContext): Promise<void> {
+		// Offline init / cache restore: always read the store first so a warm
+		// startup shows models with zero network.
+		try {
+			const entry = await context.store.read();
+			const storedModels = (entry?.models ?? []).filter(
+				(m) => m.provider === PROVIDER_LLM7,
+			) as Llm7Model[];
+			if (storedModels.length > 0) {
+				stored.all = storedModels;
+				stored.free = storedModels.filter((m) =>
+					isFreeModel({ ...m, provider: PROVIDER_LLM7 }, storedModels),
+				);
+				setView(decideView());
+			}
+		} catch (err) {
+			_logger.warn("Failed to read models store; continuing empty", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+
+		// Offline init stops here: serve the store only.
+		if (!context.allowNetwork || context.signal?.aborted) return;
+
+		// Online: build the static selector catalog. This is purely local (no
+		// fetch, no credential) — LLM7's selectors never change.
+		const { all, free } = fetchLlm7Catalog();
+		if (context.signal?.aborted) return;
+
+		// Retain the previous list on a degenerate result (poisoning guard —
+		// e.g. every selector hidden via hidden_models config).
+		if (all.length === 0) return;
+
+		ingest(all, free);
+
+		try {
+			await context.store.write({
+				// stored.all holds full Model objects at runtime (toLlm7Models output);
+				// the StoredModels type widens them to ProviderModelConfig for the toggle.
+				models: stored.all as unknown as readonly Model<Api>[],
+				checkedAt: Date.now(),
+			});
+		} catch (err) {
+			_logger.warn("Failed to persist models to store", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	const provider: Provider<"openai-completions"> = {
+		id: PROVIDER_LLM7,
+		name: "LLM7",
+		baseUrl: BASE_URL_LLM7,
+		headers: {
+			"User-Agent": "pi-free-providers",
+		},
+		auth: llm7Auth,
+		getModels: () => currentView,
+		refreshModels,
+		stream: (model, context, options) => streams.stream(model, context, options),
+		streamSimple: (model, context, options) =>
+			streams.streamSimple(model, context, options),
+	};
+
+	return { provider, stored, setView, ingest };
+}

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -6,7 +6,7 @@
  * a single OpenAI-compatible endpoint.
  *
  * Free tier:
- *   - Free token from https://token.llm7.io/
+ *   - Anonymous (no key) or free token from https://token.llm7.io/
  *   - 100 req/hr, 20 req/min, 2 req/s
  *   - No credit card required
  *
@@ -22,135 +22,165 @@
  * Endpoint:
  *   Chat: https://api.llm7.io/v1/chat/completions
  *
- * Setup:
- *   1. Get free token from https://token.llm7.io/
+ * Registered as a native pi-ai `Provider` (createProvider object form) so Pi
+ * owns credential resolution, background model refresh, and offline
+ * initialization. LLM7 is pi-free's keyless-provider proof case: its auth
+ * always resolves (empty auth when no key is configured), so the public free
+ * catalog stays visible without an API key — the legacy registration skipped
+ * the provider entirely in that case. Authenticated requests still use the
+ * ambient `LLM7_API_KEY` env var / `~/.pi/free.json` value as before.
+ *
+ *   - The factory is synchronous and network-free — it builds the provider
+ *     object and registers it. Models load via `refreshModels` (offline init
+ *     from the native models store, then a background refresh of the STATIC
+ *     selector catalog), so LLM7 no longer owns any of Pi's startup critical
+ *     path.
+ *   - Free/paid filtering stays on pi-free's re-registration toggle so it
+ *     keeps composing with the global /toggle-free system.
+ *
+ * Setup (optional — free models work without a key):
+ *   1. Get a free token from https://token.llm7.io/
  *   2. Set LLM7_API_KEY env var (or add to ~/.pi/free.json)
  *
  * Usage:
  *   pi install git:github.com/apmantza/pi-free
- *   # Set LLM7_API_KEY env var
  *   # Models appear in /model selector as "llm7/default", "llm7/fast", "llm7/pro"
  */
 
+import type { Provider } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { getLlm7ApiKey, getLlm7ShowPaid } from "../../config.ts";
-import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { createReRegister, setupProvider } from "../../provider-helper.ts";
-
-const _logger = createLogger("llm7");
-
-// =============================================================================
-// Model Definitions
-// =============================================================================
-
-const LLM7_MODELS: ProviderModelConfig[] = [
-	{
-		id: "default",
-		name: "LLM7 Default",
-		reasoning: false,
-		input: ["text"],
-		cost: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-		},
-		contextWindow: 32_000,
-		maxTokens: 4_096,
-	},
-	{
-		id: "fast",
-		name: "LLM7 Fast",
-		reasoning: false,
-		input: ["text"],
-		cost: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-		},
-		contextWindow: 32_000,
-		maxTokens: 4_096,
-	},
-	{
-		id: "pro",
-		name: "LLM7 Pro",
-		reasoning: false,
-		input: ["text"],
-		cost: {
-			input: 0.3, // Requires $12/mo LLM7 Pro subscription
-			output: 0.9,
-			cacheRead: 0,
-			cacheWrite: 0,
-		},
-		contextWindow: 32_000,
-		maxTokens: 4_096,
-	},
-];
+import {
+	getLlm7ApiKey,
+	getLlm7ShowPaid,
+	saveConfig,
+} from "../../config.ts";
+import { PROVIDER_LLM7 } from "../../constants.ts";
+import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
+import { logWarning } from "../../lib/util.ts";
+import { createLlm7Provider } from "./llm7-provider.ts";
 
 // =============================================================================
-// Extension Entry Point
+// Native provider registration
+// =============================================================================
+
+/**
+ * The >=0.81 `registerProvider(provider: Provider)` single-argument overload.
+ * The dev lockfile predates it (its ExtensionAPI only types the legacy
+ * `(name, config)` form), so we bridge the type here; the declared peer range
+ * (>=0.81) guarantees the overload exists at runtime. Re-registering the same
+ * provider object upserts by id, which is how the free/paid toggle republishes a
+ * new visible catalog without dropping native auth.
+ */
+type NativeRegistrar = {
+	registerProvider(provider: Provider): void;
+};
+
+function registerNative(
+	pi: ExtensionAPI,
+	provider: Provider<"openai-completions">,
+): void {
+	(pi as unknown as NativeRegistrar).registerProvider(provider);
+}
+
+// =============================================================================
+// Extension entry point
 // =============================================================================
 
 export default async function llm7Provider(pi: ExtensionAPI) {
-	const apiKey = getLlm7ApiKey();
+	const { provider, stored, setView } = createLlm7Provider();
 
-	if (!apiKey) {
-		_logger.info(
-			"[llm7] Skipping — LLM7_API_KEY not set. Get a free token at https://token.llm7.io/",
-		);
-		return;
-	}
+	// Register the native provider. The factory performs NO network I/O: models
+	// load via refreshModels (offline init from the store, then a background
+	// refresh of the static selector catalog), so LLM7 no longer owns any of
+	// Pi's startup critical path.
+	registerNative(pi, provider);
 
-	_logger.info("[llm7] Using LLM7_API_KEY");
+	// Re-registration republishes the same native provider object (upsert by id)
+	// with a new visible catalog, keeping native auth intact. This is the hook the
+	// global /toggle-free system and /toggle-llm7 drive.
+	const reRegister = (models: ProviderModelConfig[]) => {
+		setView(models);
+		registerNative(pi, provider);
+	};
 
-	const allModels = LLM7_MODELS;
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_LLM7 }, allModels),
-	);
+	const hasLlm7Key = !!getLlm7ApiKey();
+	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, hasLlm7Key);
 
-	const stored = { free: freeModels, all: allModels };
+	// Per-provider toggle command
+	pi.registerCommand("toggle-llm7", {
+		description: "Toggle between free and all LLM7 models",
+		handler: async (_args, ctx) => {
+			const showPaid = !getLlm7ShowPaid();
+			await saveConfig({ llm7_show_paid: showPaid });
 
-	_logger.info(
-		`[llm7] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
+			const modelsToShow =
+				showPaid && stored.all.length > 0 ? stored.all : stored.free;
+			reRegister(modelsToShow);
 
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_LLM7,
-		baseUrl: BASE_URL_LLM7,
-		apiKey,
+			const freeCount = stored.free.length;
+			const paidCount = stored.all.length - freeCount;
+			if (showPaid && stored.all.length > 0) {
+				ctx.ui.notify(
+					`llm7: showing all ${stored.all.length} models (${freeCount} free, ${paidCount} paid)`,
+					"info",
+				);
+			} else {
+				ctx.ui.notify(
+					`llm7: showing ${freeCount} free models (${paidCount} paid hidden)`,
+					"info",
+				);
+			}
+		},
 	});
 
-	// Register with global toggle
-	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, true);
+	// ToS notice on first LLM7 selection (mirrors the legacy setupProvider
+	// notice). Suppressed when an API key is configured — the "set API key for
+	// paid access" hint is only relevant to keyless users.
+	let tosShown = false;
+	pi.on("model_select", async (_event, ctx) => {
+		if (tosShown || ctx.model?.provider !== PROVIDER_LLM7) return;
+		tosShown = true;
+		if (getLlm7ApiKey()) return;
+		ctx.ui.notify(
+			"Using llm7 free models. Set API key for paid access. Terms: https://llm7.io/",
+			"info",
+		);
+	});
 
-	// Setup provider with toggle command
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_LLM7,
-			initialShowPaid: getLlm7ShowPaid(),
-			tosUrl: "https://llm7.io/",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
+	// Refresh nudge on session start. Native refreshModels (owned by Pi) keeps the
+	// catalog fresh on its throttled cycle; this only nudges the model registry
+	// when it exposes a refresh hook, and is a safe no-op otherwise.
+	pi.on(
+		"session_start",
+		wrapSessionStartHandler("llm7", (_event, ctx) => {
+			try {
+				const registry = (
+					ctx as {
+						modelRegistry?: { refresh?: (opts?: unknown) => unknown };
+					}
+				).modelRegistry;
+				const result = registry?.refresh?.({ allowNetwork: true });
+				if (result && typeof (result as Promise<void>).catch === "function") {
+					(result as Promise<void>).catch((err: unknown) =>
+						logWarning(
+							"llm7",
+							"Model refresh nudge failed",
+							err instanceof Error ? err.message : String(err),
+						),
+					);
 				}
-				reRegister(models);
-			},
-		},
-		stored,
+			} catch (err) {
+				logWarning(
+					"llm7",
+					"Model refresh nudge failed",
+					err instanceof Error ? err.message : String(err),
+				);
+			}
+			return Promise.resolve();
+		}),
 	);
-
-	// Initial registration — respect persisted toggle state
-	const showPaid = getLlm7ShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
 }

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -52,15 +52,13 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import {
-	getLlm7ApiKey,
-	getLlm7ShowPaid,
-	saveConfig,
-} from "../../config.ts";
+import { getLlm7ApiKey, getLlm7ShowPaid } from "../../config.ts";
 import { PROVIDER_LLM7 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import { logWarning } from "../../lib/util.ts";
+import {
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
 import { createLlm7Provider } from "./llm7-provider.ts";
 
 // =============================================================================
@@ -110,31 +108,11 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 	const hasLlm7Key = !!getLlm7ApiKey();
 	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, hasLlm7Key);
 
-	// Per-provider toggle command
-	pi.registerCommand("toggle-llm7", {
-		description: "Toggle between free and all LLM7 models",
-		handler: async (_args, ctx) => {
-			const showPaid = !getLlm7ShowPaid();
-			await saveConfig({ llm7_show_paid: showPaid });
-
-			const modelsToShow =
-				showPaid && stored.all.length > 0 ? stored.all : stored.free;
-			reRegister(modelsToShow);
-
-			const freeCount = stored.free.length;
-			const paidCount = stored.all.length - freeCount;
-			if (showPaid && stored.all.length > 0) {
-				ctx.ui.notify(
-					`llm7: showing all ${stored.all.length} models (${freeCount} free, ${paidCount} paid)`,
-					"info",
-				);
-			} else {
-				ctx.ui.notify(
-					`llm7: showing ${freeCount} free models (${paidCount} paid hidden)`,
-					"info",
-				);
-			}
-		},
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_LLM7,
+		stored,
+		getShowPaid: getLlm7ShowPaid,
+		reRegister,
 	});
 
 	// ToS notice on first LLM7 selection (mirrors the legacy setupProvider
@@ -151,36 +129,5 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 		);
 	});
 
-	// Refresh nudge on session start. Native refreshModels (owned by Pi) keeps the
-	// catalog fresh on its throttled cycle; this only nudges the model registry
-	// when it exposes a refresh hook, and is a safe no-op otherwise.
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler("llm7", (_event, ctx) => {
-			try {
-				const registry = (
-					ctx as {
-						modelRegistry?: { refresh?: (opts?: unknown) => unknown };
-					}
-				).modelRegistry;
-				const result = registry?.refresh?.({ allowNetwork: true });
-				if (result && typeof (result as Promise<void>).catch === "function") {
-					(result as Promise<void>).catch((err: unknown) =>
-						logWarning(
-							"llm7",
-							"Model refresh nudge failed",
-							err instanceof Error ? err.message : String(err),
-						),
-					);
-				}
-			} catch (err) {
-				logWarning(
-					"llm7",
-					"Model refresh nudge failed",
-					err instanceof Error ? err.message : String(err),
-				);
-			}
-			return Promise.resolve();
-		}),
-	);
+	registerNativeProviderRefresh(pi, PROVIDER_LLM7);
 }

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Unit tests for the LLM7 native provider (createProvider object form).
+ *
+ * Mirrors tests/cline-provider.test.ts, plus the LLM7-specific pieces:
+ *   - keyless proof case: auth always resolves (empty auth when no key), so
+ *     Pi's availability filtering keeps the public free catalog visible
+ *     with zero credential — verified through the REAL pi-ai Models registry
+ *   - static selector catalog: refreshModels performs ZERO network I/O even
+ *     when allowNetwork is true (asserted via a global fetch spy)
+ */
+
+import { createModels } from "@earendil-works/pi-ai";
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetLlm7ShowPaid = vi.hoisted(() => vi.fn(() => false));
+const mockGetLlm7ApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+const mockApplyHidden = vi.hoisted(() =>
+	vi.fn(<T extends { id: string }>(models: T[]): T[] => models),
+);
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("../config.ts", () => ({
+	getLlm7ApiKey: () => mockGetLlm7ApiKey(),
+	getLlm7ShowPaid: () => mockGetLlm7ShowPaid(),
+	applyHidden: (models: { id: string }[]) => mockApplyHidden(models),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
+}));
+
+vi.mock("../provider-helper.ts", async () => {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../provider-helper.ts",
+	);
+	return {
+		...actual,
+		enhanceWithCI: (models: unknown[]) => models,
+	};
+});
+
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import { llm7Auth } from "../providers/llm7/llm7-auth.ts";
+import { fetchLlm7Catalog } from "../providers/llm7/llm7-models.ts";
+import { createLlm7Provider } from "../providers/llm7/llm7-provider.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cfg(over: Record<string, unknown> = {}) {
+	return {
+		id: "m-1",
+		name: "Model One",
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32_000,
+		maxTokens: 4096,
+		...over,
+	};
+}
+
+function freeCfg(id: string) {
+	return cfg({ id, name: `LLM7 ${id}` });
+}
+function paidCfg(id: string) {
+	return cfg({
+		id,
+		name: `LLM7 ${id}`,
+		cost: { input: 0.3, output: 0.9, cacheRead: 0, cacheWrite: 0 },
+	});
+}
+
+function nativeCfg(id: string, paid = false) {
+	return {
+		...(paid ? paidCfg(id) : freeCfg(id)),
+		api: "openai-completions",
+		provider: "llm7",
+		baseUrl: "https://api.llm7.io/v1",
+	};
+}
+
+/** In-memory ProviderModelsStore mirroring Pi's native store contract. */
+function makeStore(seed?: ModelsStoreEntry): {
+	store: ProviderModelsStore;
+	written: ModelsStoreEntry[];
+} {
+	let entry = seed;
+	const written: ModelsStoreEntry[] = [];
+	const store: ProviderModelsStore = {
+		read: async () => entry,
+		write: async (e: ModelsStoreEntry) => {
+			entry = e;
+			written.push(e);
+		},
+		delete: async () => {
+			entry = undefined;
+		},
+	};
+	return { store, written };
+}
+
+function ctx(over: Partial<RefreshModelsContext> = {}): RefreshModelsContext {
+	const { store } = makeStore();
+	return {
+		store,
+		allowNetwork: false,
+		...over,
+	} as RefreshModelsContext;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetLlm7ShowPaid.mockReturnValue(false);
+	mockGetLlm7ApiKey.mockReturnValue(undefined);
+	mockApplyHidden.mockImplementation(<T extends { id: string }>(models: T[]) => models);
+	mockGetGlobalFreeOnly.mockReturnValue(true);
+	vi.stubGlobal("fetch", mockFetch);
+});
+
+// ---------------------------------------------------------------------------
+// Provider object shape
+// ---------------------------------------------------------------------------
+
+describe("createLlm7Provider shape", () => {
+	it("builds a native provider with auth, getModels, refreshModels, streams", () => {
+		const { provider } = createLlm7Provider();
+		expect(provider.id).toBe("llm7");
+		expect(provider.name).toBe("LLM7");
+		expect(provider.baseUrl).toBe("https://api.llm7.io/v1");
+		expect(provider.headers).toMatchObject({
+			"User-Agent": "pi-free-providers",
+		});
+		expect(typeof provider.getModels).toBe("function");
+		expect(typeof provider.refreshModels).toBe("function");
+		expect(typeof provider.stream).toBe("function");
+		expect(typeof provider.streamSimple).toBe("function");
+		// Native auth: apiKey only — LLM7 has no OAuth flow.
+		expect(provider.auth.apiKey).toBeDefined();
+		expect(provider.auth.oauth).toBeUndefined();
+		// Empty before the first refresh (dynamic provider contract).
+		expect(provider.getModels()).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Keyless auth (the proof case)
+// ---------------------------------------------------------------------------
+
+describe("keyless auth", () => {
+	it("resolves with an empty auth when no key is configured (public catalog)", async () => {
+		mockGetLlm7ApiKey.mockReturnValue(undefined);
+		const result = await llm7Auth.apiKey?.resolve({
+			ctx: {} as never,
+			credential: undefined,
+		});
+		// Must RESOLVE (not undefined) so Pi's Models.refresh() does not skip
+		// the provider for logged-out users.
+		expect(result).toBeDefined();
+		expect(result?.auth).toEqual({});
+		expect(result?.auth).not.toHaveProperty("apiKey");
+	});
+
+	it("resolves the ambient LLM7_API_KEY when configured", async () => {
+		mockGetLlm7ApiKey.mockReturnValue("sk-llm7");
+		const result = await llm7Auth.apiKey?.resolve({
+			ctx: {} as never,
+			credential: undefined,
+		});
+		expect(result?.auth).toEqual({ apiKey: "sk-llm7" });
+	});
+
+	it("prefers a natively-stored key over the ambient config", async () => {
+		mockGetLlm7ApiKey.mockReturnValue("sk-ambient");
+		const result = await llm7Auth.apiKey?.resolve({
+			ctx: {} as never,
+			credential: { type: "api_key", key: "sk-stored" },
+		});
+		expect(result?.auth).toEqual({ apiKey: "sk-stored" });
+	});
+
+	it("has no apiKey.check that could hide the public catalog", () => {
+		expect(llm7Auth.apiKey).not.toHaveProperty("check");
+	});
+
+	it("keeps the public catalog available without a credential (real Models registry)", async () => {
+		const handle = createLlm7Provider();
+		const { all, free } = fetchLlm7Catalog();
+		handle.ingest(all, free);
+
+		const models = createModels();
+		models.setProvider(handle.provider);
+
+		const available = await models.getAvailable();
+		// Free-only view by default: the default + fast selectors, no key needed.
+		expect(available.map((model) => model.id).sort()).toEqual([
+			"default",
+			"fast",
+		]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Static catalog
+// ---------------------------------------------------------------------------
+
+describe("fetchLlm7Catalog", () => {
+	it("returns the three routing selectors split into all/free", () => {
+		const { all, free } = fetchLlm7Catalog();
+		expect(all.map((m) => m.id)).toEqual(["default", "fast", "pro"]);
+		// Route A pricing detection: pro exposes cost, so free = zero-cost.
+		expect(free.map((m) => m.id)).toEqual(["default", "fast"]);
+	});
+
+	it("applies the hidden_models filter", () => {
+		mockApplyHidden.mockImplementation((models: { id: string }[]) =>
+			models.filter((m) => m.id !== "pro"),
+		);
+		const { all } = fetchLlm7Catalog();
+		expect(mockApplyHidden).toHaveBeenCalled();
+		expect(all.map((m) => m.id)).toEqual(["default", "fast"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// refreshModels: offline init
+// ---------------------------------------------------------------------------
+
+describe("refreshModels offline init", () => {
+	it("restores models from the store with zero network when allowNetwork=false", async () => {
+		const seeded = {
+			models: [nativeCfg("default"), nativeCfg("fast"), nativeCfg("pro", true)],
+			checkedAt: Date.now(),
+		} as unknown as ModelsStoreEntry;
+		const { store } = makeStore(seeded);
+		const { provider } = createLlm7Provider();
+
+		await provider.refreshModels?.(ctx({ store, allowNetwork: false }));
+
+		expect(mockFetch).not.toHaveBeenCalled();
+		// Global free-only on + no show_paid => free selectors only.
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+	});
+
+	it("stays empty when the store is empty and network is disallowed", async () => {
+		const { provider } = createLlm7Provider();
+		await provider.refreshModels?.(ctx({ allowNetwork: false }));
+		expect(mockFetch).not.toHaveBeenCalled();
+		expect(provider.getModels()).toEqual([]);
+	});
+
+	it("ignores stored models from other providers", async () => {
+		const seeded = {
+			models: [{ ...nativeCfg("default"), provider: "other" }],
+		} as unknown as ModelsStoreEntry;
+		const { store } = makeStore(seeded);
+		const { provider } = createLlm7Provider();
+		await provider.refreshModels?.(ctx({ store, allowNetwork: false }));
+		expect(provider.getModels()).toEqual([]);
+	});
+
+	it("survives a failing store read without throwing", async () => {
+		const store: ProviderModelsStore = {
+			read: async () => {
+				throw new Error("disk on fire");
+			},
+			write: async () => {},
+			delete: async () => {},
+		};
+		const { provider } = createLlm7Provider();
+		await expect(
+			provider.refreshModels?.(ctx({ store, allowNetwork: false })),
+		).resolves.toBeUndefined();
+		expect(provider.getModels()).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// refreshModels: online (static catalog — still zero network)
+// ---------------------------------------------------------------------------
+
+describe("refreshModels online", () => {
+	it("publishes the static selector catalog and persists it, with zero network", async () => {
+		const { store, written } = makeStore();
+		const { provider, stored } = createLlm7Provider();
+
+		await provider.refreshModels?.(ctx({ store, allowNetwork: true }));
+
+		// The catalog is static: NO fetch even on the online path.
+		expect(mockFetch).not.toHaveBeenCalled();
+		// Store persisted exactly once with the full catalog.
+		expect(written).toHaveLength(1);
+		expect(written[0].models.map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+		expect(typeof written[0].checkedAt).toBe("number");
+		// Persisted models carry the native wire api + provider + baseUrl.
+		expect(written[0].models.every((m) => m.api === "openai-completions")).toBe(
+			true,
+		);
+		expect(written[0].models.every((m) => m.provider === "llm7")).toBe(true);
+		expect(
+			written[0].models.every((m) => m.baseUrl === "https://api.llm7.io/v1"),
+		).toBe(true);
+		// Catalogs populated for the toggle.
+		expect(stored.all.map((m) => m.id)).toEqual(["default", "fast", "pro"]);
+		expect(stored.free.map((m) => m.id)).toEqual(["default", "fast"]);
+		// Free-only view by default.
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+	});
+
+	it("retains the previous catalog when the build returns nothing (poisoning guard)", async () => {
+		const seeded = {
+			models: [nativeCfg("default")],
+		} as unknown as ModelsStoreEntry;
+		const { store, written } = makeStore(seeded);
+		// Every selector hidden via hidden_models config.
+		mockApplyHidden.mockImplementation(() => []);
+		const { provider } = createLlm7Provider();
+
+		await provider.refreshModels?.(ctx({ store, allowNetwork: true }));
+
+		// Kept the seeded model, did not persist an empty catalog.
+		expect(provider.getModels().map((m) => m.id)).toEqual(["default"]);
+		expect(written).toHaveLength(0);
+	});
+
+	it("does not publish or persist when the signal is already aborted", async () => {
+		const { store, written } = makeStore();
+		const { provider } = createLlm7Provider();
+		const controller = new AbortController();
+		controller.abort();
+
+		await provider.refreshModels?.(
+			ctx({ store, allowNetwork: true, signal: controller.signal }),
+		);
+
+		expect(provider.getModels()).toEqual([]);
+		expect(written).toHaveLength(0);
+	});
+
+	it("publishes models even if persisting to the store fails", async () => {
+		const store: ProviderModelsStore = {
+			read: async () => undefined,
+			write: async () => {
+				throw new Error("read-only fs");
+			},
+			delete: async () => {},
+		};
+		const { provider } = createLlm7Provider();
+
+		await expect(
+			provider.refreshModels?.(ctx({ store, allowNetwork: true })),
+		).resolves.toBeUndefined();
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Toggle interop (setView / decideView)
+// ---------------------------------------------------------------------------
+
+describe("toggle interop", () => {
+	async function seededProvider() {
+		const { store } = makeStore();
+		const handle = createLlm7Provider();
+		await handle.provider.refreshModels?.(ctx({ store, allowNetwork: true }));
+		return handle;
+	}
+
+	it("setView swaps the visible catalog (what /toggle-llm7 and /toggle-free drive)", async () => {
+		const { provider, stored, setView } = await seededProvider();
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+
+		// reRegister(stored.all) -> setView(stored.all) + re-register.
+		setView(stored.all);
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+
+		// And back to free.
+		setView(stored.free);
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+	});
+
+	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
+		mockGetLlm7ShowPaid.mockReturnValue(true);
+		const { provider } = await seededProvider();
+		// show_paid true + global free-only true => all models.
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+	});
+
+	it("decideView shows all when global free-only is off", async () => {
+		mockGetGlobalFreeOnly.mockReturnValue(false);
+		const { provider } = await seededProvider();
+		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+	});
+});

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -1,0 +1,267 @@
+/**
+ * LLM7 factory wiring tests (end-to-end: extension wiring + real native
+ * provider). Mirrors tests/cline.test.ts: verifies the network-free factory,
+ * native registration, keyless registration (no skip when LLM7_API_KEY is
+ * unset), /toggle-llm7, the global /toggle-free re-register hook, the ToS
+ * notice, and the session_start refresh nudge.
+ */
+
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+} from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetLlm7ApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+const mockGetLlm7ShowPaid = vi.hoisted(() => vi.fn(() => false));
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockSaveConfig = vi.hoisted(() =>
+	vi.fn<(...args: unknown[]) => Promise<void>>(),
+);
+const mockRegisterWithGlobalToggle = vi.hoisted(() =>
+	vi.fn<(...args: unknown[]) => void>(),
+);
+const mockFetch = vi.hoisted(() => vi.fn());
+
+let capturedToggleArgs: unknown[][] = [];
+
+vi.mock("../config.ts", () => ({
+	getLlm7ApiKey: () => mockGetLlm7ApiKey(),
+	getLlm7ShowPaid: () => mockGetLlm7ShowPaid(),
+	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+	applyHidden: (models: { id: string }[]) => models,
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	registerWithGlobalToggle: (...args: unknown[]) => {
+		capturedToggleArgs.push(args);
+		mockRegisterWithGlobalToggle(...args);
+	},
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
+}));
+
+vi.mock("../provider-helper.ts", async () => {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../provider-helper.ts",
+	);
+	return { ...actual, enhanceWithCI: (models: unknown[]) => models };
+});
+
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import llm7Provider from "../providers/llm7/llm7.ts";
+
+function makeStore(): ProviderModelsStore {
+	let entry: ModelsStoreEntry | undefined;
+	return {
+		read: async () => entry,
+		write: async (e: ModelsStoreEntry) => {
+			entry = e;
+		},
+		delete: async () => {
+			entry = undefined;
+		},
+	};
+}
+
+describe("LLM7 factory wiring", () => {
+	let mockPi: ExtensionAPI;
+	let mockRegisterProvider: ReturnType<typeof vi.fn>;
+	let mockRegisterCommand: ReturnType<typeof vi.fn>;
+	let mockOn: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedToggleArgs = [];
+		mockGetLlm7ApiKey.mockReturnValue(undefined);
+		mockGetLlm7ShowPaid.mockReturnValue(false);
+		mockGetGlobalFreeOnly.mockReturnValue(true);
+		vi.stubGlobal("fetch", mockFetch);
+
+		mockRegisterProvider = vi.fn();
+		mockRegisterCommand = vi.fn();
+		mockOn = vi.fn();
+		mockPi = {
+			registerProvider: mockRegisterProvider,
+			on: mockOn,
+			registerCommand: mockRegisterCommand,
+		} as unknown as ExtensionAPI;
+	});
+
+	it("factory is network-free and registers the native provider empty — even with no API key", async () => {
+		await llm7Provider(mockPi);
+
+		// The factory never fetches: models load via refreshModels. Unlike the
+		// legacy registration, a missing LLM7_API_KEY does NOT skip the provider.
+		expect(mockFetch).not.toHaveBeenCalled();
+		expect(mockRegisterProvider).toHaveBeenCalledTimes(1);
+		const provider = mockRegisterProvider.mock.calls[0][0];
+		expect(provider.id).toBe("llm7");
+		expect(provider.getModels()).toEqual([]);
+		expect(provider.auth.apiKey).toBeDefined();
+
+		// Lifecycle handlers + toggle command registered.
+		expect(mockOn).toHaveBeenCalledWith("model_select", expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith("session_start", expect.any(Function));
+		expect(
+			mockRegisterCommand.mock.calls.some((c) => c[0] === "toggle-llm7"),
+		).toBe(true);
+	});
+
+	it("registers with the global toggle (hasKey reflects LLM7_API_KEY)", async () => {
+		await llm7Provider(mockPi);
+		expect(capturedToggleArgs).toHaveLength(1);
+		const [providerId, , , hasKey] = capturedToggleArgs[0] as [
+			string,
+			unknown,
+			unknown,
+			boolean,
+		];
+		expect(providerId).toBe("llm7");
+		expect(hasKey).toBe(false);
+
+		mockGetLlm7ApiKey.mockReturnValue("sk-llm7");
+		capturedToggleArgs = [];
+		await llm7Provider(mockPi);
+		expect(
+			(capturedToggleArgs[0] as [string, unknown, unknown, boolean])[3],
+		).toBe(true);
+	});
+
+	it("refreshModels populates; global /toggle-free reRegister republishes the same provider", async () => {
+		await llm7Provider(mockPi);
+		const provider = mockRegisterProvider.mock.calls[0][0];
+
+		expect(capturedToggleArgs).toHaveLength(1);
+		const [, stored, reRegister] = capturedToggleArgs[0] as [
+			string,
+			{ free: unknown[]; all: unknown[] },
+			(models: unknown[]) => void,
+		];
+
+		// Pi refreshes (online) -> static catalogs populate.
+		await provider.refreshModels({ store: makeStore(), allowNetwork: true });
+		expect(stored.all).toHaveLength(3);
+		expect(stored.free).toHaveLength(2);
+
+		// Global /toggle-free showing all -> reRegister(stored.all).
+		mockRegisterProvider.mockClear();
+		reRegister(stored.all);
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+		// Re-registration reused the SAME native provider object (auth preserved).
+		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
+
+		// Global /toggle-free showing free -> reRegister(stored.free).
+		reRegister(stored.free);
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+	});
+
+	it("/toggle-llm7 flips llm7_show_paid and shows the full catalog, then back", async () => {
+		await llm7Provider(mockPi);
+		const provider = mockRegisterProvider.mock.calls[0][0];
+		await provider.refreshModels({ store: makeStore(), allowNetwork: true });
+
+		const call = mockRegisterCommand.mock.calls.find(
+			(c) => c[0] === "toggle-llm7",
+		);
+		if (!call) throw new Error("toggle-llm7 not registered");
+		const notify = vi.fn();
+
+		// First toggle: free -> all.
+		await call[1].handler({}, { ui: { notify } });
+		expect(mockSaveConfig).toHaveBeenCalledWith({ llm7_show_paid: true });
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+		expect(notify).toHaveBeenCalledWith(
+			expect.stringContaining("showing all 3 models"),
+			"info",
+		);
+
+		// Second toggle: all -> free.
+		mockGetLlm7ShowPaid.mockReturnValue(true);
+		notify.mockClear();
+		await call[1].handler({}, { ui: { notify } });
+		expect(mockSaveConfig).toHaveBeenCalledWith({ llm7_show_paid: false });
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
+		expect(notify).toHaveBeenCalledWith(
+			expect.stringContaining("showing 2 free models"),
+			"info",
+		);
+	});
+
+	it("shows the ToS notice once for keyless LLM7 selections, never with a key", async () => {
+		await llm7Provider(mockPi);
+		const handler = mockOn.mock.calls.find(
+			(call) => call[0] === "model_select",
+		)?.[1];
+		expect(handler).toBeDefined();
+		const notify = vi.fn();
+
+		// Keyless: notice fires with the Terms link.
+		await handler({}, { model: { provider: "llm7" }, ui: { notify } });
+		expect(notify).toHaveBeenCalledWith(
+			expect.stringContaining("https://llm7.io/"),
+			"info",
+		);
+
+		// Only once per session.
+		notify.mockClear();
+		await handler({}, { model: { provider: "llm7" }, ui: { notify } });
+		expect(notify).not.toHaveBeenCalled();
+
+		// Other providers never trigger it.
+		const notify2 = vi.fn();
+		await handler({}, { model: { provider: "kilo" }, ui: { notify: notify2 } });
+		expect(notify2).not.toHaveBeenCalled();
+	});
+
+	it("suppresses the ToS notice when LLM7_API_KEY is configured", async () => {
+		mockGetLlm7ApiKey.mockReturnValue("sk-llm7");
+		await llm7Provider(mockPi);
+		const handler = mockOn.mock.calls.find(
+			(call) => call[0] === "model_select",
+		)?.[1];
+		const notify = vi.fn();
+		await handler({}, { model: { provider: "llm7" }, ui: { notify } });
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("session_start nudges the model registry refresh and is safe without one", async () => {
+		await llm7Provider(mockPi);
+		const handler = mockOn.mock.calls.find(
+			(call) => call[0] === "session_start",
+		)?.[1];
+		expect(handler).toBeDefined();
+
+		const refresh = vi.fn().mockResolvedValue(undefined);
+		await handler({}, { modelRegistry: { refresh } });
+		expect(refresh).toHaveBeenCalledWith({ allowNetwork: true });
+
+		// No modelRegistry on the context -> safe no-op.
+		await expect(handler({}, {})).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Migrate LLM7 from legacy registration to a native Pi `Provider`.
- Add native API-key auth that intentionally resolves keyless so LLM7's public free catalog remains visible without credentials.
- Move the static selector catalog (`default`, `fast`, `pro`) through Pi's native models-store `refreshModels` contract with offline initialization and zero network work.
- Preserve LLM7's free/all toggle, global free toggle, hidden-model filtering, CI decoration, ToS notice, endpoint, headers, and OpenAI-compatible streaming.
- Add focused tests for keyless availability, store initialization, poisoning/abort handling, toggles, and factory wiring.

## Validation

- `npm run lint`
- `npm run test:run` — 43 test files, 571 tests passed
- Primary LSP diagnostics clean for all changed files

## Notes

This is the first Phase 1 migration and deliberately proves the keyless-provider auth pattern. No LLM7 API key is required for the catalog or test suite; ZenMux will provide the keyed runtime-validation case after this lands.
