### PR TITLE
refactor: remove obsolete native model cache plumbing

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -115,7 +115,7 @@ export default async function providerName(pi: ExtensionAPI) {
 }
 ```
 
-**Cache-first loading.** Network-fetching extension providers register from the disk cache (`~/.pi/provider-cache.json`, 1-hour TTL via `lib/provider-cache.ts`) first and only hit the network on a cold or stale cache, so warm startups make no network calls. The dynamic built-in phase (including publicly discoverable FastRouter) runs concurrently with the static providers inside `piFreeEntry`'s single `Promise.allSettled`, not sequentially after it. OpenRouter is owned by Pi and is not dynamically registered by pi-free. **Native providers** use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`; remaining legacy/dynamic providers use `lib/provider-cache.ts` (see below).
+**Cache-first loading.** Legacy network-fetching extension providers register from the disk cache (`~/.pi/provider-cache.json`, 1-hour TTL via `lib/provider-cache.ts`) first and only hit the network on a cold or stale cache, so warm startups make no network calls. The dynamic built-in phase (including publicly discoverable FastRouter) runs concurrently with the static providers inside `piFreeEntry`'s single `Promise.allSettled`, not sequentially after it. OpenRouter is owned by Pi and is not dynamically registered by pi-free. **Native providers** use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`; remaining legacy/dynamic providers use `lib/provider-cache.ts` (see below). Ollama Cloud additionally retains that cache only for `/api/show` capability reuse and its manual refresh compatibility path.
 
 ### Native `Provider` providers
 

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -79,7 +79,7 @@ export interface NativeOpenAIProviderOptions {
 	getShowPaid: () => boolean;
 	/** Override the persisted mode for providers whose legacy default is paid. */
 	initialShowPaid?: boolean;
-	initialModels: ProviderModelConfig[];
+	initialModels?: ProviderModelConfig[];
 	fetchModels: (
 		apiKey: string,
 		signal?: AbortSignal,
@@ -91,7 +91,6 @@ export interface NativeOpenAIProviderOptions {
 export interface NativeOpenAIProviderHandle {
 	provider: Provider<"openai-completions">;
 	stored: StoredModels;
-	setView: (models: ProviderModelConfig[]) => void;
 	setShowPaid: (showPaid: boolean) => void;
 	getShowPaid: () => boolean;
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
@@ -159,11 +158,6 @@ export function createNativeOpenAIProvider(
 		);
 	}
 
-	function setView(_models: ProviderModelConfig[]): void {
-		// Native toggles re-register the same provider to invalidate Pi's
-		// availability snapshot. The complete catalog remains in stored.all.
-	}
-
 	function getShowPaid(): boolean {
 		return showPaidOverride ?? options.getShowPaid();
 	}
@@ -184,8 +178,9 @@ export function createNativeOpenAIProvider(
 		);
 	}
 
-	if (options.initialModels.length > 0) {
-		const all = enhanceWithCI(options.initialModels, options.providerId).map(
+	const initialModels = options.initialModels ?? [];
+	if (initialModels.length > 0) {
+		const all = enhanceWithCI(initialModels, options.providerId).map(
 			(model) =>
 				toNativeOpenAIModel(model, options.providerId, options.baseUrl),
 		);
@@ -226,9 +221,9 @@ export function createNativeOpenAIProvider(
 		headers: { "User-Agent": "pi-free-providers" },
 		auth: options.auth,
 		getModels: () =>
-			(stored.all.length > 0 ? stored.all : stored.free) as Model<
-				"openai-completions"
-			>[],
+			(stored.all.length > 0
+				? stored.all
+				: stored.free) as Model<"openai-completions">[],
 		filterModels: (models) =>
 			filterNativeModels(options.providerId, models, {
 				showPaid: getShowPaid(),
@@ -244,7 +239,6 @@ export function createNativeOpenAIProvider(
 	return {
 		provider,
 		stored,
-		setView,
 		setShowPaid,
 		getShowPaid,
 		ingest,
@@ -258,8 +252,7 @@ export function registerNativeOpenAIProvider(
 ): NativeOpenAIProviderHandle {
 	const handle = createNativeOpenAIProvider(options);
 	registerNativeProvider(pi, handle.provider);
-	const reRegister = (models: ProviderModelConfig[]) => {
-		handle.setView(models);
+	const reRegister = () => {
 		registerNativeProvider(pi, handle.provider);
 	};
 	registerWithGlobalToggle(
@@ -267,7 +260,7 @@ export function registerNativeOpenAIProvider(
 		handle.stored,
 		reRegister,
 		Boolean(options.getApiKey()),
-		{ native: true },
+		{ native: true, invalidate: reRegister },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: options.providerId,
@@ -327,10 +320,8 @@ export function registerNativeAvailabilityProbe(
 		"session_start",
 		wrapSessionStartHandler(
 			`${providerId}-auto-probe`,
-			probe.autoProbeHandler(
-				apiKey,
-				handle.stored.free,
-				() => registerNativeProvider(pi, handle.provider),
+			probe.autoProbeHandler(apiKey, handle.stored.free, () =>
+				registerNativeProvider(pi, handle.provider),
 			),
 		),
 	);
@@ -352,7 +343,7 @@ interface NativeToggleOptions {
 	};
 	getShowPaid: () => boolean;
 	setShowPaid?: (showPaid: boolean) => void;
-	reRegister: (models: ProviderModelConfig[]) => void;
+	reRegister: () => void;
 }
 
 /** Register the standard free/all toggle used by native providers. */
@@ -369,9 +360,7 @@ export function registerNativeProviderToggle(
 			await saveConfig({ [`${providerId}_show_paid`]: showPaid });
 			options.setShowPaid?.(showPaid);
 
-			const modelsToShow =
-				showPaid && stored.all.length > 0 ? stored.all : stored.free;
-			reRegister(modelsToShow);
+			reRegister();
 
 			const freeCount = stored.free.length;
 			const paidCount = stored.all.length - freeCount;

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -22,6 +22,8 @@ interface ProviderEntry {
 	hasKey: boolean;
 	/** Native providers keep the complete catalog and filter it in Pi. */
 	native?: boolean;
+	/** Re-register the native provider without rebuilding a model array. */
+	invalidate?: () => void;
 }
 
 // =============================================================================
@@ -155,7 +157,7 @@ export function registerWithGlobalToggle(
 	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] },
 	reRegister: (models: ProviderModelConfig[]) => void,
 	hasKey: boolean = false,
-	options: { native?: boolean } = {},
+	options: { native?: boolean; invalidate?: () => void } = {},
 ): void {
 	providerRegistry.set(providerId, {
 		id: providerId,
@@ -163,6 +165,7 @@ export function registerWithGlobalToggle(
 		reRegister,
 		hasKey,
 		native: options.native,
+		invalidate: options.invalidate,
 	});
 	_logger.info(
 		`[pi-free] Registered ${providerId} with global toggle (${stored.free.length} free, ${stored.all.length} total)`,
@@ -209,13 +212,17 @@ function applyFilterToProvider(
 		// Native providers expose their complete catalog through getModels().
 		// Re-register the same object only to invalidate Pi's availability
 		// snapshot; the provider's filterModels callback selects the view.
-		entry.reRegister(
-			freeOnly
-				? entry.stored.free
-				: entry.stored.all.length > 0
-					? entry.stored.all
-					: entry.stored.free,
-		);
+		if (entry.invalidate) {
+			entry.invalidate();
+		} else {
+			entry.reRegister(
+				freeOnly
+					? entry.stored.free
+					: entry.stored.all.length > 0
+						? entry.stored.all
+						: entry.stored.free,
+			);
+		}
 		_logger.info(
 			`[pi-free] ${providerId}: invalidated native model filter (${freeOnly ? "free" : "all"}${force ? ", forced" : ""})`,
 		);

--- a/providers/anyapi/anyapi.ts
+++ b/providers/anyapi/anyapi.ts
@@ -25,10 +25,6 @@ import {
 	PROVIDER_ANYAPI,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import {
-	loadProviderCache,
-	saveProviderCache,
-} from "../../lib/provider-cache.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { fetchWithRetry, mapOpenRouterModel } from "../../lib/util.ts";
 import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
@@ -207,7 +203,6 @@ async function fetchAnyApiModels(
 }
 
 export default function anyapiProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_ANYAPI) ?? [];
 	registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_ANYAPI,
 		name: "AnyAPI",
@@ -215,12 +210,8 @@ export default function anyapiProvider(pi: ExtensionAPI): Promise<void> {
 		auth: anyapiAuth,
 		getApiKey: getAnyapiApiKey,
 		getShowPaid: getAnyapiShowPaid,
-		initialModels,
-		fetchModels: async (apiKey, signal) => {
-			const models = await fetchAnyApiModels(apiKey, signal);
-			if (models.length > 0) await saveProviderCache(PROVIDER_ANYAPI, models);
-			return models;
-		},
+		fetchModels: (apiKey, signal) =>
+			fetchAnyApiModels(apiKey, signal),
 		tosUrl: "https://anyapi.ai/terms-of-service",
 		suppressTosWhenKey: true,
 	});

--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -40,10 +40,6 @@ import {
 } from "../../lib/provider-compat.ts";
 import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
-import {
-	loadProviderCache,
-	saveProviderCache,
-} from "../../lib/provider-cache.ts";
 import { baiAuth } from "./bai-auth.ts";
 
 const _logger = createLogger("bai");
@@ -175,7 +171,6 @@ async function fetchBaiModels(
 // =============================================================================
 
 export default function baiProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_BAI) ?? [];
 	registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_BAI,
 		name: "B.AI",
@@ -183,12 +178,7 @@ export default function baiProvider(pi: ExtensionAPI): Promise<void> {
 		auth: baiAuth,
 		getApiKey: getBaiApiKey,
 		getShowPaid: getBaiShowPaid,
-		initialModels,
-		fetchModels: async (apiKey, signal) => {
-			const models = await fetchBaiModels(apiKey, signal);
-			if (models.length > 0) await saveProviderCache(PROVIDER_BAI, models);
-			return models;
-		},
+		fetchModels: (apiKey, signal) => fetchBaiModels(apiKey, signal),
 		tosUrl: "https://b.ai/",
 	});
 	return Promise.resolve();

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -118,9 +118,7 @@ export interface ClineNativeProvider {
 	provider: Provider<"cline-xml-tools">;
 	/** Mutable catalogs shared with registerWithGlobalToggle / /free-providers. */
 	stored: StoredModels;
-	/** Set the visible catalog (toggle / global-toggle re-registration target). */
-	setView: (models: ProviderModelConfig[]) => void;
-	/** Ingest a freshly fetched catalog: update stored + view, per toggle state. */
+	/** Ingest a freshly fetched catalog into the complete native catalog. */
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -134,11 +132,6 @@ export function createClineProvider(): ClineNativeProvider {
 	// StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle; the
 	// runtime values are full Model objects, which are assignable.
 	const stored: StoredModels = { free: [], all: [] };
-
-	function setView(_models: ProviderModelConfig[]): void {
-		// Re-registration invalidates Pi's filtered availability snapshot; the
-		// complete catalog remains in stored.all.
-	}
 
 	function ingest(
 		all: ProviderModelConfig[],
@@ -210,5 +203,5 @@ export function createClineProvider(): ClineNativeProvider {
 			streamViaXmlBridge(model, context, options),
 	};
 
-	return { provider, stored, setView, ingest };
+	return { provider, stored, ingest };
 }

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -23,7 +23,6 @@
 import {
 	readStoredCredential,
 	type ExtensionAPI,
-	type ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import {
 	getClineApiKey,
@@ -94,7 +93,7 @@ function inspectStoredClineCredential(): void {
 // =============================================================================
 
 export default async function clineProvider(pi: ExtensionAPI) {
-	const { provider, stored, setView } = createClineProvider();
+	const { provider, stored } = createClineProvider();
 
 	// Non-destructive credential inspection (native auth reuses auth.json).
 	inspectStoredClineCredential();
@@ -105,17 +104,16 @@ export default async function clineProvider(pi: ExtensionAPI) {
 	// critical path.
 	registerNativeProvider(pi, provider);
 
-	// Re-registration republishes the same native provider object (upsert by id)
-	// with a new visible catalog, keeping native auth intact. This is the hook the
-	// global /toggle-free system and /toggle-cline drive.
-	const reRegister = (models: ProviderModelConfig[]) => {
-		setView(models);
+	// Re-registration invalidates Pi's availability snapshot while preserving the
+	// complete catalog and native auth on the same provider object.
+	const reRegister = () => {
 		registerNativeProvider(pi, provider);
 	};
 
 	const hasClineKey = !!getClineApiKey();
 	registerWithGlobalToggle(PROVIDER_CLINE, stored, reRegister, hasClineKey, {
 		native: true,
+		invalidate: reRegister,
 	});
 
 	registerNativeProviderToggle(pi, {

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -35,10 +35,6 @@ import {
 } from "../../lib/provider-compat.ts";
 import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
-import {
-	loadProviderCache,
-	saveProviderCache,
-} from "../../lib/provider-cache.ts";
 import { crofaiAuth } from "./crofai-auth.ts";
 
 const _logger = createLogger("crofai");
@@ -143,7 +139,6 @@ async function fetchCrofaiModels(
 // =============================================================================
 
 export default function crofaiProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_CROFAI) ?? [];
 	registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_CROFAI,
 		name: "CrofAI",
@@ -151,12 +146,7 @@ export default function crofaiProvider(pi: ExtensionAPI): Promise<void> {
 		auth: crofaiAuth,
 		getApiKey: getCrofaiApiKey,
 		getShowPaid: getCrofaiShowPaid,
-		initialModels,
-		fetchModels: async (apiKey, signal) => {
-			const models = await fetchCrofaiModels(apiKey, signal);
-			if (models.length > 0) await saveProviderCache(PROVIDER_CROFAI, models);
-			return models;
-		},
+		fetchModels: (apiKey, signal) => fetchCrofaiModels(apiKey, signal),
 	});
 	return Promise.resolve();
 }

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -50,7 +50,6 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
 import { deepinfraAuth } from "./deepinfra-auth.ts";
 
@@ -158,7 +157,6 @@ async function fetchDeepinfraModels(
 // =============================================================================
 
 export default function deepinfraProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_DEEPINFRA) ?? [];
 	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_DEEPINFRA,
 		name: "DeepInfra",
@@ -167,12 +165,8 @@ export default function deepinfraProvider(pi: ExtensionAPI): Promise<void> {
 		getApiKey: getDeepinfraApiKey,
 		getShowPaid: getDeepinfraShowPaid,
 		initialShowPaid: true,
-		initialModels,
-		fetchModels: async (apiKey, signal) => {
-			const models = await fetchDeepinfraModels(apiKey, signal);
-			if (models.length > 0) await saveProviderCache(PROVIDER_DEEPINFRA, models);
-			return models;
-		},
+		fetchModels: (apiKey, signal) =>
+			fetchDeepinfraModels(apiKey, signal),
 		tosUrl: "https://deepinfra.com/pricing",
 	});
 

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -62,9 +62,7 @@ export interface KiloNativeProvider {
 	provider: Provider<"openai-completions">;
 	/** Mutable catalogs shared with registerWithGlobalToggle / /free-providers. */
 	stored: StoredModels;
-	/** Set the visible catalog (toggle / global-toggle re-registration target). */
-	setView: (models: ProviderModelConfig[]) => void;
-	/** Ingest a freshly fetched catalog: update stored + view, per toggle state. */
+	/** Ingest a freshly fetched catalog into the complete native catalog. */
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -88,11 +86,6 @@ export function createKiloProvider(): KiloNativeProvider {
 	// Typed as StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle;
 	// the runtime values are full Model objects, which are assignable.
 	const stored: StoredModels = { free: [], all: [] };
-
-	function setView(_models: ProviderModelConfig[]): void {
-		// Re-registration invalidates Pi's filtered availability snapshot; the
-		// complete catalog remains in stored.all.
-	}
 
 	function ingest(
 		all: ProviderModelConfig[],
@@ -162,5 +155,5 @@ export function createKiloProvider(): KiloNativeProvider {
 			streams.streamSimple(model, context, options),
 	};
 
-	return { provider, stored, setView, ingest };
+	return { provider, stored, ingest };
 }

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -19,7 +19,6 @@
 import {
 	readStoredCredential,
 	type ExtensionAPI,
-	type ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { getKiloApiKey, getKiloShowPaid, PROVIDER_KILO } from "../../config.ts";
 import { URL_KILO_TOS } from "../../constants.ts";
@@ -190,7 +189,7 @@ function inspectStoredKiloCredential(): void {
 // =============================================================================
 
 export default async function kiloProvider(pi: ExtensionAPI) {
-	const { provider, stored, setView } = createKiloProvider();
+	const { provider, stored } = createKiloProvider();
 
 	// Non-destructive credential inspection (native auth reuses auth.json).
 	inspectStoredKiloCredential();
@@ -200,17 +199,16 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 	// fetch), so Kilo no longer owns any of Pi's startup critical path.
 	registerNativeProvider(pi, provider);
 
-	// Re-registration republishes the same native provider object (upsert by id)
-	// with a new visible catalog, keeping native auth intact. This is the hook the
-	// global /toggle-free system and /toggle-kilo drive.
-	const reRegister = (models: ProviderModelConfig[]) => {
-		setView(models);
+	// Re-registration invalidates Pi's availability snapshot while preserving the
+	// complete catalog and native auth on the same provider object.
+	const reRegister = () => {
 		registerNativeProvider(pi, provider);
 	};
 
 	const hasKiloKey = !!getKiloApiKey();
 	registerWithGlobalToggle(PROVIDER_KILO, stored, reRegister, hasKiloKey, {
 		native: true,
+		invalidate: reRegister,
 	});
 
 	registerNativeProviderToggle(pi, {

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -60,9 +60,7 @@ export interface Llm7NativeProvider {
 	provider: Provider<"openai-completions">;
 	/** Mutable catalogs shared with registerWithGlobalToggle / /free-providers. */
 	stored: StoredModels;
-	/** Set the visible catalog (toggle / global-toggle re-registration target). */
-	setView: (models: ProviderModelConfig[]) => void;
-	/** Ingest a fresh catalog: update stored + view, per toggle state. */
+	/** Ingest a fresh catalog into the complete native catalog. */
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -78,11 +76,6 @@ export function createLlm7Provider(): Llm7NativeProvider {
 	// StoredModels (ProviderModelConfig[]) for registerWithGlobalToggle; the
 	// runtime values are full Model objects, which are assignable.
 	const stored: StoredModels = { free: [], all: [] };
-
-	function setView(_models: ProviderModelConfig[]): void {
-		// Re-registration invalidates Pi's filtered availability snapshot; the
-		// complete catalog remains in stored.all.
-	}
 
 	function ingest(
 		all: ProviderModelConfig[],
@@ -149,5 +142,5 @@ export function createLlm7Provider(): Llm7NativeProvider {
 			streams.streamSimple(model, context, options),
 	};
 
-	return { provider, stored, setView, ingest };
+	return { provider, stored, ingest };
 }

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -47,10 +47,7 @@
  *   # Models appear in /model selector as "llm7/default", "llm7/fast", "llm7/pro"
  */
 
-import type {
-	ExtensionAPI,
-	ProviderModelConfig,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getLlm7ApiKey, getLlm7ShowPaid } from "../../config.ts";
 import { PROVIDER_LLM7 } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
@@ -66,7 +63,7 @@ import { createLlm7Provider } from "./llm7-provider.ts";
 // =============================================================================
 
 export default async function llm7Provider(pi: ExtensionAPI) {
-	const { provider, stored, setView } = createLlm7Provider();
+	const { provider, stored } = createLlm7Provider();
 
 	// Register the native provider. The factory performs NO network I/O: models
 	// load via refreshModels (offline init from the store, then a background
@@ -74,17 +71,16 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 	// Pi's startup critical path.
 	registerNativeProvider(pi, provider);
 
-	// Re-registration republishes the same native provider object (upsert by id)
-	// with a new visible catalog, keeping native auth intact. This is the hook the
-	// global /toggle-free system and /toggle-llm7 drive.
-	const reRegister = (models: ProviderModelConfig[]) => {
-		setView(models);
+	// Re-registration invalidates Pi's availability snapshot while preserving the
+	// complete catalog and native auth on the same provider object.
+	const reRegister = () => {
 		registerNativeProvider(pi, provider);
 	};
 
 	const hasLlm7Key = !!getLlm7ApiKey();
 	registerWithGlobalToggle(PROVIDER_LLM7, stored, reRegister, hasLlm7Key, {
 		native: true,
+		invalidate: reRegister,
 	});
 
 	registerNativeProviderToggle(pi, {

--- a/providers/novita/novita.ts
+++ b/providers/novita/novita.ts
@@ -42,10 +42,6 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import {
-	loadProviderCache,
-	saveProviderCache,
-} from "../../lib/provider-cache.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
 import { novitaAuth } from "./novita-auth.ts";
 
@@ -151,7 +147,6 @@ async function fetchNovitaModels(
 }
 
 export default function novitaProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_NOVITA) ?? [];
 	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_NOVITA,
 		name: "Novita AI",
@@ -159,21 +154,13 @@ export default function novitaProvider(pi: ExtensionAPI): Promise<void> {
 		auth: novitaAuth,
 		getApiKey: getNovitaApiKey,
 		getShowPaid: getNovitaShowPaid,
-		initialModels,
-		fetchModels: async (apiKey, signal) => {
-			const models = await fetchNovitaModels(apiKey, signal);
-			if (models.length > 0) await saveProviderCache(PROVIDER_NOVITA, models);
-			return models;
-		},
+		fetchModels: (apiKey, signal) => fetchNovitaModels(apiKey, signal),
 		tosUrl: "https://novita.ai/terms",
 	});
 	const apiKey = getNovitaApiKey();
 	if (!apiKey) return Promise.resolve();
 
-	const probe = createOpenAIAvailabilityProbe(
-		PROVIDER_NOVITA,
-		BASE_URL_NOVITA,
-	);
+	const probe = createOpenAIAvailabilityProbe(PROVIDER_NOVITA, BASE_URL_NOVITA);
 	registerNativeAvailabilityProbe(pi, {
 		providerId: PROVIDER_NOVITA,
 		label: "Novita AI",

--- a/providers/ollama/ollama-provider.ts
+++ b/providers/ollama/ollama-provider.ts
@@ -48,7 +48,6 @@ export interface OllamaProviderDeps {
 export interface OllamaNativeProvider {
 	provider: Provider<"openai-completions">;
 	stored: StoredModels;
-	setView: (models: ProviderModelConfig[]) => void;
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -81,11 +80,6 @@ export function createOllamaProvider(
 ): OllamaNativeProvider {
 	const streams = openAICompletionsApi();
 	const stored: StoredModels = { free: [], all: [] };
-
-	function setView(_models: ProviderModelConfig[]): void {
-		// Re-registration invalidates Pi's filtered availability snapshot; the
-		// complete catalog remains in stored.all.
-	}
 
 	function ingest(
 		all: ProviderModelConfig[],
@@ -147,7 +141,7 @@ export function createOllamaProvider(
 			streams.streamSimple(model, context, options),
 	};
 
-	return { provider, stored, setView, ingest };
+	return { provider, stored, ingest };
 }
 
 export function registerOllamaProvider(
@@ -159,14 +153,13 @@ export function registerOllamaProvider(
 		cachedModels && cachedModels.length > 0
 			? cachedModels
 			: deps.fallbackModels;
-	const { provider, stored, setView, ingest } = createOllamaProvider(
+	const { provider, stored, ingest } = createOllamaProvider(
 		deps,
 		initialModels,
 	);
 	registerNativeProvider(pi, provider);
 
-	const reRegister = (models: ProviderModelConfig[]) => {
-		setView(models);
+	const reRegister = () => {
 		registerNativeProvider(pi, provider);
 	};
 	const applyModelList = (models: ProviderModelConfig[]) => {
@@ -180,7 +173,7 @@ export function registerOllamaProvider(
 		stored,
 		reRegister,
 		Boolean(getOllamaApiKey()),
-		{ native: true },
+		{ native: true, invalidate: reRegister },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_OLLAMA,

--- a/providers/openmodel/openmodel.ts
+++ b/providers/openmodel/openmodel.ts
@@ -34,7 +34,10 @@ import type {
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
 import { anthropicMessagesApi } from "@earendil-works/pi-ai/compat";
-import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
 import {
 	getOpenmodelApiKey,
 	getOpenmodelShowPaid,
@@ -48,10 +51,7 @@ import {
 import { createLogger } from "../../lib/logger.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { isLikelyReasoningModel } from "../../lib/provider-compat.ts";
-import {
-	isFreeModel,
-	registerWithGlobalToggle,
-} from "../../lib/registry.ts";
+import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
 import {
 	filterNativeModels,
 	persistNativeProviderModels,
@@ -60,7 +60,6 @@ import {
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
-import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
 import { fetchWithRetry } from "../../lib/util.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { openmodelAuth } from "./openmodel-auth.ts";
@@ -393,10 +392,14 @@ async function fetchOpenModelWebCatalog(
 				return;
 			}
 			const timer = setTimeout(resolve, OPENMODEL_PAGINATION_DELAY_MS);
-			signal?.addEventListener("abort", () => {
-				clearTimeout(timer);
-				reject(new DOMException("Aborted", "AbortError"));
-			}, { once: true });
+			signal?.addEventListener(
+				"abort",
+				() => {
+					clearTimeout(timer);
+					reject(new DOMException("Aborted", "AbortError"));
+				},
+				{ once: true },
+			);
 		});
 	}
 
@@ -452,12 +455,14 @@ async function fetchOpenModelModels(
 			});
 			return [] as OpenModelCatalogItem[];
 		}),
-		fetchOpenModelProtocols(apiKey, BASE_URL_OPENMODEL, signal).catch((error) => {
-			_logger.error("[openmodel] Failed to fetch /v1/models", {
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return [] as OpenModelProtocolItem[];
-		}),
+		fetchOpenModelProtocols(apiKey, BASE_URL_OPENMODEL, signal).catch(
+			(error) => {
+				_logger.error("[openmodel] Failed to fetch /v1/models", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return [] as OpenModelProtocolItem[];
+			},
+		),
 	]);
 
 	if (catalog.length === 0 && protocols.length === 0) {
@@ -508,20 +513,20 @@ function openModelCredentialToken(
 
 export default function openmodelProvider(pi: ExtensionAPI): Promise<void> {
 	const streams = anthropicMessagesApi();
-	const initialModels = loadProviderCache(PROVIDER_OPENMODEL) ?? [];
 	const stored: StoredModels = { free: [], all: [] };
 
-	function ingest(all: ProviderModelConfig[], free?: ProviderModelConfig[]): void {
+	function ingest(
+		all: ProviderModelConfig[],
+		free?: ProviderModelConfig[],
+	): void {
 		stored.all = enhanceWithCI(all, PROVIDER_OPENMODEL).map(toOpenModel);
-		stored.free = (free ?? stored.all.filter((model) =>
-			isFreeModel(
-				{ ...model, provider: PROVIDER_OPENMODEL },
-				stored.all,
-			),
-		)).map(toOpenModel);
+		stored.free = (
+			free ??
+			stored.all.filter((model) =>
+				isFreeModel({ ...model, provider: PROVIDER_OPENMODEL }, stored.all),
+			)
+		).map(toOpenModel);
 	}
-
-	if (initialModels.length > 0) ingest(initialModels);
 
 	const provider: Provider<"anthropic-messages"> = {
 		id: PROVIDER_OPENMODEL,
@@ -560,7 +565,6 @@ export default function openmodelProvider(pi: ExtensionAPI): Promise<void> {
 				isFreeModel({ ...model, provider: PROVIDER_OPENMODEL }, models),
 			);
 			ingest(models, free);
-			await saveProviderCache(PROVIDER_OPENMODEL, models);
 			await persistNativeProviderModels(
 				PROVIDER_OPENMODEL,
 				context,
@@ -574,14 +578,13 @@ export default function openmodelProvider(pi: ExtensionAPI): Promise<void> {
 	};
 
 	registerNativeProvider(pi, provider);
-	const reRegister = (_models: ProviderModelConfig[]) =>
-		registerNativeProvider(pi, provider);
+	const reRegister = () => registerNativeProvider(pi, provider);
 	registerWithGlobalToggle(
 		PROVIDER_OPENMODEL,
 		stored,
 		reRegister,
 		Boolean(getOpenmodelApiKey()),
-		{ native: true },
+		{ native: true, invalidate: reRegister },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_OPENMODEL,

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -18,7 +18,11 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { applyHidden, getRoutewayApiKey, getRoutewayShowPaid } from "../../config.ts";
+import {
+	applyHidden,
+	getRoutewayApiKey,
+	getRoutewayShowPaid,
+} from "../../config.ts";
 import {
 	BASE_URL_ROUTEWAY,
 	DEFAULT_FETCH_TIMEOUT_MS,
@@ -35,7 +39,6 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import { loadProviderCache, saveProviderCache } from "../../lib/provider-cache.ts";
 import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
 import { routewayAuth } from "./routeway-auth.ts";
 
@@ -173,7 +176,6 @@ async function fetchRoutewayModels(
 // =============================================================================
 
 export default function routewayProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_ROUTEWAY) ?? [];
 	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_ROUTEWAY,
 		name: "Routeway",
@@ -181,12 +183,7 @@ export default function routewayProvider(pi: ExtensionAPI): Promise<void> {
 		auth: routewayAuth,
 		getApiKey: getRoutewayApiKey,
 		getShowPaid: getRoutewayShowPaid,
-		initialModels,
-		fetchModels: async (apiKey, signal) => {
-			const models = await fetchRoutewayModels(apiKey, signal);
-			if (models.length > 0) await saveProviderCache(PROVIDER_ROUTEWAY, models);
-			return models;
-		},
+		fetchModels: (apiKey, signal) => fetchRoutewayModels(apiKey, signal),
 		tosUrl: "https://routeway.ai/terms",
 	});
 

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -35,15 +35,10 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import {
-	loadProviderCache,
-	saveProviderCache,
-} from "../../lib/provider-cache.ts";
 import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
 import { sambanovaAuth } from "./sambanova-auth.ts";
 
 export default function sambanovaProvider(pi: ExtensionAPI): Promise<void> {
-	const initialModels = loadProviderCache(PROVIDER_SAMBANOVA) ?? [];
 	const handle = registerNativeOpenAIProvider(pi, {
 		providerId: PROVIDER_SAMBANOVA,
 		name: "SambaNova",
@@ -51,7 +46,6 @@ export default function sambanovaProvider(pi: ExtensionAPI): Promise<void> {
 		auth: sambanovaAuth,
 		getApiKey: getSambanovaApiKey,
 		getShowPaid: getSambanovaShowPaid,
-		initialModels,
 		fetchModels: async (apiKey, signal) => {
 			const models = await fetchOpenAICompatibleModels(
 				"sambanova",
@@ -64,8 +58,6 @@ export default function sambanovaProvider(pi: ExtensionAPI): Promise<void> {
 			for (const model of models) {
 				(model as unknown as { _pricingKnown?: boolean })._pricingKnown = true;
 			}
-			if (models.length > 0)
-				await saveProviderCache(PROVIDER_SAMBANOVA, models);
 			return models;
 		},
 		tosUrl: "https://sambanova.ai/terms",

--- a/providers/tokenrouter/tokenrouter-provider.ts
+++ b/providers/tokenrouter/tokenrouter-provider.ts
@@ -23,7 +23,6 @@ import {
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
 import { isFreeModel, registerWithGlobalToggle } from "../../lib/registry.ts";
-import { loadProviderCache } from "../../lib/provider-cache.ts";
 import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
 import { tokenRouterAuth } from "./tokenrouter-auth.ts";
 
@@ -46,7 +45,6 @@ export interface TokenRouterProviderDeps {
 export interface TokenRouterNativeProvider {
 	provider: Provider<"tokenrouter-openai-completions">;
 	stored: StoredModels;
-	setView: (models: ProviderModelConfig[]) => void;
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -87,16 +85,9 @@ function classifyFreeModels(
 
 export function createTokenRouterProvider(
 	deps: TokenRouterProviderDeps,
-	initialModels: ProviderModelConfig[] = loadProviderCache(
-		PROVIDER_TOKENROUTER,
-	) ?? [],
+	initialModels: ProviderModelConfig[] = [],
 ): TokenRouterNativeProvider {
 	const stored: StoredModels = { free: [], all: [] };
-
-	function setView(_models: ProviderModelConfig[]): void {
-		// Re-registration invalidates Pi's filtered availability snapshot; the
-		// complete catalog remains in stored.all.
-	}
 
 	function ingest(
 		all: ProviderModelConfig[],
@@ -144,7 +135,9 @@ export function createTokenRouterProvider(
 		headers: { "User-Agent": "pi-free-providers" },
 		auth: tokenRouterAuth,
 		getModels: () =>
-			(stored.all.length > 0 ? stored.all : stored.free) as TokenRouterNativeModel[],
+			(stored.all.length > 0
+				? stored.all
+				: stored.free) as TokenRouterNativeModel[],
 		filterModels: (models) =>
 			filterNativeModels(PROVIDER_TOKENROUTER, models, {
 				showPaid: getTokenrouterShowPaid(),
@@ -157,18 +150,17 @@ export function createTokenRouterProvider(
 			deps.streamSimple(model, context, options),
 	};
 
-	return { provider, stored, setView, ingest };
+	return { provider, stored, ingest };
 }
 
 export function registerTokenRouterProvider(
 	pi: ExtensionAPI,
 	deps: TokenRouterProviderDeps,
 ): void {
-	const { provider, stored, setView } = createTokenRouterProvider(deps);
+	const { provider, stored } = createTokenRouterProvider(deps);
 	registerNativeProvider(pi, provider);
 
-	const reRegister = (models: ProviderModelConfig[]) => {
-		setView(models);
+	const reRegister = () => {
 		registerNativeProvider(pi, provider);
 	};
 
@@ -177,7 +169,7 @@ export function registerTokenRouterProvider(
 		stored,
 		reRegister,
 		Boolean(getTokenrouterApiKey()),
-		{ native: true },
+		{ native: true, invalidate: reRegister },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_TOKENROUTER,

--- a/providers/zenmux/zenmux-provider.ts
+++ b/providers/zenmux/zenmux-provider.ts
@@ -24,7 +24,6 @@ type ZenmuxModel = Model<"openai-completions">;
 export interface ZenmuxNativeProvider {
 	provider: Provider<"openai-completions">;
 	stored: StoredModels;
-	setView: (models: ProviderModelConfig[]) => void;
 	ingest: (all: ProviderModelConfig[], free: ProviderModelConfig[]) => void;
 }
 
@@ -39,11 +38,6 @@ function credentialToken(credential?: Credential): string | undefined {
 export function createZenmuxProvider(): ZenmuxNativeProvider {
 	const streams = openAICompletionsApi();
 	const stored: StoredModels = { free: [], all: [] };
-
-	function setView(_models: ProviderModelConfig[]): void {
-		// Re-registration invalidates Pi's filtered availability snapshot; the
-		// complete catalog remains in stored.all.
-	}
 
 	function ingest(
 		all: ProviderModelConfig[],
@@ -103,5 +97,5 @@ export function createZenmuxProvider(): ZenmuxNativeProvider {
 			streams.streamSimple(model, context, options),
 	};
 
-	return { provider, stored, setView, ingest };
+	return { provider, stored, ingest };
 }

--- a/providers/zenmux/zenmux.ts
+++ b/providers/zenmux/zenmux.ts
@@ -11,10 +11,7 @@
  */
 
 import type { Provider } from "@earendil-works/pi-ai/compat";
-import type {
-	ExtensionAPI,
-	ProviderModelConfig,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
 import { PROVIDER_ZENMUX } from "../../constants.ts";
 import {
@@ -26,11 +23,10 @@ import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import { createZenmuxProvider } from "./zenmux-provider.ts";
 
 export default async function zenmuxProvider(pi: ExtensionAPI) {
-	const { provider, stored, setView } = createZenmuxProvider();
+	const { provider, stored } = createZenmuxProvider();
 	registerNativeProvider(pi, provider as Provider);
 
-	const reRegister = (models: ProviderModelConfig[]) => {
-		setView(models);
+	const reRegister = () => {
 		registerNativeProvider(pi, provider as Provider);
 	};
 
@@ -39,7 +35,7 @@ export default async function zenmuxProvider(pi: ExtensionAPI) {
 		stored,
 		reRegister,
 		Boolean(getZenmuxApiKey()),
-		{ native: true },
+		{ native: true, invalidate: reRegister },
 	);
 	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_ZENMUX,

--- a/tests/cline-provider.test.ts
+++ b/tests/cline-provider.test.ts
@@ -196,9 +196,9 @@ describe("refreshModels offline init", () => {
 		// getModels exposes the complete catalog; Pi applies filterModels.
 		const models = provider.getModels();
 		expect(models.map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(
-			provider.filterModels!(models, undefined).map((m) => m.id),
-		).toEqual(["a"]);
+		expect(provider.filterModels!(models, undefined).map((m) => m.id)).toEqual([
+			"a",
+		]);
 	});
 
 	it("stays empty when the store is empty and network is disallowed", async () => {
@@ -274,7 +274,12 @@ describe("refreshModels online", () => {
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
 		// getModels exposes the complete catalog; Pi applies filterModels.
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(
+			provider
+				.getModels()
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
 		expect(
 			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
 		).toEqual(["a"]);
@@ -342,7 +347,7 @@ describe("refreshModels online", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Toggle interop (setView / decideView)
+// Toggle interop (filterModels / decideView)
 // ---------------------------------------------------------------------------
 
 describe("toggle interop", () => {
@@ -358,15 +363,26 @@ describe("toggle interop", () => {
 	}
 
 	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider, stored, setView } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
+		const { provider } = await seededProvider();
+		expect(
+			provider
+				.getModels()
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 
-		// Re-registration is now an availability-snapshot invalidation signal.
-		setView(stored.all);
-		setView(stored.free);
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
+		expect(
+			provider
+				.getModels()
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 	});
 
 	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
@@ -374,8 +390,7 @@ describe("toggle interop", () => {
 		const { provider } = await seededProvider();
 		// show_paid true + global free-only true => filterModels returns all.
 		expect(
-			provider
-				.filterModels!(provider.getModels(), undefined)
+			provider.filterModels!(provider.getModels(), undefined)
 				.map((m) => m.id)
 				.sort(),
 		).toEqual(["a", "b"]);

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -16,7 +16,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetchClineCatalog = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => unknown>(),
 );
-const mockGetClineApiKey = vi.hoisted(() => vi.fn((): string | undefined => undefined));
+const mockGetClineApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
 const mockGetClineShowPaid = vi.hoisted(() => vi.fn(() => false));
 const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
 const mockSaveConfig = vi.hoisted(() =>
@@ -123,7 +125,10 @@ describe("Cline factory wiring", () => {
 		mockFetchClineCatalog.mockResolvedValue({
 			all: [
 				cfg({ id: "free-1" }),
-				cfg({ id: "paid-1", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } }),
+				cfg({
+					id: "paid-1",
+					cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+				}),
 			],
 			free: [cfg({ id: "free-1" })],
 		});
@@ -178,9 +183,9 @@ describe("Cline factory wiring", () => {
 		mockGetClineApiKey.mockReturnValue("sk-cline");
 		capturedToggleArgs = [];
 		await clineProvider(mockPi);
-		expect((capturedToggleArgs[0] as [string, unknown, unknown, boolean])[3]).toBe(
-			true,
-		);
+		expect(
+			(capturedToggleArgs[0] as [string, unknown, unknown, boolean])[3],
+		).toBe(true);
 	});
 
 	it("refreshModels populates; global /toggle-free reRegister republishes the same provider", async () => {
@@ -191,7 +196,7 @@ describe("Cline factory wiring", () => {
 		const [, stored, reRegister] = capturedToggleArgs[0] as [
 			string,
 			{ free: unknown[]; all: unknown[] },
-			(models: unknown[]) => void,
+			() => void,
 		];
 
 		// Pi refreshes (online) -> public catalogs populate.
@@ -199,23 +204,27 @@ describe("Cline factory wiring", () => {
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
 
-		// Global /toggle-free showing all -> reRegister(stored.all).
+		// Global /toggle-free showing all -> re-register the same provider.
 		mockRegisterProvider.mockClear();
-		reRegister(stored.all);
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		reRegister();
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
 
 		// Global /toggle-free showing free invalidates the same provider object;
 		// Pi's filterModels applies the free view to the complete catalog.
-		reRegister(stored.free);
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		reRegister();
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 	});
 
 	it("/toggle-cline flips cline_show_paid and shows the full catalog, then back", async () => {
@@ -232,10 +241,12 @@ describe("Cline factory wiring", () => {
 		// First toggle: free -> all.
 		await call[1].handler({}, { ui: { notify } });
 		expect(mockSaveConfig).toHaveBeenCalledWith({ cline_show_paid: true });
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 		expect(notify).toHaveBeenCalledWith(
 			expect.stringContaining("showing all 2 models"),
 			"info",
@@ -247,10 +258,12 @@ describe("Cline factory wiring", () => {
 		notify.mockClear();
 		await call[1].handler({}, { ui: { notify } });
 		expect(mockSaveConfig).toHaveBeenCalledWith({ cline_show_paid: false });
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 		expect(notify).toHaveBeenCalledWith(
 			expect.stringContaining("showing 1 free models"),
 			"info",

--- a/tests/kilo-provider.test.ts
+++ b/tests/kilo-provider.test.ts
@@ -5,7 +5,7 @@
  *   - refreshModels offline init (store-only, zero network)
  *   - refreshModels online (fetch + store.write + credential passing)
  *   - store persistence + poisoning guard + abort signal
- *   - free/paid toggle via setView / decideView
+ *   - free/paid toggle via filterModels / decideView
  *   - the native provider object shape (auth, getModels, stream wiring)
  */
 
@@ -18,7 +18,9 @@ import type {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchKiloCatalog = vi.hoisted(() => vi.fn());
-const mockGetKiloApiKey = vi.hoisted(() => vi.fn((): string | undefined => undefined));
+const mockGetKiloApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
 const mockGetKiloShowPaid = vi.hoisted(() => vi.fn(() => false));
 const mockGetKiloFreeOnly = vi.hoisted(() => vi.fn(() => false));
 const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
@@ -164,8 +166,18 @@ describe("refreshModels offline init", () => {
 	it("restores models from the store with zero network when allowNetwork=false", async () => {
 		const seeded = {
 			models: [
-				{ ...freeCfg("a"), api: "openai-completions", provider: "kilo", baseUrl: "x" },
-				{ ...paidCfg("b"), api: "openai-completions", provider: "kilo", baseUrl: "x" },
+				{
+					...freeCfg("a"),
+					api: "openai-completions",
+					provider: "kilo",
+					baseUrl: "x",
+				},
+				{
+					...paidCfg("b"),
+					api: "openai-completions",
+					provider: "kilo",
+					baseUrl: "x",
+				},
 			],
 			checkedAt: Date.now(),
 		} as unknown as ModelsStoreEntry;
@@ -178,7 +190,9 @@ describe("refreshModels offline init", () => {
 		// getModels exposes the complete catalog; Pi applies filterModels.
 		const models = provider.getModels();
 		expect(models.map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(provider.filterModels!(models, undefined).map((m) => m.id)).toEqual(["a"]);
+		expect(provider.filterModels!(models, undefined).map((m) => m.id)).toEqual([
+			"a",
+		]);
 	});
 
 	it("stays empty when the store is empty and network is disallowed", async () => {
@@ -191,7 +205,12 @@ describe("refreshModels offline init", () => {
 	it("ignores stored models from other providers", async () => {
 		const seeded = {
 			models: [
-				{ ...freeCfg("a"), api: "openai-completions", provider: "other", baseUrl: "x" },
+				{
+					...freeCfg("a"),
+					api: "openai-completions",
+					provider: "other",
+					baseUrl: "x",
+				},
 			],
 		} as unknown as ModelsStoreEntry;
 		const { store } = makeStore(seeded);
@@ -225,8 +244,15 @@ describe("refreshModels online", () => {
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
 		// getModels exposes the complete catalog; Pi applies filterModels.
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
+		expect(
+			provider
+				.getModels()
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 	});
 
 	it("passes the OAuth access token from context.credential to the fetcher", async () => {
@@ -240,7 +266,9 @@ describe("refreshModels online", () => {
 			expires: Date.now() + 1000,
 		};
 
-		await provider.refreshModels?.(ctx({ store, allowNetwork: true, credential }));
+		await provider.refreshModels?.(
+			ctx({ store, allowNetwork: true, credential }),
+		);
 
 		expect(mockFetchKiloCatalog).toHaveBeenCalledWith(
 			expect.objectContaining({ token: "oauth-access-token" }),
@@ -253,7 +281,9 @@ describe("refreshModels online", () => {
 		const { provider } = createKiloProvider();
 		const credential: Credential = { type: "api_key", key: "sk-stored" };
 
-		await provider.refreshModels?.(ctx({ store, allowNetwork: true, credential }));
+		await provider.refreshModels?.(
+			ctx({ store, allowNetwork: true, credential }),
+		);
 
 		expect(mockFetchKiloCatalog).toHaveBeenCalledWith(
 			expect.objectContaining({ token: "sk-stored" }),
@@ -276,7 +306,12 @@ describe("refreshModels online", () => {
 	it("retains the previous catalog when a fetch returns nothing (poisoning guard)", async () => {
 		const seeded = {
 			models: [
-				{ ...freeCfg("a"), api: "openai-completions", provider: "kilo", baseUrl: "x" },
+				{
+					...freeCfg("a"),
+					api: "openai-completions",
+					provider: "kilo",
+					baseUrl: "x",
+				},
 			],
 		} as unknown as ModelsStoreEntry;
 		const { store, written } = makeStore(seeded);
@@ -310,7 +345,7 @@ describe("refreshModels online", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Toggle interop (setView / decideView)
+// Toggle interop (filterModels / decideView)
 // ---------------------------------------------------------------------------
 
 describe("toggle interop", () => {
@@ -326,34 +361,55 @@ describe("toggle interop", () => {
 	}
 
 	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider, stored, setView } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
+		const { provider } = await seededProvider();
+		expect(
+			provider
+				.getModels()
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 
-		// Re-registration is now an availability-snapshot invalidation signal.
-		setView(stored.all);
-		setView(stored.free);
-		expect(provider.getModels().map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
+		expect(
+			provider
+				.getModels()
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 	});
 
 	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
 		mockGetKiloShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
 		// show_paid true + global free-only true => filterModels returns all.
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined)
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
 	});
 
 	it("filterModels shows all when global free-only is off", async () => {
 		mockGetGlobalFreeOnly.mockReturnValue(false);
 		const { provider } = await seededProvider();
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined)
+				.map((m) => m.id)
+				.sort(),
+		).toEqual(["a", "b"]);
 	});
 
 	it("filterModels forces free when kilo_free_only is set", async () => {
 		mockGetKiloFreeOnly.mockReturnValue(true);
 		mockGetKiloShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual(["a"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["a"]);
 	});
 });

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -14,7 +14,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockFetchKiloCatalog = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => unknown>(),
 );
-const mockGetKiloApiKey = vi.hoisted(() => vi.fn((): string | undefined => undefined));
+const mockGetKiloApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
 const mockGetKiloShowPaid = vi.hoisted(() => vi.fn(() => false));
 const mockGetKiloFreeOnly = vi.hoisted(() => vi.fn(() => false));
 const mockGetGlobalFreeOnly = vi.hoisted(() => vi.fn(() => true));
@@ -116,7 +118,13 @@ describe("Kilo toggle interop", () => {
 		mockGetKiloFreeOnly.mockReturnValue(false);
 		mockGetGlobalFreeOnly.mockReturnValue(true);
 		mockFetchKiloCatalog.mockResolvedValue({
-			all: [cfg({ id: "free-1" }), cfg({ id: "paid-1", cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 } })],
+			all: [
+				cfg({ id: "free-1" }),
+				cfg({
+					id: "paid-1",
+					cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+				}),
+			],
 			free: [cfg({ id: "free-1" })],
 		});
 
@@ -142,7 +150,7 @@ describe("Kilo toggle interop", () => {
 		const [providerId, stored, reRegister, hasKey] = capturedToggleArgs[0] as [
 			string,
 			{ free: unknown[]; all: unknown[] },
-			(models: unknown[]) => void,
+			() => void,
 			boolean,
 		];
 		expect(providerId).toBe("kilo");
@@ -153,23 +161,27 @@ describe("Kilo toggle interop", () => {
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
 
-		// Global /toggle-free showing all -> reRegister(stored.all).
+		// Global /toggle-free showing all -> re-register the same provider.
 		mockRegisterProvider.mockClear();
-		reRegister(stored.all);
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		reRegister();
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
 
 		// Global /toggle-free showing free invalidates the same provider object;
 		// Pi's filterModels applies the free view to the complete catalog.
-		reRegister(stored.free);
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		reRegister();
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 	});
 
 	it("/toggle-kilo flips show_paid and shows the full catalog", async () => {
@@ -185,10 +197,12 @@ describe("Kilo toggle interop", () => {
 		await call[1].handler({}, { ui: { notify } });
 
 		expect(mockSaveConfig).toHaveBeenCalledWith({ kilo_show_paid: true });
-		expect(provider.getModels().map((m: { id: string }) => m.id).sort()).toEqual([
-			"free-1",
-			"paid-1",
-		]);
+		expect(
+			provider
+				.getModels()
+				.map((m: { id: string }) => m.id)
+				.sort(),
+		).toEqual(["free-1", "paid-1"]);
 		expect(notify).toHaveBeenCalledWith(
 			expect.stringContaining("showing all 2 models"),
 			"info",

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -5,7 +5,7 @@
  * mock createKiloProvider and assert the extension factory wires it up correctly:
  *   - registers the native provider via the single-arg registerProvider(provider)
  *   - participates in the global toggle (registerWithGlobalToggle)
- *   - /toggle-kilo flips show_paid and republishes via setView + re-register
+ *   - /toggle-kilo flips show_paid and re-registers the same provider object
  *   - model_select ToS notice + session_start handler
  *   - non-destructive credential migration inspection
  */
@@ -13,7 +13,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetKiloApiKey = vi.hoisted(() => vi.fn((): string | undefined => undefined));
+const mockGetKiloApiKey = vi.hoisted(() =>
+	vi.fn((): string | undefined => undefined),
+);
 const mockGetKiloShowPaid = vi.hoisted(() => vi.fn(() => false));
 const mockSaveConfig = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => Promise<void>>(),
@@ -24,15 +26,16 @@ const mockRegisterWithGlobalToggle = vi.hoisted(() =>
 const mockReadStoredCredential = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => unknown>(),
 );
-const mockSetView = vi.hoisted(() => vi.fn());
-
 const mockProvider = vi.hoisted(() => ({
 	id: "kilo",
 	name: "Kilo",
 	auth: { apiKey: { name: "Kilo API key" }, oauth: { name: "Kilo" } },
 	getModels: () => [],
 }));
-const mockStored = vi.hoisted(() => ({ free: [] as unknown[], all: [] as unknown[] }));
+const mockStored = vi.hoisted(() => ({
+	free: [] as unknown[],
+	all: [] as unknown[],
+}));
 
 vi.mock("../config.ts", () => ({
 	getKiloApiKey: () => mockGetKiloApiKey(),
@@ -47,14 +50,14 @@ vi.mock("../lib/registry.ts", () => ({
 }));
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
-	readStoredCredential: (...args: unknown[]) => mockReadStoredCredential(...args),
+	readStoredCredential: (...args: unknown[]) =>
+		mockReadStoredCredential(...args),
 }));
 
 vi.mock("../providers/kilo/kilo-provider.ts", () => ({
 	createKiloProvider: () => ({
 		provider: mockProvider,
 		stored: mockStored,
-		setView: mockSetView,
 		ingest: vi.fn(),
 	}),
 }));
@@ -114,7 +117,7 @@ describe("Kilo extension wiring", () => {
 			mockStored,
 			expect.any(Function),
 			false,
-			{ native: true },
+			expect.objectContaining({ native: true }),
 		);
 	});
 
@@ -126,20 +129,17 @@ describe("Kilo extension wiring", () => {
 			mockStored,
 			expect.any(Function),
 			true,
-			{ native: true },
+			expect.objectContaining({ native: true }),
 		);
 	});
 
-	it("global-toggle reRegister republishes via setView + re-register (keeps native auth)", async () => {
+	it("global-toggle reRegister republishes the same provider object", async () => {
 		await kiloProvider(mockPi);
-		const reRegister = mockRegisterWithGlobalToggle.mock.calls[0][2] as (
-			models: unknown[],
-		) => void;
+		const reRegister = mockRegisterWithGlobalToggle.mock.calls[0][2] as () => void;
 		mockRegisterProvider.mockClear();
 
-		reRegister(mockStored.all);
+		reRegister();
 
-		expect(mockSetView).toHaveBeenCalledWith(mockStored.all);
 		expect(mockRegisterProvider).toHaveBeenCalledWith(mockProvider);
 	});
 
@@ -157,7 +157,6 @@ describe("Kilo extension wiring", () => {
 			await call[1].handler({}, { ui: { notify } });
 
 			expect(mockSaveConfig).toHaveBeenCalledWith({ kilo_show_paid: true });
-			expect(mockSetView).toHaveBeenCalledWith(mockStored.all);
 			expect(mockRegisterProvider).toHaveBeenCalledWith(mockProvider);
 			expect(notify).toHaveBeenCalledWith(
 				expect.stringContaining("showing all 2 models"),

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -132,7 +132,9 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	mockGetLlm7ShowPaid.mockReturnValue(false);
 	mockGetLlm7ApiKey.mockReturnValue(undefined);
-	mockApplyHidden.mockImplementation(<T extends { id: string }>(models: T[]) => models);
+	mockApplyHidden.mockImplementation(
+		<T extends { id: string }>(models: T[]) => models,
+	);
 	mockGetGlobalFreeOnly.mockReturnValue(true);
 	vi.stubGlobal("fetch", mockFetch);
 });
@@ -263,10 +265,9 @@ describe("refreshModels offline init", () => {
 			"fast",
 			"pro",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["default", "fast"]);
 	});
 
 	it("stays empty when the store is empty and network is disallowed", async () => {
@@ -340,10 +341,9 @@ describe("refreshModels online", () => {
 			"fast",
 			"pro",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["default", "fast"]);
 	});
 
 	it("retains the previous catalog when the build returns nothing (poisoning guard)", async () => {
@@ -398,7 +398,7 @@ describe("refreshModels online", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Toggle interop (setView / filterModels)
+// Toggle interop (filterModels)
 // ---------------------------------------------------------------------------
 
 describe("toggle interop", () => {
@@ -410,48 +410,40 @@ describe("toggle interop", () => {
 	}
 
 	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider, stored, setView } = await seededProvider();
+		const { provider } = await seededProvider();
 		expect(provider.getModels().map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 			"pro",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["default", "fast"]);
 
-		setView(stored.all);
-		setView(stored.free);
 		expect(provider.getModels().map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 			"pro",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["default", "fast"]);
 	});
 
 	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
 		mockGetLlm7ShowPaid.mockReturnValue(true);
 		const { provider } = await seededProvider();
 		// show_paid true + global free-only true => filterModels returns all.
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-			"pro",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["default", "fast", "pro"]);
 	});
 
 	it("decideView shows all when global free-only is off", async () => {
 		mockGetGlobalFreeOnly.mockReturnValue(false);
 		const { provider } = await seededProvider();
-		expect(provider.filterModels!(provider.getModels(), undefined).map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-			"pro",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
+		).toEqual(["default", "fast", "pro"]);
 	});
 });

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -148,7 +148,7 @@ describe("LLM7 factory wiring", () => {
 		const [, stored, reRegister] = capturedToggleArgs[0] as [
 			string,
 			{ free: unknown[]; all: unknown[] },
-			(models: unknown[]) => void,
+			() => void,
 		];
 
 		// Pi refreshes (online) -> static catalogs populate.
@@ -156,9 +156,9 @@ describe("LLM7 factory wiring", () => {
 		expect(stored.all).toHaveLength(3);
 		expect(stored.free).toHaveLength(2);
 
-		// Global /toggle-free showing all -> reRegister(stored.all).
+		// Global /toggle-free showing all -> re-register the same provider.
 		mockRegisterProvider.mockClear();
-		reRegister(stored.all);
+		reRegister();
 		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
 			"default",
 			"fast",
@@ -169,7 +169,7 @@ describe("LLM7 factory wiring", () => {
 
 		// Global /toggle-free showing free invalidates the same provider object;
 		// Pi's filterModels applies the free view to the complete catalog.
-		reRegister(stored.free);
+		reRegister();
 		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
 			"default",
 			"fast",

--- a/tests/native-filter-models.test.ts
+++ b/tests/native-filter-models.test.ts
@@ -11,7 +11,12 @@ function model(id: string): Model<"openai-completions"> {
 		baseUrl: "https://example.test/v1",
 		reasoning: false,
 		input: ["text"],
-		cost: { input: id === "free" ? 0 : 1, output: id === "free" ? 0 : 1, cacheRead: 0, cacheWrite: 0 },
+		cost: {
+			input: id === "free" ? 0 : 1,
+			output: id === "free" ? 0 : 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
 		contextWindow: 32_000,
 		maxTokens: 4_096,
 	};

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -157,6 +157,15 @@ describe("createNativeOpenAIProvider", () => {
 		expect(handle.provider.getModels()[0].provider).toBe("test-native");
 	});
 
+	it("supports native-store-only initialization without a legacy cache", () => {
+		const handle = createNativeOpenAIProvider({
+			...options,
+			initialModels: undefined,
+		});
+
+		expect(handle.provider.getModels()).toEqual([]);
+	});
+
 	it("keeps the complete catalog and filters it without replacing the provider", () => {
 		const handle = createNativeOpenAIProvider(options);
 		expect(handle.provider.getModels().map((item) => item.id)).toEqual([
@@ -164,24 +173,24 @@ describe("createNativeOpenAIProvider", () => {
 			"paid",
 		]);
 		expect(
-			handle.provider
-				.filterModels!(handle.provider.getModels(), undefined)
-				.map((item) => item.id),
+			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
+				(item) => item.id,
+			),
 		).toEqual(["free"]);
 
 		mockGetGlobalFreeOnly.mockReturnValue(false);
 		expect(
-			handle.provider
-				.filterModels!(handle.provider.getModels(), undefined)
-				.map((item) => item.id),
+			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
+				(item) => item.id,
+			),
 		).toEqual(["free", "paid"]);
 
 		mockGetGlobalFreeOnly.mockReturnValue(true);
 		mockGetGlobalFreeOnlyForced.mockReturnValue(true);
 		expect(
-			handle.provider
-				.filterModels!(handle.provider.getModels(), undefined)
-				.map((item) => item.id),
+			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
+				(item) => item.id,
+			),
 		).toEqual(["free"]);
 	});
 

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -236,17 +236,16 @@ describe("applyGlobalFilter", () => {
 
 	it("invalidates native providers even when the free catalog is empty", () => {
 		const reRegister = vi.fn();
+		const invalidate = vi.fn();
 		const all = [makePaidModel("paid")];
-		registerWithGlobalToggle(
-			"af-native",
-			{ free: [], all },
-			reRegister,
-			true,
-			{ native: true },
-		);
+		registerWithGlobalToggle("af-native", { free: [], all }, reRegister, true, {
+			native: true,
+			invalidate,
+		});
 
 		applyGlobalFilter(true, { force: true });
 
-		expect(reRegister).toHaveBeenCalledWith([]);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+		expect(reRegister).not.toHaveBeenCalled();
 	});
 });

--- a/tests/tokenrouter-provider.test.ts
+++ b/tests/tokenrouter-provider.test.ts
@@ -26,10 +26,6 @@ vi.mock("../lib/registry.ts", () => ({
 	registerWithGlobalToggle: vi.fn(),
 }));
 
-vi.mock("../lib/provider-cache.ts", () => ({
-	loadProviderCache: () => undefined,
-}));
-
 vi.mock("../lib/util.ts", () => ({
 	cleanModelName: (id: string) => id,
 	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
@@ -167,8 +163,15 @@ describe("createTokenRouterProvider", () => {
 		await provider.refreshModels?.(context(store));
 
 		expect(mockFetchWithRetry).not.toHaveBeenCalled();
-		expect(provider.getModels().map((item) => item.id)).toEqual(["free:free", "paid"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((item) => item.id)).toEqual(["free:free"]);
+		expect(provider.getModels().map((item) => item.id)).toEqual([
+			"free:free",
+			"paid",
+		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map(
+				(item) => item.id,
+			),
+		).toEqual(["free:free"]);
 	});
 
 	it("fetches with the stored key and persists the native catalog", async () => {
@@ -221,9 +224,11 @@ describe("createTokenRouterProvider", () => {
 			"free-model:free",
 			"paid-model",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((item) => item.id)).toEqual([
-			"free-model:free",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map(
+				(item) => item.id,
+			),
+		).toEqual(["free-model:free"]);
 	});
 
 	it("honors an already-aborted refresh signal", async () => {

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -159,8 +159,15 @@ describe("createZenmuxProvider", () => {
 		await provider.refreshModels?.(context(store));
 
 		expect(mockFetchWithRetry).not.toHaveBeenCalled();
-		expect(provider.getModels().map((model) => model.id)).toEqual(["free", "paid"]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((model) => model.id)).toEqual(["free"]);
+		expect(provider.getModels().map((model) => model.id)).toEqual([
+			"free",
+			"paid",
+		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map(
+				(model) => model.id,
+			),
+		).toEqual(["free"]);
 	});
 
 	it("fetches with the effective stored key and persists the catalog", async () => {
@@ -220,9 +227,11 @@ describe("createZenmuxProvider", () => {
 			"free-model",
 			"paid-model",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((model) => model.id)).toEqual([
-			"free-model",
-		]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map(
+				(model) => model.id,
+			),
+		).toEqual(["free-model"]);
 	});
 
 	it("applies hidden models before publishing", async () => {
@@ -277,18 +286,20 @@ describe("createZenmuxProvider", () => {
 	});
 
 	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider, stored, setView } = createZenmuxProvider();
+		const { provider, stored } = createZenmuxProvider();
 		const free = nativeModel("free");
 		const paid = nativeModel("paid", true);
 		stored.free = [free];
 		stored.all = [free, paid];
-		setView(stored.free);
-		setView(stored.all);
 		expect(provider.getModels().map((model) => model.id)).toEqual([
 			"free",
 			"paid",
 		]);
-		expect(provider.filterModels!(provider.getModels(), undefined).map((model) => model.id)).toEqual(["free"]);
+		expect(
+			provider.filterModels!(provider.getModels(), undefined).map(
+				(model) => model.id,
+			),
+		).toEqual(["free"]);
 	});
 });
 

--- a/tests/zenmux.test.ts
+++ b/tests/zenmux.test.ts
@@ -103,9 +103,9 @@ describe("ZenMux native factory", () => {
 		expect(provider.auth.apiKey).toBeDefined();
 		expect(provider.getModels()).toEqual([]);
 		expect(registerCommand).toHaveBeenCalledWith(
-		"toggle-zenmux",
-		expect.any(Object),
-	);
+			"toggle-zenmux",
+			expect.any(Object),
+		);
 		expect(on).toHaveBeenCalledWith("session_start", expect.any(Function));
 	});
 


### PR DESCRIPTION
## Summary

- Remove the no-op `setView` model-array plumbing from native provider handles.
- Make native toggles and global free filtering re-register the same provider object without rebuilding/passing model arrays.
- Add an explicit native availability invalidation callback to the shared registry.
- Make native OpenAI-compatible initial catalogs optional and stop migrated native providers from reading/writing the legacy `provider-cache.json` catalog cache.
- Keep `provider-cache.ts` for legacy providers and retain Ollama's cache for `/api/show` capability reuse/manual refresh compatibility.
- Leave Qoder and dynamic built-ins unchanged.
- Add native-store-only lifecycle coverage and update architecture notes.

## Validation

- `npm run lint`
- `npm run test:run` — 50 test files, 608 tests passed
- `npm run check`
- No package or lockfile changes
