### PR TITLE
fix: preserve custom tool schemas for Cline

### DIFF
--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -673,6 +673,14 @@ function assistantMessageToText(
 		.join("\n\n");
 }
 
+function getCustomToolParameters(
+	bridge: ToolBridge,
+	tools: Tool[] | undefined,
+): unknown {
+	if (bridge.remoteName !== bridge.runtimeName) return undefined;
+	return tools?.find((tool) => tool.name === bridge.remoteName)?.parameters;
+}
+
 function buildClineToolDefinitions(
 	tools: Tool[] | undefined,
 ): ClineToolDefinition[] {
@@ -681,8 +689,10 @@ function buildClineToolDefinitions(
 	for (const bridge of getToolBridges(tools)) {
 		if (seen.has(bridge.remoteName)) continue;
 		seen.add(bridge.remoteName);
+		const customParameters = getCustomToolParameters(bridge, tools);
 		const parameters =
-			bridge.remoteName === "replace_in_file"
+			customParameters ??
+			(bridge.remoteName === "replace_in_file"
 				? {
 						type: "object",
 						properties: {
@@ -697,7 +707,7 @@ function buildClineToolDefinitions(
 							bridge.parameters.map((name) => [name, { type: "string" }]),
 						),
 						required: bridge.parameters,
-					};
+					});
 		definitions.push({
 			type: "function",
 			function: {

--- a/tests/cline-xml-bridge.test.ts
+++ b/tests/cline-xml-bridge.test.ts
@@ -1131,6 +1131,65 @@ describe("Cline XML bridge", () => {
 			expect(fetchMock).toHaveBeenCalledTimes(1);
 		});
 
+		it("preserves optional and union fields for custom tool schemas", async () => {
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									tool_calls: [
+										{
+											index: 0,
+											id: "call_webfetch",
+											function: {
+												name: "aio-webfetch",
+												arguments: '{"url":"https://example.com"}',
+											},
+										},
+									],
+								},
+								finish_reason: "tool_calls",
+							},
+						],
+					},
+				]),
+			);
+			const parameters = {
+				type: "object",
+				properties: {
+					url: { type: "string" },
+					urls: { type: "array", items: { type: "string" } },
+					query: { type: "string" },
+				},
+				oneOf: [{ required: ["url"] }, { required: ["urls"] }],
+			};
+			const tools = [{ ...tool("aio-webfetch"), parameters }];
+			const stream = streamClineXml(
+				clineModel(),
+				{ ...clineContext(), tools },
+				{ apiKey: "token" },
+				{},
+			);
+			const result = await stream.result();
+			const body = requestBody(fetchMock, 0);
+			const definition = (
+				body.tools as Array<{
+					function?: { name?: string; parameters?: unknown };
+				}>
+			).find((candidate) => candidate.function?.name === "aio-webfetch");
+
+			expect(result.stopReason).toBe("toolUse");
+			expect(result.content).toContainEqual(
+				expect.objectContaining({
+					type: "toolCall",
+					name: "aio-webfetch",
+					arguments: { url: "https://example.com" },
+				}),
+			);
+			expect(definition?.function?.parameters).toEqual(parameters);
+		});
+
 		it("returns an error instead of a blank stop when Cline streams no content", async () => {
 			vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(sseResponse([]));
 


### PR DESCRIPTION
## Summary

Custom tools such as `aio-webfetch` were being advertised to Cline with a lossy synthetic schema:

- every property was forced to `type: string`
- every property was marked required
- `oneOf` / optional fields were discarded

That caused models to repeatedly retry valid calls because schemas with alternatives such as `url` vs `urls` appeared to require both parameters.

For tools whose remote and runtime names are identical (extension/custom tools), the bridge now forwards the original Pi JSON schema unchanged. Core Cline aliases retain their explicit compatibility schemas.

## Validation

- Focused Cline tests: 60 passed
- Full suite: 640 passed
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`
