### PR TITLE
feat: ship compiled dist entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Audit production dependencies
         run: npm run audit:prod
 
+      - name: Build compiled package
+        run: npm run build
+
       - name: TypeScript lint
         run: npm run lint
 
@@ -92,7 +95,7 @@ jobs:
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/check-extensions.mjs "$INSTALL_DIR"
 
-      - name: Smoke-load extension entry (catches missing runtime modules)
+      - name: Smoke-load compiled extension entry (catches missing runtime modules)
         shell: bash
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
@@ -101,5 +104,5 @@ jobs:
           fi
           export P="$INSTALL_DIR/package.json"
           ENTRY=$(node -p "require(process.env.P).pi.extensions[0]")
-          echo "Loading entry: $INSTALL_DIR/$ENTRY"
-          node --import tsx "$INSTALL_DIR/$ENTRY"
+          echo "Loading compiled entry: $INSTALL_DIR/$ENTRY"
+          node scripts/smoke-compiled.mjs "$INSTALL_DIR/$ENTRY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
         if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run audit:prod
 
+      - name: Build compiled package
+        if: steps.meta.outputs.needs_npm_publish == 'true'
+        run: npm run build
+
       - name: Type-check
         if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run lint
@@ -112,13 +116,13 @@ jobs:
           TARBALL=$(ls pi-free-*.tgz)
           node scripts/check-tarball.mjs "$TARBALL"
 
-      - name: Smoke-load source entry
+      - name: Smoke-load compiled entry
         if: steps.meta.outputs.needs_npm_publish == 'true'
         shell: bash
         run: |
           ENTRY=$(node -p "require('./package.json').pi.extensions[0]")
-          echo "Loading entry: $ENTRY"
-          node --import tsx "$ENTRY"
+          echo "Loading compiled entry: $ENTRY"
+          node scripts/smoke-compiled.mjs "$ENTRY"
 
   release:
     runs-on: ubuntu-latest

--- a/agents.md
+++ b/agents.md
@@ -253,7 +253,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 
 - **Framework:** Vitest (`vitest` v4.1.10)
 - **Run:** `npm test` (watch), `npm run test:run` (once)
-- **Startup perf:** `npx tsx scripts/bench-startup.ts <warm|cold|fastcold>` runs in a sandboxed `HOME` with mocked `fetch` (warm = no legacy network, cold = dead API worst case) and reports `importMs`, `factoryMs`, and import-inclusive `totalMs`. `importMs` includes the tsx loader/transpilation and module-graph initialization; it is not pure compiler time and is outside pi-free's runtime startup log. `factoryMs` remains the awaited `piFreeEntry` time recorded by `lib/startup-timing.ts`. Native Pi model refresh and session-start detached work are reported separately.
+- **Startup perf:** `npx tsx scripts/bench-startup.ts <warm|cold|fastcold> [source|compiled]` runs in a sandboxed `HOME` with mocked `fetch` (warm = no legacy network, cold = dead API worst case) and reports `importMs`, `factoryMs`, and import-inclusive `totalMs`. Run `npm run build` before `compiled` mode. Source mode includes tsx loader/transpilation; compiled mode measures native Node ESM loading. `factoryMs` remains the awaited `piFreeEntry` time recorded by `lib/startup-timing.ts`. Native Pi model refresh and session-start detached work are reported separately.
 - **Tests:** `tests/*.test.ts` — covers registry, toggle state, config, model detection, provider compat
 - Tests use `vi.fn()` mocks for ExtensionAPI
 

--- a/docs/build-strategy.md
+++ b/docs/build-strategy.md
@@ -1,21 +1,69 @@
-# Proposed compiled packaging strategy
+# Compiled packaging
 
-This document records a **proposed separate packaging effort** for pi-free. It is not an implementation plan for the current release: the current package still loads `index.ts`, and no `dist` build is shipped.
+Compiled packaging is implemented and is the published form of pi-free. The
+working tree remains TypeScript-first for development and tests, while npm and
+Pi load the plain Node ESM output in `dist/`.
 
-## Recommended output
+## Build
 
-Ship plain, pinned TypeScript compiler output as JavaScript in `dist/`. An initial esbuild bundler is unnecessary: the runtime imports currently consist of Node built-ins and Pi peer packages. Keep `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` external rather than bundling them. This keeps the extension aligned with the host Pi installation and avoids duplicating peer runtime code.
+`tsconfig.build.json` uses the pinned TypeScript compiler with `module` and
+`moduleResolution` set to `NodeNext`. It emits the runtime graph rooted at
+`index.ts` as ES2022 JavaScript, keeps peer imports external, and uses
+`rewriteRelativeImportExtensions` so source `.ts` imports become `.js` imports.
+The build also copies `provider-failover/benchmarks.json` to the matching
+`dist/provider-failover/` path; the benchmark loader resolves it relative to
+`import.meta.url`.
 
-The compiler configuration should emit the source module graph without bundling it. Emitted relative imports must be rewritten from `.ts` to `.js` so Node can resolve the compiled graph. The build must also copy `provider-failover/benchmarks.json` beside its emitted code: benchmark loading uses `import.meta.url`, so the data file must preserve the expected relative layout in `dist/`.
+```sh
+npm run build       # clean and emit dist/
+npm run clean       # remove dist/
+npm run lint        # type-check source
+npm run test:run    # source-mode tests
+npm run smoke:compiled
+```
 
-Dynamic imports require explicit compatibility testing, especially the OpenCode paths and `opencode-session`. The compiled entry must retain their dynamic resolution behavior rather than assuming a bundler-specific module format. Target Node `>=20.0.0`, matching the package runtime requirement.
+`prepare` runs the build for git/file installs and before npm packaging. The
+published `pi.extensions` entry and `main` are both `./dist/index.js`. The
+package `files` list publishes `dist/` plus user-facing documentation and the
+relative-import checker; source TypeScript, tests, and development scripts are
+not published. `dist/` is ignored and is intentionally not committed.
 
-## Packaging and validation
+## Validation
 
-- Add a `prepare` script so git installs compile the package before use.
-- Add tarball and CI checks that verify the compiled entry exists, the expected JSON asset is present, and the published package can load the compiled entry.
-- Validate from a clean clone, including installation through the supported package-install paths; do not rely only on a working tree with generated files.
-- Preserve the existing source tests. Run them against source as they do today, and add focused compiled-entry/tarball checks rather than replacing the source suite.
-- Measure startup with import-inclusive timing before adopting the build. The comparison must include loading the entry and its dependency graph, not only provider initialization; use the result to decide whether compilation improves the real startup path.
+Build and package checks are available with:
 
-This strategy should be introduced as a deliberate packaging change in a later effort, with its generated output and release checks reviewed independently from provider behavior changes.
+```sh
+npm run build
+npm run check
+npm pack
+node scripts/check-tarball.mjs ./pi-free-*.tgz
+node scripts/smoke-compiled.mjs ./dist/index.js
+```
+
+The tarball checker verifies the compiled entry, benchmark JSON, package
+metadata, safe contents, relative imports, and (when run after `npm ci`) loads
+the extracted compiled entry with the local peer dependencies. CI also packs,
+installs, checks, and loads the entry from the installed package on Linux,
+macOS, and Windows. `npm publish --dry-run` runs the same build lifecycle.
+
+Dynamic imports remain unbundled. In particular, the OpenCode and
+`opencode-session` paths continue to use runtime specifier resolution, so the
+compiled output must be tested with the host Pi peer packages available. The
+build targets Node `>=20.0.0`; it does not bundle or install Pi peer packages.
+
+## Startup comparison
+
+The import-inclusive benchmark supports both modes:
+
+```sh
+npx tsx scripts/bench-startup.ts warm source
+npm run build
+npx tsx scripts/bench-startup.ts warm compiled
+```
+
+The `RESULT` line includes `entryKind`, `importMs`, `factoryMs`, and the
+import-inclusive `totalMs`. `importMs` includes the `tsx` loader and module
+graph in source mode, while compiled mode measures Node's native ESM loader;
+provider initialization and the existing warm/cold network scenarios are kept
+the same. The benchmark requires `dist/` for compiled mode and does not
+exercise provider API calls beyond its existing mocked scenarios.

--- a/package.json
+++ b/package.json
@@ -29,15 +29,9 @@
 	"engines": {
 		"node": ">=20.0.0"
 	},
+	"main": "./dist/index.js",
 	"files": [
-		"index.ts",
-		"providers/**/*.ts",
-		"lib/**/*.ts",
-		"provider-failover/**/*.ts",
-		"provider-failover/**/*.json",
-		"config.ts",
-		"constants.ts",
-		"provider-helper.ts",
+		"dist/**/*",
 		"README.md",
 		"LICENSE",
 		"CHANGELOG.md",
@@ -46,13 +40,18 @@
 	],
 	"scripts": {
 		"audit:prod": "npm audit --omit=dev --audit-level=high",
+		"build": "node scripts/build.mjs",
+		"clean": "node scripts/clean.mjs",
 		"check": "node scripts/check-extensions.mjs",
 		"check:lockfile": "node scripts/check-lockfile-sync.mjs",
 		"check:tarball": "node scripts/check-tarball.mjs",
 		"lint": "tsc --noEmit",
+		"prepare": "npm run build",
 		"test": "vitest",
 		"test:ui": "vitest --ui",
 		"test:run": "vitest run",
+		"bench:startup": "tsx scripts/bench-startup.ts",
+		"smoke:compiled": "node scripts/smoke-compiled.mjs",
 		"smoke:cline": "tsx scripts/smoke-cline-xml-bridge.ts",
 		"smoke:openmodel": "tsx scripts/smoke-openmodel-wire-format.ts"
 	},
@@ -82,7 +81,7 @@
 	},
 	"pi": {
 		"extensions": [
-			"./index.ts"
+			"./dist/index.js"
 		]
 	}
 }

--- a/scripts/bench-startup.ts
+++ b/scripts/bench-startup.ts
@@ -10,7 +10,8 @@
  * it before and after a change to get a real before/after delta.
  *
  * Usage (via tsx, which is already a dev dependency):
- *   npx tsx scripts/bench-startup.ts <warm|cold|fastcold>
+ *   npx tsx scripts/bench-startup.ts <warm|cold|fastcold> [source|compiled]
+ *   npm run build && npx tsx scripts/bench-startup.ts warm compiled
  *
  * Modes:
  *   warm     - Sandbox seeded with your real ~/.pi/provider-cache.json (timestamps
@@ -36,7 +37,8 @@
  *   for i in 1 2 3 4 5; do npx tsx scripts/bench-startup.ts warm; done
  *
  * Prints a human-readable summary plus a `RESULT {...}` JSON line for scripting.
- * Both include importMs, factoryMs, and import-inclusive totalMs.
+ * Both include importMs, factoryMs, and import-inclusive totalMs. Pass
+ * `compiled` as the second argument after `npm run build` to measure dist/.
  */
 import {
 	copyFileSync,
@@ -51,8 +53,15 @@ import { join } from "node:path";
 import { freshenProviderCache } from "./bench-startup-cache.ts";
 
 const mode = process.argv[2] ?? "warm";
-if (!["warm", "cold", "fastcold"].includes(mode)) {
-	console.error("Usage: tsx scripts/bench-startup.ts <warm|cold|fastcold>");
+const entryKind = process.argv[3] ?? "source";
+if (!["warm", "cold", "fastcold"].includes(mode) || !["source", "compiled"].includes(entryKind)) {
+	console.error(
+		"Usage: tsx scripts/bench-startup.ts <warm|cold|fastcold> [source|compiled]",
+	);
+	process.exit(2);
+}
+if (entryKind === "compiled" && !existsSync(join(process.cwd(), "dist", "index.js"))) {
+	console.error("Compiled entry is missing; run `npm run build` first.");
 	process.exit(2);
 }
 
@@ -186,10 +195,13 @@ const mockPi: any = {
 // but keep its dynamic import inside the phase for a complete import boundary.
 // ---------------------------------------------------------------------------
 const importStart = performance.now();
-const mod = await import("../index.ts");
-const { getStartupSummary, formatStartupSummary } = await import(
-	"../lib/startup-timing.ts"
-);
+const entryModule = entryKind === "compiled" ? "../dist/index.js" : "../index.ts";
+const timingModule =
+	entryKind === "compiled"
+		? "../dist/lib/startup-timing.js"
+		: "../lib/startup-timing.ts";
+const mod = await import(entryModule);
+const { getStartupSummary, formatStartupSummary } = await import(timingModule);
 const importEnd = performance.now();
 const importMs = Math.round((importEnd - importStart) * 10) / 10;
 
@@ -303,7 +315,7 @@ const clineFactoryNetworkCalls = fetchUrls.filter((u) =>
 	u.includes("cline"),
 ).length;
 
-console.log(`\nmode: ${mode}`);
+console.log(`\nmode: ${mode} (${entryKind})`);
 console.log(
 	`import (loader/transpilation/module graph; outside runtime log): ${importMs}ms`,
 );
@@ -328,6 +340,7 @@ console.log(formatStartupSummary());
 
 const result = {
 	mode,
+	entryKind,
 	importMs,
 	factoryMs,
 	totalMs,

--- a/scripts/bench-startup.ts
+++ b/scripts/bench-startup.ts
@@ -316,8 +316,12 @@ const clineFactoryNetworkCalls = fetchUrls.filter((u) =>
 ).length;
 
 console.log(`\nmode: ${mode} (${entryKind})`);
+const importDescription =
+	entryKind === "compiled"
+		? "native Node ESM module graph"
+		: "tsx loader/transpilation/module graph";
 console.log(
-	`import (loader/transpilation/module graph; outside runtime log): ${importMs}ms`,
+	`import (${importDescription}; outside runtime log): ${importMs}ms`,
 );
 console.log(`factory (awaited by Pi; runtime log): ${factoryMs}ms`);
 console.log(`total (import + factory): ${totalMs}ms`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const tsc = join(root, "node_modules", "typescript", "bin", "tsc");
+
+execFileSync(process.execPath, [join(root, "scripts", "clean.mjs")], {
+	cwd: root,
+	stdio: "inherit",
+});
+execFileSync(process.execPath, [tsc, "-p", join(root, "tsconfig.build.json")], {
+	cwd: root,
+	stdio: "inherit",
+});
+
+const assetDir = join(root, "dist", "provider-failover");
+mkdirSync(assetDir, { recursive: true });
+copyFileSync(
+	join(root, "provider-failover", "benchmarks.json"),
+	join(assetDir, "benchmarks.json"),
+);
+console.log("Built dist/ and copied provider-failover/benchmarks.json");

--- a/scripts/check-extensions.mjs
+++ b/scripts/check-extensions.mjs
@@ -29,7 +29,7 @@ function resolveNpmCli() {
 function runNpmPackDryRun() {
 	return execFileSync(
 		process.execPath,
-		[resolveNpmCli(), "pack", "--dry-run", "--json"],
+		[resolveNpmCli(), "pack", "--dry-run", "--json", "--ignore-scripts"],
 		{ encoding: "utf8" },
 	);
 }
@@ -53,17 +53,25 @@ function getFiles() {
 		// Use npm pack --dry-run to inspect exactly what would be published.
 		const out = runNpmPackDryRun();
 		return parsePackFileList(out)
-			.filter((f) => f && (f.endsWith(".ts") || f.endsWith(".mjs")))
+			.filter(
+				(f) =>
+					f &&
+					(f.endsWith(".js") || f.endsWith(".ts") || f.endsWith(".mjs")),
+			)
 			.map((f) => join(installDir, f));
 	}
-	// Installed location: walk all .ts/.mjs files
+	// Installed location: walk all runtime module files
 	const files = [];
 	function walk(dir) {
 		for (const entry of readdirSync(dir)) {
 			const full = join(dir, entry);
 			if (entry === "node_modules") continue;
 			if (statSync(full).isDirectory()) walk(full);
-			else if (entry.endsWith(".ts") || entry.endsWith(".mjs"))
+			else if (
+				entry.endsWith(".js") ||
+				entry.endsWith(".ts") ||
+				entry.endsWith(".mjs")
+			)
 				files.push(full);
 		}
 	}
@@ -76,8 +84,11 @@ function resolveImport(fromFile, importPath) {
 	for (const candidate of [
 		base,
 		base.replace(/\.js$/, ".ts"), // .js → .ts (TypeScript ESM convention)
+		base.replace(/\.ts$/, ".js"),
 		base + ".ts",
+		base + ".js",
 		join(base, "index.ts"),
+		join(base, "index.js"),
 	]) {
 		try {
 			if (statSync(candidate).isFile()) return candidate;
@@ -100,10 +111,10 @@ for (const file of files) {
 	const stripped = src
 		.replaceAll(/\/\/[^\n]*/g, "")
 		.replaceAll(/\/\*[\s\S]*?\*\//g, "");
-	const importRe = /from\s+['"](\.[^'"]+)['"]/g;
+	const importRe = /(?:from\s+|import\s*\()(['"])(\.[^'"]+)\1/g;
 	let match;
 	while ((match = importRe.exec(stripped)) !== null) {
-		const importPath = match[1];
+		const importPath = match[2];
 		const key = `${relFile}:${importPath}`;
 		if (seen.has(key)) continue;
 		seen.add(key);

--- a/scripts/check-tarball.mjs
+++ b/scripts/check-tarball.mjs
@@ -10,9 +10,11 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
+	symlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 function fail(message) {
 	console.error(`ERROR: ${message}`);
@@ -79,11 +81,8 @@ const entrySet = new Set(entries);
 
 const required = [
 	"package/package.json",
-	"package/index.ts",
-	"package/config.ts",
-	"package/constants.ts",
-	"package/provider-helper.ts",
-	"package/provider-failover/benchmarks.json",
+	"package/dist/index.js",
+	"package/dist/provider-failover/benchmarks.json",
 	"package/README.md",
 	"package/CHANGELOG.md",
 	"package/LICENSE",
@@ -97,7 +96,6 @@ for (const file of required) {
 
 const forbiddenPatterns = [
 	/^package\/(?:node_modules|tests|\.github|\.pi|\.claude|\.pisessionsummaries)\//,
-	/^package\/dist\//,
 	/^package\/.+\.log$/,
 	/^package\/.+\.tsbuildinfo$/,
 	/^package\/.+\.tgz$/,
@@ -126,12 +124,14 @@ try {
 	if (!Array.isArray(extensions) || extensions.length === 0) {
 		fail("package.json has no pi.extensions entries");
 	}
+	let compiledEntry;
 	for (const extension of extensions) {
 		const normalized = String(extension).replace(/^\.\//, "");
 		if (!entrySet.has(`package/${normalized}`)) {
 			fail(`pi.extensions entry missing from tarball: ${extension}`);
 		}
 		console.log(`OK: pi.extensions -> ${extension}`);
+		if (normalized === "dist/index.js") compiledEntry = join(packageDir, normalized);
 	}
 	if (pkg.main) {
 		const normalized = String(pkg.main).replace(/^\.\//, "");
@@ -139,6 +139,35 @@ try {
 			fail(`package.json main points to missing file: ${pkg.main}`);
 		}
 		console.log(`OK: main -> ${pkg.main}`);
+	}
+	if (!compiledEntry) fail("compiled dist/index.js is not the Pi extension entry");
+
+	// Always validate JavaScript syntax. When run from a checkout after npm ci,
+	// temporarily link its peer dependencies so Node can import the extracted
+	// package exactly like the installed package smoke check does.
+	const projectNodeModules = join(process.cwd(), "node_modules");
+	const extractedNodeModules = join(packageDir, "node_modules");
+	if (existsSync(projectNodeModules)) {
+		symlinkSync(projectNodeModules, extractedNodeModules, "junction");
+		try {
+			execFileSync(
+				process.execPath,
+				[
+					"--input-type=module",
+					"-e",
+					`await import(${JSON.stringify(pathToFileURL(compiledEntry).href)});`,
+				],
+				{ stdio: "inherit" },
+			);
+			console.log("OK: compiled extension entry loads");
+		} finally {
+			rmSync(extractedNodeModules, { recursive: true, force: true });
+		}
+	} else {
+		execFileSync(process.execPath, ["--check", compiledEntry], {
+			stdio: "inherit",
+		});
+		console.log("OK: compiled extension entry syntax");
 	}
 } finally {
 	rmSync(extractDir, { recursive: true, force: true });

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+rmSync(join(root, "dist"), { recursive: true, force: true });

--- a/scripts/smoke-compiled.mjs
+++ b/scripts/smoke-compiled.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const entry = resolve(process.argv[2] ?? "dist/index.js");
+await import(pathToFileURL(entry).href);
+console.log(`Compiled entry loaded: ${entry}`);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true,
+    "rewriteRelativeImportExtensions": true,
+    "noEmitOnError": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", ".pi-lens", "tests", "scripts", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- Compile the TypeScript runtime graph to plain Node ESM JavaScript in `dist/`.
- Point Pi and `main` at `dist/index.js`, keeping Pi peer dependencies external.
- Copy `provider-failover/benchmarks.json` into the compiled layout and preserve dynamic imports.
- Add build/clean/compiled smoke commands and update import-resolution, tarball, CI, and release validation.
- Extend startup benchmarking with `source` and `compiled` entry modes.
- Document the implemented packaging strategy in `docs/build-strategy.md`.

## Validation
- `npm run build`
- `npm run lint`
- `npm run test:run -- --reporter=dot` (625 passed)
- `npm run check`
- `npm run check:lockfile`
- `npm run smoke:compiled`
- `npm pack` plus `node scripts/check-tarball.mjs` (compiled entry loaded)

Warm benchmark on this runner:
- source: import `4076.1ms`, factory `54.9ms`, total `4131.1ms`
- compiled: import `3981.7ms`, factory `62.6ms`, total `4044.3ms`

The benchmark intentionally reports loader/module-graph time separately from provider initialization; exact cold-import results vary by host and loader cache.
