### PR TITLE
chore: update benchmark data from Artificial Analysis

### DIFF
--- a/provider-failover/benchmarks.json
+++ b/provider-failover/benchmarks.json
@@ -1,5502 +1,5890 @@
 {
+	"gpt-oss-120b-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "gpt-oss-120b (low)",
+		"codingIndex": 21.2,
+		"mathIndex": 66.7,
+		"mmluPro": 0.775,
+		"gpqa": 0.672,
+		"hle": 0.052
+	},
+	"gpt-5.6-terra-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Terra (max)",
+		"codingIndex": 76.7,
+		"gpqa": 0.925,
+		"hle": 0.418
+	},
 	"gpt-oss-120b-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "gpt-oss-120b (high)",
 		"codingIndex": 30.4,
 		"mathIndex": 93.4,
 		"mmluPro": 0.808,
 		"gpqa": 0.782,
-		"hle": 0.185,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "gpt-oss-120b (high)"
+		"hle": 0.185
 	},
-	"gpt-oss-20b-high": {
-		"codingIndex": 20.7,
-		"mathIndex": 89.3,
-		"mmluPro": 0.748,
-		"gpqa": 0.688,
-		"hle": 0.098,
+	"o3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "gpt-oss-20B (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o3",
+		"mathIndex": 88.3,
+		"mmluPro": 0.853,
+		"gpqa": 0.827,
+		"hle": 0.2
+	},
+	"gpt-5.6-terra-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Terra (low)",
+		"codingIndex": 58.1,
+		"gpqa": 0.843,
+		"hle": 0.274
+	},
+	"gpt-5.6-sol-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Sol (low)",
+		"codingIndex": 69.7,
+		"gpqa": 0.898,
+		"hle": 0.366
+	},
+	"gpt-5.6-sol-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Sol (medium)",
+		"codingIndex": 76.3,
+		"gpqa": 0.926,
+		"hle": 0.397
+	},
+	"gpt-5.6-terra-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Terra (Non-reasoning)",
+		"codingIndex": 52.3,
+		"gpqa": 0.746,
+		"hle": 0.11
+	},
+	"gpt-5.6-terra-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Terra (medium)",
+		"codingIndex": 64.7,
+		"gpqa": 0.872,
+		"hle": 0.316
+	},
+	"gpt-5.3-codex-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.3 Codex (xhigh)",
+		"gpqa": 0.915,
+		"hle": 0.399
+	},
+	"gpt-5.6-luna-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Luna (max)",
+		"codingIndex": 71.4,
+		"gpqa": 0.911,
+		"hle": 0.372
 	},
 	"gpt-oss-20b-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "gpt-oss-20b (low)",
 		"mathIndex": 62.3,
 		"mmluPro": 0.718,
 		"gpqa": 0.611,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "gpt-oss-20B (low)"
+		"hle": 0.051
 	},
-	"gpt-5.5-low": {
-		"codingIndex": 60.9,
-		"gpqa": 0.91,
-		"hle": 0.31,
+	"gpt-oss-20b-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 (low)"
-	},
-	"gpt-5.5-instant-june-2026": {
-		"codingIndex": 39.4,
-		"gpqa": 0.823,
-		"hle": 0.186,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 Instant (June 2026)"
-	},
-	"gpt-oss-120b-low": {
-		"mathIndex": 66.7,
-		"mmluPro": 0.775,
-		"gpqa": 0.672,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "gpt-oss-120b (low)"
-	},
-	"gpt-5.4-nano-non-reasoning": {
-		"gpqa": 0.558,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 nano (Non-Reasoning)"
-	},
-	"gpt-5.4-mini-xhigh": {
-		"codingIndex": 56.1,
-		"gpqa": 0.875,
-		"hle": 0.266,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 mini (xhigh)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "gpt-oss-20b (high)",
+		"codingIndex": 20.7,
+		"mathIndex": 89.3,
+		"gpqa": 0.688,
+		"hle": 0.098
 	},
 	"grok-1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Grok-1"
 	},
-	"o3": {
-		"mathIndex": 88.3,
-		"mmluPro": 0.853,
-		"gpqa": 0.827,
-		"hle": 0.2,
+	"gpt-5.5-instant-june-2026": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o3"
-	},
-	"gpt-5.5-high": {
-		"codingIndex": 71.6,
-		"gpqa": 0.932,
-		"hle": 0.43,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 (high)"
-	},
-	"gpt-5.4-mini-non-reasoning": {
-		"gpqa": 0.606,
-		"hle": 0.057,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 mini (Non-Reasoning)"
-	},
-	"gpt-5.4-nano-medium": {
-		"gpqa": 0.761,
-		"hle": 0.147,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 nano (medium)"
-	},
-	"gpt-5.5-non-reasoning": {
-		"codingIndex": 56.5,
-		"gpqa": 0.768,
-		"hle": 0.126,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 (Non-reasoning)"
-	},
-	"gpt-5.5-medium": {
-		"codingIndex": 71.5,
-		"gpqa": 0.926,
-		"hle": 0.406,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 (medium)"
-	},
-	"gpt-5.3-codex-xhigh": {
-		"gpqa": 0.915,
-		"hle": 0.399,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.3 Codex (xhigh)"
-	},
-	"gpt-5.4-nano-xhigh": {
-		"codingIndex": 56.1,
-		"gpqa": 0.817,
-		"hle": 0.265,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 nano (xhigh)"
-	},
-	"gpt-5.4-mini-medium": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 Instant (June 2026)",
+		"codingIndex": 39.4,
 		"gpqa": 0.823,
-		"hle": 0.171,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 mini (medium)"
+		"hle": 0.186
 	},
-	"gpt-5.5-xhigh": {
-		"codingIndex": 74.9,
-		"gpqa": 0.935,
-		"hle": 0.443,
+	"gpt-5.6-sol-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 (xhigh)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Sol (high)",
+		"codingIndex": 77.2,
+		"gpqa": 0.928,
+		"hle": 0.441
+	},
+	"gpt-5.6-sol-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Sol (max)",
+		"codingIndex": 77.4,
+		"gpqa": 0.941,
+		"hle": 0.472
+	},
+	"gpt-5.6-sol-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Sol (xhigh)",
+		"codingIndex": 78.3,
+		"gpqa": 0.931,
+		"hle": 0.447
+	},
+	"gpt-5.6-luna-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Luna (low)",
+		"codingIndex": 44.2,
+		"gpqa": 0.835,
+		"hle": 0.188
+	},
+	"gpt-5.6-luna-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Luna (medium)",
+		"codingIndex": 50.7,
+		"gpqa": 0.859,
+		"hle": 0.245
+	},
+	"gpt-5.6-luna-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Luna (high)",
+		"codingIndex": 63.3,
+		"gpqa": 0.892,
+		"hle": 0.316
+	},
+	"gpt-5.6-sol-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Sol (Non-reasoning)",
+		"codingIndex": 65.1,
+		"gpqa": 0.79,
+		"hle": 0.158
+	},
+	"gpt-5.6-luna-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Luna (xhigh)",
+		"codingIndex": 68.6,
+		"gpqa": 0.895,
+		"hle": 0.356
+	},
+	"gpt-5.6-luna-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Luna (Non-reasoning)",
+		"codingIndex": 39.3,
+		"gpqa": 0.645,
+		"hle": 0.067
+	},
+	"gpt-5.6-terra-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Terra (xhigh)",
+		"codingIndex": 70.6,
+		"gpqa": 0.908,
+		"hle": 0.4
+	},
+	"gpt-5.6-terra-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.6 Terra (high)",
+		"codingIndex": 67.1,
+		"gpqa": 0.896,
+		"hle": 0.367
 	},
 	"llama-3.3-instruct-70b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.3 Instruct 70B",
+		"codingIndex": 11.9,
 		"mathIndex": 7.7,
 		"mmluPro": 0.713,
 		"gpqa": 0.498,
-		"hle": 0.04,
+		"hle": 0.04
+	},
+	"llama-3.1-instruct-405b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.3 Instruct 70B"
-	},
-	"llama-3.1-instruct-405b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Instruct 405B",
 		"mathIndex": 3,
 		"mmluPro": 0.732,
 		"gpqa": 0.515,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Instruct 405B"
+		"hle": 0.042
 	},
 	"llama-3.2-instruct-90b-vision": {
-		"mmluPro": 0.671,
-		"gpqa": 0.432,
-		"hle": 0.049,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.2 Instruct 90B (Vision)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.2 Instruct 90B (Vision)",
+		"mmluPro": 0.671,
+		"gpqa": 0.432,
+		"hle": 0.049
 	},
 	"llama-3.2-instruct-11b-vision": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.2 Instruct 11B (Vision)",
 		"mathIndex": 1.7,
 		"mmluPro": 0.464,
 		"gpqa": 0.221,
-		"hle": 0.052,
+		"hle": 0.052
+	},
+	"llama-4-scout": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.2 Instruct 11B (Vision)"
-	},
-	"llama-4-scout": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 4 Scout",
 		"codingIndex": 8.2,
 		"mathIndex": 14,
 		"mmluPro": 0.752,
 		"gpqa": 0.587,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 4 Scout"
+		"hle": 0.043
 	},
 	"llama-4-maverick": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 4 Maverick",
 		"codingIndex": 16.3,
 		"mathIndex": 19.3,
-		"mmluPro": 0.809,
 		"gpqa": 0.671,
-		"hle": 0.048,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 4 Maverick"
+		"hle": 0.048
 	},
 	"muse-spark": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Muse Spark",
 		"codingIndex": 58.6,
 		"gpqa": 0.884,
-		"hle": 0.399,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Muse Spark"
+		"hle": 0.399
 	},
-	"gemma-4-e2b-reasoning": {
-		"gpqa": 0.433,
-		"hle": 0.048,
+	"muse-spark-1.1-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 E2B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Muse Spark 1.1 (xhigh)",
+		"codingIndex": 71.3,
+		"gpqa": 0.898,
+		"hle": 0.451
 	},
 	"gemma-4-31b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 31B (Non-reasoning)",
+		"codingIndex": 33.2,
 		"gpqa": 0.763,
-		"hle": 0.115,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 31B (Non-reasoning)"
+		"hle": 0.115
 	},
-	"gemma-4-31b-reasoning": {
-		"codingIndex": 43.4,
-		"gpqa": 0.857,
-		"hle": 0.227,
+	"gemini-3.5-flash-lite": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 31B (Reasoning)"
-	},
-	"gemma-4-12b-reasoning": {
-		"gpqa": 0.753,
-		"hle": 0.148,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 12B (Reasoning)"
-	},
-	"gemma-4-26b-a4b-non-reasoning": {
-		"gpqa": 0.714,
-		"hle": 0.107,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 26B A4B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.5 Flash-Lite",
+		"codingIndex": 49.3,
+		"gpqa": 0.838,
+		"hle": 0.175
 	},
 	"gemma-4-e4b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 E4B (Reasoning)",
+		"codingIndex": 9.4,
 		"gpqa": 0.576,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 E4B (Reasoning)"
+		"hle": 0.037
 	},
-	"diffusiongemma-26b-a4b": {
-		"codingIndex": 19.7,
-		"gpqa": 0.669,
-		"hle": 0.102,
+	"gemma-4-26b-a4b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DiffusionGemma 26B A4B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 26B A4B (Non-reasoning)",
+		"gpqa": 0.714,
+		"hle": 0.107
 	},
-	"gemma-4-26b-a4b-reasoning": {
-		"codingIndex": 39.3,
-		"gpqa": 0.792,
-		"hle": 0.183,
+	"gemma-4-31b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 26B A4B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 31B (Reasoning)",
+		"codingIndex": 43.4,
+		"gpqa": 0.857,
+		"hle": 0.227
 	},
-	"gemini-3.1-pro-preview": {
-		"codingIndex": 68.8,
-		"gpqa": 0.941,
-		"hle": 0.447,
+	"gemma-4-e2b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3.1 Pro Preview"
-	},
-	"gemma-4-e2b-non-reasoning": {
-		"gpqa": 0.405,
-		"hle": 0.045,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 E2B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 E2B (Reasoning)",
+		"codingIndex": 7.2,
+		"gpqa": 0.433,
+		"hle": 0.048
 	},
 	"gemma-4-12b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 12B (Non-reasoning)",
 		"gpqa": 0.661,
-		"hle": 0.062,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 12B (Non-reasoning)"
+		"hle": 0.062
 	},
-	"gemini-3.1-flash-lite": {
-		"codingIndex": 34.7,
-		"gpqa": 0.822,
-		"hle": 0.162,
+	"gemma-4-12b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3.1 Flash-Lite"
-	},
-	"gemini-3.5-flash-medium": {
-		"gpqa": 0.921,
-		"hle": 0.399,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3.5 Flash (medium)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 12B (Reasoning)",
+		"codingIndex": 31,
+		"gpqa": 0.753,
+		"hle": 0.148
 	},
 	"gemma-4-e4b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 E4B (Non-reasoning)",
 		"gpqa": 0.549,
-		"hle": 0.047,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 4 E4B (Non-reasoning)"
+		"hle": 0.047
 	},
-	"gemini-2.5-pro": {
-		"codingIndex": 33.3,
-		"mathIndex": 87.7,
-		"mmluPro": 0.862,
-		"gpqa": 0.844,
-		"hle": 0.211,
+	"gemma-4-26b-a4b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Pro"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 26B A4B (Reasoning)",
+		"codingIndex": 39.3,
+		"gpqa": 0.792,
+		"hle": 0.183
 	},
-	"gemini-3.5-flash-minimal": {
-		"gpqa": 0.828,
-		"hle": 0.231,
+	"gemma-4-e2b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3.5 Flash (minimal)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 4 E2B (Non-reasoning)",
+		"gpqa": 0.405,
+		"hle": 0.045
+	},
+	"gemini-3.1-pro-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.1 Pro Preview",
+		"codingIndex": 68.8,
+		"gpqa": 0.941,
+		"hle": 0.447
 	},
 	"gemini-3.5-flash-high": {
-		"codingIndex": 70.1,
-		"gpqa": 0.922,
-		"hle": 0.41,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3.5 Flash (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.5 Flash (high)",
+		"codingIndex": 70.1,
+		"gpqa": 0.922,
+		"hle": 0.41
+	},
+	"diffusiongemma-26b-a4b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DiffusionGemma 26B A4B",
+		"codingIndex": 19.7,
+		"gpqa": 0.669,
+		"hle": 0.102
+	},
+	"gemini-3.6-flash-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.6 Flash (high)",
+		"codingIndex": 69.2,
+		"gpqa": 0.928,
+		"hle": 0.383
 	},
 	"gemma-3-270m": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3 270M",
 		"mathIndex": 2.3,
 		"mmluPro": 0.055,
 		"gpqa": 0.224,
-		"hle": 0.042,
+		"hle": 0.042
+	},
+	"gemini-3.1-flash-lite": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3 270M"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.1 Flash-Lite",
+		"codingIndex": 34.7,
+		"gpqa": 0.822,
+		"hle": 0.162
+	},
+	"gemini-2.5-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Pro",
+		"codingIndex": 33.3,
+		"mathIndex": 87.7,
+		"gpqa": 0.844,
+		"hle": 0.211
+	},
+	"gemini-3.5-flash-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.5 Flash (medium)",
+		"gpqa": 0.921,
+		"hle": 0.399
+	},
+	"gemini-3.5-flash-minimal": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3.5 Flash (minimal)",
+		"gpqa": 0.828,
+		"hle": 0.231
+	},
+	"claude-opus-5-adaptive-reasoning-low-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Low Effort)",
+		"codingIndex": 66.9,
+		"gpqa": 0.889,
+		"hle": 0.413
 	},
 	"claude-4.5-haiku-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4.5 Haiku (Reasoning)",
 		"codingIndex": 43.9,
 		"mathIndex": 83.7,
-		"mmluPro": 0.76,
 		"gpqa": 0.672,
-		"hle": 0.097,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4.5 Haiku (Reasoning)"
+		"hle": 0.097
 	},
 	"claude-fable-5-adaptive-reasoning-max-effort-opus-4.8-fallback": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Fable 5 (Adaptive Reasoning, Max Effort, Opus 4.8 Fallback)",
 		"codingIndex": 76.5,
 		"gpqa": 0.926,
-		"hle": 0.533,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Fable 5 (Adaptive Reasoning, Max Effort, Opus 4.8 Fallback)"
-	},
-	"claude-opus-4.7-adaptive-reasoning-max-effort": {
-		"codingIndex": 73.6,
-		"gpqa": 0.914,
-		"hle": 0.396,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.7 (Adaptive Reasoning, Max Effort)"
-	},
-	"claude-sonnet-4.6-non-reasoning-high-effort": {
-		"gpqa": 0.799,
-		"hle": 0.132,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, High Effort)"
-	},
-	"claude-opus-4.8-adaptive-reasoning-max-effort": {
-		"codingIndex": 74.3,
-		"gpqa": 0.92,
-		"hle": 0.457,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.8 (Adaptive Reasoning, Max Effort)"
+		"hle": 0.533
 	},
 	"claude-sonnet-5-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Sonnet 5 (Adaptive Reasoning, Max Effort)",
 		"codingIndex": 71.5,
 		"gpqa": 0.911,
-		"hle": 0.396,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Sonnet 5 (Adaptive Reasoning, Max Effort)"
+		"hle": 0.396
 	},
-	"claude-sonnet-4.6-adaptive-reasoning-max-effort": {
-		"codingIndex": 63,
-		"gpqa": 0.875,
-		"hle": 0.3,
+	"claude-sonnet-5-non-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Sonnet 4.6 (Adaptive Reasoning, Max Effort)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Sonnet 5 (Non-reasoning, High Effort)",
+		"codingIndex": 66.4,
+		"gpqa": 0.8,
+		"hle": 0.178
+	},
+	"claude-opus-5-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 78,
+		"gpqa": 0.932,
+		"hle": 0.526
+	},
+	"claude-opus-5-adaptive-reasoning-medium-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Medium Effort)",
+		"codingIndex": 74.3,
+		"gpqa": 0.919,
+		"hle": 0.492
 	},
 	"claude-4.5-haiku-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4.5 Haiku (Non-reasoning)",
 		"mathIndex": 39,
 		"mmluPro": 0.8,
 		"gpqa": 0.646,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4.5 Haiku (Non-reasoning)"
+		"hle": 0.043
 	},
 	"claude-sonnet-4.6-non-reasoning-low-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, Low Effort)",
 		"gpqa": 0.797,
-		"hle": 0.108,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, Low Effort)"
+		"hle": 0.108
 	},
-	"claude-opus-4.7-non-reasoning-high-effort": {
-		"gpqa": 0.885,
-		"hle": 0.312,
+	"claude-opus-5-adaptive-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.7 (Non-reasoning, High Effort)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, High Effort)",
+		"codingIndex": 76.5,
+		"gpqa": 0.937,
+		"hle": 0.507
+	},
+	"claude-opus-5-adaptive-reasoning-xhigh-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Xhigh Effort)",
+		"codingIndex": 77,
+		"gpqa": 0.937,
+		"hle": 0.525
 	},
 	"mistral-large-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Large 3",
 		"codingIndex": 20.1,
 		"mathIndex": 38,
 		"mmluPro": 0.807,
 		"gpqa": 0.68,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Large 3"
-	},
-	"mistral-small-4-reasoning": {
-		"gpqa": 0.769,
-		"hle": 0.095,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small 4 (Reasoning)"
-	},
-	"mistral-medium-3.5": {
-		"codingIndex": 46.9,
-		"gpqa": 0.748,
-		"hle": 0.128,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Medium 3.5"
-	},
-	"ministral-3-14b": {
-		"codingIndex": 14.4,
-		"mathIndex": 30,
-		"mmluPro": 0.693,
-		"gpqa": 0.572,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ministral 3 14B"
-	},
-	"devstral-small-2": {
-		"codingIndex": 29.3,
-		"mathIndex": 34.3,
-		"mmluPro": 0.678,
-		"gpqa": 0.532,
-		"hle": 0.034,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Devstral Small 2"
-	},
-	"mistral-small-4-non-reasoning": {
-		"gpqa": 0.571,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small 4 (Non-reasoning)"
+		"hle": 0.041
 	},
 	"magistral-small-1.2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Magistral Small 1.2",
 		"codingIndex": 14.7,
 		"mathIndex": 80.3,
 		"mmluPro": 0.768,
 		"gpqa": 0.663,
-		"hle": 0.061,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Magistral Small 1.2"
+		"hle": 0.061
 	},
-	"ministral-3-3b": {
-		"codingIndex": 4.8,
-		"mathIndex": 22,
-		"mmluPro": 0.524,
-		"gpqa": 0.358,
-		"hle": 0.053,
+	"ministral-3-14b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ministral 3 3B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ministral 3 14B",
+		"codingIndex": 14.4,
+		"mathIndex": 30,
+		"mmluPro": 0.693,
+		"gpqa": 0.572,
+		"hle": 0.046
 	},
 	"ministral-3-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ministral 3 8B",
 		"codingIndex": 9.7,
 		"mathIndex": 31.7,
 		"mmluPro": 0.642,
 		"gpqa": 0.471,
-		"hle": 0.043,
+		"hle": 0.043
+	},
+	"ministral-3-3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ministral 3 8B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ministral 3 3B",
+		"codingIndex": 4.8,
+		"mathIndex": 22,
+		"gpqa": 0.358,
+		"hle": 0.053
+	},
+	"mistral-small-4-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small 4 (Reasoning)",
+		"codingIndex": 26.6,
+		"gpqa": 0.769,
+		"hle": 0.095
 	},
 	"devstral-2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Devstral 2",
 		"codingIndex": 31.3,
 		"mathIndex": 36.7,
 		"mmluPro": 0.762,
 		"gpqa": 0.594,
-		"hle": 0.036,
+		"hle": 0.036
+	},
+	"magistral-medium-1.2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Devstral 2"
-	},
-	"magistral-medium-1.2": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Magistral Medium 1.2",
 		"codingIndex": 21.3,
 		"mathIndex": 82,
 		"mmluPro": 0.815,
 		"gpqa": 0.739,
-		"hle": 0.096,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Magistral Medium 1.2"
+		"hle": 0.096
 	},
-	"deepseek-v4-pro-reasoning-high-effort": {
-		"gpqa": 0.905,
-		"hle": 0.335,
+	"mistral-medium-3.5": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V4 Pro (Reasoning, High Effort)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Medium 3.5",
+		"codingIndex": 46.9,
+		"gpqa": 0.748,
+		"hle": 0.128
+	},
+	"mistral-small-4-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small 4 (Non-reasoning)",
+		"gpqa": 0.571,
+		"hle": 0.037
+	},
+	"devstral-small-2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Devstral Small 2",
+		"codingIndex": 29.3,
+		"mathIndex": 34.3,
+		"mmluPro": 0.678,
+		"gpqa": 0.532,
+		"hle": 0.034
 	},
 	"deepseek-v4-pro-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Pro (Reasoning, Max Effort)",
 		"codingIndex": 59.4,
 		"gpqa": 0.888,
-		"hle": 0.359,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V4 Pro (Reasoning, Max Effort)"
+		"hle": 0.359
 	},
-	"deepseek-v4-flash-non-reasoning": {
-		"gpqa": 0.716,
-		"hle": 0.07,
+	"deepseek-v4-pro-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V4 Flash (Non-reasoning)"
-	},
-	"deepseek-v4-flash-reasoning-high-effort": {
-		"gpqa": 0.867,
-		"hle": 0.278,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V4 Flash (Reasoning, High Effort)"
-	},
-	"deepseek-v4-flash-reasoning-max-effort": {
-		"codingIndex": 56.2,
-		"gpqa": 0.894,
-		"hle": 0.321,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V4 Flash (Reasoning, Max Effort)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Pro (Reasoning, High Effort)",
+		"codingIndex": 58.7,
+		"gpqa": 0.905,
+		"hle": 0.335
 	},
 	"deepseek-v4-pro-non-reasoning": {
-		"gpqa": 0.717,
-		"hle": 0.077,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V4 Pro (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Pro (Non-reasoning)",
+		"gpqa": 0.717,
+		"hle": 0.077
+	},
+	"deepseek-v4-flash-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Flash (Non-reasoning)",
+		"gpqa": 0.716,
+		"hle": 0.07
+	},
+	"deepseek-v4-flash-0731-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Flash 0731 (Reasoning, Max Effort)",
+		"codingIndex": 69.1,
+		"gpqa": 0.908,
+		"hle": 0.368
 	},
 	"r1-1776": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "R1 1776"
 	},
 	"falcon-h1r-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Falcon-H1R-7B",
 		"mathIndex": 80,
 		"mmluPro": 0.725,
 		"gpqa": 0.661,
-		"hle": 0.108,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Falcon-H1R-7B"
-	},
-	"grok-4.3-high": {
-		"codingIndex": 42.2,
-		"gpqa": 0.901,
-		"hle": 0.35,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.3 (high)"
-	},
-	"grok-4.3-medium": {
-		"gpqa": 0.89,
-		"hle": 0.281,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.3 (medium)"
-	},
-	"grok-4.3-low": {
-		"gpqa": 0.843,
-		"hle": 0.173,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.3 (low)"
+		"hle": 0.108
 	},
 	"grok-4.3-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.3 (Non-reasoning)",
 		"codingIndex": 35.2,
 		"gpqa": 0.658,
-		"hle": 0.065,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.3 (Non-reasoning)"
+		"hle": 0.065
 	},
-	"grok-build-0.1-0616": {
-		"codingIndex": 51.5,
-		"gpqa": 0.895,
-		"hle": 0.36,
+	"grok-4.5-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok Build 0.1 0616"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.5 (high)",
+		"codingIndex": 72.4,
+		"gpqa": 0.931,
+		"hle": 0.403
+	},
+	"grok-4.3-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.3 (medium)",
+		"gpqa": 0.89,
+		"hle": 0.281
+	},
+	"grok-4.3-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.3 (low)",
+		"gpqa": 0.843,
+		"hle": 0.173
 	},
 	"nova-micro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova Micro",
 		"mathIndex": 6,
 		"mmluPro": 0.531,
 		"gpqa": 0.358,
-		"hle": 0.047,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova Micro"
-	},
-	"nova-2.0-pro-preview-low": {
-		"codingIndex": 25.9,
-		"mathIndex": 63.3,
-		"mmluPro": 0.822,
-		"gpqa": 0.751,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Pro Preview (low)"
-	},
-	"nova-2.0-omni-medium": {
-		"mathIndex": 89.7,
-		"mmluPro": 0.809,
-		"gpqa": 0.76,
-		"hle": 0.068,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Omni (medium)"
-	},
-	"nova-2.0-pro-preview-medium": {
-		"codingIndex": 34,
-		"mathIndex": 89,
-		"mmluPro": 0.83,
-		"gpqa": 0.785,
-		"hle": 0.089,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Pro Preview (medium)"
-	},
-	"nova-2.0-omni-non-reasoning": {
-		"mathIndex": 37,
-		"mmluPro": 0.719,
-		"gpqa": 0.555,
-		"hle": 0.039,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Omni (Non-reasoning)"
+		"hle": 0.047
 	},
 	"nova-2.0-lite-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Lite (high)",
 		"codingIndex": 23,
 		"mathIndex": 94.3,
 		"mmluPro": 0.818,
 		"gpqa": 0.811,
-		"hle": 0.109,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Lite (high)"
-	},
-	"nova-2.0-lite-low": {
-		"mathIndex": 46.7,
-		"mmluPro": 0.788,
-		"gpqa": 0.698,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Lite (low)"
+		"hle": 0.109
 	},
 	"nova-2.0-lite-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Lite (Non-reasoning)",
 		"mathIndex": 33.7,
 		"mmluPro": 0.743,
 		"gpqa": 0.603,
-		"hle": 0.03,
+		"hle": 0.03
+	},
+	"nova-2.0-omni-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Lite (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Omni (medium)",
+		"mathIndex": 89.7,
+		"mmluPro": 0.809,
+		"gpqa": 0.76,
+		"hle": 0.068
+	},
+	"nova-2.0-omni-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Omni (Non-reasoning)",
+		"mathIndex": 37,
+		"mmluPro": 0.719,
+		"gpqa": 0.555,
+		"hle": 0.039
+	},
+	"nova-2.0-omni-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Omni (low)",
+		"mathIndex": 56,
+		"mmluPro": 0.798,
+		"gpqa": 0.699,
+		"hle": 0.04
+	},
+	"nova-2.0-pro-preview-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Pro Preview (medium)",
+		"codingIndex": 34,
+		"mathIndex": 89,
+		"mmluPro": 0.83,
+		"gpqa": 0.785,
+		"hle": 0.089
+	},
+	"nova-2.0-lite-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Lite (medium)",
+		"mathIndex": 88.7,
+		"mmluPro": 0.813,
+		"gpqa": 0.768,
+		"hle": 0.086
+	},
+	"nova-2.0-pro-preview-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Pro Preview (low)",
+		"codingIndex": 25.9,
+		"mathIndex": 63.3,
+		"mmluPro": 0.822,
+		"gpqa": 0.751,
+		"hle": 0.052
+	},
+	"nova-2.0-lite-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Lite (low)",
+		"mathIndex": 46.7,
+		"mmluPro": 0.788,
+		"gpqa": 0.698,
+		"hle": 0.042
+	},
+	"nova-premier": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova Premier",
+		"mathIndex": 17.3,
+		"mmluPro": 0.733,
+		"gpqa": 0.569,
+		"hle": 0.047
 	},
 	"nova-2.0-pro-preview-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova 2.0 Pro Preview (Non-reasoning)",
 		"codingIndex": 20.9,
 		"mathIndex": 30.7,
 		"mmluPro": 0.772,
 		"gpqa": 0.636,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Pro Preview (Non-reasoning)"
-	},
-	"nova-2.0-omni-low": {
-		"mathIndex": 56,
-		"mmluPro": 0.798,
-		"gpqa": 0.699,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Omni (low)"
-	},
-	"nova-premier": {
-		"mathIndex": 17.3,
-		"mmluPro": 0.733,
-		"gpqa": 0.569,
-		"hle": 0.047,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova Premier"
-	},
-	"nova-2.0-lite-medium": {
-		"mathIndex": 88.7,
-		"mmluPro": 0.813,
-		"gpqa": 0.768,
-		"hle": 0.086,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova 2.0 Lite (medium)"
-	},
-	"phi-4": {
-		"mathIndex": 18,
-		"mmluPro": 0.714,
-		"gpqa": 0.575,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Phi-4"
-	},
-	"phi-4-mini-instruct": {
-		"mathIndex": 6.7,
-		"mmluPro": 0.465,
-		"gpqa": 0.331,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Phi-4 Mini Instruct"
-	},
-	"phi-4-multimodal-instruct": {
-		"mmluPro": 0.485,
-		"gpqa": 0.315,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Phi-4 Multimodal Instruct"
-	},
-	"lfm2.5-1.2b-thinking": {
-		"gpqa": 0.339,
-		"hle": 0.061,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2.5-1.2B-Thinking"
-	},
-	"lfm2.5-1.2b-instruct": {
-		"gpqa": 0.326,
-		"hle": 0.068,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2.5-1.2B-Instruct"
-	},
-	"lfm2-8b-a1b": {
-		"mathIndex": 25.3,
-		"mmluPro": 0.505,
-		"gpqa": 0.344,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2 8B A1B"
-	},
-	"lfm2-2.6b": {
-		"mathIndex": 8.3,
-		"mmluPro": 0.298,
-		"gpqa": 0.306,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2 2.6B"
-	},
-	"lfm2.5-8b-a1b": {
-		"gpqa": 0.513,
-		"hle": 0.069,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2.5-8B-A1B"
-	},
-	"lfm2-24b-a2b": {
-		"gpqa": 0.474,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2 24B A2B"
-	},
-	"lfm2.5-vl-1.6b": {
-		"gpqa": 0.289,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2.5-VL-1.6B"
-	},
-	"solar-pro-2-reasoning": {
-		"mathIndex": 61.3,
-		"mmluPro": 0.805,
-		"gpqa": 0.687,
-		"hle": 0.07,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Solar Pro 2 (Reasoning)"
-	},
-	"solar-pro-3": {
-		"codingIndex": 16.2,
-		"gpqa": 0.724,
-		"hle": 0.101,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Solar Pro 3"
-	},
-	"solar-open-100b-reasoning": {
-		"gpqa": 0.657,
-		"hle": 0.092,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Solar Open 100B (Reasoning)"
-	},
-	"solar-pro-2-non-reasoning": {
-		"mathIndex": 30,
-		"mmluPro": 0.75,
-		"gpqa": 0.561,
-		"hle": 0.038,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Solar Pro 2 (Non-reasoning)"
-	},
-	"minimax-m2.7": {
-		"codingIndex": 52.6,
-		"gpqa": 0.874,
-		"hle": 0.281,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax-M2.7"
-	},
-	"minimax-m3": {
-		"codingIndex": 58.6,
-		"gpqa": 0.929,
-		"hle": 0.371,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax-M3"
-	},
-	"llama-3.1-nemotron-instruct-70b": {
-		"mathIndex": 11,
-		"mmluPro": 0.69,
-		"gpqa": 0.465,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Nemotron Instruct 70B"
-	},
-	"nvidia-nemotron-3-super-120b-a12b-reasoning": {
-		"codingIndex": 37.7,
-		"gpqa": 0.8,
-		"hle": 0.192,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron 3 Super 120B A12B (Reasoning)"
+		"hle": 0.04
 	},
 	"llama-65b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Llama 65B"
 	},
-	"nemotron-3-ultra-550b-a55b-reasoning": {
-		"codingIndex": 49.3,
-		"gpqa": 0.867,
-		"hle": 0.266,
+	"phi-4": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nemotron 3 Ultra 550B A55B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Phi-4",
+		"mathIndex": 18,
+		"mmluPro": 0.714,
+		"gpqa": 0.575,
+		"hle": 0.041
+	},
+	"phi-4-mini-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Phi-4 Mini Instruct",
+		"codingIndex": 3.8,
+		"mathIndex": 6.7,
+		"mmluPro": 0.465,
+		"gpqa": 0.331,
+		"hle": 0.042
+	},
+	"phi-4-multimodal-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Phi-4 Multimodal Instruct",
+		"mmluPro": 0.485,
+		"gpqa": 0.315,
+		"hle": 0.044
+	},
+	"lfm2.5-1.2b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2.5-1.2B-Instruct",
+		"gpqa": 0.326,
+		"hle": 0.068
+	},
+	"lfm2.5-1.2b-thinking": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2.5-1.2B-Thinking",
+		"gpqa": 0.339,
+		"hle": 0.061
+	},
+	"lfm2.5-8b-a1b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2.5-8B-A1B",
+		"gpqa": 0.513,
+		"hle": 0.069
+	},
+	"lfm2.5-vl-1.6b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2.5-VL-1.6B",
+		"gpqa": 0.289,
+		"hle": 0.051
+	},
+	"lfm2-8b-a1b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2 8B A1B",
+		"mathIndex": 25.3,
+		"mmluPro": 0.505,
+		"gpqa": 0.344,
+		"hle": 0.049
+	},
+	"lfm2-2.6b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2 2.6B",
+		"mathIndex": 8.3,
+		"gpqa": 0.306,
+		"hle": 0.052
+	},
+	"lfm2-24b-a2b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2 24B A2B",
+		"gpqa": 0.474,
+		"hle": 0.044
+	},
+	"solar-pro-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Solar Pro 3",
+		"codingIndex": 16.2,
+		"gpqa": 0.724,
+		"hle": 0.101
+	},
+	"solar-open-100b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Solar Open 100B (Reasoning)",
+		"gpqa": 0.657,
+		"hle": 0.092
+	},
+	"minimax-m3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax-M3",
+		"codingIndex": 58.6,
+		"gpqa": 0.929,
+		"hle": 0.371
+	},
+	"llama-3.1-nemotron-instruct-70b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Nemotron Instruct 70B",
+		"mathIndex": 11,
+		"mmluPro": 0.69,
+		"gpqa": 0.465,
+		"hle": 0.046
 	},
 	"nvidia-nemotron-nano-12b-v2-vl-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Non-reasoning)",
 		"mathIndex": 26.7,
 		"mmluPro": 0.649,
 		"gpqa": 0.439,
-		"hle": 0.045,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Non-reasoning)"
-	},
-	"llama-nemotron-super-49b-v1.5-non-reasoning": {
-		"mathIndex": 8,
-		"mmluPro": 0.692,
-		"gpqa": 0.481,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama Nemotron Super 49B v1.5 (Non-reasoning)"
-	},
-	"llama-3.1-nemotron-ultra-253b-v1-reasoning": {
-		"mathIndex": 63.7,
-		"mmluPro": 0.825,
-		"gpqa": 0.728,
-		"hle": 0.081,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Nemotron Ultra 253B v1 (Reasoning)"
-	},
-	"nemotron-3-nano-omni-30b-a3b-reasoning": {
-		"gpqa": 0.469,
-		"hle": 0.053,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nemotron 3 Nano Omni 30B A3B Reasoning"
-	},
-	"nvidia-nemotron-3-nano-30b-a3b-non-reasoning": {
-		"mathIndex": 13.3,
-		"mmluPro": 0.579,
-		"gpqa": 0.399,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Non-reasoning)"
-	},
-	"nvidia-nemotron-nano-12b-v2-vl-reasoning": {
-		"mathIndex": 75,
-		"mmluPro": 0.759,
-		"gpqa": 0.572,
-		"hle": 0.053,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Reasoning)"
+		"hle": 0.045
 	},
 	"nvidia-nemotron-nano-9b-v2-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Reasoning)",
 		"mathIndex": 69.7,
 		"mmluPro": 0.742,
 		"gpqa": 0.57,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Reasoning)"
-	},
-	"nemotron-cascade-2-30b-a3b": {
-		"gpqa": 0.758,
-		"hle": 0.114,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nemotron Cascade 2 30B A3B"
-	},
-	"llama-nemotron-super-49b-v1.5-reasoning": {
-		"mathIndex": 76.7,
-		"mmluPro": 0.814,
-		"gpqa": 0.748,
-		"hle": 0.068,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama Nemotron Super 49B v1.5 (Reasoning)"
+		"hle": 0.046
 	},
 	"nvidia-nemotron-nano-9b-v2-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Non-reasoning)",
 		"mathIndex": 62.3,
 		"mmluPro": 0.739,
 		"gpqa": 0.557,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Non-reasoning)"
+		"hle": 0.04
 	},
-	"nvidia-nemotron-3-nano-4b": {
-		"gpqa": 0.513,
-		"hle": 0.048,
+	"llama-3.1-nemotron-ultra-253b-v1-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron 3 Nano 4B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Nemotron Ultra 253B v1 (Reasoning)",
+		"mathIndex": 63.7,
+		"mmluPro": 0.825,
+		"gpqa": 0.728,
+		"hle": 0.081
+	},
+	"nemotron-cascade-2-30b-a3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nemotron Cascade 2 30B A3B",
+		"codingIndex": 25.3,
+		"gpqa": 0.758,
+		"hle": 0.114
+	},
+	"nemotron-3-nano-omni-30b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nemotron 3 Nano Omni 30B A3B Reasoning",
+		"codingIndex": 13.8,
+		"gpqa": 0.469,
+		"hle": 0.053
+	},
+	"nvidia-nemotron-3-super-120b-a12b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron 3 Super 120B A12B (Reasoning)",
+		"codingIndex": 37.7,
+		"gpqa": 0.8,
+		"hle": 0.192
 	},
 	"nvidia-nemotron-3-nano-30b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Reasoning)",
 		"codingIndex": 14.4,
 		"mathIndex": 91,
 		"mmluPro": 0.794,
 		"gpqa": 0.757,
-		"hle": 0.102,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Reasoning)"
+		"hle": 0.102
 	},
-	"kimi-k2.6-non-reasoning": {
-		"gpqa": 0.788,
-		"hle": 0.182,
+	"llama-nemotron-super-49b-v1.5-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2.6 (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama Nemotron Super 49B v1.5 (Non-reasoning)",
+		"mathIndex": 8,
+		"gpqa": 0.481,
+		"hle": 0.043
 	},
-	"kimi-k2.7-code": {
-		"codingIndex": 60.8,
-		"gpqa": 0.896,
-		"hle": 0.328,
+	"nemotron-3-ultra-550b-a55b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2.7 Code"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nemotron 3 Ultra 550B A55B (Reasoning)",
+		"codingIndex": 49.3,
+		"gpqa": 0.867,
+		"hle": 0.266
 	},
-	"kimi-k2.6": {
-		"codingIndex": 56,
-		"gpqa": 0.911,
-		"hle": 0.359,
+	"nvidia-nemotron-3-nano-30b-a3b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2.6"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Non-reasoning)",
+		"mathIndex": 13.3,
+		"mmluPro": 0.579,
+		"gpqa": 0.399,
+		"hle": 0.046
 	},
 	"qwen-chat-14b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Qwen Chat 14B"
 	},
+	"nvidia-nemotron-3-nano-4b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron 3 Nano 4B",
+		"codingIndex": 8,
+		"gpqa": 0.513,
+		"hle": 0.048
+	},
+	"nvidia-nemotron-nano-12b-v2-vl-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Reasoning)",
+		"mathIndex": 75,
+		"mmluPro": 0.759,
+		"gpqa": 0.572,
+		"hle": 0.053
+	},
+	"llama-nemotron-super-49b-v1.5-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama Nemotron Super 49B v1.5 (Reasoning)",
+		"mathIndex": 76.7,
+		"gpqa": 0.748,
+		"hle": 0.068
+	},
+	"kimi-k2.7-code": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2.7 Code",
+		"codingIndex": 60.8,
+		"gpqa": 0.896,
+		"hle": 0.328
+	},
+	"kimi-k2.6-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2.6 (Non-reasoning)",
+		"gpqa": 0.788,
+		"hle": 0.182
+	},
+	"kimi-k3-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K3 (max)",
+		"codingIndex": 76.2,
+		"gpqa": 0.935,
+		"hle": 0.443
+	},
+	"kimi-k3-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K3 (low)",
+		"codingIndex": 72,
+		"gpqa": 0.842,
+		"hle": 0.24
+	},
 	"kimi-linear-48b-a3b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi Linear 48B A3B Instruct",
 		"mathIndex": 36.3,
 		"mmluPro": 0.585,
 		"gpqa": 0.412,
-		"hle": 0.027,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi Linear 48B A3B Instruct"
+		"hle": 0.027
 	},
 	"step-3.7-flash": {
-		"codingIndex": 37.3,
-		"gpqa": 0.809,
-		"hle": 0.199,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Step 3.7 Flash"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Step 3.7 Flash",
+		"codingIndex": 39.6,
+		"gpqa": 0.809,
+		"hle": 0.199
 	},
 	"step3-vl-10b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Step3 VL 10B",
 		"gpqa": 0.69,
-		"hle": 0.102,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Step3 VL 10B"
-	},
-	"step-3.5-flash-2603": {
-		"gpqa": 0.826,
-		"hle": 0.226,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Step 3.5 Flash 2603"
-	},
-	"olmo-3.1-32b-think": {
-		"mathIndex": 77.3,
-		"mmluPro": 0.763,
-		"gpqa": 0.591,
-		"hle": 0.06,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Olmo 3.1 32B Think"
-	},
-	"molmo2-8b": {
-		"gpqa": 0.425,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Molmo2-8B"
+		"hle": 0.102
 	},
 	"olmo-3-7b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Olmo 3 7B Instruct",
 		"mathIndex": 41.3,
 		"mmluPro": 0.522,
 		"gpqa": 0.4,
-		"hle": 0.058,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Olmo 3 7B Instruct"
+		"hle": 0.058
 	},
 	"olmo-3.1-32b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Olmo 3.1 32B Instruct",
 		"gpqa": 0.539,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Olmo 3.1 32B Instruct"
-	},
-	"molmo-7b-d": {
-		"mathIndex": 0,
-		"mmluPro": 0.371,
-		"gpqa": 0.24,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Molmo 7B-D"
+		"hle": 0.049
 	},
 	"olmo-3-7b-think": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Olmo 3 7B Think",
 		"mathIndex": 70.7,
 		"mmluPro": 0.655,
 		"gpqa": 0.516,
-		"hle": 0.057,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Olmo 3 7B Think"
+		"hle": 0.057
 	},
-	"granite-4.1-8b": {
-		"codingIndex": 9.5,
-		"gpqa": 0.433,
-		"hle": 0.038,
+	"molmo2-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.1 8B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Molmo2-8B",
+		"gpqa": 0.425,
+		"hle": 0.044
 	},
-	"granite-4.0-h-small": {
-		"mathIndex": 13.7,
-		"mmluPro": 0.624,
-		"gpqa": 0.416,
-		"hle": 0.037,
+	"olmo-3.1-32b-think": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.0 H Small"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Olmo 3.1 32B Think",
+		"mathIndex": 77.3,
+		"mmluPro": 0.763,
+		"gpqa": 0.591,
+		"hle": 0.06
 	},
-	"granite-4.1-30b": {
-		"codingIndex": 10.4,
-		"gpqa": 0.481,
-		"hle": 0.042,
+	"molmo-7b-d": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.1 30B"
-	},
-	"granite-4.0-h-350m": {
-		"mathIndex": 1.3,
-		"mmluPro": 0.127,
-		"gpqa": 0.257,
-		"hle": 0.064,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.0 H 350M"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Molmo 7B-D",
+		"mathIndex": 0,
+		"mmluPro": 0.371,
+		"gpqa": 0.24,
+		"hle": 0.051
 	},
 	"granite-4.0-1b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.0 1B",
 		"mathIndex": 6.3,
 		"mmluPro": 0.325,
 		"gpqa": 0.281,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.0 1B"
-	},
-	"granite-4.1-3b": {
-		"gpqa": 0.314,
-		"hle": 0.034,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.1 3B"
-	},
-	"granite-4.0-350m": {
-		"mathIndex": 0,
-		"mmluPro": 0.124,
-		"gpqa": 0.261,
-		"hle": 0.057,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.0 350M"
-	},
-	"granite-4.0-micro": {
-		"mathIndex": 6,
-		"mmluPro": 0.447,
-		"gpqa": 0.336,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.0 Micro"
+		"hle": 0.051
 	},
 	"granite-4.0-h-1b": {
-		"mathIndex": 6.3,
-		"mmluPro": 0.277,
-		"gpqa": 0.263,
-		"hle": 0.05,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 4.0 H 1B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.0 H 1B",
+		"mathIndex": 6.3,
+		"gpqa": 0.263,
+		"hle": 0.05
+	},
+	"granite-4.1-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.1 8B",
+		"codingIndex": 9.5,
+		"gpqa": 0.433,
+		"hle": 0.038
+	},
+	"granite-4.0-h-small": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.0 H Small",
+		"mathIndex": 13.7,
+		"mmluPro": 0.624,
+		"gpqa": 0.416,
+		"hle": 0.037
+	},
+	"granite-4.0-h-350m": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.0 H 350M",
+		"mathIndex": 1.3,
+		"gpqa": 0.257,
+		"hle": 0.064
+	},
+	"granite-4.1-3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.1 3B",
+		"codingIndex": 4.7,
+		"gpqa": 0.314,
+		"hle": 0.034
+	},
+	"granite-4.0-micro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.0 Micro",
+		"mathIndex": 6,
+		"gpqa": 0.336,
+		"hle": 0.051
+	},
+	"granite-4.1-30b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.1 30B",
+		"codingIndex": 10.4,
+		"gpqa": 0.481,
+		"hle": 0.042
+	},
+	"granite-4.0-350m": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 4.0 350M",
+		"mathIndex": 0,
+		"gpqa": 0.261,
+		"hle": 0.057
 	},
 	"mercury-2": {
-		"gpqa": 0.77,
-		"hle": 0.155,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mercury 2"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mercury 2",
+		"codingIndex": 31.1,
+		"gpqa": 0.77,
+		"hle": 0.155
 	},
 	"reka-flash-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Reka Flash 3",
 		"mathIndex": 33.7,
 		"mmluPro": 0.669,
 		"gpqa": 0.529,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Reka Flash 3"
-	},
-	"hermes-4---llama-3.1-70b-non-reasoning": {
-		"mathIndex": 11.3,
-		"mmluPro": 0.664,
-		"gpqa": 0.491,
-		"hle": 0.036,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hermes 4 - Llama-3.1 70B (Non-reasoning)"
-	},
-	"hermes-4---llama-3.1-405b-non-reasoning": {
-		"mathIndex": 15.3,
-		"mmluPro": 0.729,
-		"gpqa": 0.536,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hermes 4 - Llama-3.1 405B (Non-reasoning)"
-	},
-	"deephermes-3---llama-3.1-8b-preview-non-reasoning": {
-		"mmluPro": 0.365,
-		"gpqa": 0.27,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepHermes 3 - Llama-3.1 8B Preview (Non-reasoning)"
-	},
-	"hermes-4---llama-3.1-405b-reasoning": {
-		"mathIndex": 69.7,
-		"mmluPro": 0.829,
-		"gpqa": 0.727,
-		"hle": 0.103,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hermes 4 - Llama-3.1 405B (Reasoning)"
+		"hle": 0.051
 	},
 	"hermes-4---llama-3.1-70b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hermes 4 - Llama-3.1 70B (Reasoning)",
 		"mathIndex": 68.7,
 		"mmluPro": 0.811,
 		"gpqa": 0.699,
-		"hle": 0.079,
+		"hle": 0.079
+	},
+	"hermes-4---llama-3.1-70b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hermes 4 - Llama-3.1 70B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hermes 4 - Llama-3.1 70B (Non-reasoning)",
+		"mathIndex": 11.3,
+		"gpqa": 0.491,
+		"hle": 0.036
+	},
+	"hermes-4---llama-3.1-405b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hermes 4 - Llama-3.1 405B (Non-reasoning)",
+		"mathIndex": 15.3,
+		"gpqa": 0.536,
+		"hle": 0.042
 	},
 	"deephermes-3---mistral-24b-preview-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepHermes 3 - Mistral 24B Preview (Non-reasoning)",
 		"mmluPro": 0.58,
 		"gpqa": 0.382,
-		"hle": 0.039,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepHermes 3 - Mistral 24B Preview (Non-reasoning)"
+		"hle": 0.039
 	},
-	"exaone-4.5-33b": {
-		"gpqa": 0.794,
-		"hle": 0.116,
+	"deephermes-3---llama-3.1-8b-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "EXAONE 4.5 33B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepHermes 3 - Llama-3.1 8B Preview (Non-reasoning)",
+		"mmluPro": 0.365,
+		"gpqa": 0.27,
+		"hle": 0.043
+	},
+	"hermes-4---llama-3.1-405b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hermes 4 - Llama-3.1 405B (Reasoning)",
+		"mathIndex": 69.7,
+		"mmluPro": 0.829,
+		"gpqa": 0.727,
+		"hle": 0.103
 	},
 	"exaone-4.0-1.2b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Exaone 4.0 1.2B (Reasoning)",
 		"mathIndex": 50.3,
-		"mmluPro": 0.588,
 		"gpqa": 0.515,
-		"hle": 0.058,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Exaone 4.0 1.2B (Reasoning)"
-	},
-	"exaone-4.0-32b-non-reasoning": {
-		"mathIndex": 39.3,
-		"mmluPro": 0.768,
-		"gpqa": 0.628,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "EXAONE 4.0 32B (Non-reasoning)"
-	},
-	"exaone-4.0-32b-reasoning": {
-		"mathIndex": 80,
-		"mmluPro": 0.818,
-		"gpqa": 0.739,
-		"hle": 0.105,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "EXAONE 4.0 32B (Reasoning)"
-	},
-	"k-exaone-non-reasoning": {
-		"mathIndex": 44,
-		"mmluPro": 0.81,
-		"gpqa": 0.695,
-		"hle": 0.054,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "K-EXAONE (Non-reasoning)"
+		"hle": 0.058
 	},
 	"k-exaone-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "K-EXAONE (Reasoning)",
+		"codingIndex": 32.1,
 		"mathIndex": 90.3,
 		"mmluPro": 0.838,
 		"gpqa": 0.783,
-		"hle": 0.131,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "K-EXAONE (Reasoning)"
+		"hle": 0.131
 	},
 	"exaone-4.0-1.2b-non-reasoning": {
-		"mathIndex": 24,
-		"mmluPro": 0.5,
-		"gpqa": 0.424,
-		"hle": 0.058,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Exaone 4.0 1.2B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Exaone 4.0 1.2B (Non-reasoning)",
+		"mathIndex": 24,
+		"gpqa": 0.424,
+		"hle": 0.058
+	},
+	"exaone-4.0-32b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "EXAONE 4.0 32B (Reasoning)",
+		"mathIndex": 80,
+		"gpqa": 0.739,
+		"hle": 0.105
+	},
+	"exaone-4.0-32b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "EXAONE 4.0 32B (Non-reasoning)",
+		"mathIndex": 39.3,
+		"gpqa": 0.628,
+		"hle": 0.049
+	},
+	"exaone-4.5-33b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "EXAONE 4.5 33B",
+		"codingIndex": 23.6,
+		"gpqa": 0.794,
+		"hle": 0.116
+	},
+	"k-exaone-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "K-EXAONE (Non-reasoning)",
+		"mathIndex": 44,
+		"mmluPro": 0.81,
+		"gpqa": 0.695,
+		"hle": 0.054
 	},
 	"mimo-v2.5-pro": {
-		"codingIndex": 60.2,
-		"gpqa": 0.866,
-		"hle": 0.338,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2.5-Pro"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2.5-Pro",
+		"codingIndex": 60.2,
+		"gpqa": 0.866,
+		"hle": 0.338
+	},
+	"mimo-v2.5": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2.5",
+		"codingIndex": 56.8,
+		"gpqa": 0.849,
+		"hle": 0.252
+	},
+	"mimo-v2.5-pro-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2.5-Pro (Non-reasoning)",
+		"gpqa": 0.762,
+		"hle": 0.133
 	},
 	"mimo-v2-flash-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2-Flash (Non-reasoning)",
 		"codingIndex": 49.8,
 		"mathIndex": 67.7,
 		"mmluPro": 0.744,
 		"gpqa": 0.656,
-		"hle": 0.08,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2-Flash (Non-reasoning)"
-	},
-	"mimo-v2.5-pro-non-reasoning": {
-		"gpqa": 0.762,
-		"hle": 0.133,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2.5-Pro (Non-reasoning)"
-	},
-	"mimo-v2.5": {
-		"gpqa": 0.849,
-		"hle": 0.252,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2.5"
-	},
-	"mimo-v2-flash-feb-2026": {
-		"gpqa": 0.835,
-		"hle": 0.2,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2-Flash (Feb 2026)"
-	},
-	"mimo-v2-omni": {
-		"gpqa": 0.828,
-		"hle": 0.199,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2-Omni"
+		"hle": 0.08
 	},
 	"mimo-v2-omni-0327": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2-Omni-0327",
 		"gpqa": 0.855,
-		"hle": 0.204,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2-Omni-0327"
+		"hle": 0.204
 	},
-	"ernie-5.0-thinking-preview": {
-		"mathIndex": 85,
-		"mmluPro": 0.83,
-		"gpqa": 0.777,
-		"hle": 0.127,
+	"mimo-v2-omni": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "ERNIE 5.0 Thinking Preview"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2-Omni",
+		"gpqa": 0.828,
+		"hle": 0.199
+	},
+	"mimo-v2-flash-feb-2026": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2-Flash (Feb 2026)",
+		"gpqa": 0.835,
+		"hle": 0.2
 	},
 	"ernie-4.5-300b-a47b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "ERNIE 4.5 300B A47B",
 		"mathIndex": 41.3,
 		"mmluPro": 0.776,
 		"gpqa": 0.811,
-		"hle": 0.035,
+		"hle": 0.035
+	},
+	"ernie-5.0-thinking-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "ERNIE 4.5 300B A47B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "ERNIE 5.0 Thinking Preview",
+		"mathIndex": 85,
+		"mmluPro": 0.83,
+		"gpqa": 0.777,
+		"hle": 0.127
 	},
 	"sarvam-30b-high": {
-		"gpqa": 0.633,
-		"hle": 0.07,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Sarvam 30B (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Sarvam 30B (high)",
+		"gpqa": 0.633,
+		"hle": 0.07
 	},
 	"sarvam-105b-high": {
-		"gpqa": 0.738,
-		"hle": 0.101,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Sarvam 105B (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Sarvam 105B (high)",
+		"gpqa": 0.738,
+		"hle": 0.101
 	},
 	"hypernova-60b-2605": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "HyperNova 60B 2605",
+		"codingIndex": 23.2,
 		"gpqa": 0.733,
-		"hle": 0.151,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "HyperNova 60B 2605"
+		"hle": 0.151
 	},
-	"hy3-preview-reasoning": {
-		"gpqa": 0.867,
-		"hle": 0.255,
+	"hy3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hy3-preview (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hy3",
+		"codingIndex": 58.8,
+		"gpqa": 0.897,
+		"hle": 0.316
 	},
 	"hy3-preview-non-reasoning": {
-		"gpqa": 0.732,
-		"hle": 0.063,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hy3-preview (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hy3-preview (Non-reasoning)",
+		"gpqa": 0.732,
+		"hle": 0.063
+	},
+	"hy3-preview-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hy3-preview (Reasoning)",
+		"gpqa": 0.867,
+		"hle": 0.255
 	},
 	"kat-coder-pro-v1": {
-		"codingIndex": 58.9,
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "KAT-Coder-Pro V1",
 		"mathIndex": 94.7,
 		"mmluPro": 0.813,
 		"gpqa": 0.764,
-		"hle": 0.334,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "KAT-Coder-Pro V1"
+		"hle": 0.334
 	},
 	"kat-coder-pro-v2": {
-		"gpqa": 0.855,
-		"hle": 0.16,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "KAT Coder Pro V2"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "KAT Coder Pro V2",
+		"codingIndex": 59.5,
+		"gpqa": 0.855,
+		"hle": 0.16
 	},
 	"intellect-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "INTELLECT-3",
 		"mathIndex": 88,
 		"mmluPro": 0.822,
 		"gpqa": 0.761,
-		"hle": 0.121,
+		"hle": 0.121
+	},
+	"motif-2-12.7b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "INTELLECT-3"
-	},
-	"motif-2-12.7b-reasoning": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Motif-2-12.7B-Reasoning",
 		"mathIndex": 80.3,
 		"mmluPro": 0.796,
 		"gpqa": 0.695,
-		"hle": 0.082,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Motif-2-12.7B-Reasoning"
+		"hle": 0.082
 	},
-	"k2-v2-medium": {
-		"mathIndex": 64.7,
-		"mmluPro": 0.761,
-		"gpqa": 0.598,
-		"hle": 0.044,
+	"motif-3-beta": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "K2-V2 (medium)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Motif 3 (Beta)",
+		"codingIndex": 62,
+		"gpqa": 0.869,
+		"hle": 0.382
 	},
 	"k2-v2-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "K2-V2 (high)",
 		"mathIndex": 78.3,
 		"mmluPro": 0.786,
 		"gpqa": 0.681,
-		"hle": 0.098,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "K2-V2 (high)"
-	},
-	"k2-think-v2": {
-		"codingIndex": 21,
-		"gpqa": 0.713,
-		"hle": 0.095,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "K2 Think V2"
+		"hle": 0.098
 	},
 	"k2-v2-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "K2-V2 (low)",
 		"mathIndex": 35.3,
 		"mmluPro": 0.713,
 		"gpqa": 0.541,
-		"hle": 0.039,
+		"hle": 0.039
+	},
+	"k2-v2-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "K2-V2 (low)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "K2-V2 (medium)",
+		"mathIndex": 64.7,
+		"mmluPro": 0.761,
+		"gpqa": 0.598,
+		"hle": 0.044
+	},
+	"k2-think-v2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "K2 Think V2",
+		"codingIndex": 21,
+		"gpqa": 0.713,
+		"hle": 0.095
 	},
 	"mi-dm-k-2.5-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mi:dm K 2.5 Pro",
 		"mathIndex": 76.7,
 		"mmluPro": 0.809,
 		"gpqa": 0.701,
-		"hle": 0.077,
+		"hle": 0.077
+	},
+	"hyperclova-x-seed-think-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mi:dm K 2.5 Pro"
-	},
-	"hyperclova-x-seed-think-32b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "HyperCLOVA X SEED Think (32B)",
 		"mathIndex": 59,
 		"mmluPro": 0.785,
 		"gpqa": 0.615,
-		"hle": 0.055,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "HyperCLOVA X SEED Think (32B)"
+		"hle": 0.055
 	},
 	"longcat-flash-lite": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LongCat Flash Lite",
 		"gpqa": 0.636,
-		"hle": 0.06,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LongCat Flash Lite"
+		"hle": 0.06
 	},
-	"tri-21b-think-preview": {
-		"gpqa": 0.538,
-		"hle": 0.057,
+	"longcat-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Tri-21B-think Preview"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LongCat 2.0",
+		"codingIndex": 45.3,
+		"gpqa": 0.78,
+		"hle": 0.321
 	},
 	"tri-21b-think": {
-		"gpqa": 0.601,
-		"hle": 0.061,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Tri-21B-Think"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Tri-21B-Think",
+		"gpqa": 0.601,
+		"hle": 0.061
 	},
 	"nanbeige4.1-3b": {
-		"gpqa": 0.849,
-		"hle": 0.1,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nanbeige4.1-3B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nanbeige4.1-3B",
+		"codingIndex": 9.6,
+		"gpqa": 0.849,
+		"hle": 0.1
 	},
 	"apertus-8b-instruct": {
-		"gpqa": 0.256,
-		"hle": 0.05,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Apertus 8B Instruct"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Apertus 8B Instruct",
+		"gpqa": 0.256,
+		"hle": 0.05
 	},
 	"apertus-70b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Apertus 70B Instruct",
 		"gpqa": 0.272,
-		"hle": 0.055,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Apertus 70B Instruct"
-	},
-	"minicpm5-1b-non-reasoning": {
-		"gpqa": 0.269,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniCPM5-1B (Non-reasoning)"
-	},
-	"minicpm-v-4.6-1.3b": {
-		"codingIndex": 0.7,
-		"gpqa": 0.305,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniCPM-V 4.6 1.3B"
+		"hle": 0.055
 	},
 	"minicpm5-1b-reasoning": {
-		"gpqa": 0.278,
-		"hle": 0.065,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniCPM5-1B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniCPM5-1B (Reasoning)",
+		"gpqa": 0.278,
+		"hle": 0.065
+	},
+	"minicpm5-1b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniCPM5-1B (Non-reasoning)",
+		"gpqa": 0.269,
+		"hle": 0.046
+	},
+	"minicpm-v-4.6-1.3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniCPM-V 4.6 1.3B",
+		"codingIndex": 0.7,
+		"gpqa": 0.305,
+		"hle": 0.049
 	},
 	"trinity-large-thinking": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Trinity Large Thinking",
+		"codingIndex": 25.8,
 		"gpqa": 0.752,
-		"hle": 0.147,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Trinity Large Thinking"
-	},
-	"jt-35b-flash": {
-		"gpqa": 0.829,
-		"hle": 0.061,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "JT-35B-Flash"
+		"hle": 0.147
 	},
 	"jt-mini": {
-		"gpqa": 0.676,
-		"hle": 0.066,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "JT-MINI"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "JT-MINI",
+		"gpqa": 0.676,
+		"hle": 0.066
+	},
+	"jt-35b-flash": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "JT-35B-Flash",
+		"gpqa": 0.829,
+		"hle": 0.061
+	},
+	"jt-4.1-flash-236b-a21b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "JT-4.1 Flash 236B A21B",
+		"codingIndex": 52.4,
+		"gpqa": 0.845,
+		"hle": 0.161
 	},
 	"nex-n2-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nex-N2-Pro",
 		"codingIndex": 59.1,
 		"gpqa": 0.892,
-		"hle": 0.324,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nex-N2-Pro"
+		"hle": 0.324
 	},
-	"glm-5-turbo": {
-		"gpqa": 0.847,
-		"hle": 0.254,
+	"inkling-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-5-Turbo"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Inkling (xhigh)",
+		"codingIndex": 52.1,
+		"gpqa": 0.872,
+		"hle": 0.297
 	},
-	"glm-5.1-reasoning": {
-		"codingIndex": 55.8,
-		"gpqa": 0.868,
-		"hle": 0.28,
+	"inkling-small": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-5.1 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Inkling Small",
+		"codingIndex": 52.9,
+		"gpqa": 0.895,
+		"hle": 0.316
+	},
+	"g9v3-3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "G9v3-3B",
+		"codingIndex": 9.9,
+		"gpqa": 0.438,
+		"hle": 0.04
 	},
 	"glm-5.2-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5.2 (max)",
 		"codingIndex": 68.8,
 		"gpqa": 0.895,
-		"hle": 0.401,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-5.2 (max)"
+		"hle": 0.401
 	},
-	"glm-5.1-non-reasoning": {
-		"gpqa": 0.839,
-		"hle": 0.256,
+	"glm-5.2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-5.1 (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5.2 (Non-reasoning)",
+		"codingIndex": 46.5,
+		"gpqa": 0.686,
+		"hle": 0.084
 	},
-	"glm-5v-turbo-reasoning": {
-		"gpqa": 0.809,
-		"hle": 0.158,
+	"command-a+": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM 5V Turbo (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Command A+",
+		"codingIndex": 27.8,
+		"gpqa": 0.761,
+		"hle": 0.114
 	},
 	"north-mini-code": {
-		"gpqa": 0.757,
-		"hle": 0.099,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "North Mini Code"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "North Mini Code",
+		"codingIndex": 36.5,
+		"gpqa": 0.757,
+		"hle": 0.1
 	},
 	"command-a": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Command A",
 		"mathIndex": 13,
 		"mmluPro": 0.712,
 		"gpqa": 0.527,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Command A"
-	},
-	"command-a+": {
-		"gpqa": 0.761,
-		"hle": 0.114,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Command A+"
+		"hle": 0.046
 	},
 	"tiny-aya-global": {
-		"gpqa": 0.305,
-		"hle": 0.052,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Tiny Aya Global"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Tiny Aya Global",
+		"gpqa": 0.305,
+		"hle": 0.052
 	},
 	"apriel-v1.6-15b-thinker": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Apriel-v1.6-15B-Thinker",
 		"mathIndex": 88,
 		"mmluPro": 0.79,
 		"gpqa": 0.733,
-		"hle": 0.098,
+		"hle": 0.098
+	},
+	"jamba-1.7-large": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Apriel-v1.6-15B-Thinker"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba 1.7 Large",
+		"mathIndex": 2.3,
+		"gpqa": 0.39,
+		"hle": 0.038
+	},
+	"jamba-1.7-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba 1.7 Mini",
+		"mathIndex": 0.3,
+		"gpqa": 0.322,
+		"hle": 0.045
 	},
 	"jamba-reasoning-3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba Reasoning 3B",
 		"mathIndex": 10.7,
 		"mmluPro": 0.577,
 		"gpqa": 0.333,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba Reasoning 3B"
-	},
-	"jamba-1.7-large": {
-		"mathIndex": 2.3,
-		"mmluPro": 0.577,
-		"gpqa": 0.39,
-		"hle": 0.038,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba 1.7 Large"
-	},
-	"jamba-1.7-mini": {
-		"mathIndex": 0.3,
-		"mmluPro": 0.388,
-		"gpqa": 0.322,
-		"hle": 0.045,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba 1.7 Mini"
-	},
-	"qwen3.6-27b-non-reasoning": {
-		"gpqa": 0.829,
-		"hle": 0.136,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.6 27B (Non-reasoning)"
-	},
-	"qwen3.5-397b-a17b-reasoning": {
-		"codingIndex": 48.2,
-		"gpqa": 0.893,
-		"hle": 0.273,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 397B A17B (Reasoning)"
-	},
-	"qwen3.5-122b-a10b-reasoning": {
-		"codingIndex": 45.7,
-		"gpqa": 0.857,
-		"hle": 0.234,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 122B A10B (Reasoning)"
-	},
-	"qwen3-next-80b-a3b-instruct": {
-		"mathIndex": 66.3,
-		"mmluPro": 0.819,
-		"gpqa": 0.738,
-		"hle": 0.073,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Next 80B A3B Instruct"
+		"hle": 0.046
 	},
 	"qwen3.5-397b-a17b-non-reasoning": {
-		"gpqa": 0.861,
-		"hle": 0.188,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 397B A17B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 397B A17B (Non-reasoning)",
+		"gpqa": 0.861,
+		"hle": 0.188
 	},
 	"qwen3-next-80b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Next 80B A3B (Reasoning)",
+		"codingIndex": 17.4,
 		"mathIndex": 84.3,
 		"mmluPro": 0.824,
 		"gpqa": 0.759,
-		"hle": 0.117,
+		"hle": 0.117
+	},
+	"qwen3.5-397b-a17b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Next 80B A3B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 397B A17B (Reasoning)",
+		"codingIndex": 48.2,
+		"gpqa": 0.893,
+		"hle": 0.273
 	},
 	"qwen3.6-35b-a3b-non-reasoning": {
-		"gpqa": 0.817,
-		"hle": 0.125,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.6 35B A3B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.6 35B A3B (Non-reasoning)",
+		"codingIndex": 28.1,
+		"gpqa": 0.817,
+		"hle": 0.125
+	},
+	"qwen3.5-4b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 4B (Non-reasoning)",
+		"codingIndex": 20.3,
+		"gpqa": 0.712,
+		"hle": 0.075
+	},
+	"qwen3.5-122b-a10b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 122B A10B (Reasoning)",
+		"codingIndex": 45.7,
+		"gpqa": 0.857,
+		"hle": 0.234
 	},
 	"qwen3.7-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.7 Max",
 		"codingIndex": 66,
 		"gpqa": 0.923,
-		"hle": 0.381,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.7 Max"
+		"hle": 0.381
 	},
-	"qwen3.6-35b-a3b-reasoning": {
-		"codingIndex": 41.9,
-		"gpqa": 0.841,
-		"hle": 0.202,
+	"qwen3-next-80b-a3b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.6 35B A3B (Reasoning)"
-	},
-	"qwen3.6-27b-reasoning": {
-		"codingIndex": 53.7,
-		"gpqa": 0.842,
-		"hle": 0.216,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.6 27B (Reasoning)"
-	},
-	"qwen3-coder-next": {
-		"gpqa": 0.737,
-		"hle": 0.093,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Coder Next"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Next 80B A3B Instruct",
+		"mathIndex": 66.3,
+		"mmluPro": 0.819,
+		"gpqa": 0.738,
+		"hle": 0.073
 	},
 	"qwen3.5-9b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 9B (Reasoning)",
 		"codingIndex": 28.7,
 		"gpqa": 0.806,
-		"hle": 0.133,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 9B (Reasoning)"
-	},
-	"qwen3-omni-30b-a3b-instruct": {
-		"mathIndex": 52.3,
-		"mmluPro": 0.725,
-		"gpqa": 0.62,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Omni 30B A3B Instruct"
+		"hle": 0.133
 	},
 	"qwen3.5-122b-a10b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 122B A10B (Non-reasoning)",
+		"codingIndex": 43.3,
 		"gpqa": 0.827,
-		"hle": 0.148,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 122B A10B (Non-reasoning)"
+		"hle": 0.148
 	},
-	"qwen3.5-omni-plus": {
-		"gpqa": 0.826,
-		"hle": 0.139,
+	"qwen3.6-35b-a3b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 Omni Plus"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.6 35B A3B (Reasoning)",
+		"codingIndex": 41.9,
+		"gpqa": 0.841,
+		"hle": 0.202
 	},
-	"qwen3.6-plus": {
-		"codingIndex": 54.5,
-		"gpqa": 0.882,
-		"hle": 0.257,
+	"qwen3.5-2b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.6 Plus"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 2B (Reasoning)",
+		"codingIndex": 2.9,
+		"gpqa": 0.456,
+		"hle": 0.021
 	},
-	"qwen3.5-35b-a3b-non-reasoning": {
-		"gpqa": 0.819,
-		"hle": 0.128,
+	"qwen3.6-27b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 35B A3B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.6 27B (Reasoning)",
+		"codingIndex": 53.7,
+		"gpqa": 0.842,
+		"hle": 0.216
 	},
-	"qwen3.5-0.8b-reasoning": {
-		"codingIndex": 15,
-		"gpqa": 0.111,
-		"hle": 0.012,
+	"qwen3.5-4b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 0.8B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 4B (Reasoning)",
+		"codingIndex": 22.6,
+		"gpqa": 0.771,
+		"hle": 0.078
 	},
 	"qwen3-omni-30b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Omni 30B A3B (Reasoning)",
 		"mathIndex": 74,
 		"mmluPro": 0.792,
 		"gpqa": 0.726,
-		"hle": 0.073,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Omni 30B A3B (Reasoning)"
+		"hle": 0.073
 	},
-	"qwen3.7-plus": {
-		"codingIndex": 55.9,
-		"gpqa": 0.9,
-		"hle": 0.334,
+	"qwen3-omni-30b-a3b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.7 Plus"
-	},
-	"qwen3.5-4b-reasoning": {
-		"codingIndex": 22.6,
-		"gpqa": 0.771,
-		"hle": 0.078,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 4B (Reasoning)"
-	},
-	"qwen3.5-2b-reasoning": {
-		"codingIndex": 19.7,
-		"gpqa": 0.456,
-		"hle": 0.021,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 2B (Reasoning)"
-	},
-	"qwen3.5-0.8b-non-reasoning": {
-		"codingIndex": 21.9,
-		"gpqa": 0.236,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 0.8B (Non-reasoning)"
-	},
-	"qwen3.5-4b-non-reasoning": {
-		"codingIndex": 20.3,
-		"gpqa": 0.712,
-		"hle": 0.075,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 4B (Non-reasoning)"
-	},
-	"qwen3.5-9b-non-reasoning": {
-		"codingIndex": 23.5,
-		"gpqa": 0.786,
-		"hle": 0.086,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 9B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Omni 30B A3B Instruct",
+		"mathIndex": 52.3,
+		"mmluPro": 0.725,
+		"gpqa": 0.62,
+		"hle": 0.051
 	},
 	"qwen3.5-2b-non-reasoning": {
-		"codingIndex": 17.4,
-		"gpqa": 0.438,
-		"hle": 0.049,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 2B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 2B (Non-reasoning)",
+		"codingIndex": 2.4,
+		"gpqa": 0.438,
+		"hle": 0.049
+	},
+	"qwen3.5-9b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 9B (Non-reasoning)",
+		"codingIndex": 23.5,
+		"gpqa": 0.786,
+		"hle": 0.086
+	},
+	"qwen3.5-omni-plus": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 Omni Plus",
+		"gpqa": 0.826,
+		"hle": 0.139
+	},
+	"qwen3.6-plus": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.6 Plus",
+		"codingIndex": 54.5,
+		"gpqa": 0.882,
+		"hle": 0.257
+	},
+	"qwen3.5-35b-a3b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 35B A3B (Non-reasoning)",
+		"codingIndex": 37,
+		"gpqa": 0.819,
+		"hle": 0.128
+	},
+	"qwen3-coder-next": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Coder Next",
+		"codingIndex": 36.2,
+		"gpqa": 0.737,
+		"hle": 0.093
 	},
 	"qwen3.5-omni-flash": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 Omni Flash",
 		"gpqa": 0.742,
-		"hle": 0.071,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 Omni Flash"
+		"hle": 0.071
 	},
-	"ling-2.6-flash": {
-		"gpqa": 0.593,
-		"hle": 0.062,
+	"qwen3.6-27b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ling 2.6 Flash"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.6 27B (Non-reasoning)",
+		"codingIndex": 46.6,
+		"gpqa": 0.829,
+		"hle": 0.136
 	},
-	"ling-mini-2.0": {
-		"mathIndex": 49.3,
-		"mmluPro": 0.671,
-		"gpqa": 0.562,
-		"hle": 0.05,
+	"qwen3.7-plus": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ling-mini-2.0"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.7 Plus",
+		"codingIndex": 55.9,
+		"gpqa": 0.9,
+		"hle": 0.334
+	},
+	"qwen3.5-0.8b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 0.8B (Reasoning)",
+		"codingIndex": 0,
+		"gpqa": 0.111,
+		"hle": 0.012
+	},
+	"qwen3.5-0.8b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 0.8B (Non-reasoning)",
+		"codingIndex": 1.2,
+		"gpqa": 0.236,
+		"hle": 0.049
 	},
 	"ling-2.6-1t": {
-		"gpqa": 0.752,
-		"hle": 0.082,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ling-2.6-1T"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ling-2.6-1T",
+		"gpqa": 0.752,
+		"hle": 0.082
 	},
 	"ring-flash-2.0": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ring-flash-2.0",
 		"mathIndex": 83.7,
 		"mmluPro": 0.793,
 		"gpqa": 0.725,
-		"hle": 0.089,
+		"hle": 0.089
+	},
+	"ling-mini-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ring-flash-2.0"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ling-mini-2.0",
+		"mathIndex": 49.3,
+		"mmluPro": 0.671,
+		"gpqa": 0.562,
+		"hle": 0.05
+	},
+	"ling-2.6-flash": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ling 2.6 Flash",
+		"codingIndex": 25.3,
+		"gpqa": 0.593,
+		"hle": 0.062
 	},
 	"ring-2.6-1t": {
-		"codingIndex": 42.8,
-		"gpqa": 0.857,
-		"hle": 0.183,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ring-2.6-1T"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ring-2.6-1T",
+		"codingIndex": 42.8,
+		"gpqa": 0.857,
+		"hle": 0.183
 	},
 	"doubao-seed-code": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Doubao Seed Code",
 		"mathIndex": 79.3,
 		"mmluPro": 0.854,
 		"gpqa": 0.764,
-		"hle": 0.133,
+		"hle": 0.133
+	},
+	"agnes-2.5-pro-alpha": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Doubao Seed Code"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Agnes 2.5 Pro Alpha",
+		"codingIndex": 58.8,
+		"gpqa": 0.876,
+		"hle": 0.319
+	},
+	"celeris-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Celeris-1",
+		"codingIndex": 14.4,
+		"gpqa": 0.631,
+		"hle": 0.066
 	},
 	"o1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o1",
 		"codingIndex": 39.7,
 		"mmluPro": 0.841,
 		"gpqa": 0.747,
-		"hle": 0.077,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o1"
+		"hle": 0.077
 	},
 	"o1-preview": {
-		"codingIndex": 34,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o1-preview"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o1-preview",
+		"codingIndex": 34
 	},
 	"o1-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o1-mini",
 		"mmluPro": 0.742,
 		"gpqa": 0.603,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o1-mini"
+		"hle": 0.049
 	},
 	"gpt-4o-aug-24": {
-		"gpqa": 0.521,
-		"hle": 0.029,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4o (Aug '24)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4o (Aug '24)",
+		"gpqa": 0.521,
+		"hle": 0.029
 	},
 	"gpt-4o-may-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4o (May '24)",
 		"codingIndex": 24.2,
 		"mmluPro": 0.74,
 		"gpqa": 0.526,
-		"hle": 0.028,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4o (May '24)"
+		"hle": 0.028
 	},
 	"gpt-4-turbo": {
-		"codingIndex": 21.5,
-		"mmluPro": 0.694,
-		"hle": 0.033,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4 Turbo"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4 Turbo",
+		"codingIndex": 21.5,
+		"mmluPro": 0.694,
+		"hle": 0.033
 	},
 	"gpt-4o-nov-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4o (Nov '24)",
 		"mathIndex": 6,
 		"mmluPro": 0.748,
 		"gpqa": 0.543,
-		"hle": 0.033,
+		"hle": 0.033
+	},
+	"gpt-4o-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4o (Nov '24)"
-	},
-	"gpt-4o-mini": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4o mini",
 		"codingIndex": 11.4,
 		"mathIndex": 14.7,
 		"mmluPro": 0.648,
 		"gpqa": 0.426,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4o mini"
+		"hle": 0.04
 	},
 	"gpt-3.5-turbo": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-3.5 Turbo",
 		"codingIndex": 10.7,
 		"mmluPro": 0.462,
-		"gpqa": 0.297,
+		"gpqa": 0.297
+	},
+	"gpt-5-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-3.5 Turbo"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 (high)",
+		"codingIndex": 37.8,
+		"mathIndex": 94.3,
+		"gpqa": 0.854,
+		"hle": 0.265
 	},
-	"gpt-5-low": {
-		"mathIndex": 83,
+	"gpt-5-minimal": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 (minimal)",
+		"mathIndex": 31.7,
+		"gpqa": 0.673,
+		"hle": 0.054
+	},
+	"gpt-5.5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 (Non-reasoning)",
+		"codingIndex": 56.5,
+		"gpqa": 0.768,
+		"hle": 0.126
+	},
+	"gpt-5.5-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 (low)",
+		"codingIndex": 60.9,
+		"gpqa": 0.91,
+		"hle": 0.31
+	},
+	"gpt-5.5-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 (medium)",
+		"codingIndex": 71.5,
+		"gpqa": 0.926,
+		"hle": 0.406
+	},
+	"gpt-5.1-codex-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.1 Codex (high)",
+		"mathIndex": 95.7,
 		"mmluPro": 0.86,
-		"gpqa": 0.808,
-		"hle": 0.184,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 (low)"
+		"gpqa": 0.86,
+		"hle": 0.234
 	},
-	"o4-mini-high": {
-		"mathIndex": 90.7,
-		"mmluPro": 0.832,
-		"gpqa": 0.784,
-		"hle": 0.175,
+	"gpt-5-mini-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o4-mini (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 mini (medium)",
+		"mathIndex": 85,
+		"gpqa": 0.803,
+		"hle": 0.146
 	},
-	"gpt-5.2-medium": {
-		"mathIndex": 96.7,
-		"mmluPro": 0.859,
-		"gpqa": 0.864,
-		"hle": 0.249,
+	"gpt-5.1-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.2 (medium)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.1 (Non-reasoning)",
+		"mathIndex": 38,
+		"mmluPro": 0.801,
+		"gpqa": 0.643,
+		"hle": 0.052
 	},
-	"gpt-5-mini-high": {
-		"mathIndex": 90.7,
-		"mmluPro": 0.837,
-		"gpqa": 0.828,
-		"hle": 0.197,
+	"gpt-5.2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 mini (high)"
-	},
-	"gpt-5-nano-medium": {
-		"mathIndex": 78.3,
-		"mmluPro": 0.772,
-		"gpqa": 0.67,
-		"hle": 0.076,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 nano (medium)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.2 (Non-reasoning)",
+		"mathIndex": 51,
+		"mmluPro": 0.814,
+		"gpqa": 0.712,
+		"hle": 0.073
 	},
 	"gpt-5.1-codex-mini-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.1 Codex mini (high)",
 		"mathIndex": 91.7,
 		"mmluPro": 0.82,
 		"gpqa": 0.813,
-		"hle": 0.169,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.1 Codex mini (high)"
+		"hle": 0.169
 	},
-	"gpt-5-mini-minimal": {
-		"mathIndex": 46.7,
-		"mmluPro": 0.775,
-		"gpqa": 0.687,
-		"hle": 0.05,
+	"gpt-5.5-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 mini (minimal)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 (xhigh)",
+		"codingIndex": 74.9,
+		"gpqa": 0.935,
+		"hle": 0.443
 	},
-	"gpt-4o-chatgpt": {
-		"mmluPro": 0.773,
-		"gpqa": 0.511,
-		"hle": 0.037,
+	"gpt-5-nano-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4o (ChatGPT)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 nano (high)",
+		"mathIndex": 83.7,
+		"mmluPro": 0.78,
+		"gpqa": 0.676,
+		"hle": 0.082
+	},
+	"gpt-5.4-mini-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 mini (medium)",
+		"gpqa": 0.823,
+		"hle": 0.171
+	},
+	"gpt-5.4-mini-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 mini (Non-Reasoning)",
+		"gpqa": 0.606,
+		"hle": 0.057
 	},
 	"gpt-5.4-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 (xhigh)",
 		"codingIndex": 71.1,
 		"gpqa": 0.92,
-		"hle": 0.416,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 (xhigh)"
+		"hle": 0.416
 	},
-	"gpt-4.1-mini": {
-		"mathIndex": 46.3,
-		"mmluPro": 0.781,
-		"gpqa": 0.664,
-		"hle": 0.046,
+	"gpt-5-nano-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4.1 mini"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 nano (medium)",
+		"mathIndex": 78.3,
+		"gpqa": 0.67,
+		"hle": 0.076
 	},
-	"gpt-5-mini-medium": {
-		"mathIndex": 85,
-		"mmluPro": 0.828,
-		"gpqa": 0.803,
-		"hle": 0.146,
+	"gpt-5.4-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 mini (medium)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 (Non-reasoning)",
+		"gpqa": 0.748,
+		"hle": 0.106
 	},
-	"gpt-5-minimal": {
-		"mathIndex": 31.7,
-		"mmluPro": 0.806,
-		"gpqa": 0.673,
-		"hle": 0.054,
+	"gpt-5.4-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 (minimal)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 (low)",
+		"gpqa": 0.871,
+		"hle": 0.289
 	},
-	"o3-pro": {
-		"gpqa": 0.845,
+	"gpt-5-nano-minimal": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o3-pro"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 nano (minimal)",
+		"mathIndex": 27.3,
+		"gpqa": 0.428,
+		"hle": 0.041
 	},
 	"gpt-4.1-nano": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4.1 nano",
 		"codingIndex": 11.1,
 		"mathIndex": 24,
 		"mmluPro": 0.657,
 		"gpqa": 0.512,
-		"hle": 0.039,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4.1 nano"
+		"hle": 0.039
 	},
-	"gpt-5.1-non-reasoning": {
-		"mathIndex": 38,
-		"mmluPro": 0.801,
-		"gpqa": 0.643,
-		"hle": 0.052,
+	"gpt-5.5-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.1 (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 (high)",
+		"codingIndex": 71.6,
+		"gpqa": 0.932,
+		"hle": 0.43
 	},
-	"gpt-5.2-non-reasoning": {
-		"mathIndex": 51,
-		"mmluPro": 0.814,
-		"gpqa": 0.712,
-		"hle": 0.073,
+	"gpt-4.1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.2 (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4.1",
+		"mathIndex": 34.7,
+		"mmluPro": 0.806,
+		"gpqa": 0.666,
+		"hle": 0.046
 	},
-	"gpt-4": {
-		"codingIndex": 13.1,
+	"gpt-5-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 (low)",
+		"mathIndex": 83,
+		"gpqa": 0.808,
+		"hle": 0.184
 	},
-	"gpt-5-nano-high": {
-		"mathIndex": 83.7,
-		"mmluPro": 0.78,
-		"gpqa": 0.676,
-		"hle": 0.082,
+	"gpt-5.2-codex-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 nano (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.2 Codex (xhigh)",
+		"gpqa": 0.899,
+		"hle": 0.335
+	},
+	"o4-mini-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o4-mini (high)",
+		"mathIndex": 90.7,
+		"mmluPro": 0.832,
+		"gpqa": 0.784,
+		"hle": 0.175
 	},
 	"gpt-5-medium": {
-		"mathIndex": 91.7,
-		"mmluPro": 0.867,
-		"gpqa": 0.842,
-		"hle": 0.235,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 (medium)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 (medium)",
+		"mathIndex": 91.7,
+		"gpqa": 0.842,
+		"hle": 0.235
 	},
 	"gpt-5.5-instant-may-2026": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.5 Instant (May 2026)",
 		"gpqa": 0.846,
-		"hle": 0.203,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.5 Instant (May 2026)"
+		"hle": 0.203
 	},
-	"gpt-5-codex-high": {
-		"mathIndex": 98.7,
-		"mmluPro": 0.865,
-		"gpqa": 0.837,
-		"hle": 0.256,
+	"gpt-5-mini-minimal": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 Codex (high)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 mini (minimal)",
+		"mathIndex": 46.7,
+		"gpqa": 0.687,
+		"hle": 0.05
 	},
-	"gpt-4.5-preview": {
+	"gpt-4.1-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4.5 (Preview)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4.1 mini",
+		"codingIndex": 20.2,
+		"mathIndex": 46.3,
+		"mmluPro": 0.781,
+		"gpqa": 0.664,
+		"hle": 0.046
+	},
+	"gpt-5.2-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.2 (xhigh)",
+		"mathIndex": 99,
+		"mmluPro": 0.874,
+		"gpqa": 0.903,
+		"hle": 0.354
+	},
+	"gpt-5.4-nano-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 nano (xhigh)",
+		"codingIndex": 56.1,
+		"gpqa": 0.817,
+		"hle": 0.265
 	},
 	"o1-pro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "o1-pro"
 	},
-	"gpt-5-chatgpt": {
-		"mathIndex": 48.3,
-		"mmluPro": 0.82,
-		"gpqa": 0.686,
-		"hle": 0.058,
+	"gpt-4.5-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 (ChatGPT)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4.5 (Preview)"
+	},
+	"gpt-4": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4",
+		"codingIndex": 13.1
+	},
+	"gpt-5.2-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.2 (medium)",
+		"mathIndex": 96.7,
+		"mmluPro": 0.859,
+		"gpqa": 0.864,
+		"hle": 0.249
+	},
+	"o3-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o3-pro",
+		"gpqa": 0.845
+	},
+	"gpt-5-codex-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 Codex (high)",
+		"mathIndex": 98.7,
+		"mmluPro": 0.865,
+		"gpqa": 0.837,
+		"hle": 0.256
+	},
+	"gpt-5.1-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.1 (high)",
+		"codingIndex": 49.4,
+		"mathIndex": 94,
+		"gpqa": 0.873,
+		"hle": 0.265
+	},
+	"gpt-5-mini-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 mini (high)",
+		"codingIndex": 15.6,
+		"mathIndex": 90.7,
+		"gpqa": 0.828,
+		"hle": 0.197
+	},
+	"gpt-5-chatgpt": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5 (ChatGPT)",
+		"mathIndex": 48.3,
+		"gpqa": 0.686,
+		"hle": 0.058
 	},
 	"gpt-4o-march-2025-chatgpt-4o-latest": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4o (March 2025, chatgpt-4o-latest)",
 		"mathIndex": 25.7,
 		"mmluPro": 0.803,
 		"gpqa": 0.655,
-		"hle": 0.05,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4o (March 2025, chatgpt-4o-latest)"
+		"hle": 0.05
 	},
-	"gpt-5.4-low": {
-		"gpqa": 0.871,
-		"hle": 0.289,
+	"gpt-4o-chatgpt": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 (low)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-4o (ChatGPT)",
+		"mmluPro": 0.773,
+		"gpqa": 0.511,
+		"hle": 0.037
 	},
-	"gpt-5.1-high": {
-		"mathIndex": 94,
-		"mmluPro": 0.87,
-		"gpqa": 0.873,
-		"hle": 0.265,
+	"gpt-5.4-mini-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.1 (high)"
-	},
-	"gpt-5.2-xhigh": {
-		"mathIndex": 99,
-		"mmluPro": 0.874,
-		"gpqa": 0.903,
-		"hle": 0.354,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.2 (xhigh)"
-	},
-	"gpt-5.4-non-reasoning": {
-		"gpqa": 0.748,
-		"hle": 0.106,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.4 (Non-reasoning)"
-	},
-	"gpt-5-high": {
-		"mathIndex": 94.3,
-		"mmluPro": 0.871,
-		"gpqa": 0.854,
-		"hle": 0.265,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 (high)"
-	},
-	"gpt-4.1": {
-		"mathIndex": 34.7,
-		"mmluPro": 0.806,
-		"gpqa": 0.666,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-4.1"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 mini (xhigh)",
+		"codingIndex": 56.1,
+		"gpqa": 0.875,
+		"hle": 0.266
 	},
 	"o3-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o3-mini",
 		"mmluPro": 0.791,
 		"gpqa": 0.748,
-		"hle": 0.087,
+		"hle": 0.087
+	},
+	"gpt-5.4-nano-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o3-mini"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 nano (medium)",
+		"gpqa": 0.761,
+		"hle": 0.147
+	},
+	"gpt-5.4-nano-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GPT-5.4 nano (Non-Reasoning)",
+		"gpqa": 0.558,
+		"hle": 0.042
 	},
 	"o3-mini-high": {
-		"codingIndex": 42.1,
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "o3-mini (high)",
+		"codingIndex": 16.3,
 		"mmluPro": 0.802,
 		"gpqa": 0.773,
-		"hle": 0.123,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "o3-mini (high)"
-	},
-	"gpt-5-nano-minimal": {
-		"mathIndex": 27.3,
-		"mmluPro": 0.556,
-		"gpqa": 0.428,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5 nano (minimal)"
-	},
-	"gpt-5.1-codex-high": {
-		"mathIndex": 95.7,
-		"mmluPro": 0.86,
-		"gpqa": 0.86,
-		"hle": 0.234,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.1 Codex (high)"
-	},
-	"gpt-5.2-codex-xhigh": {
-		"gpqa": 0.899,
-		"hle": 0.335,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GPT-5.2 Codex (xhigh)"
+		"hle": 0.123
 	},
 	"llama-3.1-instruct-70b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Instruct 70B",
 		"mathIndex": 4,
 		"mmluPro": 0.676,
 		"gpqa": 0.409,
-		"hle": 0.046,
+		"hle": 0.046
+	},
+	"llama-3.1-instruct-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Instruct 70B"
-	},
-	"llama-3.1-instruct-8b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Instruct 8B",
 		"codingIndex": 5.4,
 		"mathIndex": 4.3,
 		"mmluPro": 0.476,
 		"gpqa": 0.259,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Instruct 8B"
+		"hle": 0.051
 	},
 	"llama-3.2-instruct-3b": {
-		"mathIndex": 3.3,
-		"mmluPro": 0.347,
-		"gpqa": 0.255,
-		"hle": 0.052,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.2 Instruct 3B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.2 Instruct 3B",
+		"mathIndex": 3.3,
+		"gpqa": 0.255,
+		"hle": 0.052
 	},
 	"llama-3-instruct-70b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3 Instruct 70B",
 		"mmluPro": 0.574,
 		"gpqa": 0.379,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3 Instruct 70B"
+		"hle": 0.044
 	},
 	"llama-3-instruct-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3 Instruct 8B",
 		"mmluPro": 0.405,
 		"gpqa": 0.296,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3 Instruct 8B"
+		"hle": 0.051
 	},
 	"llama-3.2-instruct-1b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.2 Instruct 1B",
 		"mathIndex": 0,
-		"mmluPro": 0.2,
 		"gpqa": 0.196,
-		"hle": 0.053,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.2 Instruct 1B"
-	},
-	"llama-2-chat-70b": {
-		"mmluPro": 0.406,
-		"gpqa": 0.327,
-		"hle": 0.05,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 2 Chat 70B"
+		"hle": 0.053
 	},
 	"llama-2-chat-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 2 Chat 7B",
 		"mmluPro": 0.164,
 		"gpqa": 0.227,
-		"hle": 0.058,
+		"hle": 0.058
+	},
+	"llama-2-chat-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 2 Chat 7B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 2 Chat 70B",
+		"mmluPro": 0.406,
+		"gpqa": 0.327,
+		"hle": 0.05
 	},
 	"llama-2-chat-13b": {
-		"mmluPro": 0.406,
-		"gpqa": 0.321,
-		"hle": 0.047,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 2 Chat 13B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 2 Chat 13B",
+		"mmluPro": 0.406,
+		"gpqa": 0.321,
+		"hle": 0.047
 	},
 	"gemini-2.0-pro-experimental-feb-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.0 Pro Experimental (Feb '25)",
 		"codingIndex": 25.5,
 		"mmluPro": 0.805,
 		"gpqa": 0.622,
-		"hle": 0.068,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.0 Pro Experimental (Feb '25)"
+		"hle": 0.068
 	},
 	"gemini-2.0-flash-experimental": {
-		"mmluPro": 0.782,
-		"gpqa": 0.636,
-		"hle": 0.047,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.0 Flash (experimental)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.0 Flash (experimental)",
+		"mmluPro": 0.782,
+		"gpqa": 0.636,
+		"hle": 0.047
 	},
 	"gemini-1.5-pro-sep-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.5 Pro (Sep '24)",
 		"codingIndex": 23.6,
 		"mmluPro": 0.75,
 		"gpqa": 0.589,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.5 Pro (Sep '24)"
+		"hle": 0.049
 	},
 	"gemini-2.0-flash-lite-preview": {
-		"gpqa": 0.542,
-		"hle": 0.044,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.0 Flash-Lite (Preview)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.0 Flash-Lite (Preview)",
+		"gpqa": 0.542,
+		"hle": 0.044
 	},
 	"gemini-2.0-flash-feb-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.0 Flash (Feb '25)",
 		"mathIndex": 21.7,
 		"mmluPro": 0.779,
 		"gpqa": 0.623,
-		"hle": 0.053,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.0 Flash (Feb '25)"
+		"hle": 0.053
 	},
 	"gemini-1.5-flash-sep-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.5 Flash (Sep '24)",
 		"mmluPro": 0.68,
 		"gpqa": 0.463,
-		"hle": 0.035,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.5 Flash (Sep '24)"
+		"hle": 0.035
 	},
 	"gemini-1.5-flash-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.5 Flash-8B",
 		"mmluPro": 0.569,
 		"gpqa": 0.359,
-		"hle": 0.045,
+		"hle": 0.045
+	},
+	"gemini-1.5-pro-may-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.5 Flash-8B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.5 Pro (May '24)",
+		"codingIndex": 19.8,
+		"mmluPro": 0.657,
+		"gpqa": 0.371,
+		"hle": 0.039
 	},
 	"gemma-3-27b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3 27B Instruct",
 		"codingIndex": 10.1,
 		"mathIndex": 20.7,
-		"mmluPro": 0.669,
 		"gpqa": 0.428,
-		"hle": 0.047,
+		"hle": 0.047
+	},
+	"gemma-3n-e4b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3 27B Instruct"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3n E4B Instruct",
+		"codingIndex": 3.2,
+		"mathIndex": 14.3,
+		"gpqa": 0.296,
+		"hle": 0.044
+	},
+	"gemini-2.0-flash-thinking-experimental-jan-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.0 Flash Thinking Experimental (Jan '25)",
+		"codingIndex": 24.1,
+		"mmluPro": 0.798,
+		"gpqa": 0.701,
+		"hle": 0.071
+	},
+	"gemma-3-1b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3 1B Instruct",
+		"mathIndex": 3.3,
+		"gpqa": 0.237,
+		"hle": 0.052
+	},
+	"gemma-3n-e2b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3n E2B Instruct",
+		"mathIndex": 10.3,
+		"gpqa": 0.229,
+		"hle": 0.04
+	},
+	"gemini-3-pro-preview-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3 Pro Preview (high)",
+		"mathIndex": 95.7,
+		"mmluPro": 0.898,
+		"gpqa": 0.908,
+		"hle": 0.372
+	},
+	"gemma-3n-e4b-instruct-preview-may-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3n E4B Instruct Preview (May '25)",
+		"mmluPro": 0.483,
+		"gpqa": 0.278,
+		"hle": 0.049
+	},
+	"gemini-2.0-flash-lite-feb-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.0 Flash-Lite (Feb '25)",
+		"mmluPro": 0.724,
+		"gpqa": 0.535,
+		"hle": 0.036
+	},
+	"gemma-3-12b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3 12B Instruct",
+		"codingIndex": 5.8,
+		"mathIndex": 18.3,
+		"gpqa": 0.349,
+		"hle": 0.048
+	},
+	"gemini-3-flash-preview-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3 Flash Preview (Reasoning)",
+		"mathIndex": 97,
+		"mmluPro": 0.89,
+		"gpqa": 0.898,
+		"hle": 0.347
+	},
+	"gemini-2.5-flash-preview-sep-25-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Reasoning)",
+		"mathIndex": 78.3,
+		"mmluPro": 0.842,
+		"gpqa": 0.793,
+		"hle": 0.127
+	},
+	"gemini-1.5-flash-may-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.5 Flash (May '24)",
+		"mmluPro": 0.574,
+		"gpqa": 0.324,
+		"hle": 0.042
 	},
 	"palm-2": {
-		"codingIndex": 4.6,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "PALM-2"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "PALM-2",
+		"codingIndex": 4.6
+	},
+	"gemini-2.5-flash-preview-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Reasoning)",
+		"mmluPro": 0.8,
+		"gpqa": 0.698,
+		"hle": 0.116
+	},
+	"gemma-3-4b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemma 3 4B Instruct",
+		"codingIndex": 2.7,
+		"mathIndex": 12.7,
+		"gpqa": 0.291,
+		"hle": 0.052
+	},
+	"gemini-2.5-flash-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash (Non-reasoning)",
+		"mathIndex": 60.3,
+		"mmluPro": 0.809,
+		"gpqa": 0.683,
+		"hle": 0.051
+	},
+	"gemini-2.5-flash-preview-sep-25-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Non-reasoning)",
+		"mathIndex": 56.7,
+		"mmluPro": 0.836,
+		"gpqa": 0.766,
+		"hle": 0.078
+	},
+	"gemini-2.5-flash-preview-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Non-reasoning)",
+		"mmluPro": 0.783,
+		"gpqa": 0.594,
+		"hle": 0.05
+	},
+	"gemini-1.0-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.0 Pro",
+		"mmluPro": 0.431,
+		"gpqa": 0.277,
+		"hle": 0.046
+	},
+	"gemini-2.5-pro-preview-mar-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Pro Preview (Mar' 25)",
+		"codingIndex": 46.7,
+		"mmluPro": 0.858,
+		"gpqa": 0.836,
+		"hle": 0.171
+	},
+	"gemini-2.5-flash-lite-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash-Lite (Non-reasoning)",
+		"mathIndex": 35.3,
+		"gpqa": 0.474,
+		"hle": 0.037
+	},
+	"gemini-2.5-flash-lite-preview-sep-25-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Non-reasoning)",
+		"mathIndex": 46.7,
+		"mmluPro": 0.796,
+		"gpqa": 0.651,
+		"hle": 0.046
+	},
+	"gemini-2.5-flash-lite-preview-sep-25-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Reasoning)",
+		"mathIndex": 68.7,
+		"mmluPro": 0.808,
+		"gpqa": 0.709,
+		"hle": 0.066
 	},
 	"gemini-3-pro-preview-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3 Pro Preview (low)",
 		"mathIndex": 86.7,
 		"mmluPro": 0.895,
 		"gpqa": 0.887,
-		"hle": 0.276,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3 Pro Preview (low)"
+		"hle": 0.276
 	},
 	"gemini-2.0-flash-thinking-experimental-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Gemini 2.0 Flash Thinking Experimental (Dec '24)"
 	},
-	"gemini-2.5-flash-preview-non-reasoning": {
-		"mmluPro": 0.783,
-		"gpqa": 0.594,
-		"hle": 0.05,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Non-reasoning)"
-	},
-	"gemma-3-4b-instruct": {
-		"mathIndex": 12.7,
-		"mmluPro": 0.417,
-		"gpqa": 0.291,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3 4B Instruct"
-	},
-	"gemini-2.5-flash-preview-reasoning": {
-		"mmluPro": 0.8,
-		"gpqa": 0.698,
-		"hle": 0.116,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Reasoning)"
-	},
-	"gemma-3-1b-instruct": {
-		"mathIndex": 3.3,
-		"mmluPro": 0.135,
-		"gpqa": 0.237,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3 1B Instruct"
-	},
-	"gemini-1.0-pro": {
-		"mmluPro": 0.431,
-		"gpqa": 0.277,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.0 Pro"
-	},
-	"gemma-3-12b-instruct": {
-		"codingIndex": 5.8,
-		"mathIndex": 18.3,
-		"mmluPro": 0.595,
-		"gpqa": 0.349,
-		"hle": 0.048,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3 12B Instruct"
-	},
-	"gemini-3-pro-preview-high": {
-		"mathIndex": 95.7,
-		"mmluPro": 0.898,
-		"gpqa": 0.908,
-		"hle": 0.372,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3 Pro Preview (high)"
-	},
-	"gemini-2.5-flash-preview-sep-25-reasoning": {
-		"mathIndex": 78.3,
-		"mmluPro": 0.842,
-		"gpqa": 0.793,
-		"hle": 0.127,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Reasoning)"
-	},
-	"gemma-3n-e4b-instruct-preview-may-25": {
-		"mmluPro": 0.483,
-		"gpqa": 0.278,
-		"hle": 0.049,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3n E4B Instruct Preview (May '25)"
-	},
 	"gemini-1.0-ultra": {
-		"codingIndex": 17.6,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.0 Ultra"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 1.0 Ultra",
+		"codingIndex": 17.6
 	},
-	"gemini-2.0-flash-thinking-experimental-jan-25": {
-		"codingIndex": 24.1,
-		"mmluPro": 0.798,
-		"gpqa": 0.701,
-		"hle": 0.071,
+	"gemini-2.5-flash-lite-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.0 Flash Thinking Experimental (Jan '25)"
-	},
-	"gemma-3n-e4b-instruct": {
-		"codingIndex": 3.2,
-		"mathIndex": 14.3,
-		"mmluPro": 0.488,
-		"gpqa": 0.296,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3n E4B Instruct"
-	},
-	"gemma-3n-e2b-instruct": {
-		"mathIndex": 10.3,
-		"mmluPro": 0.378,
-		"gpqa": 0.229,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemma 3n E2B Instruct"
-	},
-	"gemini-1.5-flash-may-24": {
-		"mmluPro": 0.574,
-		"gpqa": 0.324,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.5 Flash (May '24)"
-	},
-	"gemini-2.5-pro-preview-may-25": {
-		"mmluPro": 0.837,
-		"gpqa": 0.822,
-		"hle": 0.154,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Pro Preview (May' 25)"
-	},
-	"gemini-2.5-flash-non-reasoning": {
-		"mathIndex": 60.3,
-		"mmluPro": 0.809,
-		"gpqa": 0.683,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash (Non-reasoning)"
-	},
-	"gemini-3-flash-preview-non-reasoning": {
-		"mathIndex": 55.7,
-		"mmluPro": 0.882,
-		"gpqa": 0.812,
-		"hle": 0.141,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3 Flash Preview (Non-reasoning)"
-	},
-	"gemini-2.0-flash-lite-feb-25": {
-		"mmluPro": 0.724,
-		"gpqa": 0.535,
-		"hle": 0.036,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.0 Flash-Lite (Feb '25)"
-	},
-	"gemini-3-flash-preview-reasoning": {
-		"mathIndex": 97,
-		"mmluPro": 0.89,
-		"gpqa": 0.898,
-		"hle": 0.347,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 3 Flash Preview (Reasoning)"
-	},
-	"gemini-1.5-pro-may-24": {
-		"codingIndex": 19.8,
-		"mmluPro": 0.657,
-		"gpqa": 0.371,
-		"hle": 0.039,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 1.5 Pro (May '24)"
-	},
-	"gemini-2.5-pro-preview-mar-25": {
-		"codingIndex": 46.7,
-		"mmluPro": 0.858,
-		"gpqa": 0.836,
-		"hle": 0.171,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Pro Preview (Mar' 25)"
-	},
-	"gemini-2.5-flash-lite-non-reasoning": {
-		"mathIndex": 35.3,
-		"mmluPro": 0.724,
-		"gpqa": 0.474,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash-Lite (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash-Lite (Reasoning)",
+		"mathIndex": 53.3,
+		"gpqa": 0.625,
+		"hle": 0.064
 	},
 	"gemini-2.5-flash-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Flash (Reasoning)",
 		"mathIndex": 73.3,
 		"mmluPro": 0.832,
 		"gpqa": 0.79,
-		"hle": 0.111,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash (Reasoning)"
+		"hle": 0.111
 	},
-	"gemini-2.5-flash-lite-preview-sep-25-reasoning": {
-		"mathIndex": 68.7,
-		"mmluPro": 0.808,
-		"gpqa": 0.709,
-		"hle": 0.066,
+	"gemini-3-flash-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 3 Flash Preview (Non-reasoning)",
+		"mathIndex": 55.7,
+		"mmluPro": 0.882,
+		"gpqa": 0.812,
+		"hle": 0.141
 	},
-	"gemini-2.5-flash-preview-sep-25-non-reasoning": {
-		"mathIndex": 56.7,
-		"mmluPro": 0.836,
-		"gpqa": 0.766,
-		"hle": 0.078,
+	"gemini-2.5-pro-preview-may-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Non-reasoning)"
-	},
-	"gemini-2.5-flash-lite-reasoning": {
-		"mathIndex": 53.3,
-		"mmluPro": 0.759,
-		"gpqa": 0.625,
-		"hle": 0.064,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash-Lite (Reasoning)"
-	},
-	"gemini-2.5-flash-lite-preview-sep-25-non-reasoning": {
-		"mathIndex": 46.7,
-		"mmluPro": 0.796,
-		"gpqa": 0.651,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Gemini 2.5 Pro Preview (May' 25)",
+		"mmluPro": 0.837,
+		"gpqa": 0.822,
+		"hle": 0.154
 	},
 	"claude-3.5-sonnet-oct-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3.5 Sonnet (Oct '24)",
 		"codingIndex": 30.2,
 		"mmluPro": 0.772,
 		"gpqa": 0.599,
-		"hle": 0.039,
+		"hle": 0.039
+	},
+	"claude-3.5-sonnet-june-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3.5 Sonnet (Oct '24)"
-	},
-	"claude-3.5-sonnet-june-24": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3.5 Sonnet (June '24)",
 		"codingIndex": 26,
 		"mmluPro": 0.751,
 		"gpqa": 0.56,
-		"hle": 0.037,
+		"hle": 0.037
+	},
+	"claude-3-opus": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3.5 Sonnet (June '24)"
-	},
-	"claude-3-opus": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3 Opus",
 		"codingIndex": 19.5,
 		"mmluPro": 0.696,
 		"gpqa": 0.489,
-		"hle": 0.031,
+		"hle": 0.031
+	},
+	"claude-3.5-haiku": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3 Opus"
-	},
-	"claude-3.5-haiku": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3.5 Haiku",
 		"codingIndex": 15.9,
 		"mmluPro": 0.634,
 		"gpqa": 0.408,
-		"hle": 0.035,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3.5 Haiku"
+		"hle": 0.035
 	},
 	"claude-3-sonnet": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3 Sonnet",
 		"mmluPro": 0.579,
 		"gpqa": 0.4,
-		"hle": 0.038,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3 Sonnet"
+		"hle": 0.038
 	},
 	"claude-3-haiku": {
-		"gpqa": 0.374,
-		"hle": 0.039,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3 Haiku"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3 Haiku",
+		"gpqa": 0.374,
+		"hle": 0.039
 	},
 	"claude-instant": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Instant",
 		"codingIndex": 7.8,
 		"mmluPro": 0.434,
 		"gpqa": 0.33,
-		"hle": 0.038,
+		"hle": 0.038
+	},
+	"claude-2.1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Instant"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 2.1",
+		"codingIndex": 14,
+		"mmluPro": 0.495,
+		"gpqa": 0.319,
+		"hle": 0.042
+	},
+	"claude-opus-4.7-non-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.7 (Non-reasoning, High Effort)",
+		"gpqa": 0.885,
+		"hle": 0.312
+	},
+	"claude-3.7-sonnet-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3.7 Sonnet (Non-reasoning)",
+		"mathIndex": 21,
+		"mmluPro": 0.803,
+		"gpqa": 0.656,
+		"hle": 0.048
+	},
+	"claude-opus-4.7-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.7 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 73.6,
+		"gpqa": 0.914,
+		"hle": 0.396
 	},
 	"claude-opus-4.6-adaptive-reasoning-max-effort": {
-		"gpqa": 0.896,
-		"hle": 0.367,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.6 (Adaptive Reasoning, Max Effort)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.6 (Adaptive Reasoning, Max Effort)",
+		"gpqa": 0.896,
+		"hle": 0.367
+	},
+	"claude-4.5-sonnet-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4.5 Sonnet (Non-reasoning)",
+		"mathIndex": 37,
+		"mmluPro": 0.86,
+		"gpqa": 0.727,
+		"hle": 0.071
+	},
+	"claude-4.1-opus-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4.1 Opus (Reasoning)",
+		"mathIndex": 80.3,
+		"mmluPro": 0.88,
+		"gpqa": 0.809,
+		"hle": 0.119
+	},
+	"claude-opus-4.5-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.5 (Reasoning)",
+		"mathIndex": 91.3,
+		"mmluPro": 0.895,
+		"gpqa": 0.866,
+		"hle": 0.284
 	},
 	"claude-opus-4.5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.5 (Non-reasoning)",
 		"mathIndex": 62.7,
 		"mmluPro": 0.889,
 		"gpqa": 0.81,
-		"hle": 0.129,
+		"hle": 0.129
+	},
+	"claude-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.5 (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 2.0",
+		"codingIndex": 12.9,
+		"mmluPro": 0.486,
+		"gpqa": 0.344
+	},
+	"claude-4-sonnet-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4 Sonnet (Reasoning)",
+		"codingIndex": 37.6,
+		"mathIndex": 74.3,
+		"gpqa": 0.777,
+		"hle": 0.096
+	},
+	"claude-4-opus-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4 Opus (Reasoning)",
+		"mathIndex": 73.3,
+		"mmluPro": 0.873,
+		"gpqa": 0.796,
+		"hle": 0.117
 	},
 	"claude-4.1-opus-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Claude 4.1 Opus (Non-reasoning)"
 	},
-	"claude-3.7-sonnet-non-reasoning": {
-		"mathIndex": 21,
-		"mmluPro": 0.803,
-		"gpqa": 0.656,
-		"hle": 0.048,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3.7 Sonnet (Non-reasoning)"
-	},
-	"claude-4-sonnet-non-reasoning": {
-		"mathIndex": 38,
-		"mmluPro": 0.837,
-		"gpqa": 0.683,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4 Sonnet (Non-reasoning)"
-	},
-	"claude-4.1-opus-reasoning": {
-		"mathIndex": 80.3,
-		"mmluPro": 0.88,
-		"gpqa": 0.809,
-		"hle": 0.119,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4.1 Opus (Reasoning)"
-	},
-	"claude-4-sonnet-reasoning": {
-		"codingIndex": 37.6,
-		"mathIndex": 74.3,
-		"mmluPro": 0.842,
-		"gpqa": 0.777,
-		"hle": 0.096,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4 Sonnet (Reasoning)"
-	},
-	"claude-2.1": {
-		"codingIndex": 14,
-		"mmluPro": 0.495,
-		"gpqa": 0.319,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 2.1"
-	},
-	"claude-4.5-sonnet-non-reasoning": {
-		"mathIndex": 37,
-		"mmluPro": 0.86,
-		"gpqa": 0.727,
-		"hle": 0.071,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4.5 Sonnet (Non-reasoning)"
-	},
 	"claude-4.5-sonnet-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4.5 Sonnet (Reasoning)",
+		"codingIndex": 52.1,
 		"mathIndex": 88,
-		"mmluPro": 0.875,
 		"gpqa": 0.834,
-		"hle": 0.173,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4.5 Sonnet (Reasoning)"
+		"hle": 0.173
 	},
-	"claude-4-opus-reasoning": {
-		"mathIndex": 73.3,
-		"mmluPro": 0.873,
-		"gpqa": 0.796,
-		"hle": 0.117,
+	"claude-sonnet-4.6-adaptive-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4 Opus (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Sonnet 4.6 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 63,
+		"gpqa": 0.875,
+		"hle": 0.3
 	},
-	"claude-opus-4.6-non-reasoning-high-effort": {
-		"gpqa": 0.84,
-		"hle": 0.186,
+	"claude-sonnet-4.6-non-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.6 (Non-reasoning, High Effort)"
-	},
-	"claude-4-opus-non-reasoning": {
-		"mathIndex": 36.3,
-		"mmluPro": 0.86,
-		"gpqa": 0.701,
-		"hle": 0.059,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 4 Opus (Non-reasoning)"
-	},
-	"claude-opus-4.5-reasoning": {
-		"mathIndex": 91.3,
-		"mmluPro": 0.895,
-		"gpqa": 0.866,
-		"hle": 0.284,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude Opus 4.5 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, High Effort)",
+		"gpqa": 0.799,
+		"hle": 0.132
 	},
 	"claude-3.7-sonnet-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 3.7 Sonnet (Reasoning)",
 		"codingIndex": 36.4,
 		"mathIndex": 56.3,
 		"mmluPro": 0.837,
 		"gpqa": 0.772,
-		"hle": 0.103,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 3.7 Sonnet (Reasoning)"
+		"hle": 0.103
 	},
-	"claude-2.0": {
-		"codingIndex": 12.9,
-		"mmluPro": 0.486,
-		"gpqa": 0.344,
+	"claude-4-opus-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Claude 2.0"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4 Opus (Non-reasoning)",
+		"mathIndex": 36.3,
+		"mmluPro": 0.86,
+		"gpqa": 0.701,
+		"hle": 0.059
+	},
+	"claude-4-sonnet-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude 4 Sonnet (Non-reasoning)",
+		"mathIndex": 38,
+		"gpqa": 0.683,
+		"hle": 0.04
+	},
+	"claude-opus-4.6-non-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.6 (Non-reasoning, High Effort)",
+		"gpqa": 0.84,
+		"hle": 0.186
+	},
+	"claude-opus-4.8-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Claude Opus 4.8 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 74.3,
+		"gpqa": 0.92,
+		"hle": 0.457
 	},
 	"mistral-large-2-nov-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Large 2 (Nov '24)",
 		"mathIndex": 14,
 		"mmluPro": 0.697,
 		"gpqa": 0.486,
-		"hle": 0.04,
+		"hle": 0.04
+	},
+	"mistral-large-2-jul-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Large 2 (Nov '24)"
-	},
-	"mistral-large-2-jul-24": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Large 2 (Jul '24)",
 		"mathIndex": 0,
 		"mmluPro": 0.683,
 		"gpqa": 0.472,
-		"hle": 0.032,
+		"hle": 0.032
+	},
+	"pixtral-large": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Large 2 (Jul '24)"
-	},
-	"pixtral-large": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Pixtral Large",
 		"mathIndex": 2.3,
 		"mmluPro": 0.701,
 		"gpqa": 0.505,
-		"hle": 0.036,
+		"hle": 0.036
+	},
+	"mistral-small-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Pixtral Large"
-	},
-	"mistral-small-3": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small 3",
 		"mathIndex": 4.3,
 		"mmluPro": 0.652,
 		"gpqa": 0.462,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small 3"
+		"hle": 0.041
 	},
 	"mistral-small-sep-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small (Sep '24)",
 		"mmluPro": 0.529,
 		"gpqa": 0.381,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small (Sep '24)"
+		"hle": 0.043
 	},
 	"mixtral-8x22b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mixtral 8x22B Instruct",
 		"mmluPro": 0.537,
 		"gpqa": 0.332,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mixtral 8x22B Instruct"
+		"hle": 0.041
 	},
 	"mistral-small-feb-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small (Feb '24)",
 		"mmluPro": 0.419,
 		"gpqa": 0.302,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small (Feb '24)"
+		"hle": 0.044
 	},
 	"mistral-large-feb-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Large (Feb '24)",
 		"mmluPro": 0.515,
 		"gpqa": 0.351,
-		"hle": 0.034,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Large (Feb '24)"
+		"hle": 0.034
 	},
 	"mixtral-8x7b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mixtral 8x7B Instruct",
 		"mmluPro": 0.387,
 		"gpqa": 0.292,
-		"hle": 0.045,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mixtral 8x7B Instruct"
+		"hle": 0.045
 	},
 	"mistral-7b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral 7B Instruct",
 		"mmluPro": 0.245,
 		"gpqa": 0.177,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral 7B Instruct"
+		"hle": 0.043
 	},
-	"mistral-medium-3.1": {
-		"codingIndex": 20.5,
-		"mathIndex": 38.3,
-		"mmluPro": 0.683,
-		"gpqa": 0.588,
-		"hle": 0.044,
+	"mistral-medium-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Medium 3.1"
-	},
-	"mistral-saba": {
-		"mmluPro": 0.611,
-		"gpqa": 0.424,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Saba"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Medium 3",
+		"mathIndex": 30.3,
+		"mmluPro": 0.76,
+		"gpqa": 0.578,
+		"hle": 0.043
 	},
 	"devstral-small-jul-25": {
-		"mathIndex": 29.3,
-		"mmluPro": 0.622,
-		"gpqa": 0.414,
-		"hle": 0.037,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Devstral Small (Jul '25)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Devstral Small (Jul '25)",
+		"mathIndex": 29.3,
+		"gpqa": 0.414,
+		"hle": 0.037
 	},
 	"mistral-small-3.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small 3.1",
 		"codingIndex": 26.3,
 		"mathIndex": 3.7,
 		"mmluPro": 0.659,
 		"gpqa": 0.454,
-		"hle": 0.048,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small 3.1"
+		"hle": 0.048
 	},
-	"mistral-medium": {
-		"mmluPro": 0.491,
-		"gpqa": 0.349,
-		"hle": 0.034,
+	"mistral-saba": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Medium"
-	},
-	"magistral-small-1": {
-		"mathIndex": 41.3,
-		"mmluPro": 0.746,
-		"gpqa": 0.641,
-		"hle": 0.072,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Magistral Small 1"
-	},
-	"mistral-small-3.2": {
-		"codingIndex": 12.5,
-		"mathIndex": 27,
-		"mmluPro": 0.681,
-		"gpqa": 0.505,
-		"hle": 0.043,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Small 3.2"
-	},
-	"devstral-small-may-25": {
-		"mmluPro": 0.632,
-		"gpqa": 0.434,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Devstral Small (May '25)"
-	},
-	"devstral-medium": {
-		"mathIndex": 4.7,
-		"mmluPro": 0.708,
-		"gpqa": 0.492,
-		"hle": 0.038,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Devstral Medium"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Saba",
+		"mmluPro": 0.611,
+		"gpqa": 0.424,
+		"hle": 0.041
 	},
 	"magistral-medium-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Magistral Medium 1",
 		"mathIndex": 40.3,
 		"mmluPro": 0.753,
 		"gpqa": 0.679,
-		"hle": 0.095,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Magistral Medium 1"
+		"hle": 0.095
 	},
-	"mistral-medium-3": {
-		"mathIndex": 30.3,
-		"mmluPro": 0.76,
-		"gpqa": 0.578,
-		"hle": 0.043,
+	"mistral-small-3.2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Mistral Medium 3"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Small 3.2",
+		"codingIndex": 12.5,
+		"mathIndex": 27,
+		"gpqa": 0.505,
+		"hle": 0.043
+	},
+	"magistral-small-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Magistral Small 1",
+		"mathIndex": 41.3,
+		"gpqa": 0.641,
+		"hle": 0.072
+	},
+	"devstral-small-may-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Devstral Small (May '25)",
+		"mmluPro": 0.632,
+		"gpqa": 0.434,
+		"hle": 0.04
+	},
+	"devstral-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Devstral Medium",
+		"mathIndex": 4.7,
+		"gpqa": 0.492,
+		"hle": 0.038
+	},
+	"mistral-medium-3.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Medium 3.1",
+		"codingIndex": 20.5,
+		"mathIndex": 38.3,
+		"gpqa": 0.588,
+		"hle": 0.044
+	},
+	"mistral-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Mistral Medium",
+		"mmluPro": 0.491,
+		"gpqa": 0.349,
+		"hle": 0.034
 	},
 	"deepseek-r1-distill-llama-70b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 Distill Llama 70B",
 		"mathIndex": 53.7,
 		"mmluPro": 0.795,
 		"gpqa": 0.402,
-		"hle": 0.061,
+		"hle": 0.061
+	},
+	"deepseek-r1-distill-qwen-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 Distill Llama 70B"
-	},
-	"deepseek-r1-distill-qwen-32b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 Distill Qwen 32B",
 		"mathIndex": 63,
 		"mmluPro": 0.739,
 		"gpqa": 0.615,
-		"hle": 0.055,
+		"hle": 0.055
+	},
+	"deepseek-v3-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 Distill Qwen 32B"
-	},
-	"deepseek-v3-dec-24": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3 (Dec '24)",
 		"codingIndex": 23,
 		"mathIndex": 26,
 		"mmluPro": 0.752,
 		"gpqa": 0.557,
-		"hle": 0.036,
+		"hle": 0.036
+	},
+	"deepseek-r1-distill-qwen-14b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3 (Dec '24)"
-	},
-	"deepseek-r1-distill-qwen-14b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 Distill Qwen 14B",
 		"mathIndex": 55.7,
 		"mmluPro": 0.74,
 		"gpqa": 0.484,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 Distill Qwen 14B"
+		"hle": 0.044
 	},
 	"deepseek-v2.5-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "DeepSeek-V2.5 (Dec '24)"
 	},
 	"deepseek-coder-v2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "DeepSeek-Coder-V2"
 	},
 	"deepseek-r1-distill-llama-8b": {
-		"mathIndex": 41.3,
-		"mmluPro": 0.543,
-		"gpqa": 0.302,
-		"hle": 0.042,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 Distill Llama 8B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 Distill Llama 8B",
+		"mathIndex": 41.3,
+		"mmluPro": 0.543,
+		"gpqa": 0.302,
+		"hle": 0.042
 	},
 	"deepseek-llm-67b-chat-v1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "DeepSeek LLM 67B Chat (V1)"
 	},
 	"deepseek-r1-distill-qwen-1.5b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 Distill Qwen 1.5B",
 		"mathIndex": 22,
 		"mmluPro": 0.269,
 		"gpqa": 0.098,
-		"hle": 0.033,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 Distill Qwen 1.5B"
+		"hle": 0.033
 	},
-	"deepseek-v3.2-speciale": {
-		"mathIndex": 96.7,
-		"mmluPro": 0.863,
-		"gpqa": 0.871,
-		"hle": 0.261,
+	"deepseek-v4-flash-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.2 Speciale"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Flash (Reasoning, High Effort)",
+		"codingIndex": 52,
+		"gpqa": 0.867,
+		"hle": 0.278
+	},
+	"deepseek-v3.1-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.1 (Reasoning)",
+		"mathIndex": 89.7,
+		"gpqa": 0.779,
+		"hle": 0.13
+	},
+	"deepseek-r1-0528-may-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 0528 (May '25)",
+		"mathIndex": 76,
+		"gpqa": 0.813,
+		"hle": 0.149
+	},
+	"deepseek-v3-0324": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3 0324",
+		"codingIndex": 21.2,
+		"mathIndex": 41,
+		"gpqa": 0.655,
+		"hle": 0.052
+	},
+	"deepseek-r1-0528-qwen3-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 0528 Qwen3 8B",
+		"mathIndex": 63.7,
+		"gpqa": 0.612,
+		"hle": 0.056
+	},
+	"deepseek-v4-flash-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V4 Flash (Reasoning, Max Effort)",
+		"codingIndex": 56.2,
+		"gpqa": 0.894,
+		"hle": 0.321
 	},
 	"deepseek-r1-jan-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek R1 (Jan '25)",
 		"codingIndex": 24.6,
 		"mathIndex": 68,
 		"mmluPro": 0.844,
 		"gpqa": 0.708,
-		"hle": 0.093,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 (Jan '25)"
+		"hle": 0.093
 	},
-	"deepseek-v3-0324": {
-		"codingIndex": 21.2,
-		"mathIndex": 41,
-		"mmluPro": 0.819,
-		"gpqa": 0.655,
-		"hle": 0.052,
+	"deepseek-v3.1-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3 0324"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.1 (Non-reasoning)",
+		"mathIndex": 49.7,
+		"gpqa": 0.735,
+		"hle": 0.063
 	},
-	"deepseek-r1-0528-may-25": {
-		"mathIndex": 76,
-		"mmluPro": 0.849,
-		"gpqa": 0.813,
-		"hle": 0.149,
+	"deepseek-coder-v2-lite-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 0528 (May '25)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek Coder V2 Lite Instruct",
+		"mmluPro": 0.429,
+		"gpqa": 0.319,
+		"hle": 0.053
 	},
 	"deepseek-v3.2-exp-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.2 Exp (Non-reasoning)",
 		"mathIndex": 57.7,
 		"mmluPro": 0.836,
 		"gpqa": 0.738,
-		"hle": 0.086,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.2 Exp (Non-reasoning)"
+		"hle": 0.086
 	},
-	"deepseek-v3.1-terminus-reasoning": {
-		"mathIndex": 89.7,
-		"mmluPro": 0.851,
-		"gpqa": 0.792,
-		"hle": 0.152,
+	"deepseek-v3.2-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.1 Terminus (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.2 (Reasoning)",
+		"codingIndex": 44.2,
+		"mathIndex": 92,
+		"mmluPro": 0.862,
+		"gpqa": 0.84,
+		"hle": 0.222
 	},
-	"deepseek-v3.1-reasoning": {
-		"mathIndex": 89.7,
-		"mmluPro": 0.851,
-		"gpqa": 0.779,
-		"hle": 0.13,
+	"deepseek-v3.1-terminus-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.1 (Reasoning)"
-	},
-	"deepseek-v2-chat": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek-V2-Chat"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.1 Terminus (Non-reasoning)",
+		"mathIndex": 53.7,
+		"mmluPro": 0.836,
+		"gpqa": 0.751,
+		"hle": 0.084
 	},
 	"deepseek-v3.2-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.2 (Non-reasoning)",
 		"mathIndex": 59,
 		"mmluPro": 0.837,
 		"gpqa": 0.751,
-		"hle": 0.105,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.2 (Non-reasoning)"
+		"hle": 0.105
 	},
 	"deepseek-v2.5": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "DeepSeek-V2.5"
 	},
+	"deepseek-v2-chat": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek-V2-Chat"
+	},
+	"deepseek-v3.2-speciale": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.2 Speciale",
+		"mathIndex": 96.7,
+		"mmluPro": 0.863,
+		"gpqa": 0.871,
+		"hle": 0.261
+	},
+	"deepseek-v3.1-terminus-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.1 Terminus (Reasoning)",
+		"codingIndex": 43.5,
+		"mathIndex": 89.7,
+		"mmluPro": 0.851,
+		"gpqa": 0.792,
+		"hle": 0.152
+	},
 	"deepseek-v3.2-exp-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DeepSeek V3.2 Exp (Reasoning)",
 		"mathIndex": 87.7,
 		"mmluPro": 0.85,
 		"gpqa": 0.797,
-		"hle": 0.138,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.2 Exp (Reasoning)"
-	},
-	"deepseek-v3.2-reasoning": {
-		"mathIndex": 92,
-		"mmluPro": 0.862,
-		"gpqa": 0.84,
-		"hle": 0.222,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.2 (Reasoning)"
-	},
-	"deepseek-v3.1-terminus-non-reasoning": {
-		"mathIndex": 53.7,
-		"mmluPro": 0.836,
-		"gpqa": 0.751,
-		"hle": 0.084,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.1 Terminus (Non-reasoning)"
-	},
-	"deepseek-v3.1-non-reasoning": {
-		"mathIndex": 49.7,
-		"mmluPro": 0.833,
-		"gpqa": 0.735,
-		"hle": 0.063,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek V3.1 (Non-reasoning)"
-	},
-	"deepseek-r1-0528-qwen3-8b": {
-		"mathIndex": 63.7,
-		"mmluPro": 0.739,
-		"gpqa": 0.612,
-		"hle": 0.056,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek R1 0528 Qwen3 8B"
-	},
-	"deepseek-coder-v2-lite-instruct": {
-		"mmluPro": 0.429,
-		"gpqa": 0.319,
-		"hle": 0.053,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DeepSeek Coder V2 Lite Instruct"
-	},
-	"sonar-pro": {
-		"mmluPro": 0.755,
-		"gpqa": 0.578,
-		"hle": 0.079,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Sonar Pro"
-	},
-	"sonar-reasoning": {
-		"gpqa": 0.623,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Sonar Reasoning"
-	},
-	"sonar": {
-		"mmluPro": 0.689,
-		"gpqa": 0.471,
-		"hle": 0.073,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Sonar"
+		"hle": 0.138
 	},
 	"sonar-reasoning-pro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Sonar Reasoning Pro"
 	},
+	"sonar": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Sonar",
+		"mmluPro": 0.689,
+		"gpqa": 0.471,
+		"hle": 0.073
+	},
+	"sonar-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Sonar Reasoning",
+		"gpqa": 0.623
+	},
+	"sonar-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Sonar Pro",
+		"mmluPro": 0.755,
+		"gpqa": 0.578,
+		"hle": 0.079
+	},
 	"grok-beta": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok Beta",
 		"mmluPro": 0.703,
 		"gpqa": 0.471,
-		"hle": 0.047,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok Beta"
+		"hle": 0.047
 	},
-	"grok-3": {
-		"mathIndex": 58,
-		"mmluPro": 0.799,
-		"gpqa": 0.693,
-		"hle": 0.051,
+	"grok-build-0.1-0616": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 3"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok Build 0.1 0616",
+		"codingIndex": 51.5,
+		"gpqa": 0.895,
+		"hle": 0.36
 	},
-	"grok-3-mini-reasoning-high": {
-		"mathIndex": 84.7,
-		"mmluPro": 0.828,
-		"gpqa": 0.791,
-		"hle": 0.111,
+	"grok-2-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 3 mini Reasoning (high)"
-	},
-	"grok-4.1-fast-reasoning": {
-		"mathIndex": 89.3,
-		"mmluPro": 0.854,
-		"gpqa": 0.853,
-		"hle": 0.176,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.1 Fast (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 2 (Dec '24)",
+		"mmluPro": 0.709,
+		"gpqa": 0.51,
+		"hle": 0.038
 	},
 	"grok-4.20-0309-v2-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.20 0309 v2 (Reasoning)",
 		"gpqa": 0.911,
-		"hle": 0.322,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.20 0309 v2 (Reasoning)"
-	},
-	"grok-code-fast-1": {
-		"mathIndex": 43.3,
-		"mmluPro": 0.793,
-		"gpqa": 0.727,
-		"hle": 0.075,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok Code Fast 1"
-	},
-	"grok-4.1-fast-non-reasoning": {
-		"mathIndex": 34.3,
-		"mmluPro": 0.743,
-		"gpqa": 0.637,
-		"hle": 0.05,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.1 Fast (Non-reasoning)"
-	},
-	"grok-4": {
-		"mathIndex": 92.7,
-		"mmluPro": 0.866,
-		"gpqa": 0.877,
-		"hle": 0.239,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4"
-	},
-	"grok-4-fast-reasoning": {
-		"mathIndex": 89.7,
-		"mmluPro": 0.85,
-		"gpqa": 0.847,
-		"hle": 0.17,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4 Fast (Reasoning)"
+		"hle": 0.322
 	},
 	"grok-4-fast-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4 Fast (Non-reasoning)",
 		"mathIndex": 41.3,
 		"mmluPro": 0.73,
 		"gpqa": 0.606,
-		"hle": 0.05,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4 Fast (Non-reasoning)"
+		"hle": 0.05
 	},
-	"grok-4.20-0309-reasoning": {
-		"gpqa": 0.885,
-		"hle": 0.3,
+	"grok-3-mini-reasoning-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.20 0309 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 3 mini Reasoning (high)",
+		"mathIndex": 84.7,
+		"mmluPro": 0.828,
+		"gpqa": 0.791,
+		"hle": 0.111
 	},
 	"grok-4.20-0309-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.20 0309 (Non-reasoning)",
 		"gpqa": 0.785,
-		"hle": 0.225,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.20 0309 (Non-reasoning)"
+		"hle": 0.225
 	},
-	"grok-2-dec-24": {
-		"mmluPro": 0.709,
-		"gpqa": 0.51,
-		"hle": 0.038,
+	"grok-4.20-0309-v2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 2 (Dec '24)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.20 0309 v2 (Non-reasoning)",
+		"gpqa": 0.776,
+		"hle": 0.242
+	},
+	"grok-4.1-fast-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.1 Fast (Reasoning)",
+		"mathIndex": 89.3,
+		"mmluPro": 0.854,
+		"gpqa": 0.853,
+		"hle": 0.176
+	},
+	"grok-4-fast-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4 Fast (Reasoning)",
+		"mathIndex": 89.7,
+		"mmluPro": 0.85,
+		"gpqa": 0.847,
+		"hle": 0.17
+	},
+	"grok-code-fast-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok Code Fast 1",
+		"mathIndex": 43.3,
+		"mmluPro": 0.793,
+		"gpqa": 0.727,
+		"hle": 0.075
+	},
+	"grok-4.20-0309-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.20 0309 (Reasoning)",
+		"gpqa": 0.885,
+		"hle": 0.3
+	},
+	"grok-4": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4",
+		"mathIndex": 92.7,
+		"mmluPro": 0.866,
+		"gpqa": 0.877,
+		"hle": 0.239
+	},
+	"grok-4.3-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.3 (high)",
+		"codingIndex": 42.2,
+		"gpqa": 0.901,
+		"hle": 0.35
+	},
+	"grok-4.1-fast-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 4.1 Fast (Non-reasoning)",
+		"mathIndex": 34.3,
+		"mmluPro": 0.743,
+		"gpqa": 0.637,
+		"hle": 0.05
+	},
+	"grok-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Grok 3",
+		"mathIndex": 58,
+		"mmluPro": 0.799,
+		"gpqa": 0.693,
+		"hle": 0.051
 	},
 	"grok-3-reasoning-beta": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Grok 3 Reasoning Beta"
 	},
-	"grok-4.20-0309-v2-non-reasoning": {
-		"gpqa": 0.776,
-		"hle": 0.242,
+	"openchat-3.5-1210": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Grok 4.20 0309 v2 (Non-reasoning)"
-	},
-	"openchat-3.5-1210": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "OpenChat 3.5 (1210)",
 		"mmluPro": 0.31,
 		"gpqa": 0.23,
-		"hle": 0.048,
+		"hle": 0.048
+	},
+	"nova-pro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "OpenChat 3.5 (1210)"
-	},
-	"nova-pro": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova Pro",
 		"mathIndex": 7,
 		"mmluPro": 0.691,
 		"gpqa": 0.499,
-		"hle": 0.034,
+		"hle": 0.034
+	},
+	"nova-lite": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova Pro"
-	},
-	"nova-lite": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Nova Lite",
 		"mathIndex": 7,
 		"mmluPro": 0.59,
 		"gpqa": 0.433,
-		"hle": 0.046,
+		"hle": 0.046
+	},
+	"phi-3-mini-instruct-3.8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Nova Lite"
-	},
-	"phi-3-mini-instruct-3.8b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Phi-3 Mini Instruct 3.8B",
 		"mathIndex": 0.3,
 		"mmluPro": 0.435,
 		"gpqa": 0.319,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Phi-3 Mini Instruct 3.8B"
+		"hle": 0.044
 	},
 	"lfm-40b": {
-		"mmluPro": 0.425,
-		"gpqa": 0.327,
-		"hle": 0.049,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM 40B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM 40B",
+		"mmluPro": 0.425,
+		"gpqa": 0.327,
+		"hle": 0.049
 	},
 	"lfm2-1.2b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "LFM2 1.2B",
 		"mathIndex": 3.3,
 		"mmluPro": 0.257,
 		"gpqa": 0.228,
-		"hle": 0.057,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "LFM2 1.2B"
+		"hle": 0.057
 	},
 	"solar-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Solar Mini"
 	},
-	"solar-pro-2-preview-non-reasoning": {
-		"mmluPro": 0.725,
-		"gpqa": 0.544,
-		"hle": 0.038,
+	"solar-pro-2-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Solar Pro 2 (Preview) (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Solar Pro 2 (Reasoning)",
+		"mathIndex": 61.3,
+		"gpqa": 0.687,
+		"hle": 0.07
 	},
 	"solar-pro-2-preview-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Solar Pro 2 (Preview) (Reasoning)",
 		"mmluPro": 0.768,
 		"gpqa": 0.578,
-		"hle": 0.057,
+		"hle": 0.057
+	},
+	"solar-pro-2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Solar Pro 2 (Preview) (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Solar Pro 2 (Non-reasoning)",
+		"mathIndex": 30,
+		"gpqa": 0.561,
+		"hle": 0.038
+	},
+	"solar-pro-2-preview-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Solar Pro 2 (Preview) (Non-reasoning)",
+		"gpqa": 0.544,
+		"hle": 0.038
 	},
 	"dbrx-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "DBRX Instruct",
 		"mmluPro": 0.397,
 		"gpqa": 0.331,
-		"hle": 0.066,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "DBRX Instruct"
+		"hle": 0.066
 	},
 	"minimax-m2.5": {
-		"gpqa": 0.848,
-		"hle": 0.191,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax-M2.5"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax-M2.5",
+		"gpqa": 0.848,
+		"hle": 0.191
+	},
+	"minimax-m2.7": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax-M2.7",
+		"codingIndex": 52.6,
+		"gpqa": 0.874,
+		"hle": 0.281
 	},
 	"minimax-m2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax-M2",
 		"mathIndex": 78.3,
 		"mmluPro": 0.82,
 		"gpqa": 0.777,
-		"hle": 0.125,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax-M2"
-	},
-	"minimax-m1-80k": {
-		"mathIndex": 61,
-		"mmluPro": 0.816,
-		"gpqa": 0.697,
-		"hle": 0.082,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax M1 80k"
+		"hle": 0.125
 	},
 	"minimax-m2.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax-M2.1",
 		"mathIndex": 82.7,
 		"mmluPro": 0.875,
 		"gpqa": 0.83,
-		"hle": 0.222,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax-M2.1"
+		"hle": 0.222
 	},
 	"minimax-m1-40k": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax M1 40k",
 		"mathIndex": 13.7,
-		"mmluPro": 0.808,
 		"gpqa": 0.682,
-		"hle": 0.075,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiniMax M1 40k"
+		"hle": 0.075
 	},
-	"llama-3.3-nemotron-super-49b-v1-reasoning": {
-		"mathIndex": 54.7,
-		"mmluPro": 0.785,
-		"gpqa": 0.643,
-		"hle": 0.065,
+	"minimax-m1-80k": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Reasoning)"
-	},
-	"llama-3.1-nemotron-nano-4b-v1.1-reasoning": {
-		"mathIndex": 50,
-		"mmluPro": 0.556,
-		"gpqa": 0.408,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Nemotron Nano 4B v1.1 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiniMax M1 80k",
+		"mathIndex": 61,
+		"mmluPro": 0.816,
+		"gpqa": 0.697,
+		"hle": 0.082
 	},
 	"llama-3.3-nemotron-super-49b-v1-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Non-reasoning)",
 		"mathIndex": 7.7,
 		"mmluPro": 0.698,
 		"gpqa": 0.517,
-		"hle": 0.035,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Non-reasoning)"
+		"hle": 0.035
 	},
-	"kimi-k2-thinking": {
-		"mathIndex": 94.7,
-		"mmluPro": 0.848,
-		"gpqa": 0.838,
-		"hle": 0.223,
+	"llama-3.3-nemotron-super-49b-v1-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2 Thinking"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Reasoning)",
+		"mathIndex": 54.7,
+		"mmluPro": 0.785,
+		"gpqa": 0.643,
+		"hle": 0.065
 	},
-	"kimi-k2.5-non-reasoning": {
-		"gpqa": 0.789,
-		"hle": 0.123,
+	"llama-3.1-nemotron-nano-4b-v1.1-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2.5 (Non-reasoning)"
-	},
-	"kimi-k2.5-reasoning": {
-		"gpqa": 0.879,
-		"hle": 0.294,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2.5 (Reasoning)"
-	},
-	"kimi-k2": {
-		"mathIndex": 57,
-		"mmluPro": 0.824,
-		"gpqa": 0.766,
-		"hle": 0.07,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Nemotron Nano 4B v1.1 (Reasoning)",
+		"mathIndex": 50,
+		"gpqa": 0.408,
+		"hle": 0.051
 	},
 	"kimi-k2-0905": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2 0905",
 		"mathIndex": 57.3,
 		"mmluPro": 0.819,
 		"gpqa": 0.767,
-		"hle": 0.063,
+		"hle": 0.063
+	},
+	"kimi-k2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Kimi K2 0905"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2",
+		"mathIndex": 57,
+		"gpqa": 0.766,
+		"hle": 0.07
+	},
+	"kimi-k2.6": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2.6",
+		"codingIndex": 61.8,
+		"gpqa": 0.911,
+		"hle": 0.359
+	},
+	"kimi-k2-thinking": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2 Thinking",
+		"mathIndex": 94.7,
+		"mmluPro": 0.848,
+		"gpqa": 0.838,
+		"hle": 0.223
+	},
+	"kimi-k2.5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2.5 (Non-reasoning)",
+		"gpqa": 0.789,
+		"hle": 0.123
+	},
+	"kimi-k2.5-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Kimi K2.5 (Reasoning)",
+		"codingIndex": 46.8,
+		"gpqa": 0.879,
+		"hle": 0.294
 	},
 	"step-3.5-flash": {
-		"gpqa": 0.831,
-		"hle": 0.191,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Step 3.5 Flash"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Step 3.5 Flash",
+		"gpqa": 0.831,
+		"hle": 0.191
+	},
+	"step-3.5-flash-2603": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Step 3.5 Flash 2603",
+		"gpqa": 0.826,
+		"hle": 0.226
 	},
 	"llama-3.1-tulu3-405b": {
-		"mmluPro": 0.716,
-		"gpqa": 0.516,
-		"hle": 0.035,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Llama 3.1 Tulu3 405B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Llama 3.1 Tulu3 405B",
+		"mmluPro": 0.716,
+		"gpqa": 0.516,
+		"hle": 0.035
 	},
 	"olmo-2-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "OLMo 2 7B",
 		"mathIndex": 0.7,
 		"mmluPro": 0.282,
 		"gpqa": 0.288,
-		"hle": 0.055,
+		"hle": 0.055
+	},
+	"olmo-3-32b-think": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "OLMo 2 7B"
-	},
-	"olmo-3-32b-think": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Olmo 3 32B Think",
 		"mathIndex": 73.7,
 		"mmluPro": 0.759,
 		"gpqa": 0.61,
-		"hle": 0.059,
+		"hle": 0.059
+	},
+	"olmo-2-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Olmo 3 32B Think"
-	},
-	"olmo-2-32b": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "OLMo 2 32B",
 		"mathIndex": 3.3,
 		"mmluPro": 0.511,
 		"gpqa": 0.328,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "OLMo 2 32B"
+		"hle": 0.037
 	},
 	"granite-3.3-8b-non-reasoning": {
-		"mathIndex": 6.7,
-		"mmluPro": 0.468,
-		"gpqa": 0.338,
-		"hle": 0.042,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Granite 3.3 8B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Granite 3.3 8B (Non-reasoning)",
+		"mathIndex": 6.7,
+		"gpqa": 0.338,
+		"hle": 0.042
 	},
 	"reka-flash-sep-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Reka Flash (Sep '24)"
 	},
 	"hermes-3---llama-3.1-70b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Hermes 3 - Llama-3.1 70B",
 		"mmluPro": 0.571,
 		"gpqa": 0.401,
-		"hle": 0.041,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Hermes 3 - Llama-3.1 70B"
+		"hle": 0.041
 	},
 	"mimo-v2-pro": {
-		"gpqa": 0.87,
-		"hle": 0.283,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2-Pro"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2-Pro",
+		"gpqa": 0.87,
+		"hle": 0.283
 	},
 	"mimo-v2-flash-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "MiMo-V2-Flash (Reasoning)",
 		"mathIndex": 96.3,
 		"mmluPro": 0.843,
 		"gpqa": 0.846,
-		"hle": 0.211,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "MiMo-V2-Flash (Reasoning)"
+		"hle": 0.211
 	},
 	"sarvam-m-reasoning": {
-		"mmluPro": 0.696,
-		"gpqa": 0.416,
-		"hle": 0.033,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Sarvam M (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Sarvam M (Reasoning)",
+		"mmluPro": 0.696,
+		"gpqa": 0.416,
+		"hle": 0.033
+	},
+	"tri-21b-think-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Tri-21B-think Preview",
+		"gpqa": 0.538,
+		"hle": 0.057
+	},
+	"glm-5.1-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5.1 (Non-reasoning)",
+		"gpqa": 0.839,
+		"hle": 0.256
 	},
 	"glm-4.7-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.7 (Non-reasoning)",
 		"mathIndex": 48,
 		"mmluPro": 0.794,
 		"gpqa": 0.664,
-		"hle": 0.061,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.7 (Non-reasoning)"
+		"hle": 0.061
 	},
 	"glm-4.7-reasoning": {
-		"mathIndex": 95,
-		"mmluPro": 0.856,
-		"gpqa": 0.859,
-		"hle": 0.251,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.7 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.7 (Reasoning)",
+		"codingIndex": 45.3,
+		"mathIndex": 95,
+		"gpqa": 0.859,
+		"hle": 0.251
+	},
+	"glm-5.1-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5.1 (Reasoning)",
+		"codingIndex": 55.8,
+		"gpqa": 0.868,
+		"hle": 0.28
+	},
+	"glm-5-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5 (Reasoning)",
+		"gpqa": 0.82,
+		"hle": 0.272
+	},
+	"glm-5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5 (Non-reasoning)",
+		"gpqa": 0.666,
+		"hle": 0.072
+	},
+	"glm-4.5-air": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.5-Air",
+		"mathIndex": 80.7,
+		"gpqa": 0.733,
+		"hle": 0.068
 	},
 	"glm-4.6-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.6 (Reasoning)",
+		"codingIndex": 45.8,
 		"mathIndex": 86,
 		"mmluPro": 0.829,
 		"gpqa": 0.78,
-		"hle": 0.133,
+		"hle": 0.133
+	},
+	"glm-4.6-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.6 (Reasoning)"
-	},
-	"glm-4.6-non-reasoning": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.6 (Non-reasoning)",
 		"mathIndex": 44.3,
 		"mmluPro": 0.784,
 		"gpqa": 0.632,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.6 (Non-reasoning)"
-	},
-	"glm-4.6v-non-reasoning": {
-		"mathIndex": 26.3,
-		"mmluPro": 0.752,
-		"gpqa": 0.566,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.6V (Non-reasoning)"
-	},
-	"glm-5-reasoning": {
-		"gpqa": 0.82,
-		"hle": 0.272,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-5 (Reasoning)"
-	},
-	"glm-4.5v-reasoning": {
-		"mathIndex": 73,
-		"mmluPro": 0.788,
-		"gpqa": 0.684,
-		"hle": 0.059,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.5V (Reasoning)"
+		"hle": 0.052
 	},
 	"glm-4.7-flash-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.7-Flash (Reasoning)",
 		"gpqa": 0.581,
-		"hle": 0.071,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.7-Flash (Reasoning)"
-	},
-	"glm-4.5-reasoning": {
-		"mathIndex": 73.7,
-		"mmluPro": 0.835,
-		"gpqa": 0.782,
-		"hle": 0.122,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.5 (Reasoning)"
-	},
-	"glm-4.5v-non-reasoning": {
-		"mathIndex": 15.3,
-		"mmluPro": 0.751,
-		"gpqa": 0.573,
-		"hle": 0.036,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.5V (Non-reasoning)"
-	},
-	"glm-5-non-reasoning": {
-		"gpqa": 0.666,
-		"hle": 0.072,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-5 (Non-reasoning)"
+		"hle": 0.071
 	},
 	"glm-4.6v-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.6V (Reasoning)",
 		"mathIndex": 85.3,
 		"mmluPro": 0.799,
 		"gpqa": 0.719,
-		"hle": 0.089,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.6V (Reasoning)"
+		"hle": 0.089
 	},
-	"glm-4.5-air": {
-		"mathIndex": 80.7,
-		"mmluPro": 0.815,
-		"gpqa": 0.733,
-		"hle": 0.068,
+	"glm-5v-turbo-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.5-Air"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM 5V Turbo (Reasoning)",
+		"gpqa": 0.809,
+		"hle": 0.158
+	},
+	"glm-4.6v-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.6V (Non-reasoning)",
+		"mathIndex": 26.3,
+		"mmluPro": 0.752,
+		"gpqa": 0.566,
+		"hle": 0.037
 	},
 	"glm-4.7-flash-non-reasoning": {
-		"gpqa": 0.452,
-		"hle": 0.049,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "GLM-4.7-Flash (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.7-Flash (Non-reasoning)",
+		"gpqa": 0.452,
+		"hle": 0.049
+	},
+	"glm-4.5-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.5 (Reasoning)",
+		"mathIndex": 73.7,
+		"mmluPro": 0.835,
+		"gpqa": 0.782,
+		"hle": 0.122
+	},
+	"glm-4.5v-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.5V (Reasoning)",
+		"mathIndex": 73,
+		"mmluPro": 0.788,
+		"gpqa": 0.684,
+		"hle": 0.059
+	},
+	"glm-4.5v-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-4.5V (Non-reasoning)",
+		"mathIndex": 15.3,
+		"mmluPro": 0.751,
+		"gpqa": 0.573,
+		"hle": 0.036
+	},
+	"glm-5-turbo": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "GLM-5-Turbo",
+		"gpqa": 0.847,
+		"hle": 0.254
 	},
 	"command-r+-apr-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Command-R+ (Apr '24)",
 		"mmluPro": 0.432,
 		"gpqa": 0.323,
-		"hle": 0.045,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Command-R+ (Apr '24)"
+		"hle": 0.045
 	},
 	"command-r-mar-24": {
-		"mmluPro": 0.338,
-		"gpqa": 0.284,
-		"hle": 0.048,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Command-R (Mar '24)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Command-R (Mar '24)",
+		"mmluPro": 0.338,
+		"gpqa": 0.284,
+		"hle": 0.048
 	},
 	"apriel-v1.5-15b-thinker": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Apriel-v1.5-15B-Thinker",
 		"mathIndex": 87.5,
 		"mmluPro": 0.773,
 		"gpqa": 0.713,
-		"hle": 0.12,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Apriel-v1.5-15B-Thinker"
-	},
-	"jamba-1.5-mini": {
-		"mmluPro": 0.371,
-		"gpqa": 0.302,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba 1.5 Mini"
-	},
-	"jamba-1.5-large": {
-		"mmluPro": 0.572,
-		"gpqa": 0.427,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba 1.5 Large"
+		"hle": 0.12
 	},
 	"jamba-1.6-large": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba 1.6 Large",
 		"mmluPro": 0.565,
 		"gpqa": 0.387,
-		"hle": 0.04,
+		"hle": 0.04
+	},
+	"jamba-1.5-large": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba 1.6 Large"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba 1.5 Large",
+		"mmluPro": 0.572,
+		"gpqa": 0.427,
+		"hle": 0.04
+	},
+	"jamba-1.5-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba 1.5 Mini",
+		"mmluPro": 0.371,
+		"gpqa": 0.302,
+		"hle": 0.051
 	},
 	"jamba-1.6-mini": {
-		"mmluPro": 0.367,
-		"gpqa": 0.3,
-		"hle": 0.046,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Jamba 1.6 Mini"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Jamba 1.6 Mini",
+		"mmluPro": 0.367,
+		"gpqa": 0.3,
+		"hle": 0.046
 	},
 	"arctic-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Arctic Instruct"
 	},
 	"qwen2.5-max": {
-		"mmluPro": 0.762,
-		"gpqa": 0.587,
-		"hle": 0.045,
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2.5 Max"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2.5 Max",
+		"mmluPro": 0.762,
+		"gpqa": 0.587,
+		"hle": 0.045
 	},
 	"qwen2.5-instruct-72b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2.5 Instruct 72B",
 		"mathIndex": 14,
 		"mmluPro": 0.72,
 		"gpqa": 0.491,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2.5 Instruct 72B"
+		"hle": 0.042
 	},
 	"qwen2.5-coder-instruct-32b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2.5 Coder Instruct 32B",
 		"mmluPro": 0.635,
 		"gpqa": 0.417,
-		"hle": 0.038,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2.5 Coder Instruct 32B"
+		"hle": 0.038
 	},
 	"qwen2.5-turbo": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2.5 Turbo",
 		"mmluPro": 0.633,
 		"gpqa": 0.41,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2.5 Turbo"
+		"hle": 0.042
 	},
 	"qwen2-instruct-72b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2 Instruct 72B",
 		"mmluPro": 0.622,
 		"gpqa": 0.371,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2 Instruct 72B"
-	},
-	"qwen3-235b-a22b-2507-instruct": {
-		"mathIndex": 71.7,
-		"mmluPro": 0.828,
-		"gpqa": 0.753,
-		"hle": 0.106,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 235B A22B 2507 Instruct"
-	},
-	"qwen3-8b-non-reasoning": {
-		"mathIndex": 24.3,
-		"mmluPro": 0.643,
-		"gpqa": 0.452,
-		"hle": 0.028,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 8B (Non-reasoning)"
-	},
-	"qwen3-coder-30b-a3b-instruct": {
-		"mathIndex": 29,
-		"mmluPro": 0.706,
-		"gpqa": 0.516,
-		"hle": 0.04,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Coder 30B A3B Instruct"
-	},
-	"qwen2.5-instruct-32b": {
-		"mmluPro": 0.697,
-		"gpqa": 0.466,
-		"hle": 0.038,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2.5 Instruct 32B"
-	},
-	"qwen3-1.7b-reasoning": {
-		"mathIndex": 38.7,
-		"mmluPro": 0.57,
-		"gpqa": 0.356,
-		"hle": 0.048,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 1.7B (Reasoning)"
-	},
-	"qwen3-vl-8b-reasoning": {
-		"mathIndex": 30.7,
-		"mmluPro": 0.749,
-		"gpqa": 0.579,
-		"hle": 0.033,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 8B (Reasoning)"
-	},
-	"qwen3-4b-non-reasoning": {
-		"mmluPro": 0.586,
-		"gpqa": 0.398,
-		"hle": 0.037,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 4B (Non-reasoning)"
-	},
-	"qwen3-4b-reasoning": {
-		"mathIndex": 22.3,
-		"mmluPro": 0.696,
-		"gpqa": 0.522,
-		"hle": 0.051,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 4B (Reasoning)"
-	},
-	"qwq-32b": {
-		"mathIndex": 29,
-		"mmluPro": 0.764,
-		"gpqa": 0.593,
-		"hle": 0.082,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "QwQ 32B"
-	},
-	"qwen3-coder-480b-a35b-instruct": {
-		"mathIndex": 39.3,
-		"mmluPro": 0.788,
-		"gpqa": 0.618,
-		"hle": 0.044,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Coder 480B A35B Instruct"
+		"hle": 0.037
 	},
 	"qwen3-235b-a22b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 235B A22B (Reasoning)",
 		"mathIndex": 82,
 		"mmluPro": 0.828,
 		"gpqa": 0.7,
-		"hle": 0.117,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 235B A22B (Reasoning)"
+		"hle": 0.117
 	},
-	"qwen3-14b-non-reasoning": {
-		"mathIndex": 58,
-		"mmluPro": 0.675,
-		"gpqa": 0.47,
-		"hle": 0.042,
+	"qwen3-vl-30b-a3b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 14B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 30B A3B (Reasoning)",
+		"mathIndex": 82.3,
+		"mmluPro": 0.807,
+		"gpqa": 0.72,
+		"hle": 0.087
 	},
-	"qwen3-14b-reasoning": {
-		"codingIndex": 13.8,
-		"mathIndex": 55.7,
-		"mmluPro": 0.774,
-		"gpqa": 0.604,
-		"hle": 0.043,
+	"qwen3-30b-a3b-2507-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 14B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 30B A3B 2507 (Reasoning)",
+		"codingIndex": 12.1,
+		"mathIndex": 56.3,
+		"mmluPro": 0.805,
+		"gpqa": 0.707,
+		"hle": 0.098
 	},
-	"qwen3-235b-a22b-non-reasoning": {
-		"mathIndex": 23.7,
-		"mmluPro": 0.762,
-		"gpqa": 0.613,
-		"hle": 0.047,
+	"qwen3-235b-a22b-2507-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 235B A22B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 235B A22B 2507 Instruct",
+		"mathIndex": 71.7,
+		"gpqa": 0.753,
+		"hle": 0.106
+	},
+	"qwen3-1.7b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 1.7B (Non-reasoning)",
+		"mathIndex": 7.3,
+		"mmluPro": 0.411,
+		"gpqa": 0.283,
+		"hle": 0.052
+	},
+	"qwen3-coder-480b-a35b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Coder 480B A35B Instruct",
+		"mathIndex": 39.3,
+		"mmluPro": 0.788,
+		"gpqa": 0.618,
+		"hle": 0.044
 	},
 	"qwen3-32b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 32B (Non-reasoning)",
 		"mathIndex": 19.7,
 		"mmluPro": 0.727,
 		"gpqa": 0.535,
-		"hle": 0.043,
+		"hle": 0.043
+	},
+	"qwq-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 32B (Non-reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "QwQ 32B",
+		"mathIndex": 29,
+		"mmluPro": 0.764,
+		"gpqa": 0.593,
+		"hle": 0.082
+	},
+	"qwen1.5-chat-110b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen1.5 Chat 110B",
+		"gpqa": 0.289
+	},
+	"qwen3-30b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 30B A3B (Reasoning)",
+		"mathIndex": 72.3,
+		"mmluPro": 0.777,
+		"gpqa": 0.616,
+		"hle": 0.066
+	},
+	"qwen3-vl-30b-a3b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 30B A3B Instruct",
+		"mathIndex": 72.3,
+		"mmluPro": 0.764,
+		"gpqa": 0.695,
+		"hle": 0.064
+	},
+	"qwen3.5-27b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 27B (Non-reasoning)",
+		"gpqa": 0.842,
+		"hle": 0.132
+	},
+	"qwen3-max-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Max (Preview)",
+		"mathIndex": 75,
+		"mmluPro": 0.838,
+		"gpqa": 0.764,
+		"hle": 0.093
+	},
+	"qwen3-vl-32b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 32B Instruct",
+		"mathIndex": 68.3,
+		"mmluPro": 0.791,
+		"gpqa": 0.671,
+		"hle": 0.063
+	},
+	"qwen3-coder-30b-a3b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Coder 30B A3B Instruct",
+		"mathIndex": 29,
+		"mmluPro": 0.706,
+		"gpqa": 0.516,
+		"hle": 0.04
+	},
+	"qwen3-8b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 8B (Non-reasoning)",
+		"mathIndex": 24.3,
+		"mmluPro": 0.643,
+		"gpqa": 0.452,
+		"hle": 0.028
+	},
+	"qwen3-235b-a22b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 235B A22B (Non-reasoning)",
+		"mathIndex": 23.7,
+		"mmluPro": 0.762,
+		"gpqa": 0.613,
+		"hle": 0.047
+	},
+	"qwen3.6-max-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.6 Max Preview",
+		"gpqa": 0.888,
+		"hle": 0.289
+	},
+	"qwen2.5-coder-instruct-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2.5 Coder Instruct 7B ",
+		"mmluPro": 0.473,
+		"gpqa": 0.339,
+		"hle": 0.048
+	},
+	"qwen3-vl-4b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 4B (Reasoning)",
+		"mathIndex": 25.7,
+		"mmluPro": 0.7,
+		"gpqa": 0.494,
+		"hle": 0.044
+	},
+	"qwen2.5-instruct-32b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen2.5 Instruct 32B",
+		"mmluPro": 0.697,
+		"gpqa": 0.466,
+		"hle": 0.038
+	},
+	"qwen3-235b-a22b-2507-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 235B A22B 2507 (Reasoning)",
+		"codingIndex": 22.1,
+		"mathIndex": 91,
+		"mmluPro": 0.843,
+		"gpqa": 0.79,
+		"hle": 0.15
+	},
+	"qwen3-30b-a3b-2507-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 30B A3B 2507 Instruct",
+		"mathIndex": 66.3,
+		"mmluPro": 0.777,
+		"gpqa": 0.659,
+		"hle": 0.068
 	},
 	"qwen3-32b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 32B (Reasoning)",
 		"codingIndex": 15.3,
 		"mathIndex": 73,
 		"mmluPro": 0.798,
 		"gpqa": 0.668,
-		"hle": 0.083,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 32B (Reasoning)"
+		"hle": 0.083
 	},
-	"qwen3-vl-30b-a3b-reasoning": {
-		"mathIndex": 82.3,
-		"mmluPro": 0.807,
-		"gpqa": 0.72,
-		"hle": 0.087,
+	"qwen3.5-27b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 30B A3B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 27B (Reasoning)",
+		"gpqa": 0.858,
+		"hle": 0.222
 	},
-	"qwen3-vl-235b-a22b-instruct": {
-		"mathIndex": 70.7,
-		"mmluPro": 0.823,
-		"gpqa": 0.712,
-		"hle": 0.063,
+	"qwq-32b-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 235B A22B Instruct"
-	},
-	"qwen3-vl-235b-a22b-reasoning": {
-		"mathIndex": 88.3,
-		"mmluPro": 0.836,
-		"gpqa": 0.772,
-		"hle": 0.101,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 235B A22B (Reasoning)"
-	},
-	"qwen3-30b-a3b-non-reasoning": {
-		"mathIndex": 21.7,
-		"mmluPro": 0.71,
-		"gpqa": 0.515,
-		"hle": 0.046,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 30B A3B (Non-reasoning)"
-	},
-	"qwen3-235b-a22b-2507-reasoning": {
-		"mathIndex": 91,
-		"mmluPro": 0.843,
-		"gpqa": 0.79,
-		"hle": 0.15,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 235B A22B 2507 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "QwQ 32B-Preview",
+		"mmluPro": 0.648,
+		"gpqa": 0.557,
+		"hle": 0.048
 	},
 	"qwen3-0.6b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 0.6B (Non-reasoning)",
 		"mathIndex": 10.3,
 		"mmluPro": 0.231,
 		"gpqa": 0.231,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 0.6B (Non-reasoning)"
+		"hle": 0.052
 	},
-	"qwen3-4b-2507-reasoning": {
-		"mathIndex": 82.7,
-		"mmluPro": 0.743,
-		"gpqa": 0.667,
-		"hle": 0.059,
+	"qwen3-vl-8b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 4B 2507 (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 8B (Reasoning)",
+		"mathIndex": 30.7,
+		"mmluPro": 0.749,
+		"gpqa": 0.579,
+		"hle": 0.033
+	},
+	"qwen3-vl-235b-a22b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 235B A22B Instruct",
+		"mathIndex": 70.7,
+		"mmluPro": 0.823,
+		"gpqa": 0.712,
+		"hle": 0.063
+	},
+	"qwen3.5-35b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3.5 35B A3B (Reasoning)",
+		"gpqa": 0.845,
+		"hle": 0.197
+	},
+	"qwen3-vl-4b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 4B Instruct",
+		"mathIndex": 37,
+		"mmluPro": 0.634,
+		"gpqa": 0.371,
+		"hle": 0.037
+	},
+	"qwen3-vl-235b-a22b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 235B A22B (Reasoning)",
+		"mathIndex": 88.3,
+		"mmluPro": 0.836,
+		"gpqa": 0.772,
+		"hle": 0.101
+	},
+	"qwen3-14b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 14B (Reasoning)",
+		"codingIndex": 13.8,
+		"mathIndex": 55.7,
+		"mmluPro": 0.774,
+		"gpqa": 0.604,
+		"hle": 0.043
 	},
 	"qwen3-8b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 8B (Reasoning)",
 		"codingIndex": 9,
 		"mathIndex": 19,
 		"mmluPro": 0.743,
 		"gpqa": 0.589,
-		"hle": 0.042,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 8B (Reasoning)"
-	},
-	"qwen3-1.7b-non-reasoning": {
-		"mathIndex": 7.3,
-		"mmluPro": 0.411,
-		"gpqa": 0.283,
-		"hle": 0.052,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 1.7B (Non-reasoning)"
-	},
-	"qwen3.5-35b-a3b-reasoning": {
-		"gpqa": 0.845,
-		"hle": 0.197,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 35B A3B (Reasoning)"
-	},
-	"qwen3.5-27b-reasoning": {
-		"gpqa": 0.858,
-		"hle": 0.222,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 27B (Reasoning)"
+		"hle": 0.042
 	},
 	"qwen3-vl-8b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 8B Instruct",
 		"mathIndex": 27.3,
 		"mmluPro": 0.686,
 		"gpqa": 0.427,
-		"hle": 0.029,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 8B Instruct"
+		"hle": 0.029
 	},
-	"qwen3-30b-a3b-reasoning": {
-		"mathIndex": 72.3,
-		"mmluPro": 0.777,
-		"gpqa": 0.616,
-		"hle": 0.066,
+	"qwen3-4b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 30B A3B (Reasoning)"
-	},
-	"qwen3.5-27b-non-reasoning": {
-		"gpqa": 0.842,
-		"hle": 0.132,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.5 27B (Non-reasoning)"
-	},
-	"qwen3-vl-30b-a3b-instruct": {
-		"mathIndex": 72.3,
-		"mmluPro": 0.764,
-		"gpqa": 0.695,
-		"hle": 0.064,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 30B A3B Instruct"
-	},
-	"qwq-32b-preview": {
-		"mmluPro": 0.648,
-		"gpqa": 0.557,
-		"hle": 0.048,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "QwQ 32B-Preview"
-	},
-	"qwen3-0.6b-reasoning": {
-		"mathIndex": 18,
-		"mmluPro": 0.347,
-		"gpqa": 0.239,
-		"hle": 0.057,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 0.6B (Reasoning)"
-	},
-	"qwen3-30b-a3b-2507-instruct": {
-		"mathIndex": 66.3,
-		"mmluPro": 0.777,
-		"gpqa": 0.659,
-		"hle": 0.068,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 30B A3B 2507 Instruct"
-	},
-	"qwen3-max-thinking": {
-		"gpqa": 0.861,
-		"hle": 0.262,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Max Thinking"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 4B (Reasoning)",
+		"mathIndex": 22.3,
+		"mmluPro": 0.696,
+		"gpqa": 0.522,
+		"hle": 0.051
 	},
 	"qwen3-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Max",
 		"mathIndex": 80.7,
 		"mmluPro": 0.841,
 		"gpqa": 0.764,
-		"hle": 0.111,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Max"
+		"hle": 0.111
 	},
-	"qwen3-vl-4b-instruct": {
-		"mathIndex": 37,
-		"mmluPro": 0.634,
-		"gpqa": 0.371,
-		"hle": 0.037,
+	"qwen3-1.7b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 4B Instruct"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 1.7B (Reasoning)",
+		"mathIndex": 38.7,
+		"mmluPro": 0.57,
+		"gpqa": 0.356,
+		"hle": 0.048
 	},
-	"qwen3-vl-4b-reasoning": {
-		"mathIndex": 25.7,
-		"mmluPro": 0.7,
-		"gpqa": 0.494,
-		"hle": 0.044,
+	"qwen3-4b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 4B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 4B (Non-reasoning)",
+		"mmluPro": 0.586,
+		"gpqa": 0.398,
+		"hle": 0.037
 	},
-	"qwen3-4b-2507-instruct": {
-		"mathIndex": 52.3,
-		"mmluPro": 0.672,
-		"gpqa": 0.517,
-		"hle": 0.047,
+	"qwen3-max-thinking": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 4B 2507 Instruct"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Max Thinking",
+		"gpqa": 0.861,
+		"hle": 0.262
 	},
-	"qwen3-vl-32b-instruct": {
-		"mathIndex": 68.3,
-		"mmluPro": 0.791,
-		"gpqa": 0.671,
-		"hle": 0.063,
+	"qwen3-0.6b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 32B Instruct"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 0.6B (Reasoning)",
+		"mathIndex": 18,
+		"mmluPro": 0.347,
+		"gpqa": 0.239,
+		"hle": 0.057
 	},
 	"qwen-chat-72b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
+		"lastUpdated": "2026-08-01",
 		"originalModel": "Qwen Chat 72B"
 	},
-	"qwen3-max-preview": {
-		"mathIndex": 75,
-		"mmluPro": 0.838,
-		"gpqa": 0.764,
-		"hle": 0.093,
+	"qwen3-4b-2507-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Max (Preview)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 4B 2507 (Reasoning)",
+		"mathIndex": 82.7,
+		"gpqa": 0.667,
+		"hle": 0.059
 	},
-	"qwen2.5-coder-instruct-7b": {
-		"mmluPro": 0.473,
-		"gpqa": 0.339,
-		"hle": 0.048,
+	"qwen3-30b-a3b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen2.5 Coder Instruct 7B "
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 30B A3B (Non-reasoning)",
+		"mathIndex": 21.7,
+		"mmluPro": 0.71,
+		"gpqa": 0.515,
+		"hle": 0.046
 	},
-	"qwen3-max-thinking-preview": {
-		"mathIndex": 82.3,
-		"mmluPro": 0.824,
-		"gpqa": 0.776,
-		"hle": 0.12,
+	"qwen3-14b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 Max Thinking (Preview)"
-	},
-	"qwen3-30b-a3b-2507-reasoning": {
-		"mathIndex": 56.3,
-		"mmluPro": 0.805,
-		"gpqa": 0.707,
-		"hle": 0.098,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 30B A3B 2507 (Reasoning)"
-	},
-	"qwen3.6-max-preview": {
-		"gpqa": 0.888,
-		"hle": 0.289,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3.6 Max Preview"
-	},
-	"qwen1.5-chat-110b": {
-		"gpqa": 0.289,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen1.5 Chat 110B"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 14B (Non-reasoning)",
+		"mathIndex": 58,
+		"mmluPro": 0.675,
+		"gpqa": 0.47,
+		"hle": 0.042
 	},
 	"qwen3-vl-32b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 VL 32B (Reasoning)",
 		"mathIndex": 84.7,
 		"mmluPro": 0.818,
 		"gpqa": 0.733,
-		"hle": 0.096,
+		"hle": 0.096
+	},
+	"qwen3-max-thinking-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Qwen3 VL 32B (Reasoning)"
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 Max Thinking (Preview)",
+		"mathIndex": 82.3,
+		"mmluPro": 0.824,
+		"gpqa": 0.776,
+		"hle": 0.12
+	},
+	"qwen3-4b-2507-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Qwen3 4B 2507 Instruct",
+		"mathIndex": 52.3,
+		"mmluPro": 0.672,
+		"gpqa": 0.517,
+		"hle": 0.047
 	},
 	"ring-1t": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ring-1T",
 		"mathIndex": 89.3,
 		"mmluPro": 0.806,
 		"gpqa": 0.774,
-		"hle": 0.102,
+		"hle": 0.102
+	},
+	"ling-1t": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ring-1T"
-	},
-	"ling-1t": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ling-1T",
 		"mathIndex": 71.3,
 		"mmluPro": 0.822,
 		"gpqa": 0.719,
-		"hle": 0.072,
+		"hle": 0.072
+	},
+	"ling-flash-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ling-1T"
-	},
-	"ling-flash-2.0": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Ling-flash-2.0",
 		"mathIndex": 65.3,
 		"mmluPro": 0.777,
 		"gpqa": 0.657,
-		"hle": 0.063,
+		"hle": 0.063
+	},
+	"seed-oss-36b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Ling-flash-2.0"
-	},
-	"seed-oss-36b-instruct": {
+		"lastUpdated": "2026-08-01",
+		"originalModel": "Seed-OSS-36B-Instruct",
 		"mathIndex": 84.7,
 		"mmluPro": 0.815,
 		"gpqa": 0.726,
-		"hle": 0.091,
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-07-01",
-		"originalModel": "Seed-OSS-36B-Instruct"
+		"hle": 0.091
 	}
 }


### PR DESCRIPTION
## Automated Benchmark Update

This PR updates the hardcoded benchmark data with fresh scores from
[Artificial Analysis](https://artificialanalysis.ai).

### Changes
- Updated `provider-failover/hardcoded-benchmarks.ts`
- New data as of 2026-07-31T21:37:09Z

### Verification
- [ ] Review score changes for major models
- [ ] Run tests: `npm run test:run`
- [ ] Check no unexpected tier downgrades

Auto-generated by GitHub Actions.