### PR TITLE
feat: migrate remaining providers and use native model filters

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -115,11 +115,11 @@ export default async function providerName(pi: ExtensionAPI) {
 }
 ```
 
-**Cache-first loading.** Network-fetching extension providers register from the disk cache (`~/.pi/provider-cache.json`, 1-hour TTL via `lib/provider-cache.ts`) first and only hit the network on a cold or stale cache, so warm startups make no network calls. The dynamic built-in phase (including publicly discoverable FastRouter) runs concurrently with the static providers inside `piFreeEntry`'s single `Promise.allSettled`, not sequentially after it. OpenRouter is owned by Pi and is not dynamically registered by pi-free. **Kilo and Cline are the exceptions**: they use Pi's native models store (`~/.pi/agent/models-store.json`) via `refreshModels`, not `lib/provider-cache.ts` (see below).
+**Cache-first loading.** Network-fetching extension providers register from the disk cache (`~/.pi/provider-cache.json`, 1-hour TTL via `lib/provider-cache.ts`) first and only hit the network on a cold or stale cache, so warm startups make no network calls. The dynamic built-in phase (including publicly discoverable FastRouter) runs concurrently with the static providers inside `piFreeEntry`'s single `Promise.allSettled`, not sequentially after it. OpenRouter is owned by Pi and is not dynamically registered by pi-free. **Native providers** use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`; remaining legacy/dynamic providers use `lib/provider-cache.ts` (see below).
 
-### Native `createProvider` providers (Kilo + Cline)
+### Native `Provider` providers
 
-Kilo and Cline are ports to Pi's modern provider API (Pi `>=0.81.0`) — Kilo is the original reference, Cline is the second data point proving the pattern. Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so the extension factory performs **no network I/O** for these providers and no longer owns any of Pi's startup critical path.
+Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, and OpenModel use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
 
 ```
 providers/kilo/kilo-provider.ts   ← createKiloProvider(): assembles the Provider
@@ -136,10 +136,10 @@ providers/cline/cline-xml-bridge.ts ← unchanged message reshaping (stream + st
 
 Key points of the pattern (the recipe for porting other unique providers):
 
-- The `Provider` is assembled **directly against the public `Provider` interface** (the same shape `createProvider()` returns) rather than via the `createProvider` helper: that helper unconditionally merges its stored dynamic overlay on top of the static baseline on every refresh, which would clobber pi-free's re-registration based free/paid toggle. Assembling directly keeps `getModels()` returning exactly the catalog pi-free chose to show.
+- The `Provider` is assembled **directly against the public `Provider` interface** (the same shape `createProvider()` returns) rather than via the `createProvider` helper: that helper unconditionally merges its stored dynamic overlay on top of the static baseline on every refresh. Native providers keep the complete catalog in `getModels()` and apply the free/paid policy through `filterModels`, so refreshes cannot clobber the selected view.
 - `refreshModels(context)`: always `await context.store.read()` first (offline init — `allowNetwork:false` stops here); when `allowNetwork:true`, fetch with `context.credential` (Pi refreshes OAuth before calling), honor `context.signal`, retain the previous list on an empty/failed fetch (poisoning guard), then `context.store.write({ models, checkedAt })`. No internal freshness gating — Pi owns the throttle and `force` (`pi update --models`), so the two never double-throttle.
 - Native `auth`: `apiKey.resolve` returns `credential?.key ?? getKiloApiKey()` (ambient env/config); `oauth` implements `login(interaction)` (device flow via `interaction.notify`), `refresh(credential)` (Kilo tokens are long-lived; expired → throw, re-login fixes), and `toAuth(credential)` → `{ apiKey: credential.access }`. Credentials persist to `~/.pi/agent/auth.json` — the same store the legacy `/login kilo` already used, so existing OAuth users need no migration.
-- The free/paid toggle stays on `registerWithGlobalToggle`: its `reRegister(models)` calls `setView(models)` and re-registers the **same** native provider object (upsert by id), which republishes the chosen catalog without dropping native auth. This keeps `/toggle-kilo` and the global `/toggle-free` working. Native `filterModels` is a possible follow-up but was not adopted because it must compose with the cross-provider global toggle.
+- The free/paid toggle stays coordinated by `registerWithGlobalToggle`: native `reRegister(models)` re-registers the **same** provider object (upsert by id) to invalidate Pi's availability snapshot, while `filterModels` selects the complete catalog view. This keeps per-provider toggles and the global `/toggle-free` working without rebuilding model arrays.
 - Because the dev lockfile can lag the declared peer minimum, `kilo.ts` and `cline.ts` register through a small documented `NativeRegistrar` type bridge; the source type-checks against both the pinned dev snapshot and the declared `>=0.81.0` runtime.
 
 Cline-specific deviations from the Kilo reference (porting recipe supplements):
@@ -209,9 +209,9 @@ Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DE
 - **Config:** `~/.pi/free.json` (auto-created)
 - **Extension log:** `~/.pi/free.log`
 - **Model match log:** `~/.pi/modelmatch.log`
-- **Provider cache:** `~/.pi/provider-cache.json` (all cache-first providers except Kilo)
-- **Native models store:** `~/.pi/agent/models-store.json` (Kilo + Cline, owned by Pi)
-- **Native auth store:** `~/.pi/agent/auth.json` (Kilo + Cline OAuth/API key, owned by Pi)
+- **Provider cache:** `~/.pi/provider-cache.json` (legacy/dynamic providers only)
+- **Native models store:** `~/.pi/agent/models-store.json` (all native providers, owned by Pi)
+- **Native auth store:** `~/.pi/agent/auth.json` (native-provider credentials, owned by Pi)
 
 ---
 
@@ -227,7 +227,7 @@ Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DE
 8. **Error handling is graceful** — providers that fail at startup are silently skipped
 9. **Model filtering happens at fetch time** — small models (< 30B, < 70B for NVIDIA) are filtered
 10. **All providers use `enhanceWithCI()`** before registration to add CI scores
-11. **Network-fetching extension providers are cache-first** (1h TTL via `lib/provider-cache.ts`); the first run after install or after the TTL fetches live, subsequent runs serve cache. Pi's built-in OpenRouter provider is not managed by this cache. **Kilo and Cline are the exceptions** — they are native `createProvider` providers that use Pi's models store + `refreshModels` (see “Native createProvider providers”).
+11. **Legacy network-fetching extension providers are cache-first** (1h TTL via `lib/provider-cache.ts`); native providers use Pi's models store + `refreshModels` instead. Pi's built-in OpenRouter provider is not managed by either extension cache.
 12. **Startup model fetches are deadline-bounded** — `loadCachedOrFetchModels` (and Cline's fetch) wrap the network fetch in `STARTUP_FETCH_DEADLINE_MS` (8s, override `PI_FREE_STARTUP_FETCH_TIMEOUT_MS`) via `withFetchDeadline` in `lib/util.ts`. On a cold/stale cache a dead provider API cannot stall Pi session start; the deadline falls back to the stale cache (or an empty list on a true cold start) and refreshes on `session_start`. Warm cache never touches the network.
 
 ---

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -16,10 +16,11 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { saveConfig } from "../config.ts";
+import { applyHidden, saveConfig } from "../config.ts";
 import { createLogger } from "./logger.ts";
 import {
 	getGlobalFreeOnly,
+	getGlobalFreeOnlyForced,
 	isFreeModel,
 	registerWithGlobalToggle,
 } from "./registry.ts";
@@ -76,6 +77,8 @@ export interface NativeOpenAIProviderOptions {
 	auth: ProviderAuth;
 	getApiKey: () => string | undefined;
 	getShowPaid: () => boolean;
+	/** Override the persisted mode for providers whose legacy default is paid. */
+	initialShowPaid?: boolean;
 	initialModels: ProviderModelConfig[];
 	fetchModels: (
 		apiKey: string,
@@ -89,6 +92,8 @@ export interface NativeOpenAIProviderHandle {
 	provider: Provider<"openai-completions">;
 	stored: StoredModels;
 	setView: (models: ProviderModelConfig[]) => void;
+	setShowPaid: (showPaid: boolean) => void;
+	getShowPaid: () => boolean;
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -113,13 +118,38 @@ function toNativeOpenAIModel(
 	} as Model<"openai-completions">;
 }
 
+/** Apply the shared global/provider free-model policy to a complete native catalog. */
+export function filterNativeModels<T extends Model<Api>>(
+	providerId: string,
+	models: readonly T[],
+	options: {
+		showPaid: boolean;
+		freeModels: readonly ProviderModelConfig[];
+		forceFree?: boolean;
+	},
+): readonly T[] {
+	const forceFree =
+		options.forceFree === true ||
+		(typeof getGlobalFreeOnlyForced === "function" &&
+			getGlobalFreeOnlyForced());
+	const freeOnly = getGlobalFreeOnly() && (forceFree || !options.showPaid);
+	const freeIds = new Set(options.freeModels.map((model) => model.id));
+	const visible = freeOnly
+		? models.filter((model) => freeIds.has(model.id))
+		: models;
+	return applyHidden(
+		visible as unknown as ProviderModelConfig[],
+		providerId,
+	) as T[];
+}
+
 /** Build a keyed OpenAI-compatible native provider with shared catalog lifecycle. */
 export function createNativeOpenAIProvider(
 	options: NativeOpenAIProviderOptions,
 ): NativeOpenAIProviderHandle {
 	const streams = openAICompletionsApi();
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: Model<"openai-completions">[] = [];
+	let showPaidOverride = options.initialShowPaid;
 
 	function classifyFree(
 		models: Model<"openai-completions">[],
@@ -129,19 +159,17 @@ export function createNativeOpenAIProvider(
 		);
 	}
 
-	function decideView(): ProviderModelConfig[] {
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		return options.getShowPaid() && stored.all.length > 0
-			? stored.all
-			: stored.free;
+	function setView(_models: ProviderModelConfig[]): void {
+		// Native toggles re-register the same provider to invalidate Pi's
+		// availability snapshot. The complete catalog remains in stored.all.
 	}
 
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = models.map((model) =>
-			toNativeOpenAIModel(model, options.providerId, options.baseUrl),
-		);
+	function getShowPaid(): boolean {
+		return showPaidOverride ?? options.getShowPaid();
+	}
+
+	function setShowPaid(next: boolean): void {
+		if (options.initialShowPaid !== undefined) showPaidOverride = next;
 	}
 
 	function ingest(
@@ -154,7 +182,6 @@ export function createNativeOpenAIProvider(
 		stored.free = enhanceWithCI(free, options.providerId).map((model) =>
 			toNativeOpenAIModel(model, options.providerId, options.baseUrl),
 		);
-		setView(decideView());
 	}
 
 	if (options.initialModels.length > 0) {
@@ -164,7 +191,6 @@ export function createNativeOpenAIProvider(
 		);
 		stored.all = all;
 		stored.free = classifyFree(all);
-		setView(decideView());
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
@@ -174,7 +200,6 @@ export function createNativeOpenAIProvider(
 			(storedModels: Model<"openai-completions">[]) => {
 				stored.all = storedModels;
 				stored.free = classifyFree(storedModels);
-				setView(decideView());
 			},
 			async () => {
 				const token = nativeCredentialToken(
@@ -190,7 +215,6 @@ export function createNativeOpenAIProvider(
 			(models) => {
 				stored.all = models;
 				stored.free = classifyFree(models);
-				setView(decideView());
 			},
 		);
 	}
@@ -201,7 +225,15 @@ export function createNativeOpenAIProvider(
 		baseUrl: options.baseUrl,
 		headers: { "User-Agent": "pi-free-providers" },
 		auth: options.auth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as Model<
+				"openai-completions"
+			>[],
+		filterModels: (models) =>
+			filterNativeModels(options.providerId, models, {
+				showPaid: getShowPaid(),
+				freeModels: stored.free,
+			}),
 		refreshModels,
 		stream: (model, context, streamOptions) =>
 			streams.stream(model, context, streamOptions),
@@ -209,7 +241,14 @@ export function createNativeOpenAIProvider(
 			streams.streamSimple(model, context, streamOptions),
 	};
 
-	return { provider, stored, setView, ingest };
+	return {
+		provider,
+		stored,
+		setView,
+		setShowPaid,
+		getShowPaid,
+		ingest,
+	};
 }
 
 /** Register a shared keyed OpenAI-compatible native provider and its lifecycle. */
@@ -228,11 +267,13 @@ export function registerNativeOpenAIProvider(
 		handle.stored,
 		reRegister,
 		Boolean(options.getApiKey()),
+		{ native: true },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: options.providerId,
 		stored: handle.stored,
-		getShowPaid: options.getShowPaid,
+		getShowPaid: handle.getShowPaid,
+		setShowPaid: handle.setShowPaid,
 		reRegister,
 	});
 	if (options.tosUrl) {
@@ -269,11 +310,13 @@ export function registerNativeAvailabilityProbe(
 			const models = handle.stored.all;
 			ctx.ui.notify(`Probing ${models.length} ${label} models…`, "info");
 			const broken = await probe.run(apiKey, models, {
-				onBroken: (ids) =>
+				onBroken: (ids) => {
 					ctx.ui.notify(
 						`Found ${ids.length} broken models (auto-hidden):\n${ids.join("\n")}`,
 						"warning",
-					),
+					);
+					registerNativeProvider(pi, handle.provider);
+				},
 			});
 			if (broken.length === 0) {
 				ctx.ui.notify(`All ${label} models are accessible ✅`, "info");
@@ -284,7 +327,11 @@ export function registerNativeAvailabilityProbe(
 		"session_start",
 		wrapSessionStartHandler(
 			`${providerId}-auto-probe`,
-			probe.autoProbeHandler(apiKey, handle.stored.free),
+			probe.autoProbeHandler(
+				apiKey,
+				handle.stored.free,
+				() => registerNativeProvider(pi, handle.provider),
+			),
 		),
 	);
 }
@@ -304,6 +351,7 @@ interface NativeToggleOptions {
 		all: ProviderModelConfig[];
 	};
 	getShowPaid: () => boolean;
+	setShowPaid?: (showPaid: boolean) => void;
 	reRegister: (models: ProviderModelConfig[]) => void;
 }
 
@@ -319,6 +367,7 @@ export function registerNativeProviderToggle(
 		handler: async (_args, ctx) => {
 			const showPaid = !getShowPaid();
 			await saveConfig({ [`${providerId}_show_paid`]: showPaid });
+			options.setShowPaid?.(showPaid);
 
 			const modelsToShow =
 				showPaid && stored.all.length > 0 ? stored.all : stored.free;

--- a/lib/provider-probe.ts
+++ b/lib/provider-probe.ts
@@ -82,6 +82,7 @@ export interface ProviderProbe {
 	autoProbeHandler: (
 		apiKey: string,
 		models: ProviderModelConfig[],
+		onBroken?: (brokenIds: string[]) => void,
 	) => () => void;
 }
 
@@ -208,6 +209,7 @@ export function createProviderProbe(
 	const autoProbeHandler: ProviderProbe["autoProbeHandler"] = (
 		apiKey,
 		models,
+		onBroken,
 	) => {
 		let done = false;
 		return () => {
@@ -228,7 +230,7 @@ export function createProviderProbe(
 			}
 
 			_logger.info(`[probe] Starting lazy auto-probe for ${providerId}...`);
-			run(apiKey, models, { useCache: true }).catch((err) => {
+			run(apiKey, models, { useCache: true, onBroken }).catch((err) => {
 				_logger.warn(`[probe] ${providerId}: auto-probe failed`, {
 					error: err instanceof Error ? err.message : String(err),
 				});

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -20,6 +20,8 @@ interface ProviderEntry {
 	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] };
 	reRegister: (models: ProviderModelConfig[]) => void;
 	hasKey: boolean;
+	/** Native providers keep the complete catalog and filter it in Pi. */
+	native?: boolean;
 }
 
 // =============================================================================
@@ -28,6 +30,7 @@ interface ProviderEntry {
 
 const providerRegistry = new Map<string, ProviderEntry>();
 let globalFreeOnly = getFreeOnly();
+let globalFreeOnlyForced = false;
 
 // =============================================================================
 // Free-model detection
@@ -152,12 +155,14 @@ export function registerWithGlobalToggle(
 	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] },
 	reRegister: (models: ProviderModelConfig[]) => void,
 	hasKey: boolean = false,
+	options: { native?: boolean } = {},
 ): void {
 	providerRegistry.set(providerId, {
 		id: providerId,
 		stored,
 		reRegister,
 		hasKey,
+		native: options.native,
 	});
 	_logger.info(
 		`[pi-free] Registered ${providerId} with global toggle (${stored.free.length} free, ${stored.all.length} total)`,
@@ -167,6 +172,11 @@ export function registerWithGlobalToggle(
 /** Get current global free-only state */
 export function getGlobalFreeOnly(): boolean {
 	return globalFreeOnly;
+}
+
+/** Whether the current global toggle explicitly overrides provider paid views. */
+export function getGlobalFreeOnlyForced(): boolean {
+	return globalFreeOnlyForced;
 }
 
 /** Access the raw registry (used by /free-providers command) */
@@ -195,6 +205,23 @@ function applyFilterToProvider(
 	freeOnly: boolean,
 	force: boolean,
 ): void {
+	if (entry.native) {
+		// Native providers expose their complete catalog through getModels().
+		// Re-register the same object only to invalidate Pi's availability
+		// snapshot; the provider's filterModels callback selects the view.
+		entry.reRegister(
+			freeOnly
+				? entry.stored.free
+				: entry.stored.all.length > 0
+					? entry.stored.all
+					: entry.stored.free,
+		);
+		_logger.info(
+			`[pi-free] ${providerId}: invalidated native model filter (${freeOnly ? "free" : "all"}${force ? ", forced" : ""})`,
+		);
+		return;
+	}
+
 	if (freeOnly) {
 		if (!force && getProviderShowPaid(providerId)) {
 			showAllForProvider(providerId, entry);
@@ -222,6 +249,7 @@ export function applyGlobalFilter(
 	options: { force?: boolean } = {},
 ): void {
 	globalFreeOnly = freeOnly;
+	globalFreeOnlyForced = freeOnly && options.force === true;
 	void saveConfig({ free_only: freeOnly });
 
 	for (const [providerId, entry] of providerRegistry) {

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -7,7 +7,7 @@
  * offline initialization:
  *
  *   - native `auth` (apiKey + oauth) persisted to ~/.pi/agent/auth.json
- *   - sync `getModels()` returning the catalog pi-free chose to show
+ *   - sync `getModels()` returning the complete catalog; Pi applies `filterModels`
  *   - `refreshModels(context)`:
  *       allowNetwork:false → restore from context.store only (fast offline init)
  *       allowNetwork:true  → fetch the PUBLIC catalog (no credential needed),
@@ -28,10 +28,9 @@
  * The object is assembled directly against the public `Provider` interface (the
  * exact shape `createProvider()` returns) rather than through the `createProvider`
  * helper: that helper unconditionally merges its stored dynamic overlay on top of
- * the static baseline on every refresh, which would clobber pi-free's
- * re-registration based free/paid toggle. Assembling directly keeps `getModels()`
- * returning precisely the view pi-free selected while still using the native
- * store and auth.
+ * the static baseline on every refresh. The complete catalog stays in
+ * `getModels()` and the shared `filterModels` policy selects the current view
+ * while still using the native store and auth.
  *
  * Pi owns refresh throttling and the `force` flag (`pi update --models`); this
  * module performs no freshness gating of its own so the two never double-throttle.
@@ -46,8 +45,9 @@ import type {
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getClineShowPaid } from "../../config.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
-import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { isFreeModel } from "../../lib/registry.ts";
 import {
+	filterNativeModels,
 	persistNativeProviderModels,
 	restoreNativeProviderModels,
 } from "../../lib/native-provider.ts";
@@ -134,26 +134,10 @@ export function createClineProvider(): ClineNativeProvider {
 	// StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle; the
 	// runtime values are full Model objects, which are assignable.
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: ClineModel[] = [];
 
-	/**
-	 * Which catalog the current toggle state wants to show. Mirrors
-	 * applyGlobalFilter's decision so the offline-init initial view matches what
-	 * the global free/paid toggle would select. Cline has no per-provider
-	 * free-only override — only the persisted show_paid flag.
-	 */
-	function decideView(): ProviderModelConfig[] {
-		// Global free-only off → show everything.
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		// Global free-only on → free, unless per-provider show_paid is persisted.
-		const showPaid = getClineShowPaid();
-		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
-	}
-
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = toClineModels(models);
+	function setView(_models: ProviderModelConfig[]): void {
+		// Re-registration invalidates Pi's filtered availability snapshot; the
+		// complete catalog remains in stored.all.
 	}
 
 	function ingest(
@@ -162,7 +146,6 @@ export function createClineProvider(): ClineNativeProvider {
 	): void {
 		stored.all = toClineModels(enhanceWithCI(all));
 		stored.free = toClineModels(enhanceWithCI(free));
-		setView(decideView());
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
@@ -174,7 +157,6 @@ export function createClineProvider(): ClineNativeProvider {
 				stored.free = storedModels.filter((model) =>
 					isFreeModel({ ...model, provider: PROVIDER_CLINE }, storedModels),
 				);
-				setView(decideView());
 			},
 		);
 
@@ -214,7 +196,13 @@ export function createClineProvider(): ClineNativeProvider {
 		name: "Cline",
 		baseUrl: BASE_URL_CLINE,
 		auth: clineAuth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as ClineModel[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_CLINE, models, {
+				showPaid: getClineShowPaid(),
+				freeModels: stored.free,
+			}),
 		refreshModels,
 		stream: (model, context, options) =>
 			streamViaXmlBridge(model, context, options),

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -114,7 +114,9 @@ export default async function clineProvider(pi: ExtensionAPI) {
 	};
 
 	const hasClineKey = !!getClineApiKey();
-	registerWithGlobalToggle(PROVIDER_CLINE, stored, reRegister, hasClineKey);
+	registerWithGlobalToggle(PROVIDER_CLINE, stored, reRegister, hasClineKey, {
+		native: true,
+	});
 
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_CLINE,

--- a/providers/deepinfra/deepinfra-auth.ts
+++ b/providers/deepinfra/deepinfra-auth.ts
@@ -1,0 +1,9 @@
+import { getDeepinfraApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const deepinfraAuth = createNativeApiKeyAuth({
+	name: "DeepInfra API key",
+	prompt: "DeepInfra API key",
+	source: "DEEPINFRA_TOKEN",
+	getApiKey: getDeepinfraApiKey,
+});

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -33,7 +33,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { getDeepinfraApiKey } from "../../config.ts";
+import { getDeepinfraApiKey, getDeepinfraShowPaid } from "../../config.ts";
 import {
 	BASE_URL_DEEPINFRA,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -45,15 +45,14 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { createProviderProbe } from "../../lib/provider-probe.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import { fetchWithRetry, fetchWithTimeout } from "../../lib/util.ts";
+import { createOpenAIAvailabilityProbe } from "../../lib/provider-probe.ts";
 import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	registerNativeAvailabilityProbe,
+	registerNativeOpenAIProvider,
+} from "../../lib/native-provider.ts";
+import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { deepinfraAuth } from "./deepinfra-auth.ts";
 
 const _logger = createLogger("deepinfra");
 
@@ -81,6 +80,7 @@ interface DeepInfraModel {
 
 async function fetchDeepinfraModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_DEEPINFRA}/models`,
@@ -89,6 +89,7 @@ async function fetchDeepinfraModels(
 				Authorization: `Bearer ${apiKey}`,
 				"Content-Type": "application/json",
 			},
+			signal,
 		},
 		3,
 		1000,
@@ -147,7 +148,7 @@ async function fetchDeepinfraModels(
 			} as ProviderModelConfig & { _pricingKnown?: boolean };
 		});
 
-	return await safeEnrichModelsWithModelsDev(mapped, {
+	return safeEnrichModelsWithModelsDev(mapped, {
 		providerId: PROVIDER_DEEPINFRA,
 	});
 }
@@ -156,126 +157,38 @@ async function fetchDeepinfraModels(
 // Extension Entry Point
 // =============================================================================
 
-export default async function deepinfraProvider(pi: ExtensionAPI) {
-	const apiKey = getDeepinfraApiKey();
-
-	if (!apiKey) {
-		_logger.info(
-			"[deepinfra] Skipping — DEEPINFRA_TOKEN not set. Sign up at https://deepinfra.com/",
-		);
-		return;
-	}
-
-	// Fetch models
-	const allModels = await loadCachedOrFetchModels(PROVIDER_DEEPINFRA, () =>
-		fetchDeepinfraModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[deepinfra] No chat models available");
-		return;
-	}
-
-	// DeepInfra is a trial credit provider — $5 one-time credit, no truly free models.
-	// Use isFreeModel for consistent detection across all providers.
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_DEEPINFRA }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[deepinfra] Registered ${allModels.length} chat models (trial credit, 0 free)`,
-	);
-
-	// Create re-register function
-	const reRegister = createReRegister(pi, {
+export default function deepinfraProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_DEEPINFRA) ?? [];
+	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_DEEPINFRA,
+		name: "DeepInfra",
 		baseUrl: BASE_URL_DEEPINFRA,
-		apiKey,
+		auth: deepinfraAuth,
+		getApiKey: getDeepinfraApiKey,
+		getShowPaid: getDeepinfraShowPaid,
+		initialShowPaid: true,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchDeepinfraModels(apiKey, signal);
+			if (models.length > 0) await saveProviderCache(PROVIDER_DEEPINFRA, models);
+			return models;
+		},
+		tosUrl: "https://deepinfra.com/pricing",
 	});
 
-	// Register with global toggle
-	registerWithGlobalToggle(PROVIDER_DEEPINFRA, stored, reRegister, true);
-
-	// Setup provider with toggle command
-	setupProvider(
-		pi,
-		{
+	const apiKey = getDeepinfraApiKey();
+	if (apiKey) {
+		const probe = createOpenAIAvailabilityProbe(
+			PROVIDER_DEEPINFRA,
+			BASE_URL_DEEPINFRA,
+		);
+		registerNativeAvailabilityProbe(pi, {
 			providerId: PROVIDER_DEEPINFRA,
-			initialShowPaid: true, // trial credit: default to showing all models
-			tosUrl: "https://deepinfra.com/pricing",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
-		},
-		stored,
-	);
-
-	// Initial registration — DeepInfra is a trial-credit provider,
-	// so always show all models. Users see them immediately on setup.
-	reRegister(allModels);
-
-	// ── Probe support ──────────────────────────────────────────────
-	const probe = createProviderProbe({
-		providerId: PROVIDER_DEEPINFRA,
-		probeModel: async (_apiKey: string, modelId: string) => {
-			try {
-				const response = await fetchWithTimeout(
-					`${BASE_URL_DEEPINFRA}/chat/completions`,
-					{
-						method: "POST",
-						headers: {
-							Authorization: `Bearer ${apiKey}`,
-							"Content-Type": "application/json",
-							"User-Agent": "pi-free-providers",
-						},
-						body: JSON.stringify({
-							model: modelId,
-							messages: [{ role: "user", content: "hi" }],
-							max_tokens: 1,
-						}),
-					},
-					10_000,
-				);
-				if (response.status === 404 || response.status >= 500) return "broken";
-				if (response.status === 429) return "ok";
-				if (response.ok) return "ok";
-				return "ok";
-			} catch {
-				return "unknown";
-			}
-		},
-	});
-
-	// Probe command
-	pi.registerCommand(`probe-${PROVIDER_DEEPINFRA}`, {
-		description: "Test all DeepInfra models for availability",
-		handler: async (_args, ctx) => {
-			ctx.ui.notify(`Probing ${allModels.length} DeepInfra models…`, "info");
-			const broken = await probe.run(apiKey, allModels, {
-				onBroken: (ids) => {
-					ctx.ui.notify(
-						`Found ${ids.length} broken models (auto-hidden):\n${ids.join("\n")}`,
-						"warning",
-					);
-				},
-			});
-			if (broken.length === 0) {
-				ctx.ui.notify("All DeepInfra models are accessible ✅", "info");
-			}
-		},
-	});
-
-	// Lazy auto-probe on first session_start
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler(
-			`${PROVIDER_DEEPINFRA}-auto-probe`,
-			probe.autoProbeHandler(apiKey, freeModels),
-		),
-	);
+			label: "DeepInfra",
+			apiKey,
+			probe,
+			handle,
+		});
+	}
+	return Promise.resolve();
 }

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -7,7 +7,7 @@
  * offline initialization:
  *
  *   - native `auth` (apiKey + oauth) persisted to ~/.pi/agent/auth.json
- *   - sync `getModels()` returning the catalog pi-free chose to show
+ *   - sync `getModels()` returning the complete catalog; Pi applies `filterModels`
  *   - `refreshModels(context)`:
  *       allowNetwork:false → restore from context.store only (fast offline init)
  *       allowNetwork:true  → fetch with context.credential, persist via
@@ -16,10 +16,9 @@
  * The object is assembled directly against the public `Provider` interface (the
  * exact shape `createProvider()` returns) rather than through the `createProvider`
  * helper: that helper unconditionally merges its stored dynamic overlay on top of
- * the static baseline on every refresh, which would clobber pi-free's
- * re-registration based free/paid toggle (the stored full catalog would always win
- * over a free-only baseline). Assembling directly keeps `getModels()` returning
- * precisely the view pi-free selected while still using the native store and auth.
+ * the static baseline on every refresh. The complete catalog stays in
+ * `getModels()` and the shared `filterModels` policy selects the current view
+ * while still using the native store and auth.
  *
  * Pi owns refresh throttling and the `force` flag (`pi update --models`); this
  * module performs no freshness gating of its own so the two never double-throttle.
@@ -40,8 +39,9 @@ import {
 	getKiloShowPaid,
 } from "../../config.ts";
 import { PROVIDER_KILO } from "../../constants.ts";
-import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { isFreeModel } from "../../lib/registry.ts";
 import {
+	filterNativeModels,
 	persistNativeProviderModels,
 	restoreNativeProviderModels,
 } from "../../lib/native-provider.ts";
@@ -88,26 +88,10 @@ export function createKiloProvider(): KiloNativeProvider {
 	// Typed as StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle;
 	// the runtime values are full Model objects, which are assignable.
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: KiloModel[] = [];
 
-	/**
-	 * Which catalog the current toggle state wants to show. Mirrors
-	 * applyGlobalFilter's decision so the offline-init initial view matches what
-	 * the global free/paid toggle would select.
-	 */
-	function decideView(): ProviderModelConfig[] {
-		if (getKiloFreeOnly()) return stored.free;
-		// Global free-only off → show everything.
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		// Global free-only on → free, unless per-provider show_paid is persisted.
-		const showPaid = getKiloShowPaid();
-		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
-	}
-
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = toKiloModels(models);
+	function setView(_models: ProviderModelConfig[]): void {
+		// Re-registration invalidates Pi's filtered availability snapshot; the
+		// complete catalog remains in stored.all.
 	}
 
 	function ingest(
@@ -116,7 +100,6 @@ export function createKiloProvider(): KiloNativeProvider {
 	): void {
 		stored.all = toKiloModels(enhanceWithCI(applyKiloCompat(all)));
 		stored.free = toKiloModels(enhanceWithCI(applyKiloCompat(free)));
-		setView(decideView());
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
@@ -128,7 +111,6 @@ export function createKiloProvider(): KiloNativeProvider {
 				stored.free = storedModels.filter((model) =>
 					isFreeModel({ ...model, provider: PROVIDER_KILO }, storedModels),
 				);
-				setView(decideView());
 			},
 		);
 
@@ -165,7 +147,14 @@ export function createKiloProvider(): KiloNativeProvider {
 			"User-Agent": "pi-free-providers",
 		},
 		auth: kiloAuth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as KiloModel[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_KILO, models, {
+				showPaid: getKiloShowPaid(),
+				freeModels: stored.free,
+				forceFree: getKiloFreeOnly(),
+			}),
 		refreshModels,
 		stream: (model, context, options) =>
 			streams.stream(model, context, options),

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -209,7 +209,9 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	};
 
 	const hasKiloKey = !!getKiloApiKey();
-	registerWithGlobalToggle(PROVIDER_KILO, stored, reRegister, hasKiloKey);
+	registerWithGlobalToggle(PROVIDER_KILO, stored, reRegister, hasKiloKey, {
+		native: true,
+	});
 
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_KILO,

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -9,7 +9,7 @@
  *   - native `auth` (apiKey only — LLM7 has no OAuth flow) persisted to
  *     ~/.pi/agent/auth.json; always resolves so the keyless public catalog
  *     stays visible (see llm7-auth.ts)
- *   - sync `getModels()` returning the catalog pi-free chose to show
+ *   - sync `getModels()` returning the complete catalog; Pi applies `filterModels`
  *   - `refreshModels(context)`:
  *       allowNetwork:false → restore from context.store only (fast offline init)
  *       allowNetwork:true  → build the STATIC selector catalog locally (no
@@ -24,10 +24,9 @@
  * The object is assembled directly against the public `Provider` interface (the
  * exact shape `createProvider()` returns) rather than through the `createProvider`
  * helper: that helper unconditionally merges its stored dynamic overlay on top of
- * the static baseline on every refresh, which would clobber pi-free's
- * re-registration based free/paid toggle. Assembling directly keeps `getModels()`
- * returning precisely the view pi-free selected while still using the native
- * store and auth.
+ * the static baseline on every refresh. The complete catalog stays in
+ * `getModels()` and the shared `filterModels` policy selects the current view
+ * while still using the native store and auth.
  *
  * Pi owns refresh throttling and the `force` flag (`pi update --models`); this
  * module performs no freshness gating of its own so the two never double-throttle.
@@ -43,8 +42,9 @@ import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getLlm7ShowPaid } from "../../config.ts";
 import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";
-import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { isFreeModel } from "../../lib/registry.ts";
 import {
+	filterNativeModels,
 	persistNativeProviderModels,
 	restoreNativeProviderModels,
 } from "../../lib/native-provider.ts";
@@ -78,26 +78,10 @@ export function createLlm7Provider(): Llm7NativeProvider {
 	// StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle; the
 	// runtime values are full Model objects, which are assignable.
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: Llm7Model[] = [];
 
-	/**
-	 * Which catalog the current toggle state wants to show. Mirrors
-	 * applyGlobalFilter's decision so the offline-init initial view matches what
-	 * the global free/paid toggle would select. LLM7 has no per-provider
-	 * free-only override — only the persisted show_paid flag.
-	 */
-	function decideView(): ProviderModelConfig[] {
-		// Global free-only off → show everything.
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		// Global free-only on → free, unless per-provider show_paid is persisted.
-		const showPaid = getLlm7ShowPaid();
-		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
-	}
-
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = toLlm7Models(models);
+	function setView(_models: ProviderModelConfig[]): void {
+		// Re-registration invalidates Pi's filtered availability snapshot; the
+		// complete catalog remains in stored.all.
 	}
 
 	function ingest(
@@ -106,7 +90,6 @@ export function createLlm7Provider(): Llm7NativeProvider {
 	): void {
 		stored.all = toLlm7Models(enhanceWithCI(all));
 		stored.free = toLlm7Models(enhanceWithCI(free));
-		setView(decideView());
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
@@ -118,7 +101,6 @@ export function createLlm7Provider(): Llm7NativeProvider {
 				stored.free = storedModels.filter((model) =>
 					isFreeModel({ ...model, provider: PROVIDER_LLM7 }, storedModels),
 				);
-				setView(decideView());
 			},
 		);
 
@@ -153,7 +135,13 @@ export function createLlm7Provider(): Llm7NativeProvider {
 			"User-Agent": "pi-free-providers",
 		},
 		auth: llm7Auth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as Llm7Model[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_LLM7, models, {
+				showPaid: getLlm7ShowPaid(),
+				freeModels: stored.free,
+			}),
 		refreshModels,
 		stream: (model, context, options) =>
 			streams.stream(model, context, options),

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -83,7 +83,9 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 	};
 
 	const hasLlm7Key = !!getLlm7ApiKey();
-	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, hasLlm7Key);
+	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, hasLlm7Key, {
+		native: true,
+	});
 
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_LLM7,

--- a/providers/ollama/ollama-provider.ts
+++ b/providers/ollama/ollama-provider.ts
@@ -13,6 +13,7 @@ import type {
 import { getOllamaApiKey, getOllamaShowPaid } from "../../config.ts";
 import { BASE_URL_OLLAMA, PROVIDER_OLLAMA } from "../../constants.ts";
 import {
+	filterNativeModels,
 	refreshNativeProviderModels,
 	registerNativeProvider,
 	registerNativeProviderRefresh,
@@ -24,10 +25,7 @@ import {
 	saveProviderCache,
 } from "../../lib/provider-cache.ts";
 import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
-import {
-	getGlobalFreeOnly,
-	registerWithGlobalToggle,
-} from "../../lib/registry.ts";
+import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { ollamaAuth } from "./ollama-auth.ts";
 
@@ -83,18 +81,10 @@ export function createOllamaProvider(
 ): OllamaNativeProvider {
 	const streams = openAICompletionsApi();
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: OllamaModel[] = [];
 
-	function decideView(): ProviderModelConfig[] {
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		const showPaid = getOllamaShowPaid();
-		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
-	}
-
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = toOllamaModels(models);
+	function setView(_models: ProviderModelConfig[]): void {
+		// Re-registration invalidates Pi's filtered availability snapshot; the
+		// complete catalog remains in stored.all.
 	}
 
 	function ingest(
@@ -103,7 +93,6 @@ export function createOllamaProvider(
 	): void {
 		stored.all = toOllamaModels(enhanceWithCI(all, PROVIDER_OLLAMA));
 		stored.free = toOllamaModels(enhanceWithCI(free, PROVIDER_OLLAMA));
-		setView(decideView());
 	}
 
 	ingest(initialModels, initialModels);
@@ -111,7 +100,6 @@ export function createOllamaProvider(
 	function restoreStoredModels(storedModels: OllamaModel[]): void {
 		stored.all = storedModels;
 		stored.free = storedModels;
-		setView(decideView());
 	}
 
 	async function refreshOllamaModels(
@@ -135,7 +123,6 @@ export function createOllamaProvider(
 			(models) => {
 				stored.all = models;
 				stored.free = models;
-				setView(decideView());
 			},
 		);
 	}
@@ -146,7 +133,13 @@ export function createOllamaProvider(
 		baseUrl: BASE_URL_OLLAMA,
 		headers: { "User-Agent": "pi-free-providers" },
 		auth: ollamaAuth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as OllamaModel[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_OLLAMA, models, {
+				showPaid: getOllamaShowPaid(),
+				freeModels: stored.free,
+			}),
 		refreshModels: refreshOllamaModels,
 		stream: (model, context, options) =>
 			streams.stream(model, context, options),
@@ -187,6 +180,7 @@ export function registerOllamaProvider(
 		stored,
 		reRegister,
 		Boolean(getOllamaApiKey()),
+		{ native: true },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_OLLAMA,

--- a/providers/openmodel/openmodel-auth.ts
+++ b/providers/openmodel/openmodel-auth.ts
@@ -1,0 +1,9 @@
+import { getOpenmodelApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const openmodelAuth = createNativeApiKeyAuth({
+	name: "OpenModel API key",
+	prompt: "OpenModel API key",
+	source: "OPENMODEL_API_KEY",
+	getApiKey: getOpenmodelApiKey,
+});

--- a/providers/openmodel/openmodel.ts
+++ b/providers/openmodel/openmodel.ts
@@ -27,9 +27,14 @@
  */
 
 import type {
-	ExtensionAPI,
-	ProviderModelConfig,
-} from "@earendil-works/pi-coding-agent";
+	Api,
+	Credential,
+	Model,
+	Provider,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import { anthropicMessagesApi } from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import {
 	getOpenmodelApiKey,
 	getOpenmodelShowPaid,
@@ -43,13 +48,22 @@ import {
 import { createLogger } from "../../lib/logger.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { isLikelyReasoningModel } from "../../lib/provider-compat.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
 import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+	isFreeModel,
+	registerWithGlobalToggle,
+} from "../../lib/registry.ts";
+import {
+	filterNativeModels,
+	persistNativeProviderModels,
+	restoreNativeProviderModels,
+	registerNativeProvider,
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
+import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
+import { openmodelAuth } from "./openmodel-auth.ts";
 
 const _logger = createLogger("openmodel");
 
@@ -327,6 +341,7 @@ const OPENMODEL_PAGINATION_DELAY_MS = 200;
 
 async function fetchOpenModelWebCatalog(
 	baseUrl: string,
+	signal?: AbortSignal,
 ): Promise<OpenModelCatalogItem[]> {
 	const items: OpenModelCatalogItem[] = [];
 	let cleanBase = baseUrl;
@@ -339,7 +354,7 @@ async function fetchOpenModelWebCatalog(
 
 		const response = await fetchWithRetry(
 			url,
-			{ headers: { Accept: "application/json" } },
+			{ headers: { Accept: "application/json" }, signal },
 			3,
 			1000,
 			DEFAULT_FETCH_TIMEOUT_MS,
@@ -372,9 +387,17 @@ async function fetchOpenModelWebCatalog(
 		page += 1;
 		// Be polite to the public endpoint — small delay between pages.
 		// pi-lens-ignore: ast-grep, await-in-loop
-		await new Promise((resolve) =>
-			setTimeout(resolve, OPENMODEL_PAGINATION_DELAY_MS),
-		);
+		await new Promise<void>((resolve, reject) => {
+			if (signal?.aborted) {
+				reject(new DOMException("Aborted", "AbortError"));
+				return;
+			}
+			const timer = setTimeout(resolve, OPENMODEL_PAGINATION_DELAY_MS);
+			signal?.addEventListener("abort", () => {
+				clearTimeout(timer);
+				reject(new DOMException("Aborted", "AbortError"));
+			}, { once: true });
+		});
 	}
 
 	_logger.info(
@@ -386,6 +409,7 @@ async function fetchOpenModelWebCatalog(
 async function fetchOpenModelProtocols(
 	apiKey: string,
 	baseUrl: string,
+	signal?: AbortSignal,
 ): Promise<OpenModelProtocolItem[]> {
 	let cleanBase = baseUrl;
 	while (cleanBase.endsWith("/")) cleanBase = cleanBase.slice(0, -1);
@@ -396,6 +420,7 @@ async function fetchOpenModelProtocols(
 				Authorization: `Bearer ${apiKey}`,
 				Accept: "application/json",
 			},
+			signal,
 		},
 		3,
 		1000,
@@ -418,15 +443,16 @@ async function fetchOpenModelProtocols(
 
 async function fetchOpenModelModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	const [catalog, protocols] = await Promise.all([
-		fetchOpenModelWebCatalog(BASE_URL_OPENMODEL).catch((error) => {
+		fetchOpenModelWebCatalog(BASE_URL_OPENMODEL, signal).catch((error) => {
 			_logger.error("[openmodel] Failed to fetch public catalog", {
 				error: error instanceof Error ? error.message : String(error),
 			});
 			return [] as OpenModelCatalogItem[];
 		}),
-		fetchOpenModelProtocols(apiKey, BASE_URL_OPENMODEL).catch((error) => {
+		fetchOpenModelProtocols(apiKey, BASE_URL_OPENMODEL, signal).catch((error) => {
 			_logger.error("[openmodel] Failed to fetch /v1/models", {
 				error: error instanceof Error ? error.message : String(error),
 			});
@@ -456,77 +482,123 @@ async function fetchOpenModelModels(
 	return applyHidden(enriched, PROVIDER_OPENMODEL);
 }
 
+type OpenModelNative = Model<"anthropic-messages">;
+
+function toOpenModel(model: ProviderModelConfig): OpenModelNative {
+	return {
+		...model,
+		api: "anthropic-messages",
+		provider: PROVIDER_OPENMODEL,
+		baseUrl: BASE_URL_OPENMODEL,
+	} as OpenModelNative;
+}
+
+function openModelCredentialToken(
+	credential: Credential | undefined,
+): string | undefined {
+	if (credential?.type === "api_key") {
+		return credential.key ?? getOpenmodelApiKey();
+	}
+	return getOpenmodelApiKey();
+}
+
 // =============================================================================
 // Extension Entry Point
 // =============================================================================
 
-export default async function openmodelProvider(pi: ExtensionAPI) {
-	const apiKey = getOpenmodelApiKey();
+export default function openmodelProvider(pi: ExtensionAPI): Promise<void> {
+	const streams = anthropicMessagesApi();
+	const initialModels = loadProviderCache(PROVIDER_OPENMODEL) ?? [];
+	const stored: StoredModels = { free: [], all: [] };
 
-	if (!apiKey) {
-		_logger.info(
-			"[openmodel] Skipping — OPENMODEL_API_KEY not set. Sign up at https://openmodel.ai/",
-		);
-		return;
+	function ingest(all: ProviderModelConfig[], free?: ProviderModelConfig[]): void {
+		stored.all = enhanceWithCI(all, PROVIDER_OPENMODEL).map(toOpenModel);
+		stored.free = (free ?? stored.all.filter((model) =>
+			isFreeModel(
+				{ ...model, provider: PROVIDER_OPENMODEL },
+				stored.all,
+			),
+		)).map(toOpenModel);
 	}
 
-	const allModels = await loadCachedOrFetchModels(PROVIDER_OPENMODEL, () =>
-		fetchOpenModelModels(apiKey),
-	);
+	if (initialModels.length > 0) ingest(initialModels);
 
-	if (allModels.length === 0) {
-		_logger.warn(
-			"[openmodel] No models available — verify OPENMODEL_API_KEY is valid and see ~/.pi/free.log for details",
-		);
-		return;
-	}
-
-	// isFreeModel handles the heavy lifting:
-	//   - Priced models (multiplier>0): Route A — free if effective cost is 0.
-	//   - Free-event models (multiplier=0, e.g. deepseek-v4-flash): Route A
-	//     sees cost 0 → free. This is the headline free model.
-	//   - Unpriced models: _freeKnown=true, _isFree=false → definitively paid.
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_OPENMODEL }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[openmodel] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	const reRegister = createReRegister(pi, {
-		providerId: PROVIDER_OPENMODEL,
+	const provider: Provider<"anthropic-messages"> = {
+		id: PROVIDER_OPENMODEL,
+		name: "OpenModel",
 		baseUrl: BASE_URL_OPENMODEL,
-		apiKey,
-		// OpenModel is an Anthropic-protocol gateway — /v1/chat/completions
-		// does not exist on it. Without `api: "anthropic-messages"`, the
-		// helper defaults to openai-completions and pi-ai POSTs to a 404
-		// path. Pin the wire format so it dispatches to the Anthropic SDK.
-		api: "anthropic-messages",
-	});
+		auth: openmodelAuth,
+		headers: { "User-Agent": "pi-free-providers" },
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as OpenModelNative[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_OPENMODEL, models, {
+				showPaid: getOpenmodelShowPaid(),
+				freeModels: stored.free,
+			}),
+		refreshModels: async (context: RefreshModelsContext) => {
+			await restoreNativeProviderModels(
+				PROVIDER_OPENMODEL,
+				context,
+				(storedModels: OpenModelNative[]) => {
+					stored.all = storedModels;
+					stored.free = storedModels.filter((model) =>
+						isFreeModel(
+							{ ...model, provider: PROVIDER_OPENMODEL },
+							storedModels,
+						),
+					);
+				},
+			);
+			if (!context.allowNetwork || context.signal?.aborted) return;
 
-	registerWithGlobalToggle(PROVIDER_OPENMODEL, stored, reRegister, true);
-
-	setupProvider(
-		pi,
-		{
-			providerId: PROVIDER_OPENMODEL,
-			initialShowPaid: getOpenmodelShowPaid(),
-			tosUrl: "https://docs.openmodel.ai/en/docs",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
+			const token = openModelCredentialToken(context.credential);
+			if (!token) return;
+			const models = await fetchOpenModelModels(token, context.signal);
+			if (context.signal?.aborted || models.length === 0) return;
+			const free = models.filter((model) =>
+				isFreeModel({ ...model, provider: PROVIDER_OPENMODEL }, models),
+			);
+			ingest(models, free);
+			await saveProviderCache(PROVIDER_OPENMODEL, models);
+			await persistNativeProviderModels(
+				PROVIDER_OPENMODEL,
+				context,
+				stored.all as unknown as readonly Model<Api>[],
+			);
 		},
-		stored,
-	);
+		stream: (model, context, options) =>
+			streams.stream(model, context, options),
+		streamSimple: (model, context, options) =>
+			streams.streamSimple(model, context, options),
+	};
 
-	const showPaid = getOpenmodelShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
+	registerNativeProvider(pi, provider);
+	const reRegister = (_models: ProviderModelConfig[]) =>
+		registerNativeProvider(pi, provider);
+	registerWithGlobalToggle(
+		PROVIDER_OPENMODEL,
+		stored,
+		reRegister,
+		Boolean(getOpenmodelApiKey()),
+		{ native: true },
+	);
+	registerNativeProviderToggle(pi, {
+		providerId: PROVIDER_OPENMODEL,
+		stored,
+		getShowPaid: getOpenmodelShowPaid,
+		reRegister,
+	});
+	registerNativeProviderRefresh(pi, PROVIDER_OPENMODEL);
+
+	let tosShown = false;
+	pi.on("model_select", (_event, ctx) => {
+		if (tosShown || ctx.model?.provider !== PROVIDER_OPENMODEL) return;
+		tosShown = true;
+		ctx.ui.notify(
+			"Using openmodel free models. Set API key for paid access. Terms: https://docs.openmodel.ai/en/docs",
+			"info",
+		);
+	});
+	return Promise.resolve();
 }

--- a/providers/routeway/routeway-auth.ts
+++ b/providers/routeway/routeway-auth.ts
@@ -1,0 +1,9 @@
+import { getRoutewayApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+export const routewayAuth = createNativeApiKeyAuth({
+	name: "Routeway API key",
+	prompt: "Routeway API key",
+	source: "ROUTEWAY_API_KEY",
+	getApiKey: getRoutewayApiKey,
+});

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -18,12 +18,7 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import {
-	applyHidden,
-	getRoutewayApiKey,
-	getRoutewayShowPaid,
-	updateConfig,
-} from "../../config.ts";
+import { applyHidden, getRoutewayApiKey, getRoutewayShowPaid } from "../../config.ts";
 import {
 	BASE_URL_ROUTEWAY,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -35,20 +30,14 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
+import { createOpenAIAvailabilityProbe } from "../../lib/provider-probe.ts";
 import {
-	areAllModelsFresh,
-	getModelsDueForProbe,
-	recordModelProbeResults,
-} from "../../lib/probe-cache.ts";
-import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { wrapSessionStartHandler } from "../../lib/session-start-metrics.ts";
+	registerNativeAvailabilityProbe,
+	registerNativeOpenAIProvider,
+} from "../../lib/native-provider.ts";
+import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
-import { fetchWithTimeout } from "../../lib/util.ts";
-import {
-	createReRegister,
-	loadCachedOrFetchModels,
-	setupProvider,
-} from "../../provider-helper.ts";
+import { routewayAuth } from "./routeway-auth.ts";
 
 const _logger = createLogger("routeway");
 
@@ -109,7 +98,7 @@ function mapRoutewayModel(
 	const outputCost = parsePricePerToken(model.pricing?.output);
 	const cacheRead = parsePricePerToken(model.pricing?.caching?.read);
 	const cacheWrite = parsePricePerToken(model.pricing?.caching?.write);
-	const hasPricing = !!(model.pricing?.input || model.pricing?.output);
+	const hasPricing = Boolean(model.pricing?.input || model.pricing?.output);
 	const reasoning =
 		model.capabilities?.reasoning === true ||
 		(model.supported_parameters ?? []).includes("reasoning_effort") ||
@@ -136,6 +125,7 @@ function mapRoutewayModel(
 
 async function fetchRoutewayModels(
 	apiKey: string,
+	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
 	_logger.info("[routeway] Fetching models from Routeway API...");
 
@@ -148,6 +138,7 @@ async function fetchRoutewayModels(
 					Accept: "application/json",
 					"Content-Type": "application/json",
 				},
+				signal,
 			},
 			3,
 			1000,
@@ -178,239 +169,40 @@ async function fetchRoutewayModels(
 }
 
 // =============================================================================
-// Probe
-// =============================================================================
-
-async function probeRoutewayModel(
-	apiKey: string,
-	modelId: string,
-): Promise<"ok" | "broken" | "unknown"> {
-	try {
-		const response = await fetchWithTimeout(
-			`${BASE_URL_ROUTEWAY}/chat/completions`,
-			{
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-					"Content-Type": "application/json",
-					"User-Agent": "pi-free-providers",
-				},
-				body: JSON.stringify({
-					model: modelId,
-					messages: [{ role: "user", content: "hi" }],
-					max_tokens: 1,
-				}),
-			},
-			10000, // 10 second timeout
-		);
-
-		// 5xx = upstream server error (model unavailable)
-		if (response.status >= 500) return "broken";
-		// 404 = model not found / not provisioned
-		if (response.status === 404) return "broken";
-		// 429 = rate limited (model works)
-		if (response.status === 429) return "ok";
-		// 401 = auth issue (model exists, key issue)
-		if (response.status === 401) return "ok";
-		// 400 = bad request (model exists, param issue)
-		if (response.status === 400) return "ok";
-		// 200 = success
-		if (response.ok) return "ok";
-		return "ok";
-	} catch {
-		return "unknown";
-	}
-}
-
-async function runRoutewayProbe(
-	apiKey: string,
-	modelsToTest: ProviderModelConfig[],
-	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] },
-	reRegister: (models: ProviderModelConfig[]) => void,
-	options: { useCache?: boolean } = {},
-): Promise<string[]> {
-	const modelIdsToProbe = options.useCache
-		? new Set(
-				getModelsDueForProbe(
-					PROVIDER_ROUTEWAY,
-					modelsToTest.map((m) => m.id),
-				),
-			)
-		: undefined;
-	const probeCandidates = modelIdsToProbe
-		? modelsToTest.filter((m) => modelIdsToProbe.has(m.id))
-		: modelsToTest;
-
-	if (probeCandidates.length === 0) {
-		_logger.info("Auto-probe: Routeway probe cache is fresh");
-		return [];
-	}
-
-	const broken: string[] = [];
-	const cacheableResults: Array<{ modelId: string; status: "ok" | "broken" }> =
-		[];
-	const batchSize = 5;
-
-	for (let i = 0; i < probeCandidates.length; i += batchSize) {
-		const batch = probeCandidates.slice(i, i + batchSize);
-		const results = await Promise.all(
-			batch.map(async (m) => {
-				const status = await probeRoutewayModel(apiKey, m.id);
-				return { id: m.id, status };
-			}),
-		);
-		for (const r of results) {
-			if (r.status === "broken") broken.push(r.id);
-			if (r.status !== "unknown") {
-				cacheableResults.push({ modelId: r.id, status: r.status });
-			}
-		}
-	}
-
-	await recordModelProbeResults(PROVIDER_ROUTEWAY, cacheableResults);
-
-	if (broken.length === 0) {
-		_logger.info("Auto-probe: all checked Routeway models are routable");
-		return [];
-	}
-
-	// Auto-hide broken models in config (provider-scoped).
-	// Use updateConfig for atomic RMW to prevent concurrent probes from
-	// clobbering each other's hidden_models.
-	await updateConfig((cfg) => {
-		const existingHidden = new Set(cfg.hidden_models ?? []);
-		for (const id of broken) existingHidden.add(`${PROVIDER_ROUTEWAY}/${id}`);
-		return { hidden_models: Array.from(existingHidden) };
-	});
-
-	// Re-register so hidden models disappear immediately
-	const filtered = await fetchRoutewayModels(apiKey);
-	stored.free = filtered;
-	stored.all = filtered;
-	reRegister(filtered);
-
-	_logger.info(
-		`Auto-probe: found ${broken.length} broken models (auto-hidden)`,
-	);
-	return broken;
-}
-
-// =============================================================================
 // Extension Entry Point
 // =============================================================================
 
-export default async function routewayProvider(pi: ExtensionAPI) {
-	const apiKey = getRoutewayApiKey();
-
-	if (!apiKey) {
-		_logger.info(
-			"[routeway] Skipping — ROUTEWAY_API_KEY not set. Sign up at https://routeway.ai/",
-		);
-		return;
-	}
-
-	const allModels = await loadCachedOrFetchModels(PROVIDER_ROUTEWAY, () =>
-		fetchRoutewayModels(apiKey),
-	);
-
-	if (allModels.length === 0) {
-		_logger.warn("[routeway] No chat models available");
-		return;
-	}
-
-	const freeModels = allModels.filter((m) =>
-		isFreeModel({ ...m, provider: PROVIDER_ROUTEWAY }, allModels),
-	);
-	const stored = { free: freeModels, all: allModels };
-
-	_logger.info(
-		`[routeway] Registered ${allModels.length} models (${freeModels.length} free)`,
-	);
-
-	const reRegister = createReRegister(pi, {
+export default function routewayProvider(pi: ExtensionAPI): Promise<void> {
+	const initialModels = loadProviderCache(PROVIDER_ROUTEWAY) ?? [];
+	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_ROUTEWAY,
+		name: "Routeway",
 		baseUrl: BASE_URL_ROUTEWAY,
-		apiKey,
+		auth: routewayAuth,
+		getApiKey: getRoutewayApiKey,
+		getShowPaid: getRoutewayShowPaid,
+		initialModels,
+		fetchModels: async (apiKey, signal) => {
+			const models = await fetchRoutewayModels(apiKey, signal);
+			if (models.length > 0) await saveProviderCache(PROVIDER_ROUTEWAY, models);
+			return models;
+		},
+		tosUrl: "https://routeway.ai/terms",
 	});
 
-	registerWithGlobalToggle(PROVIDER_ROUTEWAY, stored, reRegister, true);
-
-	setupProvider(
-		pi,
-		{
+	const apiKey = getRoutewayApiKey();
+	if (apiKey) {
+		const probe = createOpenAIAvailabilityProbe(
+			PROVIDER_ROUTEWAY,
+			BASE_URL_ROUTEWAY,
+		);
+		registerNativeAvailabilityProbe(pi, {
 			providerId: PROVIDER_ROUTEWAY,
-			initialShowPaid: getRoutewayShowPaid(),
-			tosUrl: "https://routeway.ai/terms",
-			reRegister: (models, _stored) => {
-				if (_stored) {
-					stored.free = _stored.free;
-					stored.all = _stored.all;
-				}
-				reRegister(models);
-			},
-		},
-		stored,
-	);
-
-	// ── Lazy auto-probe on first session_start ──────────────────────
-	let _autoProbeDone = false;
-	pi.on(
-		"session_start",
-		wrapSessionStartHandler("routeway", async () => {
-			if (_autoProbeDone || !apiKey) return;
-			_autoProbeDone = true;
-			if (
-				areAllModelsFresh(
-					PROVIDER_ROUTEWAY,
-					allModels.map((m) => m.id),
-				)
-			) {
-				_logger.info("Auto-probe: Routeway probe cache is fresh");
-				return;
-			}
-			_logger.info("Starting lazy auto-probe of Routeway models...");
-			runRoutewayProbe(apiKey, allModels, stored, reRegister, {
-				useCache: true,
-			}).catch((err) => {
-				_logger.warn("Auto-probe failed", {
-					error: err instanceof Error ? err.message : String(err),
-				});
-			});
-		}),
-	);
-
-	// ── Probe command: test all registered models for 5xx ─────────────
-	pi.registerCommand("probe-routeway", {
-		description:
-			"Test all Routeway models for server errors and auto-hide broken ones",
-		handler: async (_args, ctx) => {
-			if (!apiKey) {
-				ctx.ui.notify("ROUTEWAY_API_KEY not set", "error");
-				return;
-			}
-
-			const modelsToTest = allModels;
-			ctx.ui.notify(`Probing ${modelsToTest.length} Routeway models…`, "info");
-
-			const broken = await runRoutewayProbe(
-				apiKey,
-				modelsToTest,
-				stored,
-				reRegister,
-			);
-			if (broken.length > 0) {
-				ctx.ui.notify(
-					`Found ${broken.length} broken models (auto-hidden):\n${broken.map((id) => `${PROVIDER_ROUTEWAY}/${id}`).join("\n")}`,
-					"warning",
-				);
-			} else {
-				ctx.ui.notify("All Routeway models are routable ✅", "info");
-			}
-		},
-	});
-
-	const showPaid = getRoutewayShowPaid();
-	const initialModels =
-		showPaid && stored.all.length > 0 ? stored.all : freeModels;
-	reRegister(initialModels);
+			label: "Routeway",
+			apiKey,
+			probe,
+			handle,
+		});
+	}
+	return Promise.resolve();
 }

--- a/providers/tokenrouter/tokenrouter-provider.ts
+++ b/providers/tokenrouter/tokenrouter-provider.ts
@@ -16,16 +16,13 @@ import type {
 import { getTokenrouterApiKey, getTokenrouterShowPaid } from "../../config.ts";
 import { BASE_URL_TOKENROUTER, PROVIDER_TOKENROUTER } from "../../constants.ts";
 import {
+	filterNativeModels,
 	refreshNativeProviderModels,
 	registerNativeProvider,
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
-import {
-	getGlobalFreeOnly,
-	isFreeModel,
-	registerWithGlobalToggle,
-} from "../../lib/registry.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import { loadProviderCache } from "../../lib/provider-cache.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { tokenRouterAuth } from "./tokenrouter-auth.ts";
@@ -95,18 +92,10 @@ export function createTokenRouterProvider(
 	) ?? [],
 ): TokenRouterNativeProvider {
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: TokenRouterNativeModel[] = [];
 
-	function decideView(): ProviderModelConfig[] {
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		const showPaid = getTokenrouterShowPaid();
-		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
-	}
-
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = toTokenRouterModels(models);
+	function setView(_models: ProviderModelConfig[]): void {
+		// Re-registration invalidates Pi's filtered availability snapshot; the
+		// complete catalog remains in stored.all.
 	}
 
 	function ingest(
@@ -117,7 +106,6 @@ export function createTokenRouterProvider(
 		stored.free = toTokenRouterModels(
 			enhanceWithCI(free, PROVIDER_TOKENROUTER),
 		);
-		setView(decideView());
 	}
 
 	if (initialModels.length > 0) {
@@ -126,7 +114,6 @@ export function createTokenRouterProvider(
 		);
 		stored.all = all;
 		stored.free = classifyFreeModels(all);
-		setView(decideView());
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
@@ -136,7 +123,6 @@ export function createTokenRouterProvider(
 			(storedModels: TokenRouterNativeModel[]) => {
 				stored.all = storedModels;
 				stored.free = classifyFreeModels(storedModels);
-				setView(decideView());
 			},
 			async () => {
 				const token = credentialToken(context.credential);
@@ -147,7 +133,6 @@ export function createTokenRouterProvider(
 			(models) => {
 				stored.all = models;
 				stored.free = classifyFreeModels(models);
-				setView(decideView());
 			},
 		);
 	}
@@ -158,7 +143,13 @@ export function createTokenRouterProvider(
 		baseUrl: BASE_URL_TOKENROUTER,
 		headers: { "User-Agent": "pi-free-providers" },
 		auth: tokenRouterAuth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as TokenRouterNativeModel[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_TOKENROUTER, models, {
+				showPaid: getTokenrouterShowPaid(),
+				freeModels: stored.free,
+			}),
 		refreshModels,
 		stream: (model, context, options) =>
 			deps.streamSimple(model, context, options),
@@ -186,6 +177,7 @@ export function registerTokenRouterProvider(
 		stored,
 		reRegister,
 		Boolean(getTokenrouterApiKey()),
+		{ native: true },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_TOKENROUTER,

--- a/providers/zenmux/zenmux-provider.ts
+++ b/providers/zenmux/zenmux-provider.ts
@@ -10,10 +10,11 @@ import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
 import { BASE_URL_ZENMUX, PROVIDER_ZENMUX } from "../../constants.ts";
 import {
+	filterNativeModels,
 	persistNativeProviderModels,
 	restoreNativeProviderModels,
 } from "../../lib/native-provider.ts";
-import { getGlobalFreeOnly, isFreeModel } from "../../lib/registry.ts";
+import { isFreeModel } from "../../lib/registry.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { zenmuxAuth } from "./zenmux-auth.ts";
 import { fetchZenmuxCatalog, toZenmuxModels } from "./zenmux-models.ts";
@@ -38,18 +39,10 @@ function credentialToken(credential?: Credential): string | undefined {
 export function createZenmuxProvider(): ZenmuxNativeProvider {
 	const streams = openAICompletionsApi();
 	const stored: StoredModels = { free: [], all: [] };
-	let currentView: ZenmuxModel[] = [];
 
-	function decideView(): ProviderModelConfig[] {
-		if (!getGlobalFreeOnly()) {
-			return stored.all.length > 0 ? stored.all : stored.free;
-		}
-		const showPaid = getZenmuxShowPaid();
-		return showPaid && stored.all.length > 0 ? stored.all : stored.free;
-	}
-
-	function setView(models: ProviderModelConfig[]): void {
-		currentView = toZenmuxModels(models);
+	function setView(_models: ProviderModelConfig[]): void {
+		// Re-registration invalidates Pi's filtered availability snapshot; the
+		// complete catalog remains in stored.all.
 	}
 
 	function ingest(
@@ -58,7 +51,6 @@ export function createZenmuxProvider(): ZenmuxNativeProvider {
 	): void {
 		stored.all = toZenmuxModels(enhanceWithCI(all));
 		stored.free = toZenmuxModels(enhanceWithCI(free));
-		setView(decideView());
 	}
 
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
@@ -70,7 +62,6 @@ export function createZenmuxProvider(): ZenmuxNativeProvider {
 				stored.free = storedModels.filter((model) =>
 					isFreeModel({ ...model, provider: PROVIDER_ZENMUX }, storedModels),
 				);
-				setView(decideView());
 			},
 		);
 
@@ -98,7 +89,13 @@ export function createZenmuxProvider(): ZenmuxNativeProvider {
 			"User-Agent": "pi-free-providers",
 		},
 		auth: zenmuxAuth,
-		getModels: () => currentView,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as ZenmuxModel[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_ZENMUX, models, {
+				showPaid: getZenmuxShowPaid(),
+				freeModels: stored.free,
+			}),
 		refreshModels,
 		stream: (model, context, options) =>
 			streams.stream(model, context, options),

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -39,6 +39,7 @@ export default async function zenmuxProvider(pi: ExtensionAPI) {
 		stored,
 		reRegister,
 		Boolean(getZenmuxApiKey()),
+		{ native: true },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_ZENMUX,

--- a/tests/cline-provider.test.ts
+++ b/tests/cline-provider.test.ts
@@ -25,11 +25,13 @@ const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
 vi.mock("../config.ts", () => ({
 	getClineApiKey: () => mockGetClineApiKey(),
 	getClineShowPaid: () => mockGetClineShowPaid(),
+	applyHidden: (models: unknown[]) => models,
 	PROVIDER_CLINE: "cline",
 }));
 
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
 }));
 
@@ -191,9 +193,12 @@ describe("refreshModels offline init", () => {
 		await provider.refreshModels?.(ctx({ store, allowNetwork: false }));
 
 		expect(mockFetchClineCatalog).not.toHaveBeenCalled();
-		// Global free-only on + no show_paid => free models only.
+		// getModels exposes the complete catalog; Pi applies filterModels.
 		const models = provider.getModels();
-		expect(models.map((m) => m.id)).toEqual(["a"]);
+		expect(models.map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(models, undefined).map((m) => m.id),
+		).toEqual(["a"]);
 	});
 
 	it("stays empty when the store is empty and network is disallowed", async () => {
@@ -268,8 +273,11 @@ describe("refreshModels online", () => {
 		// Catalogs populated for the toggle.
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
-		// Free-only view by default.
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
+		// getModels exposes the complete catalog; Pi applies filterModels.
+		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 	});
 
 	it("retains the previous catalog when a fetch returns nothing (poisoning guard)", async () => {
@@ -349,31 +357,25 @@ describe("toggle interop", () => {
 		return handle;
 	}
 
-	it("setView swaps the visible catalog (what /toggle-cline and /toggle-free drive)", async () => {
+	it("keeps the full catalog while filterModels selects the free view", async () => {
 		const { provider, stored, setView } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
+		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
 
-		// reRegister(stored.all) -> setView(stored.all) + re-register.
+		// Re-registration is now an availability-snapshot invalidation signal.
 		setView(stored.all);
-		expect(
-			provider
-				.getModels()
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-
-		// And back to free.
 		setView(stored.free);
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
+		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
 	});
 
 	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
 		mockGetClineShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
-		// show_paid true + global free-only true => all models.
+		// show_paid true + global free-only true => filterModels returns all.
 		expect(
 			provider
-				.getModels()
+				.filterModels!(provider.getModels(), undefined)
 				.map((m) => m.id)
 				.sort(),
 		).toEqual(["a", "b"]);

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -44,6 +44,7 @@ vi.mock("../lib/registry.ts", () => ({
 		mockRegisterWithGlobalToggle(...args);
 	},
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
 }));
 
@@ -208,10 +209,12 @@ describe("Cline factory wiring", () => {
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
 
-		// Global /toggle-free showing free -> reRegister(stored.free).
+		// Global /toggle-free showing free invalidates the same provider object;
+		// Pi's filterModels applies the free view to the complete catalog.
 		reRegister(stored.free);
-		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
 			"free-1",
+			"paid-1",
 		]);
 	});
 
@@ -238,13 +241,15 @@ describe("Cline factory wiring", () => {
 			"info",
 		);
 
-		// Second toggle: all -> free.
+		// Second toggle: all -> free. The complete catalog remains registered;
+		// the filter callback selects the free view in Pi's availability layer.
 		mockGetClineShowPaid.mockReturnValue(true);
 		notify.mockClear();
 		await call[1].handler({}, { ui: { notify } });
 		expect(mockSaveConfig).toHaveBeenCalledWith({ cline_show_paid: false });
-		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
 			"free-1",
+			"paid-1",
 		]);
 		expect(notify).toHaveBeenCalledWith(
 			expect.stringContaining("showing 1 free models"),

--- a/tests/kilo-provider.test.ts
+++ b/tests/kilo-provider.test.ts
@@ -27,11 +27,13 @@ vi.mock("../config.ts", () => ({
 	getKiloApiKey: () => mockGetKiloApiKey(),
 	getKiloShowPaid: () => mockGetKiloShowPaid(),
 	getKiloFreeOnly: () => mockGetKiloFreeOnly(),
+	applyHidden: (models: unknown[]) => models,
 	PROVIDER_KILO: "kilo",
 }));
 
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
 }));
 
@@ -173,9 +175,10 @@ describe("refreshModels offline init", () => {
 		await provider.refreshModels?.(ctx({ store, allowNetwork: false }));
 
 		expect(mockFetchKiloCatalog).not.toHaveBeenCalled();
-		// Global free-only on + no show_paid => free models only.
+		// getModels exposes the complete catalog; Pi applies filterModels.
 		const models = provider.getModels();
-		expect(models.map((m) => m.id)).toEqual(["a"]);
+		expect(models.map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(models, undefined).map((m) => m.id)).toEqual(["a"]);
 	});
 
 	it("stays empty when the store is empty and network is disallowed", async () => {
@@ -221,8 +224,9 @@ describe("refreshModels online", () => {
 		// Catalogs populated for the toggle.
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
-		// Free-only view by default.
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
+		// getModels exposes the complete catalog; Pi applies filterModels.
+		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
 	});
 
 	it("passes the OAuth access token from context.credential to the fetcher", async () => {
@@ -321,36 +325,35 @@ describe("toggle interop", () => {
 		return handle;
 	}
 
-	it("setView swaps the visible catalog (what /toggle-kilo and /toggle-free drive)", async () => {
+	it("keeps the full catalog while filterModels selects the free view", async () => {
 		const { provider, stored, setView } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
-
-		// reRegister(stored.all) -> setView(stored.all) + re-register.
-		setView(stored.all);
 		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
 
-		// And back to free.
+		// Re-registration is now an availability-snapshot invalidation signal.
+		setView(stored.all);
 		setView(stored.free);
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
+		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
 	});
 
 	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
 		mockGetKiloShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
-		// show_paid true + global free-only true => all models.
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		// show_paid true + global free-only true => filterModels returns all.
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id).sort()).toEqual(["a", "b"]);
 	});
 
-	it("decideView shows all when global free-only is off", async () => {
+	it("filterModels shows all when global free-only is off", async () => {
 		mockGetGlobalFreeOnly.mockReturnValue(false);
 		const { provider } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id).sort()).toEqual(["a", "b"]);
 	});
 
-	it("decideView forces free when kilo_free_only is set", async () => {
+	it("filterModels forces free when kilo_free_only is set", async () => {
 		mockGetKiloFreeOnly.mockReturnValue(true);
 		mockGetKiloShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id)).toEqual(["a"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
 	});
 });

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -41,6 +41,7 @@ vi.mock("../lib/registry.ts", () => ({
 		mockRegisterWithGlobalToggle(...args);
 	},
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
 }));
 
@@ -162,10 +163,12 @@ describe("Kilo toggle interop", () => {
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
 
-		// Global /toggle-free showing free -> reRegister(stored.free).
+		// Global /toggle-free showing free invalidates the same provider object;
+		// Pi's filterModels applies the free view to the complete catalog.
 		reRegister(stored.free);
-		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
 			"free-1",
+			"paid-1",
 		]);
 	});
 

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -114,6 +114,7 @@ describe("Kilo extension wiring", () => {
 			mockStored,
 			expect.any(Function),
 			false,
+			{ native: true },
 		);
 	});
 
@@ -125,6 +126,7 @@ describe("Kilo extension wiring", () => {
 			mockStored,
 			expect.any(Function),
 			true,
+			{ native: true },
 		);
 	});
 

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -35,6 +35,7 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
 }));
 
@@ -256,8 +257,13 @@ describe("refreshModels offline init", () => {
 		await provider.refreshModels?.(ctx({ store, allowNetwork: false }));
 
 		expect(mockFetch).not.toHaveBeenCalled();
-		// Global free-only on + no show_paid => free selectors only.
+		// getModels exposes the complete catalog; Pi applies filterModels.
 		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 		]);
@@ -328,8 +334,13 @@ describe("refreshModels online", () => {
 		// Catalogs populated for the toggle.
 		expect(stored.all.map((m) => m.id)).toEqual(["default", "fast", "pro"]);
 		expect(stored.free.map((m) => m.id)).toEqual(["default", "fast"]);
-		// Free-only view by default.
+		// getModels exposes the complete catalog; Pi applies filterModels.
 		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 		]);
@@ -381,12 +392,13 @@ describe("refreshModels online", () => {
 		expect(provider.getModels().map((m) => m.id)).toEqual([
 			"default",
 			"fast",
+			"pro",
 		]);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// Toggle interop (setView / decideView)
+// Toggle interop (setView / filterModels)
 // ---------------------------------------------------------------------------
 
 describe("toggle interop", () => {
@@ -397,24 +409,26 @@ describe("toggle interop", () => {
 		return handle;
 	}
 
-	it("setView swaps the visible catalog (what /toggle-llm7 and /toggle-free drive)", async () => {
+	it("keeps the full catalog while filterModels selects the free view", async () => {
 		const { provider, stored, setView } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-		]);
-
-		// reRegister(stored.all) -> setView(stored.all) + re-register.
-		setView(stored.all);
 		expect(provider.getModels().map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 			"pro",
 		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+		]);
 
-		// And back to free.
+		setView(stored.all);
 		setView(stored.free);
 		expect(provider.getModels().map((m) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 		]);
@@ -423,8 +437,8 @@ describe("toggle interop", () => {
 	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
 		mockGetLlm7ShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
-		// show_paid true + global free-only true => all models.
-		expect(provider.getModels().map((m) => m.id)).toEqual([
+		// show_paid true + global free-only true => filterModels returns all.
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 			"pro",
@@ -434,7 +448,7 @@ describe("toggle interop", () => {
 	it("decideView shows all when global free-only is off", async () => {
 		mockGetGlobalFreeOnly.mockReturnValue(false);
 		const { provider } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id)).toEqual([
+		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 			"pro",

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -41,6 +41,7 @@ vi.mock("../lib/registry.ts", () => ({
 		mockRegisterWithGlobalToggle(...args);
 	},
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (m: { cost?: { input?: number } }) => (m.cost?.input ?? 0) === 0,
 }));
 
@@ -166,11 +167,13 @@ describe("LLM7 factory wiring", () => {
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
 
-		// Global /toggle-free showing free -> reRegister(stored.free).
+		// Global /toggle-free showing free invalidates the same provider object;
+		// Pi's filterModels applies the free view to the complete catalog.
 		reRegister(stored.free);
 		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
 			"default",
 			"fast",
+			"pro",
 		]);
 	});
 
@@ -198,7 +201,8 @@ describe("LLM7 factory wiring", () => {
 			"info",
 		);
 
-		// Second toggle: all -> free.
+		// Second toggle: all -> free. The complete catalog remains registered;
+		// Pi's filterModels applies the free view.
 		mockGetLlm7ShowPaid.mockReturnValue(true);
 		notify.mockClear();
 		await call[1].handler({}, { ui: { notify } });
@@ -206,6 +210,7 @@ describe("LLM7 factory wiring", () => {
 		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
 			"default",
 			"fast",
+			"pro",
 		]);
 		expect(notify).toHaveBeenCalledWith(
 			expect.stringContaining("showing 2 free models"),

--- a/tests/native-filter-models.test.ts
+++ b/tests/native-filter-models.test.ts
@@ -1,0 +1,55 @@
+import type { Model, Provider } from "@earendil-works/pi-ai/compat";
+import { createModels } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+
+function model(id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "native-filter-test",
+		baseUrl: "https://example.test/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: id === "free" ? 0 : 1, output: id === "free" ? 0 : 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32_000,
+		maxTokens: 4_096,
+	};
+}
+
+describe("native filterModels availability snapshots", () => {
+	it("settles on the filtered view after re-registering the same provider", async () => {
+		const all = [model("free"), model("paid")];
+		let freeOnly = true;
+		const provider: Provider<"openai-completions"> = {
+			id: "native-filter-test",
+			name: "Native filter test",
+			auth: {
+				apiKey: {
+					name: "Test API key",
+					resolve: async () => ({ auth: { apiKey: "test-key" } }),
+				},
+			},
+			getModels: () => all,
+			filterModels: (models) =>
+				freeOnly ? models.filter((item) => item.id === "free") : models,
+			stream: () => undefined as never,
+			streamSimple: () => undefined as never,
+		};
+		const models = createModels();
+		models.setProvider(provider);
+
+		expect((await models.getAvailable()).map((item) => item.id)).toEqual([
+			"free",
+		]);
+		expect(models.getModels().map((item) => item.id)).toEqual(["free", "paid"]);
+
+		freeOnly = false;
+		models.setProvider(provider);
+
+		expect((await models.getAvailable()).map((item) => item.id)).toEqual([
+			"free",
+			"paid",
+		]);
+	});
+});

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -10,11 +10,16 @@ import type {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
+const mockGetGlobalFreeOnlyForced = vi.hoisted(() => vi.fn(() => false));
 const mockSaveConfig = vi.hoisted(() => vi.fn(async () => undefined));
 
-vi.mock("../config.ts", () => ({ saveConfig: mockSaveConfig }));
+vi.mock("../config.ts", () => ({
+	saveConfig: mockSaveConfig,
+	applyHidden: (models: unknown[]) => models,
+}));
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => mockGetGlobalFreeOnlyForced(),
 	isFreeModel: (model: { name: string }) => /free/i.test(model.name),
 	registerWithGlobalToggle: vi.fn(),
 }));
@@ -101,6 +106,7 @@ const options = {
 beforeEach(() => {
 	vi.clearAllMocks();
 	mockGetGlobalFreeOnly.mockReturnValue(true);
+	mockGetGlobalFreeOnlyForced.mockReturnValue(false);
 });
 
 describe("createNativeApiKeyAuth", () => {
@@ -151,15 +157,41 @@ describe("createNativeOpenAIProvider", () => {
 		expect(handle.provider.getModels()[0].provider).toBe("test-native");
 	});
 
+	it("keeps the complete catalog and filters it without replacing the provider", () => {
+		const handle = createNativeOpenAIProvider(options);
+		expect(handle.provider.getModels().map((item) => item.id)).toEqual([
+			"free",
+			"paid",
+		]);
+		expect(
+			handle.provider
+				.filterModels!(handle.provider.getModels(), undefined)
+				.map((item) => item.id),
+		).toEqual(["free"]);
+
+		mockGetGlobalFreeOnly.mockReturnValue(false);
+		expect(
+			handle.provider
+				.filterModels!(handle.provider.getModels(), undefined)
+				.map((item) => item.id),
+		).toEqual(["free", "paid"]);
+
+		mockGetGlobalFreeOnly.mockReturnValue(true);
+		mockGetGlobalFreeOnlyForced.mockReturnValue(true);
+		expect(
+			handle.provider
+				.filterModels!(handle.provider.getModels(), undefined)
+				.map((item) => item.id),
+		).toEqual(["free"]);
+	});
+
 	it("fetches with the effective key and persists native models", async () => {
 		const controller = new AbortController();
-		const fetchModels = vi.fn(
-			async (key: string, signal?: AbortSignal) => {
-				expect(key).toBe("stored-key");
-				expect(signal).toBe(controller.signal);
-				return [model("fresh-free", "Fresh free")];
-			},
-		);
+		const fetchModels = vi.fn(async (key: string, signal?: AbortSignal) => {
+			expect(key).toBe("stored-key");
+			expect(signal).toBe(controller.signal);
+			return [model("fresh-free", "Fresh free")];
+		});
 		const { store, written } = makeStore();
 		const handle = createNativeOpenAIProvider({
 			...options,
@@ -168,10 +200,10 @@ describe("createNativeOpenAIProvider", () => {
 
 		await handle.provider.refreshModels?.(
 			context(store, {
-			allowNetwork: true,
-			credential: { type: "api_key", key: "stored-key" },
-			signal: controller.signal,
-		}),
+				allowNetwork: true,
+				credential: { type: "api_key", key: "stored-key" },
+				signal: controller.signal,
+			}),
 		);
 
 		expect(fetchModels).toHaveBeenCalledOnce();

--- a/tests/ollama-provider.test.ts
+++ b/tests/ollama-provider.test.ts
@@ -26,6 +26,7 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	registerWithGlobalToggle: vi.fn(),
 }));
 

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -233,4 +233,20 @@ describe("applyGlobalFilter", () => {
 		expect(() => applyGlobalFilter(true)).not.toThrow();
 		expect(goodReRegister).toHaveBeenCalledTimes(1);
 	});
+
+	it("invalidates native providers even when the free catalog is empty", () => {
+		const reRegister = vi.fn();
+		const all = [makePaidModel("paid")];
+		registerWithGlobalToggle(
+			"af-native",
+			{ free: [], all },
+			reRegister,
+			true,
+			{ native: true },
+		);
+
+		applyGlobalFilter(true, { force: true });
+
+		expect(reRegister).toHaveBeenCalledWith([]);
+	});
 });

--- a/tests/tokenrouter-provider.test.ts
+++ b/tests/tokenrouter-provider.test.ts
@@ -21,6 +21,7 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (model: { id: string }) => model.id.endsWith(":free"),
 	registerWithGlobalToggle: vi.fn(),
 }));
@@ -166,7 +167,8 @@ describe("createTokenRouterProvider", () => {
 		await provider.refreshModels?.(context(store));
 
 		expect(mockFetchWithRetry).not.toHaveBeenCalled();
-		expect(provider.getModels().map((item) => item.id)).toEqual(["free:free"]);
+		expect(provider.getModels().map((item) => item.id)).toEqual(["free:free", "paid"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((item) => item.id)).toEqual(["free:free"]);
 	});
 
 	it("fetches with the stored key and persists the native catalog", async () => {
@@ -216,6 +218,10 @@ describe("createTokenRouterProvider", () => {
 		expect(stored.free).toHaveLength(1);
 		expect(written).toHaveLength(1);
 		expect(provider.getModels().map((item) => item.id)).toEqual([
+			"free-model:free",
+			"paid-model",
+		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((item) => item.id)).toEqual([
 			"free-model:free",
 		]);
 	});

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -26,6 +26,7 @@ vi.mock("../config.ts", () => ({
 
 vi.mock("../lib/registry.ts", () => ({
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
 		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
 }));
@@ -158,7 +159,8 @@ describe("createZenmuxProvider", () => {
 		await provider.refreshModels?.(context(store));
 
 		expect(mockFetchWithRetry).not.toHaveBeenCalled();
-		expect(provider.getModels().map((model) => model.id)).toEqual(["free"]);
+		expect(provider.getModels().map((model) => model.id)).toEqual(["free", "paid"]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((model) => model.id)).toEqual(["free"]);
 	});
 
 	it("fetches with the effective stored key and persists the catalog", async () => {
@@ -216,6 +218,10 @@ describe("createZenmuxProvider", () => {
 		]);
 		expect(provider.getModels().map((model) => model.id)).toEqual([
 			"free-model",
+			"paid-model",
+		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((model) => model.id)).toEqual([
+			"free-model",
 		]);
 	});
 
@@ -270,19 +276,19 @@ describe("createZenmuxProvider", () => {
 		expect(written).toHaveLength(0);
 	});
 
-	it("switches between free and paid views", async () => {
+	it("keeps the full catalog while filterModels selects the free view", async () => {
 		const { provider, stored, setView } = createZenmuxProvider();
 		const free = nativeModel("free");
 		const paid = nativeModel("paid", true);
 		stored.free = [free];
 		stored.all = [free, paid];
 		setView(stored.free);
-		expect(provider.getModels().map((model) => model.id)).toEqual(["free"]);
 		setView(stored.all);
 		expect(provider.getModels().map((model) => model.id)).toEqual([
 			"free",
 			"paid",
 		]);
+		expect(provider.filterModels!(provider.getModels(), undefined).map((model) => model.id)).toEqual(["free"]);
 	});
 });
 

--- a/tests/zenmux.test.ts
+++ b/tests/zenmux.test.ts
@@ -26,6 +26,7 @@ vi.mock("../lib/registry.ts", () => ({
 	registerWithGlobalToggle: (...args: unknown[]) =>
 		mockRegisterWithGlobalToggle(...args),
 	getGlobalFreeOnly: () => mockGetGlobalFreeOnly(),
+	getGlobalFreeOnlyForced: () => false,
 	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
 		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
 }));


### PR DESCRIPTION
## Summary

- Migrate DeepInfra, RouteWay, and OpenModel to native Pi `Provider` registration.
- Add native API-key auth and Pi-owned models-store refresh lifecycle for all three providers.
- Preserve DeepInfra/RouteWay catalog mapping, pricing, hidden models, probes, and refresh abort signals.
- Preserve OpenModel public pricing + authenticated protocol merge, Anthropic Messages wire format, free-event pricing, and unpriced-model handling.
- Complete the native `filterModels` capstone across all native providers: `getModels()` now exposes the complete catalog and Pi applies the global/provider free-model policy.
- Preserve global and per-provider toggles by re-registering the same provider object only to invalidate Pi's availability snapshot.
- Add coverage for native filtering, provider snapshot settling, refresh behavior, and updated provider wiring.
- Update `agents.md` to document the native-provider architecture.

## Validation

- `npm run lint`
- `npm run test:run` — 50 test files, 607 tests passed
- `npm run check`
- Native provider import smoke test passed
- No package or lockfile changes
