### PR TITLE
style: apply deferred formatting

### DIFF
--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -118,9 +118,12 @@ export async function restoreNativeProviderModels<T extends Model<Api>>(
 		) as T[];
 		if (models.length > 0) onModels(models);
 	} catch (err) {
-		_logger.warn(`Failed to read ${providerId} models store; continuing empty`, {
-			error: err instanceof Error ? err.message : String(err),
-		});
+		_logger.warn(
+			`Failed to read ${providerId} models store; continuing empty`,
+			{
+				error: err instanceof Error ? err.message : String(err),
+			},
+		);
 	}
 }
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -436,9 +436,7 @@ export function mapOpenRouterModel(m: {
 }): ProviderModelConfig {
 	const promptPrice = Number.parseFloat(m.pricing?.prompt ?? "0");
 	const completionPrice = Number.parseFloat(m.pricing?.completion ?? "0");
-	const cacheReadPrice = Number.parseFloat(
-		m.pricing?.input_cache_read ?? "0",
-	);
+	const cacheReadPrice = Number.parseFloat(m.pricing?.input_cache_read ?? "0");
 	const cacheWritePrice = Number.parseFloat(
 		m.pricing?.input_cache_write ?? "0",
 	);

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -156,7 +156,10 @@ export function createClineProvider(): ClineNativeProvider {
 		currentView = toClineModels(models);
 	}
 
-	function ingest(all: ProviderModelConfig[], free: ProviderModelConfig[]): void {
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
 		stored.all = toClineModels(enhanceWithCI(all));
 		stored.free = toClineModels(enhanceWithCI(free));
 		setView(decideView());
@@ -169,10 +172,7 @@ export function createClineProvider(): ClineNativeProvider {
 			(storedModels: ClineModel[]) => {
 				stored.all = storedModels;
 				stored.free = storedModels.filter((model) =>
-					isFreeModel(
-						{ ...model, provider: PROVIDER_CLINE },
-						storedModels,
-					),
+					isFreeModel({ ...model, provider: PROVIDER_CLINE }, storedModels),
 				);
 				setView(decideView());
 			},

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -110,7 +110,10 @@ export function createKiloProvider(): KiloNativeProvider {
 		currentView = toKiloModels(models);
 	}
 
-	function ingest(all: ProviderModelConfig[], free: ProviderModelConfig[]): void {
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
 		stored.all = toKiloModels(enhanceWithCI(applyKiloCompat(all)));
 		stored.free = toKiloModels(enhanceWithCI(applyKiloCompat(free)));
 		setView(decideView());
@@ -123,10 +126,7 @@ export function createKiloProvider(): KiloNativeProvider {
 			(storedModels: KiloModel[]) => {
 				stored.all = storedModels;
 				stored.free = storedModels.filter((model) =>
-					isFreeModel(
-						{ ...model, provider: PROVIDER_KILO },
-						storedModels,
-					),
+					isFreeModel({ ...model, provider: PROVIDER_KILO }, storedModels),
 				);
 				setView(decideView());
 			},
@@ -167,7 +167,8 @@ export function createKiloProvider(): KiloNativeProvider {
 		auth: kiloAuth,
 		getModels: () => currentView,
 		refreshModels,
-		stream: (model, context, options) => streams.stream(model, context, options),
+		stream: (model, context, options) =>
+			streams.stream(model, context, options),
 		streamSimple: (model, context, options) =>
 			streams.streamSimple(model, context, options),
 	};

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -21,11 +21,7 @@ import {
 	type ExtensionAPI,
 	type ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import {
-	getKiloApiKey,
-	getKiloShowPaid,
-	PROVIDER_KILO,
-} from "../../config.ts";
+import { getKiloApiKey, getKiloShowPaid, PROVIDER_KILO } from "../../config.ts";
 import { URL_KILO_TOS } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -116,10 +116,7 @@ export function createLlm7Provider(): Llm7NativeProvider {
 			(storedModels: Llm7Model[]) => {
 				stored.all = storedModels;
 				stored.free = storedModels.filter((model) =>
-					isFreeModel(
-						{ ...model, provider: PROVIDER_LLM7 },
-						storedModels,
-					),
+					isFreeModel({ ...model, provider: PROVIDER_LLM7 }, storedModels),
 				);
 				setView(decideView());
 			},

--- a/providers/ollama/ollama-provider.ts
+++ b/providers/ollama/ollama-provider.ts
@@ -19,9 +19,15 @@ import {
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
 import { areAllModelsFresh } from "../../lib/probe-cache.ts";
-import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
+import {
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
 import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import { getGlobalFreeOnly, registerWithGlobalToggle } from "../../lib/registry.ts";
+import {
+	getGlobalFreeOnly,
+	registerWithGlobalToggle,
+} from "../../lib/registry.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { ollamaAuth } from "./ollama-auth.ts";
 
@@ -45,10 +51,7 @@ export interface OllamaNativeProvider {
 	provider: Provider<"openai-completions">;
 	stored: StoredModels;
 	setView: (models: ProviderModelConfig[]) => void;
-	ingest: (
-		all: ProviderModelConfig[],
-		free: ProviderModelConfig[],
-	) => void;
+	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
 type OllamaModel = Model<"openai-completions">;
@@ -251,14 +254,19 @@ export function registerOllamaProvider(
 	});
 
 	const runProbeInBackground = (models: ProviderModelConfig[]) => {
-		if (areAllModelsFresh(PROVIDER_OLLAMA, models.map((model) => model.id))) {
+		if (
+			areAllModelsFresh(
+				PROVIDER_OLLAMA,
+				models.map((model) => model.id),
+			)
+		) {
 			return;
 		}
 		const apiKey = getOllamaApiKey();
 		if (!apiKey) return;
-		deps.probeModels(apiKey, models, applyModelList, { useCache: true }).catch(
-			() => undefined,
-		);
+		deps
+			.probeModels(apiKey, models, applyModelList, { useCache: true })
+			.catch(() => undefined);
 	};
 
 	// Pi owns the native model refresh; this handler preserves Ollama's

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -28,7 +28,10 @@ import {
 	PROVIDER_OLLAMA,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
+import {
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
 import {
 	getModelsDueForProbe,
 	recordModelProbeResults,

--- a/providers/tokenrouter/tokenrouter-auth.ts
+++ b/providers/tokenrouter/tokenrouter-auth.ts
@@ -18,9 +18,7 @@ async function resolveTokenRouterApiKey(input: {
 	if (!key) return undefined;
 	return {
 		auth: { apiKey: key },
-		source: input.credential?.key
-			? "stored API key"
-			: "TOKENROUTER_API_KEY",
+		source: input.credential?.key ? "stored API key" : "TOKENROUTER_API_KEY",
 	};
 }
 

--- a/providers/tokenrouter/tokenrouter-provider.ts
+++ b/providers/tokenrouter/tokenrouter-provider.ts
@@ -9,7 +9,10 @@ import type {
 	AssistantMessageEventStream,
 	Context,
 } from "@earendil-works/pi-ai/compat";
-import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
 import { getTokenrouterApiKey, getTokenrouterShowPaid } from "../../config.ts";
 import { BASE_URL_TOKENROUTER, PROVIDER_TOKENROUTER } from "../../constants.ts";
 import {
@@ -60,7 +63,9 @@ function credentialToken(credential?: Credential): string | undefined {
 	return getTokenrouterApiKey();
 }
 
-function toTokenRouterModel(model: ProviderModelConfig): TokenRouterNativeModel {
+function toTokenRouterModel(
+	model: ProviderModelConfig,
+): TokenRouterNativeModel {
 	return {
 		...model,
 		api: "tokenrouter-openai-completions",
@@ -85,8 +90,9 @@ function classifyFreeModels(
 
 export function createTokenRouterProvider(
 	deps: TokenRouterProviderDeps,
-	initialModels: ProviderModelConfig[] = loadProviderCache(PROVIDER_TOKENROUTER) ??
-		[],
+	initialModels: ProviderModelConfig[] = loadProviderCache(
+		PROVIDER_TOKENROUTER,
+	) ?? [],
 ): TokenRouterNativeProvider {
 	const stored: StoredModels = { free: [], all: [] };
 	let currentView: TokenRouterNativeModel[] = [];
@@ -136,9 +142,7 @@ export function createTokenRouterProvider(
 				const token = credentialToken(context.credential);
 				if (!token) return [];
 				const all = await deps.fetchModels(token, context.signal);
-				return toTokenRouterModels(
-					enhanceWithCI(all, PROVIDER_TOKENROUTER),
-				);
+				return toTokenRouterModels(enhanceWithCI(all, PROVIDER_TOKENROUTER));
 			},
 			(models) => {
 				stored.all = models;
@@ -193,8 +197,7 @@ export function registerTokenRouterProvider(
 	pi.on("before_provider_request", (event, ctx) =>
 		deps.patchPayload(
 			event.payload,
-			deps.isModel(ctx.model ?? {}) &&
-				deps.isMinimaxModel(ctx.model?.id ?? ""),
+			deps.isModel(ctx.model ?? {}) && deps.isMinimaxModel(ctx.model?.id ?? ""),
 		),
 	);
 

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -561,15 +561,15 @@ const TOKENROUTER_PROVIDER_DEPS: TokenRouterProviderDeps = {
 	patchPayload: patchTokenRouterMinimaxThinkingPayload,
 };
 
-export function createTokenRouterProvider(initialModels?: ProviderModelConfig[]) {
+export function createTokenRouterProvider(
+	initialModels?: ProviderModelConfig[],
+) {
 	return initialModels === undefined
 		? createNativeTokenRouterProvider(TOKENROUTER_PROVIDER_DEPS)
 		: createNativeTokenRouterProvider(TOKENROUTER_PROVIDER_DEPS, initialModels);
 }
 
-export default function tokenRouterProvider(
-	pi: ExtensionAPI,
-): Promise<void> {
+export default function tokenRouterProvider(pi: ExtensionAPI): Promise<void> {
 	registerTokenRouterProvider(pi, TOKENROUTER_PROVIDER_DEPS);
 	return Promise.resolve();
 }

--- a/providers/zenmux/zenmux-provider.ts
+++ b/providers/zenmux/zenmux-provider.ts
@@ -24,10 +24,7 @@ export interface ZenmuxNativeProvider {
 	provider: Provider<"openai-completions">;
 	stored: StoredModels;
 	setView: (models: ProviderModelConfig[]) => void;
-	ingest: (
-		all: ProviderModelConfig[],
-		free: ProviderModelConfig[],
-	) => void;
+	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
 function credentialToken(credential?: Credential): string | undefined {
@@ -71,10 +68,7 @@ export function createZenmuxProvider(): ZenmuxNativeProvider {
 			(storedModels: ZenmuxModel[]) => {
 				stored.all = storedModels;
 				stored.free = storedModels.filter((model) =>
-					isFreeModel(
-						{ ...model, provider: PROVIDER_ZENMUX },
-						storedModels,
-					),
+					isFreeModel({ ...model, provider: PROVIDER_ZENMUX }, storedModels),
 				);
 				setView(decideView());
 			},

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -233,11 +233,10 @@ describe("createZenmuxProvider", () => {
 		const { store } = makeStore();
 		const handle = createZenmuxProvider();
 
-		await handle.provider.refreshModels?.(context(store, { allowNetwork: true }));
-		expect(mockApplyHidden).toHaveBeenCalledWith(
-			expect.any(Array),
-			"zenmux",
+		await handle.provider.refreshModels?.(
+			context(store, { allowNetwork: true }),
 		);
+		expect(mockApplyHidden).toHaveBeenCalledWith(expect.any(Array), "zenmux");
 		expect(handle.stored.all.map((model) => model.id)).toEqual(["visible"]);
 	});
 


### PR DESCRIPTION
## Summary

Apply the formatter's deferred line wrapping and import/function formatting across the native-provider work and shared utilities. This is formatting-only; no behavior or dependency changes.

## Validation

- `npm run lint`
- `git diff --check`
- 13 files, 65 insertions and 65 deletions.
