### PR TITLE
feat(zenmux): migrate to native Provider

### DIFF
--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -1,6 +1,7 @@
 import type {
 	Api,
 	Model,
+	Provider,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
 import type {
@@ -12,6 +13,19 @@ import { createLogger } from "./logger.ts";
 import { wrapSessionStartHandler } from "./session-start-metrics.ts";
 
 const _logger = createLogger("native-provider");
+
+/** Compatibility bridge for the native single-argument registrar. */
+export type NativeRegistrar = {
+	registerProvider(provider: Provider): void;
+};
+
+/** Register a native provider across the current dev snapshot and >=0.81 peers. */
+export function registerNativeProvider(
+	pi: ExtensionAPI,
+	provider: Provider,
+): void {
+	(pi as unknown as NativeRegistrar).registerProvider(provider);
+}
 
 interface NativeToggleOptions {
 	providerId: string;
@@ -89,6 +103,25 @@ function logRefreshFailure(providerId: string, error: unknown): void {
 	_logger.warn(`Model refresh nudge failed for ${providerId}`, {
 		error: error instanceof Error ? error.message : String(error),
 	});
+}
+
+/** Restore one provider's catalog from Pi's native models store. */
+export async function restoreNativeProviderModels<T extends Model<Api>>(
+	providerId: string,
+	context: RefreshModelsContext,
+	onModels: (models: T[]) => void,
+): Promise<void> {
+	try {
+		const entry = await context.store.read();
+		const models = (entry?.models ?? []).filter(
+			(model) => model.provider === providerId,
+		) as T[];
+		if (models.length > 0) onModels(models);
+	} catch (err) {
+		_logger.warn(`Failed to read ${providerId} models store; continuing empty`, {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
 }
 
 /** Persist a native provider catalog while retaining the previous store on failure. */

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -65,6 +65,16 @@ export async function fetchWithTimeout(
 ): Promise<Response> {
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+	const upstreamSignal = options.signal;
+	const abortFromUpstream = () => controller.abort(upstreamSignal?.reason);
+
+	if (upstreamSignal?.aborted) {
+		abortFromUpstream();
+	} else {
+		upstreamSignal?.addEventListener("abort", abortFromUpstream, {
+			once: true,
+		});
+	}
 
 	try {
 		const response = await fetch(url, {
@@ -74,6 +84,7 @@ export async function fetchWithTimeout(
 		return response;
 	} finally {
 		clearTimeout(timeoutId);
+		upstreamSignal?.removeEventListener("abort", abortFromUpstream);
 	}
 }
 
@@ -113,6 +124,7 @@ export async function fetchWithRetry(
 			return response; // Return non-ok but non-retryable responses
 		} catch (error) {
 			lastError = error;
+			if (options.signal?.aborted) throw error;
 			if (i < retries - 1) {
 				await sleep(delayMs * (i + 1));
 			}

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -46,15 +46,15 @@ import type {
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
 import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
-import { persistNativeProviderModels } from "../../lib/native-provider.ts";
+import {
+	persistNativeProviderModels,
+	restoreNativeProviderModels,
+} from "../../lib/native-provider.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { clineAuth } from "./cline-auth.ts";
 import { fetchClineCatalog, toClineModels } from "./cline-models.ts";
 import { streamClineXml } from "./cline-xml-bridge.ts";
-
-const _logger = createLogger("cline");
 
 type ClineModel = Model<"cline-xml-tools">;
 
@@ -163,25 +163,20 @@ export function createClineProvider(): ClineNativeProvider {
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
-		// Offline init / cache restore: always read the store first so a warm
-		// startup shows models with zero network.
-		try {
-			const entry = await context.store.read();
-			const storedModels = (entry?.models ?? []).filter(
-				(m) => m.provider === PROVIDER_CLINE,
-			) as ClineModel[];
-			if (storedModels.length > 0) {
+		await restoreNativeProviderModels(
+			PROVIDER_CLINE,
+			context,
+			(storedModels: ClineModel[]) => {
 				stored.all = storedModels;
-				stored.free = storedModels.filter((m) =>
-					isFreeModel({ ...m, provider: PROVIDER_CLINE }, storedModels),
+				stored.free = storedModels.filter((model) =>
+					isFreeModel(
+						{ ...model, provider: PROVIDER_CLINE },
+						storedModels,
+					),
 				);
 				setView(decideView());
-			}
-		} catch (err) {
-			_logger.warn("Failed to read models store; continuing empty", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
+			},
+		);
 
 		// Offline init stops here: serve the store only.
 		if (!context.allowNetwork || context.signal?.aborted) return;

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -20,7 +20,6 @@
  * paid catalog.
  */
 
-import type { Provider } from "@earendil-works/pi-ai/compat";
 import {
 	readStoredCredential,
 	type ExtensionAPI,
@@ -34,6 +33,7 @@ import {
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import {
+	registerNativeProvider,
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
@@ -41,29 +41,6 @@ import { isOAuthCredential } from "../../provider-helper.ts";
 import { createClineProvider, rotateClineTaskId } from "./cline-provider.ts";
 
 const _logger = createLogger("cline");
-
-// =============================================================================
-// Native provider registration
-// =============================================================================
-
-/**
- * The >=0.81 `registerProvider(provider: Provider)` single-argument overload.
- * The dev lockfile predates it (its ExtensionAPI only types the legacy
- * `(name, config)` form), so we bridge the type here; the declared peer range
- * (>=0.81) guarantees the overload exists at runtime. Re-registering the same
- * provider object upserts by id, which is how the free/paid toggle republishes a
- * new visible catalog without dropping native auth.
- */
-type NativeRegistrar = {
-	registerProvider(provider: Provider): void;
-};
-
-function registerNative(
-	pi: ExtensionAPI,
-	provider: Provider<"cline-xml-tools">,
-): void {
-	(pi as unknown as NativeRegistrar).registerProvider(provider);
-}
 
 // =============================================================================
 // Credential inspection (non-destructive)
@@ -126,14 +103,14 @@ export default async function clineProvider(pi: ExtensionAPI) {
 	// load via refreshModels (offline init from the store, then a background
 	// fetch of the public catalog), so Cline no longer owns any of Pi's startup
 	// critical path.
-	registerNative(pi, provider);
+	registerNativeProvider(pi, provider);
 
 	// Re-registration republishes the same native provider object (upsert by id)
 	// with a new visible catalog, keeping native auth intact. This is the hook the
 	// global /toggle-free system and /toggle-cline drive.
 	const reRegister = (models: ProviderModelConfig[]) => {
 		setView(models);
-		registerNative(pi, provider);
+		registerNativeProvider(pi, provider);
 	};
 
 	const hasClineKey = !!getClineApiKey();

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -40,9 +40,11 @@ import {
 	getKiloShowPaid,
 } from "../../config.ts";
 import { PROVIDER_KILO } from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
 import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
-import { persistNativeProviderModels } from "../../lib/native-provider.ts";
+import {
+	persistNativeProviderModels,
+	restoreNativeProviderModels,
+} from "../../lib/native-provider.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { kiloAuth } from "./kilo-auth.ts";
 import {
@@ -51,8 +53,6 @@ import {
 	KILO_GATEWAY_BASE,
 	toKiloModels,
 } from "./kilo-models.ts";
-
-const _logger = createLogger("kilo");
 
 type KiloModel = Model<"openai-completions">;
 
@@ -117,25 +117,20 @@ export function createKiloProvider(): KiloNativeProvider {
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
-		// Offline init / cache restore: always read the store first so a warm
-		// startup shows models with zero network.
-		try {
-			const entry = await context.store.read();
-			const storedModels = (entry?.models ?? []).filter(
-				(m) => m.provider === PROVIDER_KILO,
-			) as KiloModel[];
-			if (storedModels.length > 0) {
+		await restoreNativeProviderModels(
+			PROVIDER_KILO,
+			context,
+			(storedModels: KiloModel[]) => {
 				stored.all = storedModels;
-				stored.free = storedModels.filter((m) =>
-					isFreeModel({ ...m, provider: PROVIDER_KILO }, storedModels),
+				stored.free = storedModels.filter((model) =>
+					isFreeModel(
+						{ ...model, provider: PROVIDER_KILO },
+						storedModels,
+					),
 				);
 				setView(decideView());
-			}
-		} catch (err) {
-			_logger.warn("Failed to read models store; continuing empty", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
+			},
+		);
 
 		// Offline init stops here: serve the store only.
 		if (!context.allowNetwork || context.signal?.aborted) return;

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -16,7 +16,6 @@
  * Run /login kilo or use /toggle-kilo to access paid models.
  */
 
-import type { Provider } from "@earendil-works/pi-ai/compat";
 import {
 	readStoredCredential,
 	type ExtensionAPI,
@@ -31,6 +30,7 @@ import { URL_KILO_TOS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import {
+	registerNativeProvider,
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
@@ -143,29 +143,6 @@ function parseXmlToolCalls(
 }
 
 // =============================================================================
-// Native provider registration
-// =============================================================================
-
-/**
- * The >=0.81 `registerProvider(provider: Provider)` single-argument overload.
- * The dev lockfile predates it (its ExtensionAPI only types the legacy
- * `(name, config)` form), so we bridge the type here; the declared peer range
- * (>=0.81) guarantees the overload exists at runtime. Re-registering the same
- * provider object upserts by id, which is how the free/paid toggle republishes a
- * new visible catalog without dropping native auth.
- */
-type NativeRegistrar = {
-	registerProvider(provider: Provider): void;
-};
-
-function registerNative(
-	pi: ExtensionAPI,
-	provider: Provider<"openai-completions">,
-): void {
-	(pi as unknown as NativeRegistrar).registerProvider(provider);
-}
-
-// =============================================================================
 // Credential migration (non-destructive)
 // =============================================================================
 
@@ -225,14 +202,14 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	// Register the native provider. The factory performs NO network I/O: models
 	// load via refreshModels (offline init from the store, then a background
 	// fetch), so Kilo no longer owns any of Pi's startup critical path.
-	registerNative(pi, provider);
+	registerNativeProvider(pi, provider);
 
 	// Re-registration republishes the same native provider object (upsert by id)
 	// with a new visible catalog, keeping native auth intact. This is the hook the
 	// global /toggle-free system and /toggle-kilo drive.
 	const reRegister = (models: ProviderModelConfig[]) => {
 		setView(models);
-		registerNative(pi, provider);
+		registerNativeProvider(pi, provider);
 	};
 
 	const hasKiloKey = !!getKiloApiKey();

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -43,14 +43,14 @@ import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getLlm7ShowPaid } from "../../config.ts";
 import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
 import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
-import { persistNativeProviderModels } from "../../lib/native-provider.ts";
+import {
+	persistNativeProviderModels,
+	restoreNativeProviderModels,
+} from "../../lib/native-provider.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { llm7Auth } from "./llm7-auth.ts";
 import { fetchLlm7Catalog, toLlm7Models } from "./llm7-models.ts";
-
-const _logger = createLogger("llm7");
 
 type Llm7Model = Model<"openai-completions">;
 
@@ -110,25 +110,20 @@ export function createLlm7Provider(): Llm7NativeProvider {
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
-		// Offline init / cache restore: always read the store first so a warm
-		// startup shows models with zero network.
-		try {
-			const entry = await context.store.read();
-			const storedModels = (entry?.models ?? []).filter(
-				(m) => m.provider === PROVIDER_LLM7,
-			) as Llm7Model[];
-			if (storedModels.length > 0) {
+		await restoreNativeProviderModels(
+			PROVIDER_LLM7,
+			context,
+			(storedModels: Llm7Model[]) => {
 				stored.all = storedModels;
-				stored.free = storedModels.filter((m) =>
-					isFreeModel({ ...m, provider: PROVIDER_LLM7 }, storedModels),
+				stored.free = storedModels.filter((model) =>
+					isFreeModel(
+						{ ...model, provider: PROVIDER_LLM7 },
+						storedModels,
+					),
 				);
 				setView(decideView());
-			}
-		} catch (err) {
-			_logger.warn("Failed to read models store; continuing empty", {
-				error: err instanceof Error ? err.message : String(err),
-			});
-		}
+			},
+		);
 
 		// Offline init stops here: serve the store only.
 		if (!context.allowNetwork || context.signal?.aborted) return;

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -47,7 +47,6 @@
  *   # Models appear in /model selector as "llm7/default", "llm7/fast", "llm7/pro"
  */
 
-import type { Provider } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
@@ -56,33 +55,11 @@ import { getLlm7ApiKey, getLlm7ShowPaid } from "../../config.ts";
 import { PROVIDER_LLM7 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import {
+	registerNativeProvider,
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
 import { createLlm7Provider } from "./llm7-provider.ts";
-
-// =============================================================================
-// Native provider registration
-// =============================================================================
-
-/**
- * The >=0.81 `registerProvider(provider: Provider)` single-argument overload.
- * The dev lockfile predates it (its ExtensionAPI only types the legacy
- * `(name, config)` form), so we bridge the type here; the declared peer range
- * (>=0.81) guarantees the overload exists at runtime. Re-registering the same
- * provider object upserts by id, which is how the free/paid toggle republishes a
- * new visible catalog without dropping native auth.
- */
-type NativeRegistrar = {
-	registerProvider(provider: Provider): void;
-};
-
-function registerNative(
-	pi: ExtensionAPI,
-	provider: Provider<"openai-completions">,
-): void {
-	(pi as unknown as NativeRegistrar).registerProvider(provider);
-}
 
 // =============================================================================
 // Extension entry point
@@ -95,14 +72,14 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 	// load via refreshModels (offline init from the store, then a background
 	// refresh of the static selector catalog), so LLM7 no longer owns any of
 	// Pi's startup critical path.
-	registerNative(pi, provider);
+	registerNativeProvider(pi, provider);
 
 	// Re-registration republishes the same native provider object (upsert by id)
 	// with a new visible catalog, keeping native auth intact. This is the hook the
 	// global /toggle-free system and /toggle-llm7 drive.
 	const reRegister = (models: ProviderModelConfig[]) => {
 		setView(models);
-		registerNative(pi, provider);
+		registerNativeProvider(pi, provider);
 	};
 
 	const hasLlm7Key = !!getLlm7ApiKey();

--- a/providers/zenmux/zenmux-auth.ts
+++ b/providers/zenmux/zenmux-auth.ts
@@ -1,0 +1,39 @@
+/** Native API-key authentication for ZenMux. */
+
+import type {
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	ProviderAuth,
+} from "@earendil-works/pi-ai/compat";
+import { getZenmuxApiKey } from "../../config.ts";
+
+async function resolveZenmuxApiKey(input: {
+	ctx: AuthContext;
+	credential?: ApiKeyCredential;
+}): Promise<AuthResult | undefined> {
+	const key = input.credential?.key ?? getZenmuxApiKey();
+	if (!key) return undefined;
+	return {
+		auth: { apiKey: key },
+		source: input.credential?.key ? "stored API key" : "ZENMUX_API_KEY",
+	};
+}
+
+export const zenmuxApiKeyAuth: ApiKeyAuth = {
+	name: "ZenMux API key",
+	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+		const key = await interaction.prompt({
+			type: "secret",
+			message: "ZenMux API key",
+		});
+		return { type: "api_key", key };
+	},
+	resolve: resolveZenmuxApiKey,
+};
+
+export const zenmuxAuth: ProviderAuth = {
+	apiKey: zenmuxApiKeyAuth,
+};

--- a/providers/zenmux/zenmux-models.ts
+++ b/providers/zenmux/zenmux-models.ts
@@ -1,0 +1,130 @@
+import type { Model } from "@earendil-works/pi-ai/compat";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import {
+	BASE_URL_ZENMUX,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_ZENMUX,
+} from "../../constants.ts";
+import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
+import { getProxyModelCompat } from "../../lib/provider-compat.ts";
+import { isFreeModel } from "../../lib/registry.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { createLogger } from "../../lib/logger.ts";
+
+const _logger = createLogger("zenmux-models");
+
+export interface ZenMuxModel {
+	id: string;
+	display_name?: string;
+	context_length?: number;
+	input_modalities?: string[];
+	output_modalities?: string[];
+	capabilities?: {
+		reasoning?: boolean;
+	};
+	pricings?: {
+		prompt?: Array<{ value: number }>;
+		completion?: Array<{ value: number }>;
+		input_cache_read?: Array<{ value: number }>;
+	};
+}
+
+/** Extract ZenMux's per-million-token price as a per-token Pi cost. */
+export function extractZenmuxPrice(
+	pricings: ZenMuxModel["pricings"],
+	key: "prompt" | "completion" | "input_cache_read",
+): number {
+	const entries = pricings?.[key];
+	if (!entries || entries.length === 0) return 0;
+	return (entries[0].value ?? 0) / 1_000_000;
+}
+
+/** Fetch and convert the authenticated ZenMux catalog. */
+export async function fetchZenmuxCatalog(options: {
+	token?: string;
+	signal?: AbortSignal;
+}): Promise<{ all: ProviderModelConfig[]; free: ProviderModelConfig[] }> {
+	if (!options.token || options.signal?.aborted) {
+		return { all: [], free: [] };
+	}
+
+	try {
+		const response = await fetchWithRetry(
+			`${BASE_URL_ZENMUX}/models`,
+			{
+				headers: {
+					Authorization: `Bearer ${options.token}`,
+					"Content-Type": "application/json",
+				},
+				signal: options.signal,
+			},
+			3,
+			1000,
+			DEFAULT_FETCH_TIMEOUT_MS,
+		);
+
+		if (!response.ok) {
+			throw new Error(`ZenMux API error: ${response.status}`);
+		}
+
+		const data = (await response.json()) as { data?: ZenMuxModel[] };
+		const mapped = (data.data ?? []).map((model) => {
+			const hasPricings = model.pricings !== undefined;
+			return {
+				id: model.id,
+				name: model.display_name || model.id,
+				reasoning: model.capabilities?.reasoning ?? false,
+				input: model.input_modalities?.includes("image")
+					? ["text", "image"]
+					: ["text"],
+				cost: {
+					input: extractZenmuxPrice(model.pricings, "prompt"),
+					output: extractZenmuxPrice(model.pricings, "completion"),
+					cacheRead: extractZenmuxPrice(
+						model.pricings,
+						"input_cache_read",
+					),
+					cacheWrite: 0,
+				},
+				contextWindow: model.context_length || 128000,
+				maxTokens: model.context_length
+					? Math.floor(model.context_length / 2)
+					: 4096,
+				compat: getProxyModelCompat(model),
+				_pricingKnown: hasPricings,
+			} as ProviderModelConfig & { _pricingKnown?: boolean };
+		});
+
+		const visible = applyHidden(mapped, PROVIDER_ZENMUX);
+		const all = await safeEnrichModelsWithModelsDev(visible, {
+			providerId: PROVIDER_ZENMUX,
+		});
+		const free = all.filter((model) =>
+			isFreeModel({ ...model, provider: PROVIDER_ZENMUX }, all),
+		);
+		return { all, free };
+	} catch (error) {
+		_logger.error("Failed to fetch ZenMux models", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { all: [], free: [] };
+	}
+}
+
+export function toZenmuxModel(
+	model: ProviderModelConfig,
+): Model<"openai-completions"> {
+	return {
+		...model,
+		api: "openai-completions",
+		provider: PROVIDER_ZENMUX,
+		baseUrl: model.baseUrl ?? BASE_URL_ZENMUX,
+	} as Model<"openai-completions">;
+}
+
+export function toZenmuxModels(
+	models: ProviderModelConfig[],
+): Model<"openai-completions">[] {
+	return models.map(toZenmuxModel);
+}

--- a/providers/zenmux/zenmux-provider.ts
+++ b/providers/zenmux/zenmux-provider.ts
@@ -1,0 +1,116 @@
+import type {
+	Api,
+	Credential,
+	Model,
+	Provider,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
+import { BASE_URL_ZENMUX, PROVIDER_ZENMUX } from "../../constants.ts";
+import {
+	persistNativeProviderModels,
+	restoreNativeProviderModels,
+} from "../../lib/native-provider.ts";
+import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
+import { zenmuxAuth } from "./zenmux-auth.ts";
+import { fetchZenmuxCatalog, toZenmuxModels } from "./zenmux-models.ts";
+
+type ZenmuxModel = Model<"openai-completions">;
+
+export interface ZenmuxNativeProvider {
+	provider: Provider<"openai-completions">;
+	stored: StoredModels;
+	setView: (models: ProviderModelConfig[]) => void;
+	ingest: (
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	) => void;
+}
+
+function credentialToken(credential?: Credential): string | undefined {
+	if (!credential) return getZenmuxApiKey();
+	if (credential.type === "api_key") {
+		return credential.key ?? getZenmuxApiKey();
+	}
+	return getZenmuxApiKey();
+}
+
+export function createZenmuxProvider(): ZenmuxNativeProvider {
+	const streams = openAICompletionsApi();
+	const stored: StoredModels = { free: [], all: [] };
+	let currentView: ZenmuxModel[] = [];
+
+	function decideView(): ProviderModelConfig[] {
+		if (!getGlobalFreeOnly()) {
+			return stored.all.length > 0 ? stored.all : stored.free;
+		}
+		const showPaid = getZenmuxShowPaid();
+		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
+	}
+
+	function setView(models: ProviderModelConfig[]): void {
+		currentView = toZenmuxModels(models);
+	}
+
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
+		stored.all = toZenmuxModels(enhanceWithCI(all));
+		stored.free = toZenmuxModels(enhanceWithCI(free));
+		setView(decideView());
+	}
+
+	async function refreshModels(context: RefreshModelsContext): Promise<void> {
+		await restoreNativeProviderModels(
+			PROVIDER_ZENMUX,
+			context,
+			(storedModels: ZenmuxModel[]) => {
+				stored.all = storedModels;
+				stored.free = storedModels.filter((model) =>
+					isFreeModel(
+						{ ...model, provider: PROVIDER_ZENMUX },
+						storedModels,
+					),
+				);
+				setView(decideView());
+			},
+		);
+
+		if (!context.allowNetwork || context.signal?.aborted) return;
+
+		const { all, free } = await fetchZenmuxCatalog({
+			token: credentialToken(context.credential),
+			signal: context.signal,
+		});
+		if (context.signal?.aborted || all.length === 0) return;
+
+		ingest(all, free);
+		await persistNativeProviderModels(
+			PROVIDER_ZENMUX,
+			context,
+			stored.all as unknown as readonly Model<Api>[],
+		);
+	}
+
+	const provider: Provider<"openai-completions"> = {
+		id: PROVIDER_ZENMUX,
+		name: "ZenMux",
+		baseUrl: BASE_URL_ZENMUX,
+		headers: {
+			"User-Agent": "pi-free-providers",
+		},
+		auth: zenmuxAuth,
+		getModels: () => currentView,
+		refreshModels,
+		stream: (model, context, options) =>
+			streams.stream(model, context, options),
+		streamSimple: (model, context, options) =>
+			streams.streamSimple(model, context, options),
+	};
+
+	return { provider, stored, setView, ingest };
+}

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -1,207 +1,50 @@
 /**
  * ZenMux Provider Extension
  *
- * Provides access to ZenMux AI gateway - unified API for 200+ models from
- * OpenAI, Anthropic, Google, and other providers.
+ * ZenMux is an OpenAI-compatible gateway for models from multiple providers.
+ * It is registered as a native Pi Provider so Pi owns credential resolution,
+ * models-store persistence, refresh throttling, and offline initialization.
  *
  * Setup:
- *   1. Get API key from https://zenmux.ai
- *   2. Set ZENMUX_API_KEY env var or add to ~/.pi/free.json
- *
- * Responds to global free-only filter.
- *
- * Usage:
- *   pi install git:github.com/apmantza/pi-free
- *   # Set ZENMUX_API_KEY env var
- *   # Models appear in /model selector
+ *   1. Get an API key from https://zenmux.ai
+ *   2. Set ZENMUX_API_KEY or add zenmux_api_key to ~/.pi/free.json
  */
 
+import type { Provider } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
+import { PROVIDER_ZENMUX } from "../../constants.ts";
 import {
-	BASE_URL_ZENMUX,
-	DEFAULT_FETCH_TIMEOUT_MS,
-	PROVIDER_ZENMUX,
-} from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
-import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
-import { getProxyModelCompat } from "../../lib/provider-compat.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
-import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
-
-const _logger = createLogger("zenmux");
-
-// =============================================================================
-// Fetch ZenMux models
-// =============================================================================
-
-interface ZenMuxModel {
-	id: string;
-	display_name?: string;
-	context_length?: number;
-	input_modalities?: string[];
-	output_modalities?: string[];
-	capabilities?: {
-		reasoning?: boolean;
-	};
-	pricings?: {
-		prompt?: Array<{ value: number }>;
-		completion?: Array<{ value: number }>;
-		input_cache_read?: Array<{ value: number }>;
-	};
-}
-
-/**
- * Extract the first pricing value from a ZenMux pricings array.
- * ZenMux uses a structured format: pricings.prompt[0].value (per-million-tokens).
- * We divide by 1_000_000 to convert to per-token price (Pi's convention).
- * Returns 0 if pricing is missing or empty.
- */
-function extractZenmuxPrice(
-	pricings: ZenMuxModel["pricings"],
-	key: "prompt" | "completion" | "input_cache_read",
-): number {
-	const entries = pricings?.[key];
-	if (!entries || entries.length === 0) return 0;
-	return (entries[0].value ?? 0) / 1_000_000;
-}
-
-async function fetchZenmuxModels(
-	apiKey: string,
-): Promise<ProviderModelConfig[]> {
-	_logger.info("[zenmux] Fetching models from ZenMux API...");
-
-	try {
-		const response = await fetchWithRetry(
-			`${BASE_URL_ZENMUX}/models`,
-			{
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-					"Content-Type": "application/json",
-				},
-			},
-			3,
-			1000,
-			DEFAULT_FETCH_TIMEOUT_MS,
-		);
-
-		if (!response.ok) {
-			throw new Error(`ZenMux API error: ${response.status}`);
-		}
-
-		const data = (await response.json()) as { data?: ZenMuxModel[] };
-		const models = data.data ?? [];
-
-		_logger.info(`[zenmux] Fetched ${models.length} models`);
-
-		const mapped = models.map((m) => {
-			const hasPricings = m.pricings !== undefined;
-			return {
-				id: m.id,
-				name: m.display_name || m.id,
-				reasoning: m.capabilities?.reasoning ?? false,
-				input: m.input_modalities?.includes("image")
-					? ["text", "image"]
-					: ["text"],
-				cost: {
-					input: extractZenmuxPrice(m.pricings, "prompt"),
-					output: extractZenmuxPrice(m.pricings, "completion"),
-					cacheRead: extractZenmuxPrice(m.pricings, "input_cache_read"),
-					cacheWrite: 0,
-				},
-				contextWindow: m.context_length || 128000,
-				maxTokens: m.context_length ? Math.floor(m.context_length / 2) : 4096,
-				compat: getProxyModelCompat(m),
-				_pricingKnown: hasPricings,
-			} as ProviderModelConfig & { _pricingKnown?: boolean };
-		});
-
-		return await safeEnrichModelsWithModelsDev(mapped, {
-			providerId: PROVIDER_ZENMUX,
-		});
-	} catch (error) {
-		_logger.error("[zenmux] Failed to fetch models:", {
-			error: error instanceof Error ? error.message : String(error),
-		});
-		return [];
-	}
-}
-
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
+	registerNativeProvider,
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
+import { registerWithGlobalToggle } from "../../lib/registry.ts";
+import { createZenmuxProvider } from "./zenmux-provider.ts";
 
 export default async function zenmuxProvider(pi: ExtensionAPI) {
-	const apiKey = getZenmuxApiKey();
+	const { provider, stored, setView } = createZenmuxProvider();
+	registerNativeProvider(pi, provider as Provider);
 
-	if (!apiKey) {
-		_logger.info(
-			"[zenmux] Skipping - ZENMUX_API_KEY not set (env var or ~/.pi/free.json)",
-		);
-		return;
-	}
+	const reRegister = (models: ProviderModelConfig[]) => {
+		setView(models);
+		registerNativeProvider(pi, provider as Provider);
+	};
 
-	// Fetch models
-	const allModels = await loadCachedOrFetchModels(PROVIDER_ZENMUX, () =>
-		fetchZenmuxModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[zenmux] No models available");
-		return;
-	}
-
-	// Use isFreeModel with allModels for proper detection
-	// ZenMux exposes pricing, so Route A (OR logic) will be used:
-	// FREE if cost=0 OR "free" in name
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_ZENMUX }, allModels),
-	);
-
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[zenmux] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_ZENMUX,
-		baseUrl: BASE_URL_ZENMUX,
-		apiKey,
-	});
-
-	// Register with global toggle
-	registerWithGlobalToggle(PROVIDER_ZENMUX, stored, reRegister, true);
-
-	// Setup provider with toggle command
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_ZENMUX,
-			initialShowPaid: getZenmuxShowPaid(),
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
-		},
+	registerWithGlobalToggle(
+		PROVIDER_ZENMUX,
 		stored,
+		reRegister,
+		Boolean(getZenmuxApiKey()),
 	);
-
-	// Initial registration — respect persisted toggle state
-	const showPaid = getZenmuxShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_ZENMUX,
+		stored,
+		getShowPaid: getZenmuxShowPaid,
+		reRegister,
+	});
+	registerNativeProviderRefresh(pi, PROVIDER_ZENMUX);
 }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -354,6 +354,28 @@ describe("Utility Functions", () => {
 				}),
 			);
 		});
+
+		it("propagates an upstream abort signal", async () => {
+			const controller = new AbortController();
+			const fetchMock = vi.fn(
+				(_url: string | Request | URL, options?: RequestInit) =>
+					new Promise<Response>((_resolve, reject) => {
+						options?.signal?.addEventListener("abort", () =>
+							reject(new Error("aborted")),
+						);
+					}),
+			);
+			globalThis.fetch = fetchMock;
+
+			const request = fetchWithTimeout(
+				"https://api.example.com/data",
+				{ signal: controller.signal },
+				5000,
+			);
+			controller.abort();
+
+			await expect(request).rejects.toThrow("aborted");
+		});
 	});
 
 	describe("fetchWithRetry", () => {

--- a/tests/zenmux-auth.test.ts
+++ b/tests/zenmux-auth.test.ts
@@ -1,0 +1,58 @@
+import type { AuthInteraction } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it, vi } from "vitest";
+
+const mockGetZenmuxApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+
+vi.mock("../config.ts", () => ({
+	getZenmuxApiKey: () => mockGetZenmuxApiKey(),
+}));
+
+import { zenmuxAuth } from "../providers/zenmux/zenmux-auth.ts";
+
+describe("ZenMux native API-key auth", () => {
+	it("returns undefined when no credential or ambient key exists", async () => {
+		mockGetZenmuxApiKey.mockReturnValue(undefined);
+		expect(
+			await zenmuxAuth.apiKey?.resolve({
+				ctx: {} as never,
+				credential: undefined,
+			}),
+		).toBeUndefined();
+	});
+
+	it("uses the ambient ZenMux key", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
+		expect(
+			await zenmuxAuth.apiKey?.resolve({
+				ctx: {} as never,
+				credential: undefined,
+			}),
+		).toMatchObject({ auth: { apiKey: "sk-ambient" } });
+	});
+
+	it("prefers a natively stored key", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
+		expect(
+			await zenmuxAuth.apiKey?.resolve({
+				ctx: {} as never,
+				credential: { type: "api_key", key: "sk-stored" },
+			}),
+		).toMatchObject({ auth: { apiKey: "sk-stored" } });
+	});
+
+	it("prompts for a key through native login", async () => {
+		const prompt = vi.fn().mockResolvedValue("sk-prompted");
+		const login = zenmuxAuth.apiKey?.login;
+		if (!login) throw new Error("ZenMux native login is unavailable");
+		const credential = await login({
+			prompt,
+		} as unknown as AuthInteraction);
+		expect(prompt).toHaveBeenCalledWith({
+			type: "secret",
+			message: "ZenMux API key",
+		});
+		expect(credential).toEqual({ type: "api_key", key: "sk-prompted" });
+	});
+});

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -1,0 +1,295 @@
+import { createModels } from "@earendil-works/pi-ai";
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetZenmuxApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+const mockGetZenmuxShowPaid = vi.hoisted(() => vi.fn(() => false));
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockApplyHidden = vi.hoisted(() =>
+	vi.fn((models: { id: string }[], _providerId?: string) => models),
+);
+const mockFetchWithRetry = vi.hoisted(() => vi.fn());
+
+vi.mock("../config.ts", () => ({
+	getZenmuxApiKey: () => mockGetZenmuxApiKey(),
+	getZenmuxShowPaid: () => mockGetZenmuxShowPaid(),
+	applyHidden: (models: { id: string }[], providerId?: string) =>
+		mockApplyHidden(models, providerId),
+	saveConfig: vi.fn(),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
+		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
+}));
+
+vi.mock("../lib/util.ts", () => ({
+	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+}));
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T[]) => models,
+}));
+
+vi.mock("../lib/provider-compat.ts", () => ({
+	getProxyModelCompat: () => undefined,
+}));
+
+vi.mock("../provider-helper.ts", async () => {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../provider-helper.ts",
+	);
+	return {
+		...actual,
+		enhanceWithCI: (models: unknown[]) => models,
+	};
+});
+
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import { zenmuxAuth } from "../providers/zenmux/zenmux-auth.ts";
+import { fetchZenmuxCatalog } from "../providers/zenmux/zenmux-models.ts";
+import { createZenmuxProvider } from "../providers/zenmux/zenmux-provider.ts";
+
+function nativeModel(id: string, paid = false) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: {
+			input: paid ? 0.000001 : 0,
+			output: paid ? 0.000002 : 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 32_000,
+		maxTokens: 16_000,
+		api: "openai-completions",
+		provider: "zenmux",
+		baseUrl: "https://zenmux.ai/api/v1",
+	};
+}
+
+function makeStore(seed?: ModelsStoreEntry): {
+	store: ProviderModelsStore;
+	written: ModelsStoreEntry[];
+} {
+	let entry = seed;
+	const written: ModelsStoreEntry[] = [];
+	return {
+		store: {
+			read: async () => entry,
+			write: async (next: ModelsStoreEntry) => {
+				entry = next;
+				written.push(next);
+			},
+			delete: async () => {
+				entry = undefined;
+			},
+		},
+		written,
+	};
+}
+
+function context(
+	store: ProviderModelsStore,
+	overrides: Partial<RefreshModelsContext> = {},
+): RefreshModelsContext {
+	return { store, allowNetwork: false, ...overrides } as RefreshModelsContext;
+}
+
+function response(data: unknown) {
+	return {
+		ok: true,
+		status: 200,
+		json: async () => ({ data }),
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetZenmuxApiKey.mockReturnValue(undefined);
+	mockGetZenmuxShowPaid.mockReturnValue(false);
+	mockGetGlobalFreeOnly.mockReturnValue(true);
+	mockApplyHidden.mockImplementation((models) => models);
+});
+
+describe("createZenmuxProvider", () => {
+	it("builds a keyed native provider", async () => {
+		const { provider } = createZenmuxProvider();
+		expect(provider.id).toBe("zenmux");
+		expect(provider.name).toBe("ZenMux");
+		expect(provider.baseUrl).toBe("https://zenmux.ai/api/v1");
+		expect(provider.auth.apiKey).toBeDefined();
+		expect(provider.auth.oauth).toBeUndefined();
+		expect(provider.getModels()).toEqual([]);
+
+		const models = createModels();
+		models.setProvider(provider);
+		expect(await models.getAvailable()).toEqual([]);
+		// Keyed providers must not appear authenticated without a credential.
+		expect(
+			await zenmuxAuth.apiKey?.resolve({ ctx: {} as never }),
+		).toBeUndefined();
+	});
+
+	it("restores the native store offline without network", async () => {
+		const { store } = makeStore({
+			models: [nativeModel("free"), nativeModel("paid", true)],
+			checkedAt: Date.now(),
+		} as unknown as ModelsStoreEntry);
+		const { provider } = createZenmuxProvider();
+
+		await provider.refreshModels?.(context(store));
+
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+		expect(provider.getModels().map((model) => model.id)).toEqual(["free"]);
+	});
+
+	it("fetches with the effective stored key and persists the catalog", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
+		mockFetchWithRetry.mockResolvedValue(
+			response([
+				{
+					id: "free-model",
+					display_name: "Free Model",
+					context_length: 64_000,
+					input_modalities: ["text"],
+					pricings: {
+						prompt: [{ value: 0 }],
+						completion: [{ value: 0 }],
+					},
+				},
+				{
+					id: "paid-model",
+					context_length: 128_000,
+					input_modalities: ["text", "image"],
+					pricings: {
+						prompt: [{ value: 1 }],
+						completion: [{ value: 2 }],
+					},
+				},
+			]),
+		);
+		const { store, written } = makeStore();
+		const { provider, stored } = createZenmuxProvider();
+
+		await provider.refreshModels?.(
+			context(store, {
+				allowNetwork: true,
+				credential: { type: "api_key", key: "sk-stored" },
+			}),
+		);
+
+		expect(mockFetchWithRetry).toHaveBeenCalledWith(
+			"https://zenmux.ai/api/v1/models",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer sk-stored",
+				}),
+			}),
+			3,
+			1000,
+			10_000,
+		);
+		expect(stored.all).toHaveLength(2);
+		expect(stored.free).toHaveLength(1);
+		expect(written).toHaveLength(1);
+		expect(written[0].models.map((model) => model.id)).toEqual([
+			"free-model",
+			"paid-model",
+		]);
+		expect(provider.getModels().map((model) => model.id)).toEqual([
+			"free-model",
+		]);
+	});
+
+	it("applies hidden models before publishing", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
+		mockApplyHidden.mockImplementation((models: { id: string }[]) =>
+			models.filter((model) => model.id !== "hidden"),
+		);
+		mockFetchWithRetry.mockResolvedValue(
+			response([
+				{ id: "visible", pricings: { prompt: [{ value: 0 }] } },
+				{ id: "hidden", pricings: { prompt: [{ value: 0 }] } },
+			]),
+		);
+		const { store } = makeStore();
+		const handle = createZenmuxProvider();
+
+		await handle.provider.refreshModels?.(context(store, { allowNetwork: true }));
+		expect(mockApplyHidden).toHaveBeenCalledWith(
+			expect.any(Array),
+			"zenmux",
+		);
+		expect(handle.stored.all.map((model) => model.id)).toEqual(["visible"]);
+	});
+
+	it("retains the previous catalog when the fetch is empty", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
+		mockFetchWithRetry.mockResolvedValue(response([]));
+		const { store, written } = makeStore({
+			models: [nativeModel("existing")],
+			checkedAt: Date.now(),
+		} as unknown as ModelsStoreEntry);
+		const { provider } = createZenmuxProvider();
+
+		await provider.refreshModels?.(context(store, { allowNetwork: true }));
+
+		expect(provider.getModels().map((model) => model.id)).toEqual(["existing"]);
+		expect(written).toHaveLength(0);
+	});
+
+	it("honors an already-aborted refresh signal", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
+		const controller = new AbortController();
+		controller.abort();
+		const { store, written } = makeStore();
+		const { provider } = createZenmuxProvider();
+
+		await provider.refreshModels?.(
+			context(store, { allowNetwork: true, signal: controller.signal }),
+		);
+
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+		expect(written).toHaveLength(0);
+	});
+
+	it("switches between free and paid views", async () => {
+		const { provider, stored, setView } = createZenmuxProvider();
+		const free = nativeModel("free");
+		const paid = nativeModel("paid", true);
+		stored.free = [free];
+		stored.all = [free, paid];
+		setView(stored.free);
+		expect(provider.getModels().map((model) => model.id)).toEqual(["free"]);
+		setView(stored.all);
+		expect(provider.getModels().map((model) => model.id)).toEqual([
+			"free",
+			"paid",
+		]);
+	});
+});
+
+describe("fetchZenmuxCatalog", () => {
+	it("returns an empty catalog without a token", async () => {
+		expect(await fetchZenmuxCatalog({})).toEqual({ all: [], free: [] });
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+	});
+});

--- a/tests/zenmux.test.ts
+++ b/tests/zenmux.test.ts
@@ -1,0 +1,157 @@
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+} from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetZenmuxApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+const mockGetZenmuxShowPaid = vi.hoisted(() => vi.fn(() => false));
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockSaveConfig = vi.hoisted(() =>
+	vi.fn<(...args: unknown[]) => Promise<void>>(),
+);
+const mockRegisterWithGlobalToggle = vi.hoisted(() => vi.fn());
+
+vi.mock("../config.ts", () => ({
+	getZenmuxApiKey: () => mockGetZenmuxApiKey(),
+	getZenmuxShowPaid: () => mockGetZenmuxShowPaid(),
+	applyHidden: (models: { id: string }[]) => models,
+	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	registerWithGlobalToggle: (...args: unknown[]) =>
+		mockRegisterWithGlobalToggle(...args),
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
+		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
+}));
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T[]) => models,
+}));
+
+vi.mock("../lib/provider-compat.ts", () => ({
+	getProxyModelCompat: () => undefined,
+}));
+
+vi.mock("../lib/util.ts", () => ({
+	fetchWithRetry: vi.fn(),
+}));
+
+vi.mock("../provider-helper.ts", async () => {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../provider-helper.ts",
+	);
+	return {
+		...actual,
+		enhanceWithCI: (models: unknown[]) => models,
+	};
+});
+
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import zenmuxProvider from "../providers/zenmux/zenmux.ts";
+
+function makeStore(): ProviderModelsStore {
+	const entry: ModelsStoreEntry | undefined = undefined;
+	return {
+		read: async () => entry,
+		write: async () => {},
+		delete: async () => {},
+	};
+}
+
+describe("ZenMux native factory", () => {
+	let mockPi: ExtensionAPI;
+	let registerProvider: ReturnType<typeof vi.fn>;
+	let registerCommand: ReturnType<typeof vi.fn>;
+	let on: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetZenmuxApiKey.mockReturnValue(undefined);
+		mockGetZenmuxShowPaid.mockReturnValue(false);
+		mockGetGlobalFreeOnly.mockReturnValue(true);
+		registerProvider = vi.fn();
+		registerCommand = vi.fn();
+		on = vi.fn();
+		mockPi = {
+			registerProvider,
+			registerCommand,
+			on,
+		} as unknown as ExtensionAPI;
+	});
+
+	it("registers a native provider without a key but does no network work", async () => {
+		await zenmuxProvider(mockPi);
+
+		expect(registerProvider).toHaveBeenCalledTimes(1);
+		const provider = registerProvider.mock.calls[0][0];
+		expect(provider.id).toBe("zenmux");
+		expect(provider.auth.apiKey).toBeDefined();
+		expect(provider.getModels()).toEqual([]);
+		expect(registerCommand).toHaveBeenCalledWith(
+		"toggle-zenmux",
+		expect.any(Object),
+	);
+		expect(on).toHaveBeenCalledWith("session_start", expect.any(Function));
+	});
+
+	it("passes keyed-provider state to the global toggle registry", async () => {
+		mockGetZenmuxApiKey.mockReturnValue("sk-zenmux");
+		await zenmuxProvider(mockPi);
+		const args = mockRegisterWithGlobalToggle.mock.calls[0];
+		expect(args[0]).toBe("zenmux");
+		expect(args[3]).toBe(true);
+	});
+
+	it("re-registers the same native provider object on the global toggle", async () => {
+		await zenmuxProvider(mockPi);
+		const provider = registerProvider.mock.calls[0][0];
+		const reRegister = mockRegisterWithGlobalToggle.mock.calls[0][2] as (
+			models: unknown[],
+		) => void;
+
+		reRegister([]);
+		expect(registerProvider).toHaveBeenLastCalledWith(provider);
+	});
+
+	it("wires the toggle and session refresh handlers", async () => {
+		await zenmuxProvider(mockPi);
+		const toggle = registerCommand.mock.calls.find(
+			(call) => call[0] === "toggle-zenmux",
+		);
+		if (!toggle) throw new Error("toggle-zenmux was not registered");
+		await toggle[1].handler({}, { ui: { notify: vi.fn() } });
+		expect(mockSaveConfig).toHaveBeenCalledWith({ zenmux_show_paid: true });
+
+		const sessionStart = on.mock.calls.find(
+			(call) => call[0] === "session_start",
+		)?.[1];
+		const refresh = vi.fn().mockResolvedValue(undefined);
+		await sessionStart({}, { modelRegistry: { refresh } });
+		expect(refresh).toHaveBeenCalledWith({ allowNetwork: true });
+		await expect(sessionStart({}, {})).resolves.toBeUndefined();
+	});
+
+	it("does not perform model refresh work during factory registration", async () => {
+		await zenmuxProvider(mockPi);
+		const provider = registerProvider.mock.calls[0][0];
+		await provider.refreshModels?.({
+			store: makeStore(),
+			allowNetwork: false,
+		});
+		expect(provider.getModels()).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- Migrate ZenMux from legacy registration to a native Pi `Provider`.
- Add keyed native API-key auth with stored-credential precedence and correct unconfigured-provider gating.
- Move ZenMux catalog discovery to Pi's native models store with offline initialization, refresh abort handling, poisoning protection, hidden-model filtering, pricing conversion, and CI enrichment.
- Preserve OpenAI-compatible streaming, endpoint/headers, free/paid classification, `/toggle-zenmux`, and global free toggles.
- Reuse shared native-provider lifecycle helpers and extract the registrar/store-restore paths to avoid repeating the Kilo/Cline/LLM7 scaffolding.
- Preserve upstream abort signals through `fetchWithTimeout`/`fetchWithRetry` so native refresh cancellation is effective.

## Validation

- `npm run lint`
- `npm run test:run` — 46 test files, 589 tests passed
- Direct authenticated ZenMux catalog smoke check: HTTP 200, 148 models; the credential was not printed or persisted.
- No package or lockfile changes.

## Notes

This is the first keyed-provider Phase 1 migration and provides the runtime validation case after the keyless LLM7 migration.
