### PR TITLE
feat: measure import-inclusive startup time

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -253,7 +253,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 
 - **Framework:** Vitest (`vitest` v4.1.10)
 - **Run:** `npm test` (watch), `npm run test:run` (once)
-- **Startup perf:** `npx tsx scripts/bench-startup.ts <warm|cold|fastcold>` times the awaited `piFreeEntry` factory in a sandboxed `HOME` with mocked `fetch` (warm = no legacy network, cold = dead API worst case). Import/transpile time is intentionally outside that benchmark; include it before evaluating a compiled `dist` package. Native Pi model refresh and session-start detached work are reported separately.
+- **Startup perf:** `npx tsx scripts/bench-startup.ts <warm|cold|fastcold>` runs in a sandboxed `HOME` with mocked `fetch` (warm = no legacy network, cold = dead API worst case) and reports `importMs`, `factoryMs`, and import-inclusive `totalMs`. `importMs` includes the tsx loader/transpilation and module-graph initialization; it is not pure compiler time and is outside pi-free's runtime startup log. `factoryMs` remains the awaited `piFreeEntry` time recorded by `lib/startup-timing.ts`. Native Pi model refresh and session-start detached work are reported separately.
 - **Tests:** `tests/*.test.ts` — covers registry, toggle state, config, model detection, provider compat
 - Tests use `vi.fn()` mocks for ExtensionAPI
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -62,6 +62,8 @@ Telemetry is local and opt-in through actual use of free models. It records aggr
 
 `/free-startup` reports the latest extension startup timing, including provider setup durations, per-provider cache/network activity, failed network attempts, session-start handler durations, detached post-handler work, and failures. `/pi-free-health` adds a credential-free status summary, registered-provider count, problem list, and the path to `~/.pi/free.log` (or the configured log path). Legacy/dynamic startup model fetches have an 8-second default deadline, configurable with `PI_FREE_STARTUP_FETCH_TIMEOUT_MS`; native provider refresh is handled by Pi after registration and its session-start nudge is measured without blocking the event.
 
+For reproducible import-inclusive measurements, run `npx tsx scripts/bench-startup.ts <warm|cold|fastcold>`. The benchmark reports `importMs` (tsx loader/transpilation and module-graph initialization, not pure compiler time and outside pi-free's runtime log), `factoryMs` (the awaited factory measured by runtime startup timing), and `totalMs` (import plus factory) in both its human summary and `RESULT` JSON. Native offline-init checks are reported separately.
+
 ## Provider protocols
 
 Most providers use OpenAI-compatible APIs. Notable custom integrations are:

--- a/scripts/bench-startup.ts
+++ b/scripts/bench-startup.ts
@@ -1,10 +1,13 @@
 /**
  * Startup benchmark for pi-free.
  *
- * Times the `piFreeEntry` extension factory — the exact thing Pi awaits before
- * flushing provider registrations — under controlled cache/network conditions,
- * so startup performance can be measured rather than guessed. Run it before and
- * after a change to get a real before/after delta.
+ * Measures the TypeScript import/loader phase separately from the `piFreeEntry`
+ * extension factory — the exact thing Pi awaits before flushing provider
+ * registrations — under controlled cache/network conditions, so startup
+ * performance can be measured rather than guessed. The import measurement
+ * includes loader/transpilation and module-graph initialization; it is not a
+ * pure compiler measurement and is outside pi-free's runtime startup log. Run
+ * it before and after a change to get a real before/after delta.
  *
  * Usage (via tsx, which is already a dev dependency):
  *   npx tsx scripts/bench-startup.ts <warm|cold|fastcold>
@@ -33,6 +36,7 @@
  *   for i in 1 2 3 4 5; do npx tsx scripts/bench-startup.ts warm; done
  *
  * Prints a human-readable summary plus a `RESULT {...}` JSON line for scripting.
+ * Both include importMs, factoryMs, and import-inclusive totalMs.
  */
 import {
 	copyFileSync,
@@ -176,20 +180,29 @@ const mockPi: any = {
 };
 
 // ---------------------------------------------------------------------------
-// Import (tsx transpile happens here, OUTSIDE the timed region), then time only
-// the factory — that is what Pi awaits before flushing registrations.
+// Measure imports separately from the factory. With tsx this phase includes
+// TypeScript loader/transpilation and module-graph initialization, not just
+// compiler work. The startup-timing module is already part of index.ts's graph,
+// but keep its dynamic import inside the phase for a complete import boundary.
 // ---------------------------------------------------------------------------
+const importStart = performance.now();
 const mod = await import("../index.ts");
 const { getStartupSummary, formatStartupSummary } = await import(
 	"../lib/startup-timing.ts"
 );
+const importEnd = performance.now();
+const importMs = Math.round((importEnd - importStart) * 10) / 10;
 
+// This remains the factory-only measurement: it is the work Pi awaits before
+// flushing provider registrations and is the duration recorded by pi-free's
+// runtime startup-timing module.
 const t0 = performance.now();
 await mod.default(mockPi);
 const t1 = performance.now();
 
 const summary = getStartupSummary();
 const factoryMs = Math.round((t1 - t0) * 10) / 10;
+const totalMs = Math.round((t1 - importStart) * 10) / 10;
 
 // ---------------------------------------------------------------------------
 // Exercise Kilo's native offline-init path. Kilo no longer fetches in the
@@ -291,7 +304,11 @@ const clineFactoryNetworkCalls = fetchUrls.filter((u) =>
 ).length;
 
 console.log(`\nmode: ${mode}`);
-console.log(`factory (awaited by Pi): ${factoryMs}ms`);
+console.log(
+	`import (loader/transpilation/module graph; outside runtime log): ${importMs}ms`,
+);
+console.log(`factory (awaited by Pi; runtime log): ${factoryMs}ms`);
+console.log(`total (import + factory): ${totalMs}ms`);
 console.log(`registered providers: ${registered.size}`);
 console.log(`network calls during factory: ${fetchCalls}`);
 console.log(`kilo factory network calls: ${kiloFactoryNetworkCalls}`);
@@ -311,7 +328,9 @@ console.log(formatStartupSummary());
 
 const result = {
 	mode,
+	importMs,
 	factoryMs,
+	totalMs,
 	summaryTotalMs: summary.totalMs,
 	seededProviders,
 	registeredProviders: registered.size,


### PR DESCRIPTION
## Summary
- Measure source-module import/loader/transpilation time separately from `piFreeEntry`.
- Report `importMs`, `factoryMs`, and import-inclusive `totalMs` in benchmark output and `RESULT` JSON.
- Document that `importMs` includes the tsx loader and module-graph initialization; it is not pure compiler time and remains outside pi-free's runtime log.

## Validation
- `npm run lint`
- Warm benchmark: import `4258.4ms`, factory `91.2ms`, total `4349.6ms`
- Fast-cold benchmark: import `4270.8ms`, factory `41ms`, total `4311.8ms`
