### PR TITLE
fix: support generic Cline extension-tool DSML

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -1012,14 +1012,123 @@ type ParsedToolCalls = {
  * after matching rather than interpolated into a regular expression.
  */
 const DSML_TOOL_CALL_RE =
-	/<｜DSML｜([^>]+)>([^]*?)<\/｜DSML｜\1>/g;
+	/<｜DSML｜([^>\s]+)>([^]*?)<\/｜DSML｜\1>/g;
+const DSML_INVOKE_RE =
+	/<｜DSML｜invoke(?:\s+name=(?:"([^"]*)"|'([^']*)'))?[^>]*>([^]*?)<\/｜DSML｜invoke>/g;
+const DSML_WRAPPER_RE =
+	/<｜DSML｜(?:function_calls|tool_calls)>([^]*?)<\/｜DSML｜(?:function_calls|tool_calls)>/g;
+const DSML_PARAMETER_RE =
+	/<｜DSML｜parameter\s+name=(?:"([^"]*)"|'([^']*)')(?:\s+string=(?:"([^"]*)"|'([^']*)'))?[^>]*>([^]*?)<\/｜DSML｜parameter>/g;
+const DSML_MALFORMED_PARAMETER_RE =
+	/<([A-Za-z_][A-Za-z0-9_.-]*)>\s*([^]*?)<\/｜DSML｜parameter>/g;
 
-function normalizeDsmlToolCalls(text: string, toolNames: Set<string>): string {
+function dsmlParameterXml(body: string): string | undefined {
+	const parameters: string[] = [];
+	let cursor = 0;
+	let match: RegExpExecArray | null;
+
+	DSML_PARAMETER_RE.lastIndex = 0;
+	while ((match = DSML_PARAMETER_RE.exec(body)) !== null) {
+		if (body.slice(cursor, match.index).trim()) return undefined;
+		const name = match[1] ?? match[2];
+		if (!name) return undefined;
+		const stringFlag = match[3] ?? match[4];
+		const value = decodeXmlEntities(match[5].trim());
+		const encodedValue =
+			stringFlag?.toLowerCase() === "true" ? JSON.stringify(value) : value;
+		parameters.push(`<${name}>${xmlEscape(encodedValue)}</${name}>`);
+		cursor = match.index + match[0].length;
+	}
+	if (parameters.length > 0) {
+		return body.slice(cursor).trim() ? undefined : parameters.join("\n");
+	}
+	if (!body.trim()) return "";
+
+	// Some models omit the parameter opener but retain its DSML closer, for
+	// example `<path>file</｜DSML｜parameter>`. Recover this only when the
+	// field name is a valid XML-style parameter name and the whole body is
+	// consumed; unknown or partial markup remains ordinary text.
+	DSML_MALFORMED_PARAMETER_RE.lastIndex = 0;
+	while ((match = DSML_MALFORMED_PARAMETER_RE.exec(body)) !== null) {
+		if (body.slice(cursor, match.index).trim()) return undefined;
+		parameters.push(
+			`<${match[1]}>${xmlEscape(decodeXmlEntities(match[2].trim()))}</${match[1]}>`,
+		);
+		cursor = match.index + match[0].length;
+	}
+	return parameters.length > 0 && !body.slice(cursor).trim()
+		? parameters.join("\n")
+		: undefined;
+}
+
+function normalizeDsmlInvoke(
+	name: string | undefined,
+	body: string,
+	toolNames: ReadonlySet<string>,
+): string | undefined {
+	const resolvedName = name && decodeXmlEntities(name).trim();
+	if (!resolvedName || !toolNames.has(resolvedName)) return undefined;
+	const parameterXml = dsmlParameterXml(body);
+	return parameterXml === undefined
+		? undefined
+		: `<${resolvedName}>${parameterXml}</${resolvedName}>`;
+}
+
+function normalizeDsmlToolCalls(
+	text: string,
+	toolNames: ReadonlySet<string>,
+): string {
 	if (toolNames.size === 0) return text;
-	return text.replace(
+
+	// DeepSeek DSML also has a wrapper/invoke dialect. Normalize only when all
+	// calls are complete and refer to exact registered names.
+	let normalized = text.replace(DSML_WRAPPER_RE, (match, body: string) => {
+		const calls: string[] = [];
+		let cursor = 0;
+		let invokeMatch: RegExpExecArray | null;
+		DSML_INVOKE_RE.lastIndex = 0;
+		while ((invokeMatch = DSML_INVOKE_RE.exec(body)) !== null) {
+			if (body.slice(cursor, invokeMatch.index).trim()) return match;
+			const call = normalizeDsmlInvoke(
+				invokeMatch[1] ?? invokeMatch[2],
+				invokeMatch[3],
+				toolNames,
+			);
+			if (!call) return match;
+			calls.push(call);
+			cursor = invokeMatch.index + invokeMatch[0].length;
+		}
+		return calls.length > 0 && !body.slice(cursor).trim()
+			? calls.join("\n\n")
+			: match;
+	});
+
+	// Accept an unwrapped invoke call as well.
+	normalized = normalized.replace(
+		DSML_INVOKE_RE,
+		(match, quotedName, alternateName, body) =>
+			normalizeDsmlInvoke(
+				quotedName ?? alternateName,
+				body,
+				toolNames,
+			) ?? match,
+	);
+
+	// Finally normalize the direct named form. The name is deliberately looked
+	// up as-is; extension tools are plain registered Pi names, not MCP aliases.
+	normalized = normalized.replace(
 		DSML_TOOL_CALL_RE,
 		(match, name: string, body: string) =>
 			toolNames.has(name) ? `<${name}>${body}</${name}>` : match,
+	);
+
+	// Recover the observed mismatched form where a named call closes as invoke.
+	const malformedDirectCallRe =
+		/<｜DSML｜([^>\s]+)>([^]*?)<\/｜DSML｜invoke>/g;
+	return normalized.replace(
+		malformedDirectCallRe,
+		(match, name: string, body: string) =>
+			normalizeDsmlInvoke(name, body, toolNames) ?? match,
 	);
 }
 

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -117,6 +117,93 @@ describe("Cline XML bridge", () => {
 			});
 		});
 
+		it("normalizes exact plain extension tool names without provider-specific aliases", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<｜DSML｜aio-websearch>",
+					" <query>pi extension tools</query>",
+					" <max>5</max>",
+					"</｜DSML｜aio-websearch>",
+					"<｜DSML｜extension-notify>",
+					" <message>done</message>",
+					"</｜DSML｜extension-notify>",
+				].join("\n"),
+				[
+					{
+						...tool("aio-websearch"),
+						parameters: {
+							type: "object",
+							properties: {
+								query: { type: "string" },
+								max: { type: "number" },
+							},
+						},
+					},
+					{
+						...tool("extension-notify"),
+						parameters: {
+							type: "object",
+							properties: { message: { type: "string" } },
+						},
+					},
+				],
+			);
+
+			expect(parsed).toEqual({
+				text: "",
+				toolCalls: [
+					{
+						name: "aio-websearch",
+						arguments: { query: "pi extension tools", max: 5 },
+					},
+					{ name: "extension-notify", arguments: { message: "done" } },
+				],
+			});
+		});
+
+		it("recovers malformed DSML parameter and invoke wrappers for an exact registered core name", () => {
+			const malformed = [
+				"<｜DSML｜read_file>",
+				" <path>C:/tmp/strategy-memory.ts</｜DSML｜parameter>",
+				"</｜DSML｜invoke>",
+			].join("\n");
+			const parsed = __test__.parseXmlToolCalls(malformed, [tool("read")]);
+
+			expect(parsed).toEqual({
+				text: "",
+				toolCalls: [
+					{
+						name: "read",
+						arguments: { path: "C:/tmp/strategy-memory.ts" },
+					},
+				],
+			});
+		});
+
+		it("parses DSML invoke and parameter wrappers with plain extension names", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<｜DSML｜function_calls>",
+					' <｜DSML｜invoke name="aio-websearch">',
+					'  <｜DSML｜parameter name="query" string="true">hello</｜DSML｜parameter>',
+					'  <｜DSML｜parameter name="max" string="false">5</｜DSML｜parameter>',
+					" </｜DSML｜invoke>",
+					"</｜DSML｜function_calls>",
+				].join("\n"),
+				[tool("aio-websearch")],
+			);
+
+			expect(parsed).toEqual({
+				text: "",
+				toolCalls: [
+					{
+						name: "aio-websearch",
+						arguments: { query: "hello", max: 5 },
+					},
+				],
+			});
+		});
+
 		it("parses multiline JSON arguments in DSML calls", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
@@ -486,6 +573,26 @@ describe("Cline XML bridge", () => {
 			]);
 		});
 
+		it("recovers a plain extension DSML call emitted in the reasoning field", () => {
+			const parsed = __test__.parseReasoningToolCalls(
+				[
+					"I should search before answering.",
+					"<｜DSML｜aio-websearch>",
+					" <query>reasoning field</query>",
+					"</｜DSML｜aio-websearch>",
+				].join("\n"),
+				[tool("aio-websearch"), tool("extension-notify")],
+			);
+
+			expect(parsed.thinking).toEqual(["I should search before answering."]);
+			expect(parsed.toolCalls).toEqual([
+			{
+				name: "aio-websearch",
+				arguments: { query: "reasoning field" },
+			},
+		]);
+		});
+
 		it("does not leak XML code fence markers as text", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
@@ -822,6 +929,85 @@ describe("Cline XML bridge", () => {
 					}),
 				]),
 			);
+		});
+
+		it("dispatches plain extension DSML from content and reasoning with the real provider context shape", async () => {
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									reasoning:
+										"<｜DSML｜aio-websearch><query>live context</query></｜DSML｜aio-websearch>",
+								content:
+									"<｜DSML｜extension-notify><message>done</message></｜DSML｜extension-notify>",
+							},
+								finish_reason: "stop",
+							},
+						],
+					},
+				]),
+			);
+			const tools = [
+				tool("read"),
+				{
+					...tool("aio-websearch"),
+					parameters: {
+						type: "object",
+						properties: { query: { type: "string" } },
+						required: ["query"],
+					},
+				},
+				{
+					...tool("extension-notify"),
+					parameters: {
+						type: "object",
+						properties: { message: { type: "string" } },
+					},
+				},
+			];
+			const stream = streamClineXml(
+				clineModel(),
+				{ ...clineContext(), tools },
+				{ apiKey: "token" },
+				{},
+			);
+			const result = await stream.result();
+			const body = requestBody(fetchMock, 0);
+
+			expect(result.stopReason).toBe("toolUse");
+			expect(result.content).not.toContainEqual(
+				expect.objectContaining({
+					type: "text",
+					text: expect.stringContaining("<｜DSML｜"),
+				}),
+		);
+			expect(result.content).toContainEqual(
+				expect.objectContaining({
+					type: "toolCall",
+					name: "aio-websearch",
+					arguments: { query: "live context" },
+				}),
+		);
+			expect(result.content).toContainEqual(
+			expect.objectContaining({
+					type: "toolCall",
+					name: "extension-notify",
+					arguments: { message: "done" },
+				}),
+		);
+		expect(body.tools).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					function: expect.objectContaining({ name: "aio-websearch" }),
+				}),
+				expect.objectContaining({
+					function: expect.objectContaining({ name: "extension-notify" }),
+				}),
+			]),
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 		});
 
 		it("returns an error instead of a blank stop when Cline streams no content", async () => {

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -45,7 +45,11 @@ function sseResponse(chunks: unknown[], status = 200): Response {
 
 function requestBody(fetchMock: ReturnType<typeof vi.spyOn>, index: number) {
 	const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined;
-	return JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+	try {
+		return JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
 }
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Follow-up to #377 and #376. Some Cline models emit DeepSeek-style DSML tool calls either in visible content or reasoning, including malformed parameter/invoke wrappers. The bridge now handles arbitrary **exactly registered Pi tool names** from the current provider context.

- Supports direct, invoke/parameter, wrapper, and observed malformed DSML forms.
- Handles content and reasoning fields.
- Preserves unknown/incomplete markup as ordinary text.
- Makes no pi-webaio, MCP, provider, or tool-name assumptions.
- Adds arbitrary extension-tool and realistic provider-context regressions.

Fixes #376.

## Validation

- Focused Cline tests: 54 passed
- Full suite: 634 passed
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`
