### PR TITLE
feat: migrate five API providers to native providers

### DIFF
--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -1,16 +1,31 @@
 import type {
 	Api,
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	Credential,
 	Model,
 	Provider,
+	ProviderAuth,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { saveConfig } from "../config.ts";
 import { createLogger } from "./logger.ts";
+import {
+	getGlobalFreeOnly,
+	isFreeModel,
+	registerWithGlobalToggle,
+} from "./registry.ts";
 import { wrapSessionStartHandler } from "./session-start-metrics.ts";
+import type { ProviderProbe } from "./provider-probe.ts";
+import { enhanceWithCI, type StoredModels } from "../provider-helper.ts";
 
 const _logger = createLogger("native-provider");
 
@@ -18,6 +33,261 @@ const _logger = createLogger("native-provider");
 export type NativeRegistrar = {
 	registerProvider(provider: Provider): void;
 };
+
+export interface NativeApiKeyAuthOptions {
+	name: string;
+	prompt: string;
+	source: string;
+	getApiKey: () => string | undefined;
+}
+
+/** Build the standard persisted API-key auth used by keyed native providers. */
+export function createNativeApiKeyAuth(
+	options: NativeApiKeyAuthOptions,
+): ProviderAuth {
+	const apiKey: ApiKeyAuth = {
+		name: options.name,
+		async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+			const key = await interaction.prompt({
+				type: "secret",
+				message: options.prompt,
+			});
+			return { type: "api_key", key };
+		},
+		async resolve(input: {
+			ctx: AuthContext;
+			credential?: ApiKeyCredential;
+		}): Promise<AuthResult | undefined> {
+			const key = input.credential?.key ?? options.getApiKey();
+			if (!key) return undefined;
+			return {
+				auth: { apiKey: key },
+				source: input.credential?.key ? "stored API key" : options.source,
+			};
+		},
+	};
+	return { apiKey };
+}
+
+export interface NativeOpenAIProviderOptions {
+	providerId: string;
+	name: string;
+	baseUrl: string;
+	auth: ProviderAuth;
+	getApiKey: () => string | undefined;
+	getShowPaid: () => boolean;
+	initialModels: ProviderModelConfig[];
+	fetchModels: (
+		apiKey: string,
+		signal?: AbortSignal,
+	) => Promise<ProviderModelConfig[]>;
+	tosUrl?: string;
+	suppressTosWhenKey?: boolean;
+}
+
+export interface NativeOpenAIProviderHandle {
+	provider: Provider<"openai-completions">;
+	stored: StoredModels;
+	setView: (models: ProviderModelConfig[]) => void;
+	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
+}
+
+function nativeCredentialToken(
+	credential: Credential | undefined,
+	getApiKey: () => string | undefined,
+): string | undefined {
+	if (credential?.type === "api_key") return credential.key ?? getApiKey();
+	return getApiKey();
+}
+
+function toNativeOpenAIModel(
+	model: ProviderModelConfig,
+	providerId: string,
+	baseUrl: string,
+): Model<"openai-completions"> {
+	return {
+		...model,
+		api: "openai-completions",
+		provider: providerId,
+		baseUrl,
+	} as Model<"openai-completions">;
+}
+
+/** Build a keyed OpenAI-compatible native provider with shared catalog lifecycle. */
+export function createNativeOpenAIProvider(
+	options: NativeOpenAIProviderOptions,
+): NativeOpenAIProviderHandle {
+	const streams = openAICompletionsApi();
+	const stored: StoredModels = { free: [], all: [] };
+	let currentView: Model<"openai-completions">[] = [];
+
+	function classifyFree(
+		models: Model<"openai-completions">[],
+	): Model<"openai-completions">[] {
+		return models.filter((model) =>
+			isFreeModel({ ...model, provider: options.providerId }, models),
+		);
+	}
+
+	function decideView(): ProviderModelConfig[] {
+		if (!getGlobalFreeOnly()) {
+			return stored.all.length > 0 ? stored.all : stored.free;
+		}
+		return options.getShowPaid() && stored.all.length > 0
+			? stored.all
+			: stored.free;
+	}
+
+	function setView(models: ProviderModelConfig[]): void {
+		currentView = models.map((model) =>
+			toNativeOpenAIModel(model, options.providerId, options.baseUrl),
+		);
+	}
+
+	function ingest(
+		all: ProviderModelConfig[],
+		free: ProviderModelConfig[],
+	): void {
+		stored.all = enhanceWithCI(all, options.providerId).map((model) =>
+			toNativeOpenAIModel(model, options.providerId, options.baseUrl),
+		);
+		stored.free = enhanceWithCI(free, options.providerId).map((model) =>
+			toNativeOpenAIModel(model, options.providerId, options.baseUrl),
+		);
+		setView(decideView());
+	}
+
+	if (options.initialModels.length > 0) {
+		const all = enhanceWithCI(options.initialModels, options.providerId).map(
+			(model) =>
+				toNativeOpenAIModel(model, options.providerId, options.baseUrl),
+		);
+		stored.all = all;
+		stored.free = classifyFree(all);
+		setView(decideView());
+	}
+
+	async function refreshModels(context: RefreshModelsContext): Promise<void> {
+		await refreshNativeProviderModels(
+			options.providerId,
+			context,
+			(storedModels: Model<"openai-completions">[]) => {
+				stored.all = storedModels;
+				stored.free = classifyFree(storedModels);
+				setView(decideView());
+			},
+			async () => {
+				const token = nativeCredentialToken(
+					context.credential,
+					options.getApiKey,
+				);
+				if (!token) return [];
+				const all = await options.fetchModels(token, context.signal);
+				return enhanceWithCI(all, options.providerId).map((model) =>
+					toNativeOpenAIModel(model, options.providerId, options.baseUrl),
+				);
+			},
+			(models) => {
+				stored.all = models;
+				stored.free = classifyFree(models);
+				setView(decideView());
+			},
+		);
+	}
+
+	const provider: Provider<"openai-completions"> = {
+		id: options.providerId,
+		name: options.name,
+		baseUrl: options.baseUrl,
+		headers: { "User-Agent": "pi-free-providers" },
+		auth: options.auth,
+		getModels: () => currentView,
+		refreshModels,
+		stream: (model, context, streamOptions) =>
+			streams.stream(model, context, streamOptions),
+		streamSimple: (model, context, streamOptions) =>
+			streams.streamSimple(model, context, streamOptions),
+	};
+
+	return { provider, stored, setView, ingest };
+}
+
+/** Register a shared keyed OpenAI-compatible native provider and its lifecycle. */
+export function registerNativeOpenAIProvider(
+	pi: ExtensionAPI,
+	options: NativeOpenAIProviderOptions,
+): NativeOpenAIProviderHandle {
+	const handle = createNativeOpenAIProvider(options);
+	registerNativeProvider(pi, handle.provider);
+	const reRegister = (models: ProviderModelConfig[]) => {
+		handle.setView(models);
+		registerNativeProvider(pi, handle.provider);
+	};
+	registerWithGlobalToggle(
+		options.providerId,
+		handle.stored,
+		reRegister,
+		Boolean(options.getApiKey()),
+	);
+	registerNativeProviderToggle(pi, {
+		providerId: options.providerId,
+		stored: handle.stored,
+		getShowPaid: options.getShowPaid,
+		reRegister,
+	});
+	if (options.tosUrl) {
+		let tosShown = false;
+		pi.on("model_select", (_event, ctx) => {
+			if (tosShown || ctx.model?.provider !== options.providerId) return;
+			tosShown = true;
+			if (options.suppressTosWhenKey && options.getApiKey()) return;
+			ctx.ui.notify(
+				`Using ${options.providerId} free models. Terms: ${options.tosUrl}`,
+				"info",
+			);
+		});
+	}
+	registerNativeProviderRefresh(pi, options.providerId);
+	return handle;
+}
+
+/** Register a standard availability probe for a native OpenAI provider. */
+export function registerNativeAvailabilityProbe(
+	pi: ExtensionAPI,
+	options: {
+		providerId: string;
+		label: string;
+		apiKey: string;
+		probe: ProviderProbe;
+		handle: NativeOpenAIProviderHandle;
+	},
+): void {
+	const { providerId, label, apiKey, probe, handle } = options;
+	pi.registerCommand(`probe-${providerId}`, {
+		description: `Test all ${label} models for availability`,
+		handler: async (_args, ctx) => {
+			const models = handle.stored.all;
+			ctx.ui.notify(`Probing ${models.length} ${label} models…`, "info");
+			const broken = await probe.run(apiKey, models, {
+				onBroken: (ids) =>
+					ctx.ui.notify(
+						`Found ${ids.length} broken models (auto-hidden):\n${ids.join("\n")}`,
+						"warning",
+					),
+			});
+			if (broken.length === 0) {
+				ctx.ui.notify(`All ${label} models are accessible ✅`, "info");
+			}
+		},
+	});
+	pi.on(
+		"session_start",
+		wrapSessionStartHandler(
+			`${providerId}-auto-probe`,
+			probe.autoProbeHandler(apiKey, handle.stored.free),
+		),
+	);
+}
 
 /** Register a native provider across the current dev snapshot and >=0.81 peers. */
 export function registerNativeProvider(

--- a/lib/provider-probe.ts
+++ b/lib/provider-probe.ts
@@ -23,6 +23,7 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { updateConfig } from "../config.ts";
 import { createLogger } from "./logger.ts";
+import { fetchWithTimeout } from "./util.ts";
 import {
 	areAllModelsFresh,
 	getModelsDueForProbe,
@@ -87,6 +88,42 @@ export interface ProviderProbe {
 // =============================================================================
 // Factory
 // =============================================================================
+
+/** Build the standard one-token probe used by OpenAI-compatible gateways. */
+export function createOpenAIAvailabilityProbe(
+	providerId: string,
+	baseUrl: string,
+): ProviderProbe {
+	return createProviderProbe({
+		providerId,
+		probeModel: async (apiKey, modelId) => {
+			try {
+				const response = await fetchWithTimeout(
+					`${baseUrl}/chat/completions`,
+					{
+						method: "POST",
+						headers: {
+							Authorization: `Bearer ${apiKey}`,
+							"Content-Type": "application/json",
+							"User-Agent": "pi-free-providers",
+						},
+						body: JSON.stringify({
+							model: modelId,
+							messages: [{ role: "user", content: "hi" }],
+							max_tokens: 1,
+						}),
+					},
+					10_000,
+				);
+				return response.status === 404 || response.status >= 500
+					? "broken"
+					: "ok";
+			} catch {
+				return "unknown";
+			}
+		},
+	});
+}
 
 export function createProviderProbe(
 	options: ProviderProbeOptions,

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -534,6 +534,7 @@ export async function fetchOpenAICompatibleModels(
 	apiKey: string,
 	defaults: OpenAIModelDefaults = {},
 	callbacks: OpenAIModelCallbacks = {},
+	signal?: AbortSignal,
 ): Promise<PiProviderModelConfig[]> {
 	const logger = createLogger(providerId);
 	const detectReasoning = callbacks.detectReasoning ?? isLikelyReasoningModel;
@@ -549,6 +550,7 @@ export async function fetchOpenAICompatibleModels(
 					Authorization: `Bearer ${apiKey}`,
 					"Content-Type": "application/json",
 				},
+				signal,
 			},
 			3,
 			1000,

--- a/providers/anyapi/anyapi-auth.ts
+++ b/providers/anyapi/anyapi-auth.ts
@@ -1,0 +1,9 @@
+import { getAnyapiApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const anyapiAuth = createNativeApiKeyAuth({
+	name: "AnyAPI API key",
+	prompt: "AnyAPI API key",
+	source: "ANYAPI_API_KEY",
+	getApiKey: getAnyapiApiKey,
+});

--- a/providers/anyapi/anyapi.ts
+++ b/providers/anyapi/anyapi.ts
@@ -25,15 +25,14 @@ import {
 	PROVIDER_ANYAPI,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { loadProviderCache } from "../../lib/provider-cache.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import {
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { fetchWithRetry, mapOpenRouterModel } from "../../lib/util.ts";
-import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
+import { anyapiAuth } from "./anyapi-auth.ts";
 
 const _logger = createLogger("anyapi");
 
@@ -161,6 +160,7 @@ function isTextModel(model: AnyApiModel): boolean {
 
 async function fetchAnyApiModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<AnyApiProviderModel[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_ANYAPI}/models`,
@@ -170,6 +170,7 @@ async function fetchAnyApiModels(
 				Accept: "application/json",
 				"Content-Type": "application/json",
 			},
+			signal,
 		},
 		3,
 		1000,
@@ -205,66 +206,23 @@ async function fetchAnyApiModels(
 	) as AnyApiProviderModel[];
 }
 
-export default async function anyapiProvider(pi: ExtensionAPI) {
-	const apiKey = getAnyapiApiKey();
-	if (!apiKey) {
-		_logger.info("[anyapi] Skipping — ANYAPI_API_KEY not set.");
-		return;
-	}
-
-	const cachedModels = loadProviderCache(PROVIDER_ANYAPI) as
-		| AnyApiProviderModel[]
-		| undefined;
-	const needsMetadataMigration = cachedModels?.some(
-		(model) => model._anyapiMetadataVersion !== ANYAPI_METADATA_VERSION,
-	);
-	const allModels = await loadCachedOrFetchModels(
-		PROVIDER_ANYAPI,
-		() => fetchAnyApiModels(apiKey),
-		// Force one refresh for caches written before context metadata was added;
-		// subsequent warm startups continue using the normal one-hour cache.
-		needsMetadataMigration ? { ttlMs: -1 } : undefined,
-	);
-	if (allModels.length === 0) {
-		_logger.warn("[anyapi] No text models available");
-		return;
-	}
-
-	const freeModels = allModels.filter((model) =>
-		isFreeModel({ ...model, provider: PROVIDER_ANYAPI }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[anyapi] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	const reRegister = createReRegister(pi, {
+export default function anyapiProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_ANYAPI) ?? [];
+	registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_ANYAPI,
+		name: "AnyAPI",
 		baseUrl: BASE_URL_ANYAPI,
-		apiKey,
-	});
-
-	registerWithGlobalToggle(PROVIDER_ANYAPI, stored, reRegister, true);
-
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_ANYAPI,
-			initialShowPaid: getAnyapiShowPaid(),
-			hasKey: true,
-			tosUrl: "https://anyapi.ai/terms-of-service",
-			reRegister: (models, current) => {
-				if (current) {
-					stored.free = current.free;
-					stored.all = current.all;
-				}
-				reRegister(models);
-			},
+		auth: anyapiAuth,
+		getApiKey: getAnyapiApiKey,
+		getShowPaid: getAnyapiShowPaid,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchAnyApiModels(apiKey, signal);
+			if (models.length > 0) await saveProviderCache(PROVIDER_ANYAPI, models);
+			return models;
 		},
-		stored,
-	);
-
-	const showPaid = getAnyapiShowPaid();
-	reRegister(showPaid ? stored.all : stored.free);
+		tosUrl: "https://anyapi.ai/terms-of-service",
+		suppressTosWhenKey: true,
+	});
+	return Promise.resolve();
 }

--- a/providers/bai/bai-auth.ts
+++ b/providers/bai/bai-auth.ts
@@ -1,0 +1,9 @@
+import { getBaiApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const baiAuth = createNativeApiKeyAuth({
+	name: "B.AI API key",
+	prompt: "B.AI API key",
+	source: "BAI_API_KEY",
+	getApiKey: getBaiApiKey,
+});

--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -38,13 +38,13 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
+import { baiAuth } from "./bai-auth.ts";
 
 const _logger = createLogger("bai");
 
@@ -127,7 +127,10 @@ function mapBaiModel(model: BaiModel): ProviderModelConfig & {
 // Fetch Models
 // =============================================================================
 
-async function fetchBaiModels(apiKey: string): Promise<ProviderModelConfig[]> {
+async function fetchBaiModels(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
 	_logger.info("[bai] Fetching models from B.AI API...");
 
 	try {
@@ -139,6 +142,7 @@ async function fetchBaiModels(apiKey: string): Promise<ProviderModelConfig[]> {
 					Accept: "application/json",
 					"Content-Type": "application/json",
 				},
+				signal,
 			},
 			3,
 			1000,
@@ -167,72 +171,25 @@ async function fetchBaiModels(apiKey: string): Promise<ProviderModelConfig[]> {
 }
 
 // =============================================================================
-// Extension Entry Point
+// Native Provider Entry Point
 // =============================================================================
 
-export default async function baiProvider(pi: ExtensionAPI) {
-	const apiKey = getBaiApiKey();
-
-	if (!apiKey) {
-		_logger.info(
-			"[bai] Skipping — BAI_API_KEY not set. Sign up at https://b.ai/",
-		);
-		return;
-	}
-
-	const allModels = await loadCachedOrFetchModels(PROVIDER_BAI, () =>
-		fetchBaiModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		// Either the API failed (already logged inside fetchBaiModels) or
-		// the API returned zero text chat models. We can't tell the user
-		// which, but we can give a hint to check the log / their key.
-		_logger.warn(
-			"[bai] No text chat models available — verify BAI_API_KEY is valid and see ~/.pi/free.log for details",
-		);
-		return;
-	}
-
-	// Use isFreeModel with allModels for proper detection
-	// B.AI doesn't expose pricing, so Route B (name-based) applies:
-	// FREE if name contains "free" OR _isFree is true (known-free hardcoded).
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_BAI }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[bai] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	const reRegister = createReRegister(pi, {
+export default function baiProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_BAI) ?? [];
+	registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_BAI,
+		name: "B.AI",
 		baseUrl: BASE_URL_BAI,
-		apiKey,
-	});
-
-	registerWithGlobalToggle(PROVIDER_BAI, stored, reRegister, true);
-
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_BAI,
-			initialShowPaid: getBaiShowPaid(),
-			tosUrl: "https://b.ai/",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
+		auth: baiAuth,
+		getApiKey: getBaiApiKey,
+		getShowPaid: getBaiShowPaid,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchBaiModels(apiKey, signal);
+			if (models.length > 0) await saveProviderCache(PROVIDER_BAI, models);
+			return models;
 		},
-		stored,
-	);
-
-	const showPaid = getBaiShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
+		tosUrl: "https://b.ai/",
+	});
+	return Promise.resolve();
 }

--- a/providers/crofai/crofai-auth.ts
+++ b/providers/crofai/crofai-auth.ts
@@ -1,0 +1,9 @@
+import { getCrofaiApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const crofaiAuth = createNativeApiKeyAuth({
+	name: "CrofAI API key",
+	prompt: "CrofAI API key",
+	source: "CROFAI_API_KEY",
+	getApiKey: getCrofaiApiKey,
+});

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -33,13 +33,13 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
 import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
+import { crofaiAuth } from "./crofai-auth.ts";
 
 const _logger = createLogger("crofai");
 
@@ -75,6 +75,7 @@ function parseCrofaiPrice(priceStr: string | undefined): number {
 
 async function fetchCrofaiModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_CROFAI}/models`,
@@ -83,6 +84,7 @@ async function fetchCrofaiModels(
 				Authorization: `Bearer ${apiKey}`,
 				"Content-Type": "application/json",
 			},
+			signal,
 		},
 		3,
 		1000,
@@ -137,69 +139,24 @@ async function fetchCrofaiModels(
 }
 
 // =============================================================================
-// Extension Entry Point
+// Native Provider Entry Point
 // =============================================================================
 
-export default async function crofaiProvider(pi: ExtensionAPI) {
-	const apiKey = getCrofaiApiKey();
-
-	if (!apiKey) {
-		_logger.info(
-			"[crofai] Skipping - CROFAI_API_KEY not set (env var or ~/.pi/free.json)",
-		);
-		return;
-	}
-
-	// Fetch models
-	const allModels = await loadCachedOrFetchModels(PROVIDER_CROFAI, () =>
-		fetchCrofaiModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[crofai] No models available");
-		return;
-	}
-
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_CROFAI }, allModels),
-	);
-
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[crofai] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
+export default function crofaiProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_CROFAI) ?? [];
+	registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_CROFAI,
+		name: "CrofAI",
 		baseUrl: BASE_URL_CROFAI,
-		apiKey,
-	});
-
-	// Register with global toggle
-	registerWithGlobalToggle(PROVIDER_CROFAI, stored, reRegister, true);
-
-	// Setup provider with toggle command
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_CROFAI,
-			initialShowPaid: getCrofaiShowPaid(),
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
+		auth: crofaiAuth,
+		getApiKey: getCrofaiApiKey,
+		getShowPaid: getCrofaiShowPaid,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchCrofaiModels(apiKey, signal);
+			if (models.length > 0) await saveProviderCache(PROVIDER_CROFAI, models);
+			return models;
 		},
-		stored,
-	);
-
-	// Initial registration — respect persisted toggle state
-	const showPaid = getCrofaiShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
+	});
+	return Promise.resolve();
 }

--- a/providers/novita/novita-auth.ts
+++ b/providers/novita/novita-auth.ts
@@ -1,0 +1,9 @@
+import { getNovitaApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const novitaAuth = createNativeApiKeyAuth({
+	name: "Novita API key",
+	prompt: "Novita API key",
+	source: "NOVITA_API_KEY",
+	getApiKey: getNovitaApiKey,
+});

--- a/providers/novita/novita.ts
+++ b/providers/novita/novita.ts
@@ -37,15 +37,17 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { createProviderProbe } from "../../lib/provider-probe.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import { fetchWithRetry, fetchWithTimeout } from "../../lib/util.ts";
+import { createOpenAIAvailabilityProbe } from "../../lib/provider-probe.ts";
 import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	registerNativeAvailabilityProbe,
+	registerNativeOpenAIProvider,
+} from "../../lib/native-provider.ts";
+import {
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { novitaAuth } from "./novita-auth.ts";
 
 const _logger = createLogger("novita");
 
@@ -75,6 +77,7 @@ interface NovitaModel {
 
 async function fetchNovitaModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	_logger.info("[novita] Fetching models from Novita API...");
 
@@ -86,6 +89,7 @@ async function fetchNovitaModels(
 					Authorization: `Bearer ${apiKey}`,
 					"Content-Type": "application/json",
 				},
+				signal,
 			},
 			3,
 			1000,
@@ -146,133 +150,36 @@ async function fetchNovitaModels(
 	}
 }
 
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
-
-export default async function novitaProvider(pi: ExtensionAPI) {
-	const apiKey = getNovitaApiKey();
-
-	if (!apiKey) {
-		_logger.info(
-			"[novita] Skipping — NOVITA_API_KEY not set. Sign up at https://novita.ai/",
-		);
-		return;
-	}
-
-	// Fetch models
-	const allModels = await loadCachedOrFetchModels(PROVIDER_NOVITA, () =>
-		fetchNovitaModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[novita] No chat models available");
-		return;
-	}
-
-	// Use isFreeModel with allModels for proper detection
-	// Novita returns pricing for all models → _pricingKnown=true → Route A OR logic
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_NOVITA }, allModels),
-	);
-
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[novita] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
+export default function novitaProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_NOVITA) ?? [];
+	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_NOVITA,
+		name: "Novita AI",
 		baseUrl: BASE_URL_NOVITA,
-		apiKey,
-	});
-
-	// Register with global toggle
-	registerWithGlobalToggle(PROVIDER_NOVITA, stored, reRegister, true);
-
-	// Setup provider with toggle command
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_NOVITA,
-			initialShowPaid: getNovitaShowPaid(),
-			tosUrl: "https://novita.ai/terms",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
+		auth: novitaAuth,
+		getApiKey: getNovitaApiKey,
+		getShowPaid: getNovitaShowPaid,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchNovitaModels(apiKey, signal);
+			if (models.length > 0) await saveProviderCache(PROVIDER_NOVITA, models);
+			return models;
 		},
-		stored,
+		tosUrl: "https://novita.ai/terms",
+	});
+	const apiKey = getNovitaApiKey();
+	if (!apiKey) return Promise.resolve();
+
+	const probe = createOpenAIAvailabilityProbe(
+		PROVIDER_NOVITA,
+		BASE_URL_NOVITA,
 	);
-
-	// Initial registration — respect persisted toggle state
-	const showPaid = getNovitaShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
-
-	// ── Probe support ──────────────────────────────────────────────
-	const probe = createProviderProbe({
+	registerNativeAvailabilityProbe(pi, {
 		providerId: PROVIDER_NOVITA,
-		probeModel: async (_apiKey: string, modelId: string) => {
-			try {
-				const response = await fetchWithTimeout(
-					`${BASE_URL_NOVITA}/chat/completions`,
-					{
-						method: "POST",
-						headers: {
-							Authorization: `Bearer ${apiKey}`,
-							"Content-Type": "application/json",
-							"User-Agent": "pi-free-providers",
-						},
-						body: JSON.stringify({
-							model: modelId,
-							messages: [{ role: "user", content: "hi" }],
-							max_tokens: 1,
-						}),
-					},
-					10_000,
-				);
-				if (response.status === 404 || response.status >= 500) return "broken";
-				if (response.status === 429) return "ok";
-				if (response.ok) return "ok";
-				return "ok";
-			} catch {
-				return "unknown";
-			}
-		},
+		label: "Novita AI",
+		apiKey,
+		probe,
+		handle,
 	});
-
-	// Probe command
-	pi.registerCommand(`probe-${PROVIDER_NOVITA}`, {
-		description: "Test all Novita AI models for availability",
-		handler: async (_args, ctx) => {
-			ctx.ui.notify(`Probing ${allModels.length} Novita AI models…`, "info");
-			const broken = await probe.run(apiKey, allModels, {
-				onBroken: (ids) => {
-					ctx.ui.notify(
-						`Found ${ids.length} broken models (auto-hidden):\n${ids.join("\n")}`,
-						"warning",
-					);
-				},
-			});
-			if (broken.length === 0) {
-				ctx.ui.notify("All Novita AI models are accessible ✅", "info");
-			}
-		},
-	});
-
-	// Lazy auto-probe on first session_start
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler(
-			`${PROVIDER_NOVITA}-auto-probe`,
-			probe.autoProbeHandler(apiKey, freeModels),
-		),
-	);
+	return Promise.resolve();
 }

--- a/providers/sambanova/sambanova-auth.ts
+++ b/providers/sambanova/sambanova-auth.ts
@@ -1,0 +1,9 @@
+import { getSambanovaApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const sambanovaAuth = createNativeApiKeyAuth({
+	name: "SambaNova API key",
+	prompt: "SambaNova API key",
+	source: "SAMBANOVA_API_KEY",
+	getApiKey: getSambanovaApiKey,
+});

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -30,158 +30,59 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getSambanovaApiKey, getSambanovaShowPaid } from "../../config.ts";
 import { BASE_URL_SAMBANOVA, PROVIDER_SAMBANOVA } from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
-import { createProviderProbe } from "../../lib/provider-probe.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
+import { createOpenAIAvailabilityProbe } from "../../lib/provider-probe.ts";
 import {
-	fetchOpenAICompatibleModels,
-	fetchWithTimeout,
-} from "../../lib/util.ts";
+	registerNativeAvailabilityProbe,
+	registerNativeOpenAIProvider,
+} from "../../lib/native-provider.ts";
 import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	loadProviderCache,
+	saveProviderCache,
+} from "../../lib/provider-cache.ts";
+import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
+import { sambanovaAuth } from "./sambanova-auth.ts";
 
-const _logger = createLogger("sambanova");
-
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
-
-export default async function sambanovaProvider(pi: ExtensionAPI) {
-	const apiKey = getSambanovaApiKey();
-
-	if (!apiKey) {
-		_logger.info(
-			"[sambanova] Skipping — SAMBANOVA_API_KEY not set. Sign up at https://cloud.sambanova.ai/",
-		);
-		return;
-	}
-
-	// Fetch models via shared OpenAI-compatible helper
-	const allModels = await loadCachedOrFetchModels(PROVIDER_SAMBANOVA, () =>
-		fetchOpenAICompatibleModels(
-			"sambanova",
-			BASE_URL_SAMBANOVA,
-			apiKey,
-			{ maxTokens: 8_192 },
-		),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[sambanova] No models available");
-		return;
-	}
-
-	// All SambaNova models are free-tier (no payment method required).
-	// Rate limits are lower on free tier but all models are accessible.
-	// Override _pricingKnown so isFreeModel trusts the zero costs.
-	for (const m of allModels) {
-		(m as unknown as { _pricingKnown?: boolean })._pricingKnown = true;
-	}
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_SAMBANOVA }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[sambanova] Registered ${allModels.length} models (all free tier)`,
-	);
-
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
+export default function sambanovaProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_SAMBANOVA) ?? [];
+	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_SAMBANOVA,
+		name: "SambaNova",
 		baseUrl: BASE_URL_SAMBANOVA,
-		apiKey,
-	});
-
-	// Register with global toggle
-	registerWithGlobalToggle(PROVIDER_SAMBANOVA, stored, reRegister, true);
-
-	// Setup provider with toggle command
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_SAMBANOVA,
-			initialShowPaid: getSambanovaShowPaid(),
-			tosUrl: "https://sambanova.ai/terms",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
+		auth: sambanovaAuth,
+		getApiKey: getSambanovaApiKey,
+		getShowPaid: getSambanovaShowPaid,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchOpenAICompatibleModels(
+				"sambanova",
+				BASE_URL_SAMBANOVA,
+				apiKey,
+				{ maxTokens: 8_192 },
+				{},
+				signal,
+			);
+			for (const model of models) {
+				(model as unknown as { _pricingKnown?: boolean })._pricingKnown = true;
+			}
+			if (models.length > 0)
+				await saveProviderCache(PROVIDER_SAMBANOVA, models);
+			return models;
 		},
-		stored,
+		tosUrl: "https://sambanova.ai/terms",
+	});
+	const apiKey = getSambanovaApiKey();
+	if (!apiKey) return Promise.resolve();
+
+	const probe = createOpenAIAvailabilityProbe(
+		PROVIDER_SAMBANOVA,
+		BASE_URL_SAMBANOVA,
 	);
-
-	// Initial registration — respect persisted toggle state
-	const showPaid = getSambanovaShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
-
-	// ── Probe support ──────────────────────────────────────────────
-	const probe = createProviderProbe({
+	registerNativeAvailabilityProbe(pi, {
 		providerId: PROVIDER_SAMBANOVA,
-		probeModel: async (_apiKey: string, modelId: string) => {
-			try {
-				const response = await fetchWithTimeout(
-					`${BASE_URL_SAMBANOVA}/chat/completions`,
-					{
-						method: "POST",
-						headers: {
-							Authorization: `Bearer ${apiKey}`,
-							"Content-Type": "application/json",
-							"User-Agent": "pi-free-providers",
-						},
-						body: JSON.stringify({
-							model: modelId,
-							messages: [{ role: "user", content: "hi" }],
-							max_tokens: 1,
-						}),
-					},
-					10_000,
-				);
-				// SambaNova may return 404 for preview/unavailable models
-				if (response.status === 404 || response.status >= 500) return "broken";
-				if (response.status === 429) return "ok";
-				if (response.ok) return "ok";
-				return "ok";
-			} catch {
-				return "unknown";
-			}
-		},
+		label: "SambaNova",
+		apiKey,
+		probe,
+		handle,
 	});
-
-	// Probe command
-	pi.registerCommand(`probe-${PROVIDER_SAMBANOVA}`, {
-		description: "Test all SambaNova models for availability",
-		handler: async (_args, ctx) => {
-			ctx.ui.notify(`Probing ${allModels.length} SambaNova models…`, "info");
-			const broken = await probe.run(apiKey, allModels, {
-				onBroken: (ids) => {
-					ctx.ui.notify(
-						`Found ${ids.length} broken models (auto-hidden):\n${ids.join("\n")}`,
-						"warning",
-					);
-				},
-			});
-			if (broken.length === 0) {
-				ctx.ui.notify("All SambaNova models are accessible ✅", "info");
-			}
-		},
-	});
-
-	// Lazy auto-probe on first session_start
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler(
-			`${PROVIDER_SAMBANOVA}-auto-probe`,
-			probe.autoProbeHandler(apiKey, freeModels),
-		),
-	);
+	return Promise.resolve();
 }

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -1,0 +1,206 @@
+import type {
+	ModelsStoreEntry,
+	ProviderModelsStore,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockSaveConfig = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../config.ts", () => ({ saveConfig: mockSaveConfig }));
+vi.mock("../lib/registry.ts", () => ({
+	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	isFreeModel: (model: { name: string }) => /free/i.test(model.name),
+	registerWithGlobalToggle: vi.fn(),
+}));
+vi.mock("../provider-helper.ts", () => ({
+	enhanceWithCI: (models: ProviderModelConfig[]) => models,
+}));
+vi.mock("../lib/logger.ts", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+vi.mock("../lib/session-start-metrics.ts", () => ({
+	wrapSessionStartHandler: (_id: string, handler: unknown) => handler,
+}));
+
+import {
+	createNativeApiKeyAuth,
+	createNativeOpenAIProvider,
+	registerNativeOpenAIProvider,
+} from "../lib/native-provider.ts";
+
+function model(id: string, name: string): ProviderModelConfig {
+	return {
+		id,
+		name,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	};
+}
+
+function makeStore(seed?: ModelsStoreEntry): {
+	store: ProviderModelsStore;
+	written: ModelsStoreEntry[];
+} {
+	let entry = seed;
+	const written: ModelsStoreEntry[] = [];
+	return {
+		store: {
+			read: async () => entry,
+			write: async (next: ModelsStoreEntry) => {
+				entry = next;
+				written.push(next);
+			},
+			delete: async () => {
+				entry = undefined;
+			},
+		},
+		written,
+	};
+}
+
+function context(
+	store: ProviderModelsStore,
+	overrides: Partial<RefreshModelsContext> = {},
+): RefreshModelsContext {
+	return { store, allowNetwork: false, ...overrides } as RefreshModelsContext;
+}
+
+const options = {
+	providerId: "test-native",
+	name: "Test Native",
+	baseUrl: "https://example.test/v1",
+	auth: createNativeApiKeyAuth({
+		name: "Test API key",
+		prompt: "Test API key",
+		source: "TEST_API_KEY",
+		getApiKey: () => "ambient-key",
+	}),
+	getApiKey: () => "ambient-key",
+	getShowPaid: () => false,
+	initialModels: [model("free", "Free model"), model("paid", "Paid model")],
+	fetchModels: async (
+		_key: string,
+		_signal?: AbortSignal,
+	): Promise<ProviderModelConfig[]> => [],
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetGlobalFreeOnly.mockReturnValue(true);
+});
+
+describe("createNativeApiKeyAuth", () => {
+	it("prefers stored keys and supports native login", async () => {
+		const prompt = vi.fn(async () => "prompted-key");
+		const auth = createNativeApiKeyAuth({
+			name: "Test API key",
+			prompt: "Enter test key",
+			source: "TEST_API_KEY",
+			getApiKey: () => "ambient-key",
+		});
+
+		expect(
+			await auth.apiKey?.resolve({
+				ctx: {} as never,
+				credential: { type: "api_key", key: "stored-key" },
+			}),
+		).toMatchObject({ auth: { apiKey: "stored-key" } });
+		const apiKeyAuth = auth.apiKey;
+		if (!apiKeyAuth?.login) throw new Error("API-key login was not created");
+		expect(await apiKeyAuth.login({ prompt } as never)).toEqual({
+			type: "api_key",
+			key: "prompted-key",
+		});
+	});
+});
+
+describe("createNativeOpenAIProvider", () => {
+	it("restores offline and exposes the selected free view", async () => {
+		const { store } = makeStore({
+			models: [
+				{
+					...model("stored-free", "Stored free"),
+					provider: "test-native",
+					api: "openai-completions",
+					baseUrl: "https://example.test/v1",
+				},
+			],
+			checkedAt: Date.now(),
+		} as unknown as ModelsStoreEntry);
+		const handle = createNativeOpenAIProvider(options);
+
+		await handle.provider.refreshModels?.(context(store));
+
+		expect(handle.provider.getModels().map((item) => item.id)).toEqual([
+			"stored-free",
+		]);
+		expect(handle.provider.getModels()[0].provider).toBe("test-native");
+	});
+
+	it("fetches with the effective key and persists native models", async () => {
+		const controller = new AbortController();
+		const fetchModels = vi.fn(
+			async (key: string, signal?: AbortSignal) => {
+				expect(key).toBe("stored-key");
+				expect(signal).toBe(controller.signal);
+				return [model("fresh-free", "Fresh free")];
+			},
+		);
+		const { store, written } = makeStore();
+		const handle = createNativeOpenAIProvider({
+			...options,
+			fetchModels,
+		});
+
+		await handle.provider.refreshModels?.(
+			context(store, {
+			allowNetwork: true,
+			credential: { type: "api_key", key: "stored-key" },
+			signal: controller.signal,
+		}),
+		);
+
+		expect(fetchModels).toHaveBeenCalledOnce();
+		expect(written).toHaveLength(1);
+		expect(written[0].models[0]).toMatchObject({
+			id: "fresh-free",
+			provider: "test-native",
+			api: "openai-completions",
+		});
+	});
+
+	it("registers one stable provider object and shared lifecycle hooks", () => {
+		const registerProvider = vi.fn();
+		const registerCommand = vi.fn();
+		const on = vi.fn();
+		const pi = {
+			registerProvider,
+			registerCommand,
+			on,
+		} as unknown as ExtensionAPI;
+
+		registerNativeOpenAIProvider(pi, options);
+
+		expect(registerProvider).toHaveBeenCalledOnce();
+		expect(registerProvider.mock.calls[0][0].id).toBe("test-native");
+		expect(registerCommand).toHaveBeenCalledWith(
+			"toggle-test-native",
+			expect.any(Object),
+		);
+		expect(on).toHaveBeenCalledWith("session_start", expect.any(Function));
+	});
+});


### PR DESCRIPTION
## Summary

- Migrate B.AI, CrofAI, AnyAPI, SambaNova, and Novita AI to native Pi `Provider` objects.
- Add shared native OpenAI-compatible provider construction, API-key auth, catalog refresh, free/paid toggles, native models-store persistence, and offline initialization.
- Preserve provider-specific model mapping, pricing/free detection, hidden-model handling, AnyAPI metadata enrichment, SambaNova free-tier semantics, and Novita/B.AI/CrofAI catalogs.
- Preserve SambaNova and Novita availability probes using a shared OpenAI probe helper.
- Thread native refresh abort signals through model catalog fetches.

## Validation

- `npm run test:run` — 49 test files, 604 tests passed
- `npm run lint`
- `npm run check`
- Fresh pi-lens scan: 0 primary LSP diagnostics and no blocking diagnostics.
- No package or lockfile changes.
