### PR TITLE
feat: migrate TokenRouter and Ollama to native providers

### DIFF
--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -124,6 +124,29 @@ export async function restoreNativeProviderModels<T extends Model<Api>>(
 	}
 }
 
+/** Refresh, publish, and persist a native provider catalog. */
+export async function refreshNativeProviderModels<T extends Model<Api>>(
+	providerId: string,
+	context: RefreshModelsContext,
+	onRestore: (models: T[]) => void,
+	fetchModels: () => Promise<T[]>,
+	onFetched: (models: T[]) => void | Promise<void>,
+): Promise<void> {
+	await restoreNativeProviderModels(providerId, context, onRestore);
+	if (!context.allowNetwork || context.signal?.aborted) return;
+
+	try {
+		const models = await fetchModels();
+		if (context.signal?.aborted || models.length === 0) return;
+		await onFetched(models);
+		await persistNativeProviderModels(providerId, context, models);
+	} catch (err) {
+		_logger.warn(`Failed to refresh ${providerId} models; retaining previous`, {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
 /** Persist a native provider catalog while retaining the previous store on failure. */
 export async function persistNativeProviderModels(
 	providerId: string,

--- a/providers/ollama/ollama-auth.ts
+++ b/providers/ollama/ollama-auth.ts
@@ -1,0 +1,39 @@
+/** Native API-key authentication for Ollama Cloud. */
+
+import type {
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	ProviderAuth,
+} from "@earendil-works/pi-ai/compat";
+import { getOllamaApiKey } from "../../config.ts";
+
+async function resolveOllamaApiKey(input: {
+	ctx: AuthContext;
+	credential?: ApiKeyCredential;
+}): Promise<AuthResult | undefined> {
+	const key = input.credential?.key ?? getOllamaApiKey();
+	if (!key) return undefined;
+	return {
+		auth: { apiKey: key },
+		source: input.credential?.key ? "stored API key" : "OLLAMA_API_KEY",
+	};
+}
+
+export const ollamaApiKeyAuth: ApiKeyAuth = {
+	name: "Ollama Cloud API key",
+	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+		const key = await interaction.prompt({
+			type: "secret",
+			message: "Ollama Cloud API key",
+		});
+		return { type: "api_key", key };
+	},
+	resolve: resolveOllamaApiKey,
+};
+
+export const ollamaAuth: ProviderAuth = {
+	apiKey: ollamaApiKeyAuth,
+};

--- a/providers/ollama/ollama-provider.ts
+++ b/providers/ollama/ollama-provider.ts
@@ -1,0 +1,274 @@
+import type {
+	Credential,
+	Model,
+	Provider,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import { getOllamaApiKey, getOllamaShowPaid } from "../../config.ts";
+import { BASE_URL_OLLAMA, PROVIDER_OLLAMA } from "../../constants.ts";
+import {
+	refreshNativeProviderModels,
+	registerNativeProvider,
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
+import { areAllModelsFresh } from "../../lib/probe-cache.ts";
+import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
+import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
+import { getGlobalFreeOnly, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
+import { ollamaAuth } from "./ollama-auth.ts";
+
+export interface OllamaProviderDeps {
+	fallbackModels: ProviderModelConfig[];
+	fetchModels: (
+		apiKey: string,
+		cachedModels?: ProviderModelConfig[],
+		signal?: AbortSignal,
+	) => Promise<ProviderModelConfig[]>;
+	probeModels: (
+		apiKey: string,
+		models: ProviderModelConfig[],
+		applyModels: (models: ProviderModelConfig[]) => void,
+		options?: { useCache?: boolean },
+	) => Promise<string[]>;
+}
+
+/** Native Ollama Cloud provider handle used by the extension factory and probes. */
+export interface OllamaNativeProvider {
+	provider: Provider<"openai-completions">;
+	stored: StoredModels;
+	setView: (models: ProviderModelConfig[]) => void;
+	ingest: (
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	) => void;
+}
+
+type OllamaModel = Model<"openai-completions">;
+
+function credentialToken(credential?: Credential): string | undefined {
+	if (!credential) return getOllamaApiKey();
+	if (credential.type === "api_key") {
+		return credential.key ?? getOllamaApiKey();
+	}
+	return getOllamaApiKey();
+}
+
+function toOllamaModel(model: ProviderModelConfig): OllamaModel {
+	return {
+		...model,
+		api: "openai-completions",
+		provider: PROVIDER_OLLAMA,
+		baseUrl: BASE_URL_OLLAMA,
+	} as OllamaModel;
+}
+
+function toOllamaModels(models: ProviderModelConfig[]): OllamaModel[] {
+	return models.map(toOllamaModel);
+}
+
+export function createOllamaProvider(
+	deps: OllamaProviderDeps,
+	initialModels: ProviderModelConfig[] = deps.fallbackModels,
+): OllamaNativeProvider {
+	const streams = openAICompletionsApi();
+	const stored: StoredModels = { free: [], all: [] };
+	let currentView: OllamaModel[] = [];
+
+	function decideView(): ProviderModelConfig[] {
+		if (!getGlobalFreeOnly()) {
+			return stored.all.length > 0 ? stored.all : stored.free;
+		}
+		const showPaid = getOllamaShowPaid();
+		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
+	}
+
+	function setView(models: ProviderModelConfig[]): void {
+		currentView = toOllamaModels(models);
+	}
+
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
+		stored.all = toOllamaModels(enhanceWithCI(all, PROVIDER_OLLAMA));
+		stored.free = toOllamaModels(enhanceWithCI(free, PROVIDER_OLLAMA));
+		setView(decideView());
+	}
+
+	ingest(initialModels, initialModels);
+
+	function restoreStoredModels(storedModels: OllamaModel[]): void {
+		stored.all = storedModels;
+		stored.free = storedModels;
+		setView(decideView());
+	}
+
+	async function refreshOllamaModels(
+		context: RefreshModelsContext,
+	): Promise<void> {
+		await refreshNativeProviderModels(
+			PROVIDER_OLLAMA,
+			context,
+			restoreStoredModels,
+			async () => {
+				const token = credentialToken(context.credential);
+				if (!token) return [];
+				const fresh = await deps.fetchModels(
+					token,
+					loadProviderCache(PROVIDER_OLLAMA),
+					context.signal,
+				);
+				await saveProviderCache(PROVIDER_OLLAMA, fresh);
+				return toOllamaModels(enhanceWithCI(fresh, PROVIDER_OLLAMA));
+			},
+			(models) => {
+				stored.all = models;
+				stored.free = models;
+				setView(decideView());
+			},
+		);
+	}
+
+	const provider: Provider<"openai-completions"> = {
+		id: PROVIDER_OLLAMA,
+		name: "Ollama Cloud",
+		baseUrl: BASE_URL_OLLAMA,
+		headers: { "User-Agent": "pi-free-providers" },
+		auth: ollamaAuth,
+		getModels: () => currentView,
+		refreshModels: refreshOllamaModels,
+		stream: (model, context, options) =>
+			streams.stream(model, context, options),
+		streamSimple: (model, context, options) =>
+			streams.streamSimple(model, context, options),
+	};
+
+	return { provider, stored, setView, ingest };
+}
+
+export function registerOllamaProvider(
+	pi: ExtensionAPI,
+	deps: OllamaProviderDeps,
+): void {
+	const cachedModels = loadProviderCache(PROVIDER_OLLAMA);
+	const initialModels =
+		cachedModels && cachedModels.length > 0
+			? cachedModels
+			: deps.fallbackModels;
+	const { provider, stored, setView, ingest } = createOllamaProvider(
+		deps,
+		initialModels,
+	);
+	registerNativeProvider(pi, provider);
+
+	const reRegister = (models: ProviderModelConfig[]) => {
+		setView(models);
+		registerNativeProvider(pi, provider);
+	};
+	const applyModelList = (models: ProviderModelConfig[]) => {
+		ingest(models, models);
+		registerNativeProvider(pi, provider);
+	};
+	const currentModels = () => stored.all;
+
+	registerWithGlobalToggle(
+		PROVIDER_OLLAMA,
+		stored,
+		reRegister,
+		Boolean(getOllamaApiKey()),
+	);
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_OLLAMA,
+		stored,
+		getShowPaid: getOllamaShowPaid,
+		reRegister,
+	});
+
+	pi.registerCommand("ollama-cloud-refresh", {
+		description:
+			"Re-fetch Ollama Cloud models from the API and update the provider live",
+		handler: async (_args: string, ctx: ExtensionCommandContext) => {
+			const apiKey = getOllamaApiKey();
+			if (!apiKey) {
+				ctx.ui.notify("OLLAMA_API_KEY not set", "error");
+				return;
+			}
+			ctx.ui.notify("Refreshing Ollama Cloud models…", "info");
+			try {
+				const fresh = await deps.fetchModels(
+					apiKey,
+					loadProviderCache(PROVIDER_OLLAMA),
+				);
+				await saveProviderCache(PROVIDER_OLLAMA, fresh);
+				applyModelList(fresh);
+				ctx.ui.notify(
+					`Registered ${fresh.length} Ollama Cloud models (refresh complete)`,
+					"info",
+				);
+			} catch (error) {
+				ctx.ui.notify(
+					`Refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
+			}
+		},
+	});
+
+	pi.registerCommand("probe-ollama", {
+		description: "Test all Ollama Cloud models for 403 'access denied' errors",
+		handler: async (_args: string, ctx: ExtensionCommandContext) => {
+			const apiKey = getOllamaApiKey();
+			if (!apiKey) {
+				ctx.ui.notify("OLLAMA_API_KEY not set", "error");
+				return;
+			}
+
+			const modelsToTest = currentModels();
+			ctx.ui.notify(`Probing ${modelsToTest.length} Ollama models…`, "info");
+			const notFound = await deps.probeModels(
+				apiKey,
+				modelsToTest,
+				applyModelList,
+			);
+
+			if (notFound.length === 0) {
+				ctx.ui.notify("All Ollama models are accessible ✅", "info");
+				return;
+			}
+			ctx.ui.notify(
+				`Found ${notFound.length} broken models (auto-hidden):\n${notFound.join("\n")}`,
+				"warning",
+			);
+		},
+	});
+
+	const runProbeInBackground = (models: ProviderModelConfig[]) => {
+		if (areAllModelsFresh(PROVIDER_OLLAMA, models.map((model) => model.id))) {
+			return;
+		}
+		const apiKey = getOllamaApiKey();
+		if (!apiKey) return;
+		deps.probeModels(apiKey, models, applyModelList, { useCache: true }).catch(
+			() => undefined,
+		);
+	};
+
+	// Pi owns the native model refresh; this handler preserves Ollama's
+	// background accessibility probe without reintroducing a second catalog fetch.
+	pi.on(
+		"session_start",
+		wrapSessionStartHandler("ollama-cloud", () => {
+			runProbeInBackground(currentModels());
+			return Promise.resolve();
+		}),
+	);
+	registerNativeProviderRefresh(pi, PROVIDER_OLLAMA);
+}

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -19,37 +19,27 @@
 
 import type {
 	ExtensionAPI,
-	ExtensionCommandContext,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import {
-	applyHidden,
-	getOllamaApiKey,
-	getOllamaShowPaid,
-	updateConfig,
-} from "../../config.ts";
+import { applyHidden, updateConfig } from "../../config.ts";
 import {
 	BASE_URL_OLLAMA,
 	DEFAULT_FETCH_TIMEOUT_MS,
 	PROVIDER_OLLAMA,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
 import {
-	DEFAULT_PROVIDER_CACHE_TTL_MS,
-	isProviderCacheFresh,
-	loadProviderCache,
-	saveProviderCache,
-} from "../../lib/provider-cache.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import {
-	areAllModelsFresh,
 	getModelsDueForProbe,
 	recordModelProbeResults,
 } from "../../lib/probe-cache.ts";
-import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import { fetchWithRetry, fetchWithTimeout } from "../../lib/util.ts";
-import { createReRegister, enhanceWithCI } from "../../provider-helper.ts";
 import { resolveThinkingMap } from "./thinking-levels.ts";
+import {
+	createOllamaProvider as createNativeOllamaProvider,
+	registerOllamaProvider,
+	type OllamaProviderDeps,
+} from "./ollama-provider.ts";
 
 const _logger = createLogger("ollama-cloud");
 
@@ -75,7 +65,7 @@ const OLLAMA_KNOWN_403_MODELS: ReadonlySet<string> = new Set([
 // =============================================================================
 // Fallback models (used when API is unreachable and no cache exists)
 // =============================================================================
-const FALLBACK_MODELS: ProviderModelConfig[] = [
+export const FALLBACK_MODELS: ProviderModelConfig[] = [
 	{
 		id: "glm-5.1",
 		name: "GLM 5.1",
@@ -187,7 +177,10 @@ async function concurrentMap<T, R>(
 // Fetch: /v1/models → list of model IDs
 // =============================================================================
 
-async function fetchModelIds(apiKey: string): Promise<string[]> {
+async function fetchModelIds(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<string[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_OLLAMA}/models`,
 		{
@@ -195,6 +188,7 @@ async function fetchModelIds(apiKey: string): Promise<string[]> {
 				Authorization: `Bearer ${apiKey}`,
 				"Content-Type": "application/json",
 			},
+			signal,
 		},
 		3,
 		1000,
@@ -220,6 +214,7 @@ async function fetchModelIds(apiKey: string): Promise<string[]> {
 async function fetchModelDetails(
 	apiKey: string,
 	modelId: string,
+	signal?: AbortSignal,
 ): Promise<OllamaShowResponse> {
 	const response = await fetchWithTimeout(
 		`${OLLAMA_API_BASE}/api/show`,
@@ -230,6 +225,7 @@ async function fetchModelDetails(
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ model: modelId }),
+			signal,
 		},
 		DETAIL_FETCH_TIMEOUT_MS,
 	);
@@ -319,13 +315,14 @@ function assembleModels(
 // Fetch all models (orchestrates /v1/models + /api/show)
 // =============================================================================
 
-async function fetchAllModels(
+export async function fetchAllModels(
 	apiKey: string,
 	cachedModels: ProviderModelConfig[] = loadProviderCache(PROVIDER_OLLAMA) ??
 		[],
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	// Step 1: Get model IDs
-	const modelIds = await fetchModelIds(apiKey);
+	const modelIds = await fetchModelIds(apiKey, signal);
 	_logger.info(
 		`[ollama-cloud] Found ${modelIds.length} model IDs, fetching details...`,
 	);
@@ -351,7 +348,7 @@ async function fetchAllModels(
 		DETAIL_CONCURRENCY,
 		async (id) => {
 			try {
-				const result = await fetchModelDetails(apiKey, id);
+				const result = await fetchModelDetails(apiKey, id, signal);
 				succeeded++;
 				return [id, result] as const;
 			} catch {
@@ -400,7 +397,7 @@ async function fetchAllModels(
 	return applyHidden(models, PROVIDER_OLLAMA);
 }
 
-async function runOllamaProbe(
+export async function runOllamaProbe(
 	apiKey: string,
 	modelsToTest: ProviderModelConfig[],
 	applyModels: (models: ProviderModelConfig[]) => void,
@@ -478,200 +475,21 @@ async function runOllamaProbe(
 	return notFound;
 }
 
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
+const OLLAMA_PROVIDER_DEPS: OllamaProviderDeps = {
+	fallbackModels: FALLBACK_MODELS,
+	fetchModels: fetchAllModels,
+	probeModels: runOllamaProbe,
+};
 
-export default async function ollamaProvider(pi: ExtensionAPI) {
-	const apiKey = getOllamaApiKey();
+export function createOllamaProvider(initialModels?: ProviderModelConfig[]) {
+	return initialModels === undefined
+		? createNativeOllamaProvider(OLLAMA_PROVIDER_DEPS)
+		: createNativeOllamaProvider(OLLAMA_PROVIDER_DEPS, initialModels);
+}
 
-	if (!apiKey) {
-		_logger.info(
-			"[ollama-cloud] Skipping - OLLAMA_API_KEY not set (env var or ~/.pi/free.json)",
-		);
-		return;
-	}
-
-	// ── Try cache first for fast startup ────────────────────────────
-	let allModels: ProviderModelConfig[];
-	let fromCache = false;
-
-	const cachedModels = loadProviderCache(PROVIDER_OLLAMA);
-	if (cachedModels && cachedModels.length > 0) {
-		allModels = cachedModels;
-		fromCache = true;
-		_logger.info(
-			`[ollama-cloud] Using ${cachedModels.length} cached models for fast startup`,
-		);
-	} else {
-		allModels = FALLBACK_MODELS;
-		_logger.info("[ollama-cloud] No cache available, using fallback models");
-	}
-
-	// ── Register immediately with cached/fallback models ────────────
-	const freeModels = allModels;
-	const stored = { free: freeModels, all: allModels };
-	const hasKey = true;
-
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_OLLAMA,
-		baseUrl: BASE_URL_OLLAMA,
-		apiKey,
-	});
-	const applyModelList = (models: ProviderModelConfig[]) => {
-		allModels = models;
-		stored.free = models;
-		stored.all = models;
-		reRegister(models);
-	};
-
-	registerWithGlobalToggle(PROVIDER_OLLAMA, stored, reRegister, hasKey);
-
-	const initialModels = getOllamaShowPaid() ? allModels : freeModels;
-	pi.registerProvider(PROVIDER_OLLAMA, {
-		baseUrl: BASE_URL_OLLAMA,
-		apiKey,
-		api: "openai-completions" as const,
-		models: enhanceWithCI(initialModels),
-	});
-
-	_logger.info(
-		`[ollama-cloud] Registered ${initialModels.length} models` +
-			(fromCache ? " (from cache)" : " (fallback)") +
-			", refresh scheduled on session start...",
-	);
-
-	// ── Background refresh ─────────────────────────────────────────
-	async function refreshModels(): Promise<ProviderModelConfig[]> {
-		try {
-			const freshModels = await fetchAllModels(
-				apiKey!,
-				loadProviderCache(PROVIDER_OLLAMA),
-			);
-			await saveProviderCache(PROVIDER_OLLAMA, freshModels);
-			return freshModels;
-		} catch (error) {
-			_logger.error("[ollama-cloud] Background refresh failed", {
-				error: error instanceof Error ? error.message : String(error),
-			});
-			// Return current models so we don't lose what we have
-			return allModels;
-		}
-	}
-
-	// ── /ollama-cloud-refresh command ───────────────────────────────
-	pi.registerCommand("ollama-cloud-refresh", {
-		description:
-			"Re-fetch Ollama Cloud models from the API and update the provider live",
-		handler: async (_args: string, ctx: ExtensionCommandContext) => {
-			ctx.ui.notify("Refreshing Ollama Cloud models…", "info");
-			try {
-				const fresh = await fetchAllModels(
-					apiKey!,
-					loadProviderCache(PROVIDER_OLLAMA),
-				);
-				await saveProviderCache(PROVIDER_OLLAMA, fresh);
-				applyModelList(fresh);
-				ctx.ui.notify(
-					`Registered ${fresh.length} Ollama Cloud models (refresh complete)`,
-					"info",
-				);
-			} catch (error) {
-				ctx.ui.notify(
-					`Refresh failed: ${error instanceof Error ? error.message : String(error)}`,
-					"error",
-				);
-			}
-		},
-	});
-
-	// ── /probe-ollama command ───────────────────────────────────────
-	pi.registerCommand("probe-ollama", {
-		description: "Test all Ollama Cloud models for 403 'access denied' errors",
-		handler: async (_args: string, ctx: ExtensionCommandContext) => {
-			if (!apiKey) {
-				ctx.ui.notify("OLLAMA_API_KEY not set", "error");
-				return;
-			}
-
-			const modelsToTest = allModels;
-			ctx.ui.notify(`Probing ${modelsToTest.length} Ollama models…`, "info");
-
-			const notFound = await runOllamaProbe(
-				apiKey,
-				modelsToTest,
-				applyModelList,
-			);
-
-			if (notFound.length === 0) {
-				ctx.ui.notify("All Ollama models are accessible ✅", "info");
-				return;
-			}
-
-			ctx.ui.notify(
-				`Found ${notFound.length} broken models (auto-hidden):\n${notFound.join("\n")}`,
-				"warning",
-			);
-		},
-	});
-
-	const runProbeInBackground = (models: ProviderModelConfig[]) => {
-		// Skip scheduling entirely if every model was probed recently.
-		// Without this check the probe runs on every session_start and
-		// only then discovers the cache is fresh inside runOllamaProbe.
-		if (
-			areAllModelsFresh(
-				PROVIDER_OLLAMA,
-				models.map((m) => m.id),
-			)
-		) {
-			_logger.info("Auto-probe: Ollama probe cache is fresh");
-			return;
-		}
-		runOllamaProbe(apiKey, models, applyModelList, { useCache: true }).catch(
-			(error) => {
-				_logger.warn("Auto-probe failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			},
-		);
-	};
-
-	// ── Background refresh on session_start ─────────────────────────
-	let refreshInFlight: Promise<void> | undefined;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	pi.on(
-		"session_start" as any,
-		wrapSessionStartHandler("ollama-cloud", (_event: any, ctx: any) => {
-			if (refreshInFlight) return Promise.resolve();
-
-			if (
-				isProviderCacheFresh(PROVIDER_OLLAMA, DEFAULT_PROVIDER_CACHE_TTL_MS)
-			) {
-				_logger.info(
-					"session_start: Ollama Cloud cache is fresh; skipping refresh",
-				);
-				runProbeInBackground(allModels);
-				return Promise.resolve();
-			}
-
-			refreshInFlight = refreshModels()
-				.then((fresh) => {
-					applyModelList(fresh);
-					ctx.ui.notify(`Ollama Cloud: ${fresh.length} models ready`, "info");
-					runProbeInBackground(fresh);
-				})
-				.catch((error) => {
-					_logger.warn("Background refresh failed", {
-						error: error instanceof Error ? error.message : String(error),
-					});
-				})
-				.finally(() => {
-					refreshInFlight = undefined;
-				});
-			return Promise.resolve();
-		}),
-	);
+export default function ollamaProvider(pi: ExtensionAPI): Promise<void> {
+	registerOllamaProvider(pi, OLLAMA_PROVIDER_DEPS);
+	return Promise.resolve();
 }
 
 // =============================================================================

--- a/providers/tokenrouter/tokenrouter-auth.ts
+++ b/providers/tokenrouter/tokenrouter-auth.ts
@@ -1,0 +1,41 @@
+/** Native API-key authentication for TokenRouter. */
+
+import type {
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	ProviderAuth,
+} from "@earendil-works/pi-ai/compat";
+import { getTokenrouterApiKey } from "../../config.ts";
+
+async function resolveTokenRouterApiKey(input: {
+	ctx: AuthContext;
+	credential?: ApiKeyCredential;
+}): Promise<AuthResult | undefined> {
+	const key = input.credential?.key ?? getTokenrouterApiKey();
+	if (!key) return undefined;
+	return {
+		auth: { apiKey: key },
+		source: input.credential?.key
+			? "stored API key"
+			: "TOKENROUTER_API_KEY",
+	};
+}
+
+export const tokenRouterApiKeyAuth: ApiKeyAuth = {
+	name: "TokenRouter API key",
+	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+		const key = await interaction.prompt({
+			type: "secret",
+			message: "TokenRouter API key",
+		});
+		return { type: "api_key", key };
+	},
+	resolve: resolveTokenRouterApiKey,
+};
+
+export const tokenRouterAuth: ProviderAuth = {
+	apiKey: tokenRouterApiKeyAuth,
+};

--- a/providers/tokenrouter/tokenrouter-provider.ts
+++ b/providers/tokenrouter/tokenrouter-provider.ts
@@ -1,0 +1,208 @@
+import type {
+	Api,
+	AssistantMessage,
+	Credential,
+	Model,
+	Provider,
+	RefreshModelsContext,
+	SimpleStreamOptions,
+	AssistantMessageEventStream,
+	Context,
+} from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { getTokenrouterApiKey, getTokenrouterShowPaid } from "../../config.ts";
+import { BASE_URL_TOKENROUTER, PROVIDER_TOKENROUTER } from "../../constants.ts";
+import {
+	refreshNativeProviderModels,
+	registerNativeProvider,
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
+import {
+	getGlobalFreeOnly,
+	isFreeModel,
+	registerWithGlobalToggle,
+} from "../../lib/registry.ts";
+import { loadProviderCache } from "../../lib/provider-cache.ts";
+import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
+import { tokenRouterAuth } from "./tokenrouter-auth.ts";
+
+export interface TokenRouterProviderDeps {
+	fetchModels: (
+		apiKey: string,
+		signal?: AbortSignal,
+	) => Promise<ProviderModelConfig[]>;
+	streamSimple: (
+		model: Model<Api>,
+		context: Context,
+		options?: SimpleStreamOptions,
+	) => AssistantMessageEventStream;
+	isModel: (model: { provider?: string }) => boolean;
+	isMinimaxModel: (modelId: string) => boolean;
+	normalizeMessage: (message: AssistantMessage) => AssistantMessage;
+	patchPayload: (payload: unknown, force?: boolean) => unknown;
+}
+
+export interface TokenRouterNativeProvider {
+	provider: Provider<"tokenrouter-openai-completions">;
+	stored: StoredModels;
+	setView: (models: ProviderModelConfig[]) => void;
+	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
+}
+
+type TokenRouterNativeModel = Model<"tokenrouter-openai-completions">;
+
+function credentialToken(credential?: Credential): string | undefined {
+	if (!credential) return getTokenrouterApiKey();
+	if (credential.type === "api_key") {
+		return credential.key ?? getTokenrouterApiKey();
+	}
+	return getTokenrouterApiKey();
+}
+
+function toTokenRouterModel(model: ProviderModelConfig): TokenRouterNativeModel {
+	return {
+		...model,
+		api: "tokenrouter-openai-completions",
+		provider: PROVIDER_TOKENROUTER,
+		baseUrl: BASE_URL_TOKENROUTER,
+	} as TokenRouterNativeModel;
+}
+
+function toTokenRouterModels(
+	models: ProviderModelConfig[],
+): TokenRouterNativeModel[] {
+	return models.map(toTokenRouterModel);
+}
+
+function classifyFreeModels(
+	models: TokenRouterNativeModel[],
+): TokenRouterNativeModel[] {
+	return models.filter((model) =>
+		isFreeModel({ ...model, provider: PROVIDER_TOKENROUTER }, models),
+	);
+}
+
+export function createTokenRouterProvider(
+	deps: TokenRouterProviderDeps,
+	initialModels: ProviderModelConfig[] = loadProviderCache(PROVIDER_TOKENROUTER) ??
+		[],
+): TokenRouterNativeProvider {
+	const stored: StoredModels = { free: [], all: [] };
+	let currentView: TokenRouterNativeModel[] = [];
+
+	function decideView(): ProviderModelConfig[] {
+		if (!getGlobalFreeOnly()) {
+			return stored.all.length > 0 ? stored.all : stored.free;
+		}
+		const showPaid = getTokenrouterShowPaid();
+		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
+	}
+
+	function setView(models: ProviderModelConfig[]): void {
+		currentView = toTokenRouterModels(models);
+	}
+
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
+		stored.all = toTokenRouterModels(enhanceWithCI(all, PROVIDER_TOKENROUTER));
+		stored.free = toTokenRouterModels(
+			enhanceWithCI(free, PROVIDER_TOKENROUTER),
+		);
+		setView(decideView());
+	}
+
+	if (initialModels.length > 0) {
+		const all = toTokenRouterModels(
+			enhanceWithCI(initialModels, PROVIDER_TOKENROUTER),
+		);
+		stored.all = all;
+		stored.free = classifyFreeModels(all);
+		setView(decideView());
+	}
+
+	async function refreshModels(context: RefreshModelsContext): Promise<void> {
+		await refreshNativeProviderModels(
+			PROVIDER_TOKENROUTER,
+			context,
+			(storedModels: TokenRouterNativeModel[]) => {
+				stored.all = storedModels;
+				stored.free = classifyFreeModels(storedModels);
+				setView(decideView());
+			},
+			async () => {
+				const token = credentialToken(context.credential);
+				if (!token) return [];
+				const all = await deps.fetchModels(token, context.signal);
+				return toTokenRouterModels(
+					enhanceWithCI(all, PROVIDER_TOKENROUTER),
+				);
+			},
+			(models) => {
+				stored.all = models;
+				stored.free = classifyFreeModels(models);
+				setView(decideView());
+			},
+		);
+	}
+
+	const provider: Provider<"tokenrouter-openai-completions"> = {
+		id: PROVIDER_TOKENROUTER,
+		name: "TokenRouter",
+		baseUrl: BASE_URL_TOKENROUTER,
+		headers: { "User-Agent": "pi-free-providers" },
+		auth: tokenRouterAuth,
+		getModels: () => currentView,
+		refreshModels,
+		stream: (model, context, options) =>
+			deps.streamSimple(model, context, options),
+		streamSimple: (model, context, options) =>
+			deps.streamSimple(model, context, options),
+	};
+
+	return { provider, stored, setView, ingest };
+}
+
+export function registerTokenRouterProvider(
+	pi: ExtensionAPI,
+	deps: TokenRouterProviderDeps,
+): void {
+	const { provider, stored, setView } = createTokenRouterProvider(deps);
+	registerNativeProvider(pi, provider);
+
+	const reRegister = (models: ProviderModelConfig[]) => {
+		setView(models);
+		registerNativeProvider(pi, provider);
+	};
+
+	registerWithGlobalToggle(
+		PROVIDER_TOKENROUTER,
+		stored,
+		reRegister,
+		Boolean(getTokenrouterApiKey()),
+	);
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_TOKENROUTER,
+		stored,
+		getShowPaid: getTokenrouterShowPaid,
+		reRegister,
+	});
+
+	pi.on("before_provider_request", (event, ctx) =>
+		deps.patchPayload(
+			event.payload,
+			deps.isModel(ctx.model ?? {}) &&
+				deps.isMinimaxModel(ctx.model?.id ?? ""),
+		),
+	);
+
+	pi.on("message_end", (event, ctx) => {
+		if (!deps.isModel(ctx.model ?? {})) return;
+		if (event.message.role !== "assistant") return;
+		return { message: deps.normalizeMessage(event.message) };
+	});
+
+	registerNativeProviderRefresh(pi, PROVIDER_TOKENROUTER);
+}

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -28,11 +28,7 @@ import type {
 } from "@earendil-works/pi-ai/compat";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
-import {
-	getTokenrouterApiKey,
-	getTokenrouterShowPaid,
-	applyHidden,
-} from "../../config.ts";
+import { applyHidden } from "../../config.ts";
 import {
 	BASE_URL_TOKENROUTER,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -45,13 +41,12 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 import {
-	enhanceWithCI,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	createTokenRouterProvider as createNativeTokenRouterProvider,
+	registerTokenRouterProvider,
+	type TokenRouterProviderDeps,
+} from "./tokenrouter-provider.ts";
 
 const _logger = createLogger("tokenrouter");
 const streamSimpleOpenAICompletions = openAICompletionsApi().streamSimple;
@@ -109,7 +104,7 @@ function extractThinkBlocks(text: string): ExtractedThinking {
 	};
 }
 
-function isTokenRouterModel(model: { provider?: string }): boolean {
+export function isTokenRouterModel(model: { provider?: string }): boolean {
 	return model.provider === PROVIDER_TOKENROUTER;
 }
 
@@ -118,7 +113,7 @@ function isTokenRouterModel(model: { provider?: string }): boolean {
 // TokenRouter doesn't expose pricing via /v1/models.
 // Known-free detection uses `:free` name suffix for promotional models.
 // =============================================================================
-const TOKENROUTER_OPENAI_API = "tokenrouter-openai-completions" as const;
+export const TOKENROUTER_OPENAI_API = "tokenrouter-openai-completions" as const;
 const TOKENROUTER_HIGH_LOAD_RETRY_DELAY_MS = 30_000;
 const MINIMAX_ADAPTIVE_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
 	...DEEPSEEK_PROXY_COMPAT,
@@ -164,7 +159,7 @@ function isTextChatModel(model: TokenRouterModel): boolean {
 	return model.supported_endpoint_types.some((t) => CHAT_ENDPOINT_TYPES.has(t));
 }
 
-function isTokenRouterMinimaxModel(modelId: string): boolean {
+export function isTokenRouterMinimaxModel(modelId: string): boolean {
 	return modelId.toLowerCase().includes("minimax");
 }
 
@@ -511,8 +506,9 @@ export function mapTokenRouterModel(
 // Fetch Models
 // =============================================================================
 
-async function fetchTokenRouterModels(
+export async function fetchTokenRouterModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	_logger.info("[tokenrouter] Fetching models from TokenRouter API...");
 
@@ -525,6 +521,7 @@ async function fetchTokenRouterModels(
 					Accept: "application/json",
 					"Content-Type": "application/json",
 				},
+				signal,
 			},
 			3,
 			1000,
@@ -555,82 +552,24 @@ async function fetchTokenRouterModels(
 	}
 }
 
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
+const TOKENROUTER_PROVIDER_DEPS: TokenRouterProviderDeps = {
+	fetchModels: fetchTokenRouterModels,
+	streamSimple: streamSimpleTokenRouter,
+	isModel: isTokenRouterModel,
+	isMinimaxModel: isTokenRouterMinimaxModel,
+	normalizeMessage: normalizeAssistantMessage,
+	patchPayload: patchTokenRouterMinimaxThinkingPayload,
+};
 
-export default async function tokenRouterProvider(pi: ExtensionAPI) {
-	const apiKey = getTokenrouterApiKey();
+export function createTokenRouterProvider(initialModels?: ProviderModelConfig[]) {
+	return initialModels === undefined
+		? createNativeTokenRouterProvider(TOKENROUTER_PROVIDER_DEPS)
+		: createNativeTokenRouterProvider(TOKENROUTER_PROVIDER_DEPS, initialModels);
+}
 
-	if (!apiKey) {
-		_logger.info("[tokenrouter] Skipping — TOKENROUTER_API_KEY not set.");
-		return;
-	}
-
-	const allModels = await loadCachedOrFetchModels(PROVIDER_TOKENROUTER, () =>
-		fetchTokenRouterModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[tokenrouter] No text chat models available");
-		return;
-	}
-
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_TOKENROUTER }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[tokenrouter] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	const reRegister = (models: ProviderModelConfig[]) => {
-		pi.registerProvider(PROVIDER_TOKENROUTER, {
-			baseUrl: BASE_URL_TOKENROUTER,
-			apiKey,
-			api: TOKENROUTER_OPENAI_API,
-			streamSimple: streamSimpleTokenRouter,
-			headers: { "User-Agent": "pi-free-providers" },
-			models: enhanceWithCI(models, PROVIDER_TOKENROUTER),
-		});
-	};
-
-	registerWithGlobalToggle(PROVIDER_TOKENROUTER, stored, reRegister, true);
-
-	pi.on("before_provider_request", (event, ctx) =>
-		patchTokenRouterMinimaxThinkingPayload(
-			event.payload,
-			isTokenRouterModel(ctx.model ?? {}) &&
-				isTokenRouterMinimaxModel(ctx.model?.id ?? ""),
-		),
-	);
-
-	pi.on("message_end", (event, ctx) => {
-		if (!isTokenRouterModel(ctx.model ?? {})) return;
-		if (event.message.role !== "assistant") return;
-		return { message: normalizeAssistantMessage(event.message) };
-	});
-
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_TOKENROUTER,
-			initialShowPaid: getTokenrouterShowPaid(),
-			tosUrl: "https://tokenrouter.com/terms",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
-		},
-		stored,
-	);
-
-	const showPaid = getTokenrouterShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
+export default function tokenRouterProvider(
+	pi: ExtensionAPI,
+): Promise<void> {
+	registerTokenRouterProvider(pi, TOKENROUTER_PROVIDER_DEPS);
+	return Promise.resolve();
 }

--- a/tests/ollama-provider.test.ts
+++ b/tests/ollama-provider.test.ts
@@ -1,0 +1,239 @@
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetOllamaApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+const mockGetOllamaShowPaid = vi.hoisted(() => vi.fn(() => false));
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockFetchWithRetry = vi.hoisted(() => vi.fn());
+const mockFetchWithTimeout = vi.hoisted(() => vi.fn());
+const mockSaveProviderCache = vi.hoisted(() =>
+	vi.fn(async (..._args: unknown[]) => undefined),
+);
+
+vi.mock("../config.ts", () => ({
+	getOllamaApiKey: () => mockGetOllamaApiKey(),
+	getOllamaShowPaid: () => mockGetOllamaShowPaid(),
+	applyHidden: (models: unknown[]) => models,
+	updateConfig: vi.fn(),
+	saveConfig: vi.fn(),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	registerWithGlobalToggle: vi.fn(),
+}));
+
+vi.mock("../lib/provider-cache.ts", () => ({
+	loadProviderCache: () => undefined,
+	saveProviderCache: (providerId: string, models: unknown[]) =>
+		mockSaveProviderCache(providerId, models),
+}));
+
+vi.mock("../lib/probe-cache.ts", () => ({
+	getModelsDueForProbe: () => [],
+	recordModelProbeResults: vi.fn(async () => undefined),
+	areAllModelsFresh: () => true,
+}));
+
+vi.mock("../lib/session-start-metrics.ts", () => ({
+	wrapSessionStartHandler: (_providerId: string, handler: unknown) => handler,
+}));
+
+vi.mock("../lib/util.ts", () => ({
+	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+	fetchWithTimeout: (...args: unknown[]) => mockFetchWithTimeout(...args),
+}));
+
+vi.mock("../provider-helper.ts", () => ({
+	enhanceWithCI: (models: unknown[]) => models,
+}));
+
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import ollamaEntry, {
+	createOllamaProvider,
+} from "../providers/ollama/ollama.ts";
+import { ollamaAuth } from "../providers/ollama/ollama-auth.ts";
+
+function makeStore(seed?: ModelsStoreEntry): {
+	store: ProviderModelsStore;
+	written: ModelsStoreEntry[];
+} {
+	let entry = seed;
+	const written: ModelsStoreEntry[] = [];
+	return {
+		store: {
+			read: async () => entry,
+			write: async (next: ModelsStoreEntry) => {
+				entry = next;
+				written.push(next);
+			},
+			delete: async () => {
+				entry = undefined;
+			},
+		},
+		written,
+	};
+}
+
+function context(
+	store: ProviderModelsStore,
+	overrides: Partial<RefreshModelsContext> = {},
+): RefreshModelsContext {
+	return { store, allowNetwork: false, ...overrides } as RefreshModelsContext;
+}
+
+function model(id: string) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32_000,
+		maxTokens: 16_384,
+		api: "openai-completions",
+		provider: "ollama-cloud",
+		baseUrl: "https://ollama.com/v1",
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetOllamaApiKey.mockReturnValue(undefined);
+	mockGetOllamaShowPaid.mockReturnValue(false);
+	mockGetGlobalFreeOnly.mockReturnValue(true);
+});
+
+describe("createOllamaProvider", () => {
+	it("builds an OpenAI-compatible native provider", async () => {
+		const { provider } = createOllamaProvider([model("initial")]);
+		expect(provider.id).toBe("ollama-cloud");
+		expect(provider.baseUrl).toBe("https://ollama.com/v1");
+		expect(provider.getModels().map((item) => item.id)).toEqual(["initial"]);
+		expect(
+			await ollamaAuth.apiKey?.resolve({ ctx: {} as never }),
+		).toBeUndefined();
+	});
+
+	it("restores the native store offline without network access", async () => {
+		const { store } = makeStore({
+			models: [model("stored")],
+			checkedAt: Date.now(),
+		} as unknown as ModelsStoreEntry);
+		const { provider } = createOllamaProvider([model("initial")]);
+
+		await provider.refreshModels?.(context(store));
+
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+		expect(provider.getModels().map((item) => item.id)).toEqual(["stored"]);
+	});
+
+	it("fetches model details with the effective key and persists the catalog", async () => {
+		mockGetOllamaApiKey.mockReturnValue("ollama-ambient");
+		const controller = new AbortController();
+		mockFetchWithRetry.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ data: [{ id: "cloud-model" }] }),
+		});
+		mockFetchWithTimeout.mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			json: async () => ({
+				details: {
+					parameter_size: "7B",
+					quantization_level: "Q4_K_M",
+				},
+				model_info: { "x.context_length": 64_000 },
+				capabilities: ["tools", "thinking"],
+			}),
+		});
+		const { store, written } = makeStore();
+		const { provider } = createOllamaProvider([]);
+
+		await provider.refreshModels?.(
+			context(store, {
+				allowNetwork: true,
+				credential: { type: "api_key", key: "ollama-stored" },
+				signal: controller.signal,
+			}),
+		);
+
+		expect(mockFetchWithRetry).toHaveBeenCalledWith(
+			"https://ollama.com/v1/models",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer ollama-stored",
+				}),
+				signal: controller.signal,
+			}),
+			3,
+			1000,
+			10_000,
+		);
+		expect(mockFetchWithTimeout).toHaveBeenCalledWith(
+			"https://ollama.com/api/show",
+			expect.objectContaining({ signal: controller.signal }),
+			10_000,
+		);
+		expect(mockSaveProviderCache).toHaveBeenCalled();
+		expect(written).toHaveLength(1);
+		expect(provider.getModels().map((item) => item.id)).toEqual([
+			"cloud-model",
+		]);
+	});
+
+	it("honors an already-aborted refresh signal", async () => {
+		mockGetOllamaApiKey.mockReturnValue("ollama-ambient");
+		const controller = new AbortController();
+		controller.abort();
+		const { store, written } = makeStore();
+		const { provider } = createOllamaProvider([model("initial")]);
+
+		await provider.refreshModels?.(
+			context(store, { allowNetwork: true, signal: controller.signal }),
+		);
+
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+		expect(written).toHaveLength(0);
+	});
+});
+
+describe("Ollama native factory", () => {
+	it("registers a native provider with fallback models without network work", async () => {
+		const registerProvider = vi.fn();
+		const registerCommand = vi.fn();
+		const on = vi.fn();
+		const pi = {
+			registerProvider,
+			registerCommand,
+			on,
+		} as unknown as ExtensionAPI;
+
+		await ollamaEntry(pi);
+
+		expect(registerProvider).toHaveBeenCalledTimes(1);
+		expect(registerProvider.mock.calls[0][0].id).toBe("ollama-cloud");
+		expect(registerCommand).toHaveBeenCalledWith(
+			"toggle-ollama-cloud",
+			expect.any(Object),
+		);
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+	});
+});

--- a/tests/tokenrouter-provider.test.ts
+++ b/tests/tokenrouter-provider.test.ts
@@ -1,0 +1,260 @@
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetTokenrouterApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
+const mockGetTokenrouterShowPaid = vi.hoisted(() => vi.fn(() => false));
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockFetchWithRetry = vi.hoisted(() => vi.fn());
+
+vi.mock("../config.ts", () => ({
+	getTokenrouterApiKey: () => mockGetTokenrouterApiKey(),
+	getTokenrouterShowPaid: () => mockGetTokenrouterShowPaid(),
+	applyHidden: (models: unknown[]) => models,
+	saveConfig: vi.fn(),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (model: { id: string }) => model.id.endsWith(":free"),
+	registerWithGlobalToggle: vi.fn(),
+}));
+
+vi.mock("../lib/provider-cache.ts", () => ({
+	loadProviderCache: () => undefined,
+}));
+
+vi.mock("../lib/util.ts", () => ({
+	cleanModelName: (id: string) => id,
+	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+}));
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T[]) => models,
+}));
+
+vi.mock("../lib/provider-compat.ts", () => ({
+	getProxyModelCompat: () => undefined,
+	isLikelyReasoningModel: () => false,
+	DEEPSEEK_PROXY_COMPAT: {},
+}));
+
+vi.mock("../provider-helper.ts", async () => {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../provider-helper.ts",
+	);
+	return {
+		...actual,
+		enhanceWithCI: (models: unknown[]) => models,
+	};
+});
+
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { tokenRouterAuth } from "../providers/tokenrouter/tokenrouter-auth.ts";
+import tokenRouterEntry, {
+	createTokenRouterProvider,
+} from "../providers/tokenrouter/tokenrouter.ts";
+
+function makeStore(seed?: ModelsStoreEntry): {
+	store: ProviderModelsStore;
+	written: ModelsStoreEntry[];
+} {
+	let entry = seed;
+	const written: ModelsStoreEntry[] = [];
+	return {
+		store: {
+			read: async () => entry,
+			write: async (next: ModelsStoreEntry) => {
+				entry = next;
+				written.push(next);
+			},
+			delete: async () => {
+				entry = undefined;
+			},
+		},
+		written,
+	};
+}
+
+function context(
+	store: ProviderModelsStore,
+	overrides: Partial<RefreshModelsContext> = {},
+): RefreshModelsContext {
+	return { store, allowNetwork: false, ...overrides } as RefreshModelsContext;
+}
+
+function response(data: unknown) {
+	return {
+		ok: true,
+		status: 200,
+		json: async () => ({ data }),
+	};
+}
+
+function model(id: string, paid = false) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: {
+			input: paid ? 0.000001 : 0,
+			output: paid ? 0.000002 : 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		api: "tokenrouter-openai-completions",
+		provider: "tokenrouter",
+		baseUrl: "https://api.tokenrouter.com/v1",
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetTokenrouterApiKey.mockReturnValue(undefined);
+	mockGetTokenrouterShowPaid.mockReturnValue(false);
+	mockGetGlobalFreeOnly.mockReturnValue(true);
+});
+
+describe("createTokenRouterProvider", () => {
+	it("builds a keyed native provider and hides it without credentials", async () => {
+		const { provider } = createTokenRouterProvider();
+		expect(provider.id).toBe("tokenrouter");
+		expect(provider.baseUrl).toBe("https://api.tokenrouter.com/v1");
+		expect(provider.getModels()).toEqual([]);
+		expect(
+			await tokenRouterAuth.apiKey?.resolve({ ctx: {} as never }),
+		).toBeUndefined();
+	});
+
+	it("prefers the stored credential over the ambient key", async () => {
+		mockGetTokenrouterApiKey.mockReturnValue("sk-ambient");
+		await expect(
+			tokenRouterAuth.apiKey?.resolve({
+				ctx: {} as never,
+				credential: { type: "api_key", key: "sk-stored" },
+			}),
+		).resolves.toMatchObject({
+			auth: { apiKey: "sk-stored" },
+			source: "stored API key",
+		});
+	});
+
+	it("restores the native store offline", async () => {
+		const { store } = makeStore({
+			models: [model("free:free"), model("paid", true)],
+			checkedAt: Date.now(),
+		} as unknown as ModelsStoreEntry);
+		const { provider } = createTokenRouterProvider();
+
+		await provider.refreshModels?.(context(store));
+
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+		expect(provider.getModels().map((item) => item.id)).toEqual(["free:free"]);
+	});
+
+	it("fetches with the stored key and persists the native catalog", async () => {
+		mockGetTokenrouterApiKey.mockReturnValue("sk-ambient");
+		mockFetchWithRetry.mockResolvedValue(
+			response([
+				{
+					id: "free-model:free",
+					object: "model",
+					created: 0,
+					owned_by: "tokenrouter",
+					supported_endpoint_types: ["openai"],
+					tags: "text",
+				},
+				{
+					id: "paid-model",
+					object: "model",
+					created: 0,
+					owned_by: "tokenrouter",
+					supported_endpoint_types: ["openai"],
+					tags: "text",
+				},
+			]),
+		);
+		const { store, written } = makeStore();
+		const { provider, stored } = createTokenRouterProvider();
+
+		await provider.refreshModels?.(
+			context(store, {
+				allowNetwork: true,
+				credential: { type: "api_key", key: "sk-stored" },
+			}),
+		);
+
+		expect(mockFetchWithRetry).toHaveBeenCalledWith(
+			"https://api.tokenrouter.com/v1/models",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer sk-stored",
+				}),
+			}),
+			3,
+			1000,
+			10_000,
+		);
+		expect(stored.all).toHaveLength(2);
+		expect(stored.free).toHaveLength(1);
+		expect(written).toHaveLength(1);
+		expect(provider.getModels().map((item) => item.id)).toEqual([
+			"free-model:free",
+		]);
+	});
+
+	it("honors an already-aborted refresh signal", async () => {
+		mockGetTokenrouterApiKey.mockReturnValue("sk-ambient");
+		const controller = new AbortController();
+		controller.abort();
+		const { store, written } = makeStore();
+		const { provider } = createTokenRouterProvider();
+
+		await provider.refreshModels?.(
+			context(store, { allowNetwork: true, signal: controller.signal }),
+		);
+
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+		expect(written).toHaveLength(0);
+	});
+});
+
+describe("TokenRouter native factory", () => {
+	it("registers a native provider without doing network work", async () => {
+		const registerProvider = vi.fn();
+		const registerCommand = vi.fn();
+		const on = vi.fn();
+		const pi = {
+			registerProvider,
+			registerCommand,
+			on,
+		} as unknown as ExtensionAPI;
+
+		await tokenRouterEntry(pi);
+
+		expect(registerProvider).toHaveBeenCalledTimes(1);
+		expect(registerProvider.mock.calls[0][0].id).toBe("tokenrouter");
+		expect(registerCommand).toHaveBeenCalledWith(
+			"toggle-tokenrouter",
+			expect.any(Object),
+		);
+		expect(mockFetchWithRetry).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- Migrate TokenRouter and Ollama Cloud from legacy registration to native Pi `Provider` objects.
- Add native API-key auth with stored-credential precedence for both providers.
- Move model catalogs to Pi's native models store with offline restore, abort-aware refresh, empty-result protection, and stable provider-object re-registration.
- Preserve TokenRouter's custom streaming API, MiniMax thinking payload patching, high-load retry, and assistant `<think>` normalization.
- Preserve Ollama's `/api/show` capability discovery, provider cache reuse, fallback catalog, `/ollama-cloud-refresh`, `/probe-ollama`, auto-hide behavior, and background probe scheduling.
- Extend the shared native lifecycle with refresh/publish/persist handling.
- Thread native refresh abort signals through Ollama model-list and detail fetches.

## Validation

- `npm run lint`
- `npm run test:run` — 48 test files, 600 tests passed
- `npm run check`
- Fresh pi-lens scan: 0 primary LSP diagnostics and no blocking diagnostics.
- No package or lockfile changes.
