### PR TITLE
fix: recognize Cline free model aliases

### DIFF
--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -3,8 +3,9 @@
  *
  * Fetches Cline's own model catalog from api.cline.bot instead of OpenRouter.
  * Cline also exposes a recommended/free-to-try list; those models may have
- * non-zero list pricing in the catalog, so we mark exact recommended-free IDs
- * as zero-cost for pi-free's free-model filter.
+ * non-zero list pricing in the catalog, so we mark recommended-free IDs (and
+ * their conservative provider/date aliases) as zero-cost for pi-free's
+ * free-model filter.
  */
 
 import type { Model } from "@earendil-works/pi-ai/compat";
@@ -132,6 +133,53 @@ function modelFromRecommended(
 	};
 }
 
+// Cline's free endpoint can use a provider-qualified ID while the catalog
+// uses the leaf ID (or vice versa). It also occasionally gives a dated
+// catalog entry for an otherwise identical recommended model, for example
+// `deepseek-v4-flash` -> `deepseek-v4-flash-0731`.
+//
+// Keep this deliberately narrow: only valid date-shaped release suffixes are
+// removed, and two provider-qualified IDs must have the same qualifier. This
+// avoids turning similarly named paid variants (such as `-pro`) into free ones.
+const CLINE_RELEASE_DATE_SUFFIX =
+	/(?:-(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])|-(?:19|20)\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])|-(?:19|20)\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]))$/;
+
+function splitClineModelId(id: string): {
+	qualifier?: string;
+	leaf: string;
+} {
+	const separator = id.lastIndexOf("/");
+	return separator < 0
+		? { leaf: id }
+		: { qualifier: id.slice(0, separator), leaf: id.slice(separator + 1) };
+}
+
+function stripClineReleaseDateSuffix(id: string): string {
+	return id.replace(CLINE_RELEASE_DATE_SUFFIX, "");
+}
+
+function isClineFreeToTryId(
+	modelId: string,
+	freeToTryIds: ReadonlySet<string>,
+): boolean {
+	if (freeToTryIds.has(modelId)) return true;
+
+	const model = splitClineModelId(modelId);
+	const normalizedModelLeaf = stripClineReleaseDateSuffix(model.leaf);
+	for (const freeToTryId of freeToTryIds) {
+		const free = splitClineModelId(freeToTryId);
+		if (model.qualifier && free.qualifier && model.qualifier !== free.qualifier) {
+			continue;
+		}
+		if (
+			normalizedModelLeaf === stripClineReleaseDateSuffix(free.leaf)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function modelFromCatalog(
 	info: ClineRaw,
 	freeToTryIds: ReadonlySet<string>,
@@ -140,7 +188,7 @@ function modelFromCatalog(
 		info.supported_parameters?.includes("include_reasoning") ||
 		info.supported_parameters?.includes("reasoning")
 	);
-	const isFreeToTry = freeToTryIds.has(info.id);
+	const isFreeToTry = isClineFreeToTryId(info.id, freeToTryIds);
 	const inputCost = isFreeToTry ? 0 : parsePricing(info.pricing?.prompt);
 	const outputCost = isFreeToTry ? 0 : parsePricing(info.pricing?.completion);
 	const cacheRead = isFreeToTry

--- a/tests/cline-models.test.ts
+++ b/tests/cline-models.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../config.ts", () => ({
+	applyHidden: <T>(models: T[]) => models,
+}));
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T[]) => models,
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
+		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
+}));
+
+import { fetchClineCatalog } from "../providers/cline/cline-models.ts";
+
+function catalogModel(id: string) {
+	return {
+		id,
+		pricing: {
+			prompt: "0.000001",
+			completion: "0.000002",
+		},
+		architecture: { output_modalities: ["text"] },
+	};
+}
+
+function stubClineEndpoints(freeIds: string[], catalog: unknown[]) {
+	const fetchMock = vi.fn(async (url: string) => {
+		const body = url.includes("recommended-models")
+			? { free: freeIds.map((id) => ({ id })) }
+			: { data: catalog };
+		return new Response(JSON.stringify(body), {
+			status: 200,
+			statusText: "OK",
+			headers: { "Content-Type": "application/json" },
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("Cline free-to-try catalog aliases", () => {
+	it("applies free pricing before native free splitting for qualified and leaf date aliases", async () => {
+		const freeId = "deepseek/deepseek-v4-flash";
+		const datedQualifiedId = "deepseek/deepseek-v4-flash-0731";
+		const datedLeafId = "deepseek-v4-flash-0731";
+		const paidVariantId = "deepseek/deepseek-v4-flash-pro";
+		const otherProviderId = "other/deepseek-v4-flash-0731";
+
+		stubClineEndpoints(
+			[freeId],
+			[
+				catalogModel(freeId),
+				catalogModel(datedQualifiedId),
+				catalogModel(datedLeafId),
+				catalogModel(paidVariantId),
+				catalogModel(otherProviderId),
+			],
+		);
+
+		const { all, free } = await fetchClineCatalog();
+		const byId = new Map(all.map((model) => [model.id, model]));
+
+		for (const id of [freeId, datedQualifiedId, datedLeafId]) {
+			expect(byId.get(id)).toMatchObject({
+				cost: { input: 0, output: 0 },
+				name: expect.not.stringContaining("💰"),
+			});
+		}
+
+		expect(free.map((model) => model.id)).toEqual([
+			freeId,
+			datedQualifiedId,
+			datedLeafId,
+		]);
+		expect(byId.get(paidVariantId)?.cost.input).toBeGreaterThan(0);
+		expect(byId.get(otherProviderId)?.cost.input).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary
- Recognize Cline's free-to-try model aliases across provider-qualified and leaf IDs.
- Normalize only validated release/date suffixes such as `-0731`.
- Preserve paid variants such as `-pro` and unrelated provider-qualified models.
- Apply free pricing before native free-model splitting.

Fixes #370.

## Validation
- Focused Cline tests: 16 passed
- `npm run lint`
- `npm run check`
