### PR TITLE
fix: cover DSML parameter-wrapped fields

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -256,7 +256,20 @@ function parseSearchReplaceBlocks(
 	diff: string,
 ): Array<{ oldText: string; newText: string }> {
 	const edits: Array<{ oldText: string; newText: string }> = [];
-	const normalized = diff.replaceAll("\r\n", "\n");
+	const lines = diff.replaceAll("\r\n", "\n").split("\n");
+	const markerIndents = lines
+		.filter((line) => /^(?:\s*)(?:------- SEARCH|=======|\+{7} REPLACE)\s*$/.test(line))
+		.map((line) => line.length - line.trimStart().length)
+		.filter((indent) => indent > 0);
+	const commonIndent = markerIndents.length > 0 ? Math.min(...markerIndents) : 0;
+	const normalized = lines
+		.map((line) => {
+			const indent = line.length - line.trimStart().length;
+			return commonIndent > 0 && indent >= commonIndent
+				? line.slice(commonIndent)
+				: line;
+		})
+		.join("\n");
 	let cursor = 0;
 
 	while (cursor < normalized.length) {
@@ -1021,6 +1034,8 @@ const DSML_MALFORMED_PARAMETER_RE =
 	/<([A-Za-z_][A-Za-z0-9_.-]*)>\s*([^]*?)<\/｜DSML｜parameter>/g;
 const DSML_NAMED_FIELD_RE =
 	/<｜DSML｜([A-Za-z_][A-Za-z0-9_.-]*)>([^]*?)<\/｜DSML｜\1>/g;
+const DSML_NAMED_PARAMETER_RE =
+	/<｜DSML｜([A-Za-z_][A-Za-z0-9_.-]*)>([^]*?)<\/｜DSML｜parameter>/g;
 
 function dsmlParameterXml(body: string): string | undefined {
 	const parameters: string[] = [];
@@ -1043,6 +1058,22 @@ function dsmlParameterXml(body: string): string | undefined {
 		return body.slice(cursor).trim() ? undefined : parameters.join("\n");
 	}
 	if (!body.trim()) return "";
+
+	// Some models wrap fields in DSML tags but close every field with the
+	// generic `parameter` tag, for example:
+	// `<｜DSML｜path>file</｜DSML｜parameter>`. Convert only a fully-consumed
+	// field sequence; unknown or partial markup remains ordinary text.
+	DSML_NAMED_PARAMETER_RE.lastIndex = 0;
+	while ((match = DSML_NAMED_PARAMETER_RE.exec(body)) !== null) {
+		if (body.slice(cursor, match.index).trim()) return undefined;
+		parameters.push(
+			`<${match[1]}>${xmlEscape(decodeXmlEntities(match[2].trim()))}</${match[1]}>`,
+		);
+		cursor = match.index + match[0].length;
+	}
+	if (parameters.length > 0) {
+		return body.slice(cursor).trim() ? undefined : parameters.join("\n");
+	}
 
 	// Some models wrap fields in DSML tags instead of using the standard
 	// `parameter name=...` form, for example:

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -207,6 +207,34 @@ describe("Cline XML bridge", () => {
 			});
 		});
 
+		it("recovers DSML-named fields closed by the generic parameter tag", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<｜DSML｜replace_in_file>",
+					" <｜DSML｜path>C:/tmp/search.ts</｜DSML｜parameter>",
+					" <｜DSML｜diff>",
+					" ------- SEARCH",
+					" old value",
+					" =======",
+					" new value",
+					" +++++++ REPLACE",
+					" </｜DSML｜parameter>",
+					"</｜DSML｜invoke>",
+				].join("\n"),
+				[tool("edit")],
+			);
+
+			expect(parsed.toolCalls).toEqual([
+				{
+					name: "edit",
+					arguments: {
+						path: "C:/tmp/search.ts",
+						edits: [{ oldText: "old value", newText: "new value" }],
+					},
+				},
+			]);
+		});
+
 		it("parses DSML invoke and parameter wrappers with plain extension names", () => {
 			const parsed = __test__.parseXmlToolCalls(
 				[
@@ -226,6 +254,29 @@ describe("Cline XML bridge", () => {
 					{
 						name: "aio-websearch",
 						arguments: { query: "hello", max: 5 },
+					},
+				],
+			});
+		});
+
+		it("parses the official DSML tool_calls wrapper", () => {
+			const parsed = __test__.parseXmlToolCalls(
+				[
+					"<｜DSML｜tool_calls>",
+					' <｜DSML｜invoke name="aio-websearch">',
+					'  <｜DSML｜parameter name="query" string="true">hello</｜DSML｜parameter>',
+					" </｜DSML｜invoke>",
+					"</｜DSML｜tool_calls>",
+				].join("\n"),
+				[tool("aio-websearch")],
+			);
+
+			expect(parsed).toEqual({
+				text: "",
+				toolCalls: [
+					{
+						name: "aio-websearch",
+						arguments: { query: "hello" },
 					},
 				],
 			});


### PR DESCRIPTION
## Summary

Follow-up to merged PR #381. DeepSeek's documented DSML grammar uses `<｜DSML｜tool_calls>` with `<｜DSML｜invoke>` and `<｜DSML｜parameter name=... string=...>`, but the observed Cline response is a hybrid form:

```text
<｜DSML｜replace_in_file>
 <｜DSML｜path>C:/.../search.ts</｜DSML｜parameter>
 <｜DSML｜diff>
 ------- SEARCH
 ...
 =======
 ...
 +++++++ REPLACE
 </｜DSML｜parameter>
</｜DSML｜invoke>
```

This follow-up:

- Converts DSML-named fields closed by the generic `parameter` tag.
- Keeps the existing official `tool_calls` grammar covered.
- Handles common indentation in SEARCH/REPLACE diffs.
- Remains extension-agnostic and only dispatches exact registered tool names.
- Preserves incomplete/unknown markup as text.

## Validation

- Focused Cline tests: 57 passed
- `npm run lint`
- `git diff --check`
