### PR TITLE
fix: build git installs without dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "22"
 
@@ -38,6 +39,29 @@ jobs:
       - name: TypeScript lint
         run: npm run lint
 
+  source-install-build:
+    name: Production source install
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22"
+
+      # This is the path used by `pi install git:...`: devDependencies are
+      # omitted, but npm still runs prepare. The build must fetch its pinned
+      # compiler transiently rather than require a pre-existing node_modules.
+      - name: Install source checkout with production dependencies
+        run: npm install --omit=dev --no-audit --no-fund
+
+      - name: Verify production source build
+        run: |
+          test -f dist/index.js
+          node scripts/smoke-compiled.mjs ./dist/index.js
+
   test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -45,7 +69,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "22"
 
@@ -67,7 +92,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "22"
 
@@ -95,7 +121,8 @@ jobs:
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/check-extensions.mjs "$INSTALL_DIR"
 
-      - name: Smoke-load compiled extension entry (catches missing runtime modules)
+      - name: Smoke-load compiled extension entry
+        # Catches missing runtime modules.
         shell: bash
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
       # omitted, but npm still runs prepare. The build must fetch its pinned
       # compiler transiently rather than require a pre-existing node_modules.
       - name: Install source checkout with production dependencies
-        run: npm install --omit=dev --no-audit --no-fund
+        # Required here: prepare is the behavior under test. # NOSONAR
+        run: npm ci --omit=dev --no-audit --no-fund # NOSONAR
 
       - name: Verify production source build
         run: |

--- a/docs/build-strategy.md
+++ b/docs/build-strategy.md
@@ -28,6 +28,13 @@ package `files` list publishes `dist/` plus user-facing documentation and the
 relative-import checker; source TypeScript, tests, and development scripts are
 not published. `dist/` is ignored and is intentionally not committed.
 
+Git installs omit devDependencies, so `scripts/build.mjs` uses the local
+TypeScript compiler during development and falls back to a pinned transient
+`npx` compiler during `prepare`. The build tsconfig is emit-only (`noCheck` and
+`types: []`); CI runs the full source type-check separately. This keeps
+`npm install --omit=dev`—the path used by `pi install git:...`—self-contained
+without requiring users to repair or manually populate `node_modules`.
+
 ## Validation
 
 Build and package checks are available with:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -31,14 +31,14 @@ if (existsSync(localTsc)) {
 		"-p",
 		buildConfig,
 	];
-	const npxCandidates = [
+	const npxCli = [
 		process.env.npm_execpath
 			? join(dirname(process.env.npm_execpath), "npx-cli.js")
 			: undefined,
 		join(dirname(process.execPath), "node_modules", "npm", "bin", "npx-cli.js"),
-	].filter((candidate) => candidate && existsSync(candidate));
-	if (npxCandidates[0]) {
-		execFileSync(process.execPath, [npxCandidates[0], ...npxArgs], {
+	].find((candidate) => candidate !== undefined && existsSync(candidate));
+	if (npxCli) {
+		execFileSync(process.execPath, [npxCli, ...npxArgs], {
 			cwd: root,
 			stdio: "inherit",
 		});

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,20 +1,56 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const tsc = join(root, "node_modules", "typescript", "bin", "tsc");
+const localTsc = join(root, "node_modules", "typescript", "bin", "tsc");
+const buildConfig = join(root, "tsconfig.build.json");
 
 execFileSync(process.execPath, [join(root, "scripts", "clean.mjs")], {
 	cwd: root,
 	stdio: "inherit",
 });
-execFileSync(process.execPath, [tsc, "-p", join(root, "tsconfig.build.json")], {
-	cwd: root,
-	stdio: "inherit",
-});
+// Git-based Pi installs run `npm install --omit=dev`, so the local compiler is
+// intentionally absent during `prepare`. Match pi-lens's production-install
+// strategy: use the pinned local compiler when available, otherwise fetch the
+// exact compiler transiently with npx instead of asking users to repair the
+// checkout manually.
+if (existsSync(localTsc)) {
+	execFileSync(process.execPath, [localTsc, "-p", buildConfig], {
+		cwd: root,
+		stdio: "inherit",
+	});
+} else {
+	const npxArgs = [
+		"--yes",
+		"-p",
+		"typescript@7.0.2",
+		"tsc",
+		"-p",
+		buildConfig,
+	];
+	const npxCandidates = [
+		process.env.npm_execpath
+			? join(dirname(process.env.npm_execpath), "npx-cli.js")
+			: undefined,
+		join(dirname(process.execPath), "node_modules", "npm", "bin", "npx-cli.js"),
+	].filter((candidate) => candidate && existsSync(candidate));
+	if (npxCandidates[0]) {
+		execFileSync(process.execPath, [npxCandidates[0], ...npxArgs], {
+			cwd: root,
+			stdio: "inherit",
+		});
+	} else {
+		const npx = process.platform === "win32" ? "npx.cmd" : "npx";
+		execFileSync(npx, npxArgs, {
+			cwd: root,
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+	}
+}
 
 const assetDir = join(root, "dist", "provider-failover");
 mkdirSync(assetDir, { recursive: true });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    "noCheck": true,
+    "types": [],
     "outDir": "dist",
     "rootDir": ".",
     "declaration": false,


### PR DESCRIPTION
## Summary

`pi install git:...` runs `npm install --omit=dev`, which triggers `prepare` without the local TypeScript devDependency. The build previously hard-coded `node_modules/typescript/bin/tsc` and failed with `MODULE_NOT_FOUND`.

- Use the local compiler when present.
- Fall back to the pinned TypeScript compiler through npm's `npx-cli.js` during production/source installs.
- Make the dist config emit-only so omitted `@types/node` is not required.
- Add CI coverage for a clean `npm install --omit=dev` source checkout.
- Document the install path and compiler fallback.

This follows pi-lens's clean Git-install strategy.

## Validation

- Clean source checkout: `npm install --omit=dev` + compiled smoke load passed
- Full tests: 54 files, 625 tests passed
- `npm run build`
- `npm run lint`
- `npm run check`
- `npm run check:lockfile`
