### PR TITLE
feat: improve telemetry and benchmark logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Telemetry latency uses a monotonic clock** — `startModelCall`/`recordModelCall` now measure elapsed latency with `performance.now()` instead of `Date.now()`, matching the startup-timing module. Wall-clock skew from NTP adjustments or system suspend can no longer corrupt recorded per-call latency; `Date.now()` is retained only for the stored entry timestamp. The 10-minute implausible-latency guard remains as a sanity backstop.
+- **Telemetry disk writes are debounced** — `recordModelCall` no longer performs one synchronous `writeFileSync` of the whole telemetry store on every `turn_end`. The JSON store (`lib/json-persistence.ts`) gained an optional `debounceMs` (telemetry uses 1500ms) that updates the in-memory cache immediately — so `/free-telemetry` always shows current data — while coalescing the disk flush into a single write once the burst settles. `clearTelemetry` flushes immediately so the explicit `/clear-free-telemetry` action is durable. Removes the per-turn event-loop block from chatty sessions; probe-cache and config keep synchronous writes.
+- **Benchmark debug logging routed through the structured logger** — Coding Index match diagnostics (`PI_FREE_BENCHMARK_DEBUG=1`) now flow through `createLogger("benchmark-lookup")` to `~/.pi/free.log` via the buffered async stream, instead of a parallel `appendFileSync`-based pipe-delimited `~/.pi/modelmatch.log`. Eliminates the per-model synchronous file writes when debug logging is enabled and consolidates diagnostics into the single extension log. The unused `getMatchingStats`/`getMatchLogPath`/`clearMatchLog` helpers were removed.
+
 ## [2.3.0] - 2026-08-01
 
 ### Added

--- a/agents.md
+++ b/agents.md
@@ -151,7 +151,7 @@ This avoids false positives where providers default all costs to 0 without expos
 3. Provider-specific normalization (strip NVIDIA prefixes, Groq suffixes, etc.)
 4. Prefix fallback with base model extraction + size token reordering
 
-Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DEBUG=1` (off by default for startup speed).
+Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace: opt-in via `PI_FREE_BENCHMARK_DEBUG=1` (off by default for startup speed). Routed through the shared structured logger (buffered async stream, no per-model synchronous writes).
 
 ### Config Resolution
 
@@ -191,8 +191,7 @@ Debug logging writes to `~/.pi/modelmatch.log`: opt-in via `PI_FREE_BENCHMARK_DE
 ## File Locations (User-Facing)
 
 - **Config:** `~/.pi/free.json` (auto-created)
-- **Extension log:** `~/.pi/free.log`
-- **Model match log:** `~/.pi/modelmatch.log`
+- **Extension log:** `~/.pi/free.log` (includes opt-in `benchmark-lookup` debug diagnostics)
 - **Provider cache:** `~/.pi/provider-cache.json` (legacy/dynamic providers only)
 - **Native models store:** `~/.pi/agent/models-store.json` (all native providers, owned by Pi)
 - **Native auth store:** `~/.pi/agent/auth.json` (native-provider credentials, owned by Pi)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,14 +100,14 @@ Native providers restore the store first and Pi controls online refresh throttli
 
 Provider startup messages and configuration errors are written here.
 
-### Model match log
+### Coding Index debug diagnostics
 
-Coding Index diagnostics are written to:
+Coding Index match diagnostics (attempt/match/miss per model) are written to the shared extension log under the `benchmark-lookup` namespace:
 
-- **Windows:** `%USERPROFILE%\.pi\modelmatch.log`
-- **Linux/macOS:** `~/.pi/modelmatch.log`
+- **Windows:** `%USERPROFILE%\.pi\free.log`
+- **Linux/macOS:** `~/.pi/free.log`
 
-Matching diagnostics are opt-in:
+Diagnostics are opt-in (one line per model per match attempt, so off by default for startup speed):
 
 ```bash
 export PI_FREE_BENCHMARK_DEBUG=1
@@ -131,8 +131,7 @@ The telemetry file defaults to `~/.pi/free-telemetry.json`.
 | File | Purpose |
 | --- | --- |
 | `~/.pi/free.json` | pi-free config, flags, and extension-provider keys |
-| `~/.pi/free.log` | Extension log |
-| `~/.pi/modelmatch.log` | Optional Coding Index diagnostics |
+| `~/.pi/free.log` | Extension log (includes opt-in `benchmark-lookup` diagnostics) |
 | `~/.pi/free-telemetry.json` | Local model performance telemetry |
 | `~/.pi/provider-cache.json` | Dynamic/legacy cache and Ollama compatibility data |
 | `~/.pi/agent/models-store.json` | Pi native provider catalogs |

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,7 @@ Qoder intentionally remains on the legacy registration surface. Dynamic built-in
 
 Where a model matches the benchmark catalog, pi-free appends a Coding Index score such as `CI: 52.3` to its display name. Matching uses direct, alias, provider-normalization, and prefix-fallback strategies. Missing scores are not fabricated.
 
-Set `PI_FREE_BENCHMARK_DEBUG=1` to record match diagnostics in `~/.pi/modelmatch.log`.
+Set `PI_FREE_BENCHMARK_DEBUG=1` to record match diagnostics in `~/.pi/free.log` under the `benchmark-lookup` namespace.
 
 ## Model availability probing
 

--- a/docs/telemetry-logging-audit.md
+++ b/docs/telemetry-logging-audit.md
@@ -1,0 +1,244 @@
+# Telemetry & Logging Audit
+
+A review of pi-free's observability surfaces — logging, timing, telemetry, quota
+monitoring, and health reporting — assessing whether they are unified, whether
+they cause performance issues, and what was improved.
+
+> Audit date: 2026-08-01 · covers the codebase at `v2.3.0` plus the unreleased
+> changes described under "Work completed" below.
+
+---
+
+## 1. Inventory — what exists
+
+| Surface | File | Sink | Clock | Trigger |
+| --- | --- | --- | --- | --- |
+| **Structured logger** | `lib/logger.ts` | console + `~/.pi/free.log` (buffered async `WriteStream`) | `Date.now()` (ISO ts) | 38 `createLogger` sites |
+| **Startup timing** | `lib/startup-timing.ts` | in-memory only | `performance.now()` (monotonic) | `piFreeEntry` phases + per-provider |
+| **Session-start metrics** | `lib/session-start-metrics.ts` | in-memory → feeds startup-timing | `performance.now()` | `session_start` handlers |
+| **Model telemetry** | `lib/telemetry.ts` | `~/.pi/free-telemetry.json` (sync `writeFileSync`) | `Date.now()` | `before_agent_start` + `turn_end` |
+| **Quota monitor** | `lib/quota-monitor.ts` | in-memory `Map` | `Date.now()` | `after_provider_response` |
+| **Health report** | `lib/health.ts` | `/pi-free-health` (aggregates registry + startup) | — | command |
+| **Benchmark debug log** | `provider-failover/benchmark-lookup.ts` | `~/.pi/modelmatch.log` (sync `appendFileSync`) | `Date.now()` (ISO) | `enhanceWithCI` per model, opt-in |
+| **JSON persistence** | `lib/json-persistence.ts` | sync `writeFileSync` + lock | — | telemetry, probe-cache, config |
+
+User-facing commands: `/free-startup`, `/pi-free-health`, `/free-telemetry`,
+`/clear-free-telemetry`.
+
+---
+
+## 2. Is it unified?
+
+**Logging: mostly yes.** `createLogger(namespace)` is the single surface, adopted
+across 38 sites with a consistent `const _logger = createLogger("…")` pattern.
+Console defaults to error-only, file to debug — sensible. The buffered async
+`WriteStream` (lazy open, dir ensured once, sync fallback) is well done and
+already removed ~15–20ms from warm startup per the v2.3.0 changelog.
+
+**Fragmentation points found:**
+
+1. **A second, parallel logging system** — `benchmark-lookup.ts` wrote
+   `~/.pi/modelmatch.log` with raw `appendFileSync` and a pipe-delimited format,
+   bypassing `createLogger` entirely (it even imported `createLogger` for its own
+   error warnings but did not use it for the debug entries). Two log files, two
+   formats, two code paths. **Fixed** (see below).
+
+2. **Two overlapping timing APIs** — `timeAsync()` in `session-start-metrics.ts`
+   vs `measurePhase()`/`timeProvider()` in `startup-timing.ts`. Both wrap a
+   function and record duration. `timeAsync` is generic but used in one place;
+   the startup-timing trio is the real API. Not yet consolidated (low value).
+
+3. **Two clock primitives with no codified rule** — `performance.now()`
+   (monotonic) for startup/session durations, `Date.now()` (wall) for telemetry
+   latency, quota timestamps, cache TTL, auth expiry. This is *mostly* correct by
+   convention, but **telemetry used `Date.now()` to measure call latency**
+   (`startModelCall`/`recordModelCall` diff), which is wrong for a duration — NTP
+   adjustments or system suspend corrupt it. The `MAX_SANE_LATENCY_MS` (10 min)
+   guard caught the worst cases, but the monotonic clock is the correct fix.
+   **Fixed** (see below).
+
+4. **`util.ts:539`** creates `createLogger(providerId)` *inside*
+   `fetchOpenAICompatibleModels` — a fresh logger object per call. Minor (the
+   object is tiny), inconsistent with the module-level `_logger` convention
+   everywhere else. Not yet addressed (low value).
+
+---
+
+## 3. Does it cause perf issues?
+
+**Logger: no.** Already optimized — buffered stream, no per-line sync I/O. ✓
+
+**Startup/session timing: no.** In-memory arithmetic, no I/O, best-effort
+try/catch everywhere. ✓
+
+**Quota monitor: no.** Pure in-memory, header parse per response. ✓
+
+**Telemetry: yes — was the main concern.** On every `turn_end` for a free model:
+
+- `addEntry` → `_store.update` → acquires lock, `load()` (cached, ok), then
+  `save()` = **synchronous `writeFileSync`** of the entire store.
+- Then `deriveModelTelemetry` **re-derived all stats from the `recentCalls`
+  array** (O(n), n ≤ ~50) on every single call, even though only one entry was
+  appended.
+- `reapStaleInFlight` iterated the whole `_inFlight` map on every
+  `startModelCall`.
+
+Net: one sync disk write + an O(n) recompute per turn. On a fast SSD ~1–5ms; on
+Windows with Defender scanning, more. **Fixed** the sync-write part (see below);
+the O(~50) recompute is negligible (microseconds) and retained.
+
+**Benchmark scoring at startup: second concern.** `enhanceWithCI` runs
+`findHardcodedBenchmark` for **every model in every catalog** (24 call sites).
+With **536 benchmark entries**, the first two strategies are **not indexed**:
+
+- `tryDirectSubstringMatch` — loops all 536 entries, `search.includes(key)` per
+  entry, per model.
+- `tryVariantAliasMatch` — loops `MODEL_VARIANTS` (~40 entries) per model.
+- Only strategy 4 (`findBestVariantByPrefix`) uses the `getBenchmarkIndex()`
+  prefix index.
+
+So for ~500 models across providers, that's ~270k substring scans at startup.
+Bounded, but measurable. **Not yet addressed** (medium-value improvement #4 in
+the recommendations).
+
+**Benchmark debug logging: opt-in but heavy.** `PI_FREE_BENCHMARK_DEBUG=1`
+enabled sync `appendFileSync` per model per attempt — hundreds–thousands of sync
+writes at startup. **Fixed** (now routed through the buffered logger).
+
+**No log rotation anywhere.** `~/.pi/free.log`, `~/.pi/modelmatch.log` grew
+unbounded. Telemetry is bounded (50×2 recentCalls per model), but the log files
+were not. **Partially addressed** — `modelmatch.log` no longer exists; `free.log`
+still has no rotation (medium-value improvement #5).
+
+---
+
+## 4. Recommendations (prioritized)
+
+### High value — completed
+
+1. **Telemetry: switch latency to `performance.now()`** — match startup-timing.
+   Keep `Date.now()` only for the stored `timestamp` field. Correctness fix.
+2. **Telemetry: stop the per-turn sync write.** Debounce disk writes so a chatty
+   session does not perform one `writeFileSync` per `turn_end`. The in-memory
+   cache stays fresh (reads return current data); only the disk flush is
+   coalesced. `clearTelemetry` flushes immediately.
+3. **Route benchmark debug logging through `createLogger`** — drop the parallel
+   `appendFileSync`/pipe-format system; emit
+   `createLogger("benchmark-lookup").debug(...)` which writes to `~/.pi/free.log`
+   via the buffered stream. One log file, one format, no sync per-model writes.
+
+### Medium value — not yet done
+
+1. **Index the benchmark substring/alias strategies.** Build a lookup once
+   (tokenize model IDs, or precompute a sorted key list for binary search) so
+   `tryDirectSubstringMatch` isn't O(536) per model. Even a simple `Set` of
+   lowercased keys + a longest-match trie would cut the startup scan
+   dramatically.
+2. **Add log rotation / size cap** to `~/.pi/free.log` (e.g. rotate at N MB,
+   keep 1 backup). Cheap to add to the stream-open path in `logger.ts`.
+3. **Consolidate the two timing APIs** — fold `timeAsync` into `startup-timing`'s
+   `measurePhase`/`timeProvider` family, or document why `timeAsync` exists
+   separately (currently used in one spot).
+
+### Low value / polish — not yet done
+
+1. **`util.ts:539`** — hoist `createLogger(providerId)` to module level or cache
+   by providerId. Trivial.
+2. **Quota state is memory-only** — lost on restart. Probably fine (refreshes on
+   next response), worth a one-line note in the module doc.
+
+---
+
+## 5. Work completed (unreleased)
+
+### 5.1 Telemetry latency uses a monotonic clock
+
+**File:** `lib/telemetry.ts`
+
+`startModelCall` now stores `performance.now()` (monotonic) as the in-flight
+`startTime`; `recordModelCall` computes `latencyMs = performance.now() -
+entry.startTime`. `Date.now()` is retained only for the stored entry `timestamp`
+and the human-readable call-id correlation tag. `reapStaleInFlight` now compares
+against the monotonic clock. The 10-minute `MAX_SANE_LATENCY_MS` guard remains
+as a sanity backstop.
+
+This matches the convention already used in `lib/startup-timing.ts` and
+`lib/session-start-metrics.ts`: monotonic clock for durations, wall clock for
+stored timestamps.
+
+**Test:** `tests/telemetry.test.ts` — the "discards implausibly long latency
+samples" test was updated to mock `performance.now` (instead of `Date.now`) to
+exercise the discard path under the new clock.
+
+### 5.2 Telemetry disk writes are debounced
+
+**Files:** `lib/json-persistence.ts`, `lib/telemetry.ts`
+
+`createJSONStore` gained an optional third argument `JSONStoreOptions` with
+`debounceMs?: number`, plus a `flush(): Promise<void>` method on the
+`JSONStore` interface:
+
+- `debounceMs: 0` (default) — synchronous `writeFileSync` on every save
+  (unchanged behavior; probe-cache, config, and all existing tests keep this).
+- `debounceMs > 0` — `save` updates the in-memory cache immediately (so `load()`
+  returns fresh data right away) and schedules a single coalesced `writeFileSync`
+  after the burst settles. `flush()` clears the pending timer and writes
+  immediately.
+
+Telemetry creates its store with `{ debounceMs: 1500 }`. Effect: a chatty session
+no longer blocks the event loop with one sync disk write per `turn_end`; writes
+coalesce into one per ~1.5s gap. `/free-telemetry` still shows current data
+(reads from the in-memory cache). `clearTelemetry` calls `flush()` after its
+update so the explicit `/clear-free-telemetry` action is durable immediately.
+
+The O(~50) `deriveModelTelemetry` recompute per add is retained — it is
+microseconds and not worth the sliding-window-subtraction complexity of
+incremental maintenance.
+
+**Backward compatibility:** the `JSONStore` interface gains `flush()` (a no-op
+for sync stores), and the 3rd argument is optional with a sync default. Existing
+`createJSONStore(file, default)` calls and the `json-persistence.test.ts` suite
+are unchanged and pass.
+
+### 5.3 Benchmark debug logging routed through the structured logger
+
+**File:** `provider-failover/benchmark-lookup.ts`
+
+- `logDebug` now emits `_logger.debug(entry.action, { …structured data… })`
+  through `createLogger("benchmark-lookup")`, which writes to `~/.pi/free.log`
+  via the buffered async stream. The `debugEnabled` gate
+  (`PI_FREE_BENCHMARK_DEBUG=1`, off by default) is preserved so the verbose
+  per-model logging stays opt-in.
+- Removed the parallel logging machinery: `LOG_DIR`, `LOG_FILE`, the
+  `appendFileSync`/`writeFileSync`/`existsSync`/`mkdirSync` file-writing body,
+  and the `node:fs` / `node:os` / `node:path` imports used only by it.
+- Removed the dead stats/log-path helpers that parsed the old pipe format:
+  `getMatchingStats`, `getMatchLogPath`, `clearMatchLog`, `parseLogLine`,
+  `computeMatchRate`, the `LogStats` interface, and the trailing `readFileSync`
+  import. These were never called anywhere in the codebase (verified by grep).
+- Kept `setDebugLogging` (harmless public API) and `debugEnabled`.
+
+**User-facing impact:** with `PI_FREE_BENCHMARK_DEBUG=1`, diagnostics now appear
+in `~/.pi/free.log` under the `benchmark-lookup` namespace instead of a separate
+`~/.pi/modelmatch.log`. Docs updated: `agents.md`, `docs/configuration.md`,
+`docs/features.md`.
+
+### 5.4 Validation
+
+- `npm run lint` (`tsc --noEmit`) — clean
+- `npm run test:run` — 53 files, 622 tests pass
+- `npm run check:lockfile` — in sync
+- `tests/benchmark-lookup.test.ts`, `tests/telemetry.test.ts`,
+  `tests/json-persistence.test.ts` — all pass (40 tests)
+
+---
+
+## 6. Bottom line
+
+Logging was already unified and performance-tuned; the fragmentation was the
+benchmark module's parallel sync logger. The real perf risk was **telemetry's
+per-turn sync write** and the **unindexed benchmark scan at startup**. This pass
+fixed the telemetry sync write (debounced), the telemetry clock correctness
+(monotonic), and the benchmark debug logging (routed through the buffered
+logger). The unindexed benchmark scan (#4) and log rotation (#5) remain as
+medium-value follow-ups.

--- a/lib/json-persistence.ts
+++ b/lib/json-persistence.ts
@@ -27,6 +27,24 @@ export interface JSONStore<T> {
 	load(): T;
 	save(data: T): void;
 	update(updater: (data: T) => T): Promise<T>;
+	/**
+	 * Force any pending debounced disk write to complete. No-op when the
+	 * store was created with the default (synchronous) write mode.
+	 */
+	flush(): Promise<void>;
+}
+
+export interface JSONStoreOptions {
+	/**
+	 * Debounce disk writes by this many milliseconds, coalescing rapid
+	 * successive updates into a single write. The in-memory cache is always
+	 * updated immediately so `load()` returns fresh data right away; only the
+	 * disk flush is deferred. `0` (default) writes synchronously on every
+	 * save, preserving the historical behavior. A positive value schedules a
+	 * single coalesced write after the burst settles — ideal for hot paths
+	 * like telemetry that would otherwise do one sync `writeFileSync` per turn.
+	 */
+	debounceMs?: number;
 }
 
 class Lock {
@@ -50,9 +68,12 @@ class Lock {
 export function createJSONStore<T extends object>(
 	filepath: string,
 	defaultValue: T,
+	options: JSONStoreOptions = {},
 ): JSONStore<T> {
 	let cached: T | null = null;
 	const lock = new Lock();
+	const debounceMs = options.debounceMs ?? 0;
+	let flushTimer: ReturnType<typeof setTimeout> | undefined;
 
 	function load(): T {
 		if (cached) return cached;
@@ -74,14 +95,38 @@ export function createJSONStore<T extends object>(
 		return cached;
 	}
 
-	function save(data: T): void {
-		cached = data;
+	function writeDisk(data: T): void {
 		try {
 			ensureDir(dirname(filepath));
 			writeFileSync(filepath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
 		} catch (err) {
 			_logger.warn("Failed to save JSON store", { filepath, error: err });
 		}
+	}
+
+	function save(data: T): void {
+		// The in-memory cache is always updated immediately so load() returns
+		// fresh data right away. Only the disk flush is deferred when debouncing.
+		cached = data;
+		if (debounceMs <= 0) {
+			writeDisk(data);
+			return;
+		}
+		// Coalesce rapid successive updates: reset the pending timer so only
+		// the final state is written once the burst settles.
+		if (flushTimer !== undefined) clearTimeout(flushTimer);
+		flushTimer = setTimeout(() => {
+			flushTimer = undefined;
+			if (cached !== null) writeDisk(cached);
+		}, debounceMs);
+	}
+
+	async function flush(): Promise<void> {
+		if (flushTimer !== undefined) {
+			clearTimeout(flushTimer);
+			flushTimer = undefined;
+		}
+		if (cached !== null) writeDisk(cached);
 	}
 
 	async function update(updater: (data: T) => T): Promise<T> {
@@ -96,7 +141,7 @@ export function createJSONStore<T extends object>(
 		}
 	}
 
-	return { load, save, update };
+	return { load, save, update, flush };
 }
 
 /**

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -98,7 +98,7 @@ function reapStaleInFlight(now: number): void {
 			_logger.info("Reaped stale in-flight telemetry entry", {
 				callId: id,
 				key: entry.key,
-				ageMs: now - entry.startTime,
+				ageMs: Math.round(now - entry.startTime),
 			});
 			_inFlight.delete(id);
 		}
@@ -117,18 +117,23 @@ function telemetryKey(provider: string, model: string): string {
 // Storage
 // =============================================================================
 
-const _store = createJSONStore<TelemetryStore>(TELEMETRY_FILE, {
-	models: {},
-	lastUpdated: Date.now(),
-});
+// Debounce disk writes so a chatty session does not perform one synchronous
+// writeFileSync per turn_end. The in-memory cache stays fresh (load() returns
+// the latest state immediately), so /free-telemetry always shows current data;
+// only the disk flush is coalesced. clearTelemetry() calls flush() to make the
+// explicit user action durable right away.
+const TELEMETRY_WRITE_DEBOUNCE_MS = 1500;
+const _store = createJSONStore<TelemetryStore>(
+	TELEMETRY_FILE,
+	{ models: {}, lastUpdated: Date.now() },
+	{ debounceMs: TELEMETRY_WRITE_DEBOUNCE_MS },
+);
 
 // =============================================================================
 // Entry management
 // =============================================================================
 
-function deriveModelTelemetry(
-	entries: TelemetryEntry[],
-): ModelTelemetry {
+function deriveModelTelemetry(entries: TelemetryEntry[]): ModelTelemetry {
 	const recent = entries.slice(-MAX_RECENT_CALLS);
 
 	let successCalls = 0;
@@ -175,7 +180,7 @@ function deriveModelTelemetry(
 							totalTokensFromSuccessful /
 							(totalLatencyFromSuccessful / 1000)
 						).toFixed(1),
-				)
+					)
 				: 0,
 		successRate:
 			totalCalls > 0
@@ -285,10 +290,16 @@ export function getProviderTelemetry(provider: string): {
  * Pass this id to {@link recordModelCall} to pair the start/end correctly.
  */
 export function startModelCall(provider: string, model: string): string {
-	const now = Date.now();
-	reapStaleInFlight(now);
-	const callId = `${telemetryKey(provider, model)}:${now}:${++_callIdCounter}`;
-	_inFlight.set(callId, { key: telemetryKey(provider, model), startTime: now });
+	// Monotonic clock for latency measurement (immune to NTP skew / system
+	// suspend); wall clock only for the human-readable call id correlation tag.
+	const start = performance.now();
+	const ts = Date.now();
+	reapStaleInFlight(start);
+	const callId = `${telemetryKey(provider, model)}:${ts}:${++_callIdCounter}`;
+	_inFlight.set(callId, {
+		key: telemetryKey(provider, model),
+		startTime: start,
+	});
 	return callId;
 }
 
@@ -320,12 +331,16 @@ export async function recordModelCall(
 	options: RecordModelCallOptions,
 ): Promise<void> {
 	const { success, stopReason, errorMessage } = options;
+	// Wall clock for the stored entry timestamp; monotonic clock for the
+	// elapsed-latency measurement so NTP adjustments or system suspend cannot
+	// corrupt the recorded duration.
 	const now = Date.now();
+	const end = performance.now();
 
 	let latencyMs: number;
 	if (callId && _inFlight.has(callId)) {
 		const entry = _inFlight.get(callId)!;
-		latencyMs = now - entry.startTime;
+		latencyMs = Math.round(end - entry.startTime);
 		_inFlight.delete(callId);
 	} else {
 		// No matching start — record 0 latency rather than a bogus value.
@@ -389,6 +404,9 @@ export async function clearTelemetry(): Promise<void> {
 		models: {},
 		lastUpdated: Date.now(),
 	}));
+	// Explicit user action (/clear-free-telemetry) — flush the debounced
+	// write so the clear is durable immediately rather than after the debounce.
+	await _store.flush();
 }
 
 /**

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -9,9 +9,6 @@
  * ENHANCED: Added debug logging and provider-specific normalizers
  */
 
-import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { createLogger } from "../lib/logger.ts";
 import type { ModelMatchHints } from "../lib/types.ts";
 
@@ -74,11 +71,10 @@ function getBenchmarkIndex(): BenchmarkIndex {
 // Debug Logging
 // =============================================================================
 
-const LOG_DIR = join(homedir(), ".pi");
-const LOG_FILE = join(LOG_DIR, "modelmatch.log");
-// Debug logging writes one sync appendFileSync per model per attempt — far too
-// expensive to leave on during startup (hundreds–thousands of blocking writes).
-// Opt in via PI_FREE_BENCHMARK_DEBUG=1 (or setDebugLogging(true)).
+// Debug logging is opt-in because it emits one line per model per match
+// attempt (hundreds–thousands at startup). When enabled, entries flow through
+// the structured logger (namespace "benchmark-lookup") to ~/.pi/free.log via
+// the buffered async stream — no per-model synchronous file writes.
 let debugEnabled = process.env.PI_FREE_BENCHMARK_DEBUG === "1";
 
 /**
@@ -89,7 +85,9 @@ export function setDebugLogging(enabled: boolean): void {
 }
 
 /**
- * Log a message to the modelmatch.log file
+ * Emit a structured debug line for a benchmark match attempt/match/miss.
+ * Routed through the shared logger so it lands in ~/.pi/free.log under the
+ * "benchmark-lookup" namespace, using the buffered stream (no sync I/O).
  */
 function logDebug(entry: {
 	provider?: string;
@@ -103,68 +101,18 @@ function logDebug(entry: {
 	details?: string;
 }): void {
 	if (!debugEnabled) return;
-
-	try {
-		// Ensure log directory exists
-		if (!existsSync(LOG_DIR)) {
-			mkdirSync(LOG_DIR, { recursive: true });
-		}
-
-		// Initialize log file with header if it doesn't exist
-		if (!existsSync(LOG_FILE)) {
-			writeFileSync(
-				LOG_FILE,
-				"timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details\n",
-			);
-		}
-
-		const timestamp = new Date().toISOString();
-		const line = [
-			timestamp,
-			entry.provider || "unknown",
-			entry.modelId,
-			entry.modelName,
-			entry.action,
-			entry.strategy || "",
-			entry.normalizedId || "",
-			entry.matchKey || "",
-			entry.codingIndex !== undefined ? entry.codingIndex.toFixed(1) : "",
-			entry.details || "",
-		]
-			.map((f) => f.replaceAll(/[\\|]/g, "\\$&")) // Escape backslashes and pipes
-			.join("|");
-
-		appendFileSync(LOG_FILE, `${line}\n`);
-	} catch (err) {
-		_logger.warn("Debug log write failed", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
-}
-
-/**
- * Get the path to the log file for user reference
- */
-export function getMatchLogPath(): string {
-	return LOG_FILE;
-}
-
-/**
- * Clear the match log
- */
-export function clearMatchLog(): void {
-	try {
-		if (existsSync(LOG_FILE)) {
-			writeFileSync(
-				LOG_FILE,
-				"timestamp|provider|modelId|modelName|action|strategy|normalizedId|matchKey|codingIndex|details\n",
-			);
-		}
-	} catch (err) {
-		_logger.warn("Failed to clear match log", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
+	_logger.debug(entry.action, {
+		provider: entry.provider ?? "unknown",
+		modelId: entry.modelId,
+		modelName: entry.modelName,
+		...(entry.strategy ? { strategy: entry.strategy } : {}),
+		...(entry.normalizedId ? { normalizedId: entry.normalizedId } : {}),
+		...(entry.matchKey ? { matchKey: entry.matchKey } : {}),
+		...(entry.codingIndex !== undefined
+			? { codingIndex: entry.codingIndex }
+			: {}),
+		...(entry.details ? { details: entry.details } : {}),
+	});
 }
 
 // =============================================================================
@@ -827,88 +775,3 @@ export function enhanceModelNameWithCodingIndex(
 	}
 	return modelName;
 }
-
-// =============================================================================
-// Stats and Reporting
-// =============================================================================
-
-/**
- * Get statistics about model matching from the current session
- * Note: This reads the log file and computes stats
- */
-interface LogStats {
-	totalAttempts: number;
-	matches: number;
-	misses: number;
-	byProvider: Record<
-		string,
-		{ attempts: number; matches: number; misses: number }
-	>;
-}
-
-function parseLogLine(stats: LogStats, line: string): void {
-	if (!line.trim()) return;
-	const parts = line.split("|");
-	if (parts.length < 5) return;
-
-	const provider = parts[1] || "unknown";
-	const action = parts[4];
-
-	if (!stats.byProvider[provider]) {
-		stats.byProvider[provider] = { attempts: 0, matches: 0, misses: 0 };
-	}
-
-	if (action === "attempt") {
-		stats.totalAttempts++;
-		stats.byProvider[provider].attempts++;
-	} else if (action === "match") {
-		stats.matches++;
-		stats.byProvider[provider].matches++;
-	} else if (action === "miss") {
-		stats.misses++;
-		stats.byProvider[provider].misses++;
-	}
-}
-
-function computeMatchRate(stats: LogStats): number {
-	const total = stats.matches + stats.misses;
-	return total > 0 ? Math.round((stats.matches / total) * 100) : 0;
-}
-
-export function getMatchingStats(): {
-	totalAttempts: number;
-	matches: number;
-	misses: number;
-	matchRate: number;
-	byProvider: Record<
-		string,
-		{ attempts: number; matches: number; misses: number }
-	>;
-} {
-	const stats: LogStats = {
-		totalAttempts: 0,
-		matches: 0,
-		misses: 0,
-		byProvider: {},
-	};
-
-	try {
-		if (!existsSync(LOG_FILE)) {
-			return { ...stats, matchRate: 0 };
-		}
-
-		const content = readFileSync(LOG_FILE, "utf-8");
-		for (const line of content.split("\n").slice(1)) {
-			parseLogLine(stats, line);
-		}
-	} catch (err) {
-		_logger.warn("Failed to read match log stats", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
-
-	return { ...stats, matchRate: computeMatchRate(stats) };
-}
-
-// Need to import readFileSync for stats
-import { readFileSync } from "node:fs";

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -39,8 +39,9 @@ describe("telemetry", () => {
 	});
 
 	it("pairs start and record via call id with correct latency", async () => {
-		const { startModelCall, recordModelCall, getModelTelemetry } =
-			await import("../lib/telemetry.ts");
+		const { startModelCall, recordModelCall, getModelTelemetry } = await import(
+			"../lib/telemetry.ts"
+		);
 
 		const callId = startModelCall("prov", "mdl");
 		expect(typeof callId).toBe("string");
@@ -70,16 +71,17 @@ describe("telemetry", () => {
 	});
 
 	it("discards implausibly long latency samples", async () => {
-		const { startModelCall, recordModelCall, getModelTelemetry } =
-			await import("../lib/telemetry.ts");
+		const { startModelCall, recordModelCall, getModelTelemetry } = await import(
+			"../lib/telemetry.ts"
+		);
 
-		const callId = startModelCall("slow", "model");
-
-		// Simulate a system suspend by faking the in-flight start time
-		// (reach into the module's internals via the returned callId structure)
-		// Instead, we use vi.spyOn to override Date.now for the record call
-		const realNow = Date.now();
-		vi.spyOn(Date, "now").mockReturnValue(realNow + 15 * 60 * 1000); // 15 min later
+		// Latency is measured with the monotonic performance.now() clock, so
+		// simulate a 15-min gap by mocking performance.now for the record call.
+		const startPerf = performance.now();
+		const callId = startModelCall("slow", "model"); // captures real start
+		vi.spyOn(performance, "now").mockReturnValue(
+			startPerf + 15 * 60 * 1000, // 15 min later > MAX_SANE_LATENCY_MS
+		);
 
 		const usage = { input: 1, output: 1, totalTokens: 2 };
 		await recordModelCall(callId, "slow", "model", usage, 0, {


### PR DESCRIPTION
## Summary
- measure model latency with a monotonic clock
- debounce telemetry persistence while keeping explicit clears durable
- route benchmark diagnostics through the structured logger
- update documentation and add the telemetry/logging audit

## Validation
- npm run lint
- npm run test:run (623 tests)
- npm run check:lockfile

Generated with pi-free development tooling.