### PR TITLE
fix: recover nested DSML tool fields

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -979,8 +979,7 @@ function parseToolArguments(
 		// `content` and selected provider-specific fields are explicitly string
 		// parameters (file bodies, SEARCH/REPLACE diffs). Parsing them as JSON
 		// corrupts JSON file content into "[object Object]".
-		const shouldParseJson =
-			tag !== "content" && !preserveStringTags.has(tag);
+		const shouldParseJson = tag !== "content" && !preserveStringTags.has(tag);
 		if (shouldParseJson) {
 			try {
 				args[tag] = JSON.parse(raw);
@@ -1011,8 +1010,7 @@ type ParsedToolCalls = {
  * pattern is static; tool names are checked against the current Pi context
  * after matching rather than interpolated into a regular expression.
  */
-const DSML_TOOL_CALL_RE =
-	/<｜DSML｜([^>\s]+)>([^]*?)<\/｜DSML｜\1>/g;
+const DSML_TOOL_CALL_RE = /<｜DSML｜([^>\s]+)>([^]*?)<\/｜DSML｜\1>/g;
 const DSML_INVOKE_RE =
 	/<｜DSML｜invoke(?:\s+name=(?:"([^"]*)"|'([^']*)'))?[^>]*>([^]*?)<\/｜DSML｜invoke>/g;
 const DSML_WRAPPER_RE =
@@ -1021,6 +1019,8 @@ const DSML_PARAMETER_RE =
 	/<｜DSML｜parameter\s+name=(?:"([^"]*)"|'([^']*)')(?:\s+string=(?:"([^"]*)"|'([^']*)'))?[^>]*>([^]*?)<\/｜DSML｜parameter>/g;
 const DSML_MALFORMED_PARAMETER_RE =
 	/<([A-Za-z_][A-Za-z0-9_.-]*)>\s*([^]*?)<\/｜DSML｜parameter>/g;
+const DSML_NAMED_FIELD_RE =
+	/<｜DSML｜([A-Za-z_][A-Za-z0-9_.-]*)>([^]*?)<\/｜DSML｜\1>/g;
 
 function dsmlParameterXml(body: string): string | undefined {
 	const parameters: string[] = [];
@@ -1043,6 +1043,22 @@ function dsmlParameterXml(body: string): string | undefined {
 		return body.slice(cursor).trim() ? undefined : parameters.join("\n");
 	}
 	if (!body.trim()) return "";
+
+	// Some models wrap fields in DSML tags instead of using the standard
+	// `parameter name=...` form, for example:
+	// `<｜DSML｜path>file</｜DSML｜path>`. Convert only a fully-consumed field
+	// sequence; unknown or partial markup remains ordinary text.
+	DSML_NAMED_FIELD_RE.lastIndex = 0;
+	while ((match = DSML_NAMED_FIELD_RE.exec(body)) !== null) {
+		if (body.slice(cursor, match.index).trim()) return undefined;
+		parameters.push(
+			`<${match[1]}>${xmlEscape(decodeXmlEntities(match[2].trim()))}</${match[1]}>`,
+		);
+		cursor = match.index + match[0].length;
+	}
+	if (parameters.length > 0) {
+		return body.slice(cursor).trim() ? undefined : parameters.join("\n");
+	}
 
 	// Some models omit the parameter opener but retain its DSML closer, for
 	// example `<path>file</｜DSML｜parameter>`. Recover this only when the
@@ -1107,11 +1123,8 @@ function normalizeDsmlToolCalls(
 	normalized = normalized.replace(
 		DSML_INVOKE_RE,
 		(match, quotedName, alternateName, body) =>
-			normalizeDsmlInvoke(
-				quotedName ?? alternateName,
-				body,
-				toolNames,
-			) ?? match,
+			normalizeDsmlInvoke(quotedName ?? alternateName, body, toolNames) ??
+			match,
 	);
 
 	// Finally normalize the direct named form. The name is deliberately looked
@@ -1123,8 +1136,7 @@ function normalizeDsmlToolCalls(
 	);
 
 	// Recover the observed mismatched form where a named call closes as invoke.
-	const malformedDirectCallRe =
-		/<｜DSML｜([^>\s]+)>([^]*?)<\/｜DSML｜invoke>/g;
+	const malformedDirectCallRe = /<｜DSML｜([^>\s]+)>([^]*?)<\/｜DSML｜invoke>/g;
 	return normalized.replace(
 		malformedDirectCallRe,
 		(match, name: string, body: string) =>

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -184,6 +184,29 @@ describe("Cline XML bridge", () => {
 			});
 		});
 
+		it("recovers DSML-nested fields from the observed invoke wrapper", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<｜DSML｜read_file>",
+					" <｜DSML｜path>C:/Users/apman/OneDrive/Desktop/pi-webaio/src/strategy-memory.ts</｜DSML｜path>",
+					"</｜DSML｜invoke>",
+				].join("\n"),
+				[tool("read")],
+			);
+
+			expect(parsed).toEqual({
+				text: "",
+				toolCalls: [
+					{
+						name: "read",
+						arguments: {
+							path: "C:/Users/apman/OneDrive/Desktop/pi-webaio/src/strategy-memory.ts",
+						},
+					},
+				],
+			});
+		});
+
 		it("parses DSML invoke and parameter wrappers with plain extension names", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
@@ -261,10 +284,9 @@ describe("Cline XML bridge", () => {
 				"<｜DSML｜general-tool>",
 				" <value>missing the closing call tag</value>",
 			].join("\n");
-			const parsed = __test__.parseXmlToolCalls(
-				malformed,
-				[tool("general-tool")],
-			);
+			const parsed = __test__.parseXmlToolCalls(malformed, [
+				tool("general-tool"),
+			]);
 
 			expect(parsed).toEqual({ text: malformed, toolCalls: [] });
 
@@ -590,11 +612,11 @@ describe("Cline XML bridge", () => {
 
 			expect(parsed.thinking).toEqual(["I should search before answering."]);
 			expect(parsed.toolCalls).toEqual([
-			{
-				name: "aio-websearch",
-				arguments: { query: "reasoning field" },
-			},
-		]);
+				{
+					name: "aio-websearch",
+					arguments: { query: "reasoning field" },
+				},
+			]);
 		});
 
 		it("does not leak XML code fence markers as text", () => {
@@ -868,7 +890,7 @@ describe("Cline XML bridge", () => {
 								delta: {
 									reasoning:
 										"Now read the file. Let me inspect the current contents.",
-							},
+								},
 							},
 						],
 					},
@@ -897,7 +919,7 @@ describe("Cline XML bridge", () => {
 									tool_calls: [
 										{
 											index: 0,
-											function: { arguments: "README.md\"}" },
+											function: { arguments: 'README.md"}' },
 										},
 									],
 								},
@@ -944,9 +966,9 @@ describe("Cline XML bridge", () => {
 								delta: {
 									reasoning:
 										"<｜DSML｜aio-websearch><query>live context</query></｜DSML｜aio-websearch>",
-								content:
-									"<｜DSML｜extension-notify><message>done</message></｜DSML｜extension-notify>",
-							},
+									content:
+										"<｜DSML｜extension-notify><message>done</message></｜DSML｜extension-notify>",
+								},
 								finish_reason: "stop",
 							},
 						],
@@ -986,32 +1008,32 @@ describe("Cline XML bridge", () => {
 					type: "text",
 					text: expect.stringContaining("<｜DSML｜"),
 				}),
-		);
+			);
 			expect(result.content).toContainEqual(
 				expect.objectContaining({
 					type: "toolCall",
 					name: "aio-websearch",
 					arguments: { query: "live context" },
 				}),
-		);
+			);
 			expect(result.content).toContainEqual(
-			expect.objectContaining({
+				expect.objectContaining({
 					type: "toolCall",
 					name: "extension-notify",
 					arguments: { message: "done" },
 				}),
-		);
-		expect(body.tools).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					function: expect.objectContaining({ name: "aio-websearch" }),
-				}),
-				expect.objectContaining({
-					function: expect.objectContaining({ name: "extension-notify" }),
-				}),
-			]),
-		);
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+			);
+			expect(body.tools).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						function: expect.objectContaining({ name: "aio-websearch" }),
+					}),
+					expect.objectContaining({
+						function: expect.objectContaining({ name: "extension-notify" }),
+					}),
+				]),
+			);
+			expect(fetchMock).toHaveBeenCalledTimes(1);
 		});
 
 		it("returns an error instead of a blank stop when Cline streams no content", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #380. Some Cline/DeepSeek-compatible responses emit a registered tool as:

```text
<｜DSML｜read_file>
 <｜DSML｜path>C:/.../strategy-memory.ts</｜DSML｜path>
</｜DSML｜invoke>
```

The outer call is registered, but its argument fields are DSML-wrapped and the outer close tag uses `invoke`. The bridge now converts fully-consumed DSML-nested fields into normal tool arguments without adding any provider/tool-specific allowlist.

- Supports multiple nested DSML fields.
- Keeps unknown or partial markup as ordinary text.
- Preserves existing direct, invoke/parameter, reasoning, and extension-tool parsing.
- Adds a regression test for the exact observed payload.

Fixes #376.

## Validation

- Focused Cline tests: 55 passed
- Full suite: 635 passed
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`
