### PR TITLE
perf: remove coding-agent root import at startup

### DIFF
--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -20,73 +20,19 @@
  * paid catalog.
  */
 
-import {
-	readStoredCredential,
-	type ExtensionAPI,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	getClineApiKey,
 	getClineShowPaid,
 	PROVIDER_CLINE,
 } from "../../config.ts";
-import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import {
 	registerNativeProvider,
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
-import { isOAuthCredential } from "../../provider-helper.ts";
 import { createClineProvider, rotateClineTaskId } from "./cline-provider.ts";
-
-const _logger = createLogger("cline");
-
-// =============================================================================
-// Credential inspection (non-destructive)
-// =============================================================================
-
-/**
- * Per-load credential inspection (the extension factory loads once per process,
- * so this runs once). Native auth reads the SAME ~/.pi/agent/auth.json that the
- * legacy `/login cline` flow already persisted to, so existing OAuth credentials
- * work with no destructive migration. This only logs status and flags malformed
- * old credentials (re-login is the recovery path); it never rewrites or deletes.
- * The inspection is a pure read + log, so it is idempotent by nature.
- */
-function inspectStoredClineCredential(): void {
-	try {
-		const cred = readStoredCredential(PROVIDER_CLINE);
-		if (!cred) {
-			_logger.info(
-				"No stored Cline credential; using ambient CLINE_API_KEY if configured",
-			);
-			return;
-		}
-		if (isOAuthCredential(cred)) {
-			if (typeof cred.access === "string" && cred.access.length > 0) {
-				_logger.info(
-					"Reusing existing Cline OAuth credential from auth.json (no migration needed)",
-				);
-			} else {
-				_logger.warn(
-					"Stored Cline OAuth credential is malformed; run /login cline to re-authenticate",
-				);
-			}
-			return;
-		}
-		if (cred.type === "api_key") {
-			_logger.info("Found stored Cline API key credential in auth.json");
-			return;
-		}
-		_logger.warn(
-			"Unrecognized stored Cline credential shape; run /login cline if auth fails",
-		);
-	} catch (err) {
-		_logger.warn("Failed to inspect stored Cline credential", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
-}
 
 // =============================================================================
 // Extension entry point
@@ -94,9 +40,6 @@ function inspectStoredClineCredential(): void {
 
 export default async function clineProvider(pi: ExtensionAPI) {
 	const { provider, stored } = createClineProvider();
-
-	// Non-destructive credential inspection (native auth reuses auth.json).
-	inspectStoredClineCredential();
 
 	// Register the native provider. The factory performs NO network I/O: models
 	// load via refreshModels (offline init from the store, then a background

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -16,13 +16,9 @@
  * Run /login kilo or use /toggle-kilo to access paid models.
  */
 
-import {
-	readStoredCredential,
-	type ExtensionAPI,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getKiloApiKey, getKiloShowPaid, PROVIDER_KILO } from "../../config.ts";
 import { URL_KILO_TOS } from "../../constants.ts";
-import { createLogger } from "../../lib/logger.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
 import {
 	registerNativeProvider,
@@ -30,10 +26,8 @@ import {
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
 import { logWarning } from "../../lib/util.ts";
-import { isOAuthCredential } from "../../provider-helper.ts";
+import { isCurrentModelOAuth } from "../../provider-helper.ts";
 import { createKiloProvider } from "./kilo-provider.ts";
-
-const _logger = createLogger("kilo");
 
 // =============================================================================
 // XML leak detection and auto-retry
@@ -138,61 +132,11 @@ function parseXmlToolCalls(
 }
 
 // =============================================================================
-// Credential migration (non-destructive)
-// =============================================================================
-
-/**
- * Per-load credential inspection (the extension factory loads once per process,
- * so this runs once). Native auth reads the SAME ~/.pi/agent/auth.json that the
- * legacy `/login kilo` flow already persisted to, so existing OAuth credentials
- * work with no destructive migration. This only logs status and flags malformed
- * old credentials (re-login is the recovery path); it never rewrites or deletes.
- * The inspection is a pure read + log, so it is idempotent by nature.
- */
-function inspectStoredKiloCredential(): void {
-	try {
-		const cred = readStoredCredential(PROVIDER_KILO);
-		if (!cred) {
-			_logger.info(
-				"No stored Kilo credential; using ambient KILO_API_KEY if configured",
-			);
-			return;
-		}
-		if (isOAuthCredential(cred)) {
-			if (typeof cred.access === "string" && cred.access.length > 0) {
-				_logger.info(
-					"Reusing existing Kilo OAuth credential from auth.json (no migration needed)",
-				);
-			} else {
-				_logger.warn(
-					"Stored Kilo OAuth credential is malformed; run /login kilo to re-authenticate",
-				);
-			}
-			return;
-		}
-		if (cred.type === "api_key") {
-			_logger.info("Found stored Kilo API key credential in auth.json");
-			return;
-		}
-		_logger.warn(
-			"Unrecognized stored Kilo credential shape; run /login kilo if auth fails",
-		);
-	} catch (err) {
-		_logger.warn("Failed to inspect stored Kilo credential", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-	}
-}
-
-// =============================================================================
 // Extension entry point
 // =============================================================================
 
 export default async function kiloProvider(pi: ExtensionAPI) {
 	const { provider, stored } = createKiloProvider();
-
-	// Non-destructive credential inspection (native auth reuses auth.json).
-	inspectStoredKiloCredential();
 
 	// Register the native provider. The factory performs NO network I/O: models
 	// load via refreshModels (offline init from the store, then a background
@@ -224,8 +168,7 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		if (ctx.model?.provider !== PROVIDER_KILO) return;
 		if (tosShown) return;
 		tosShown = true;
-		const cred = readStoredCredential(PROVIDER_KILO);
-		if (isOAuthCredential(cred)) return;
+		if (isCurrentModelOAuth(ctx)) return;
 		const paidCount = stored.all.length - stored.free.length;
 		if (paidCount > 0) {
 			ctx.ui.notify(

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -2,8 +2,8 @@
  * Cline factory wiring tests (end-to-end: extension wiring + real native
  * provider, network mocked). Mirrors tests/kilo-toggle.test.ts: verifies the
  * network-free factory, native registration, /toggle-cline, the global
- * /toggle-free re-register hook, task-id rotation, the session_start refresh
- * nudge, and the non-destructive credential inspection.
+ * /toggle-free re-register hook, task-id rotation, and the session_start
+ * refresh nudge.
  */
 
 import type {
@@ -27,10 +27,6 @@ const mockSaveConfig = vi.hoisted(() =>
 const mockRegisterWithGlobalToggle = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => void>(),
 );
-const mockReadStoredCredential = vi.hoisted(() =>
-	vi.fn((): unknown => undefined),
-);
-
 let capturedToggleArgs: unknown[][] = [];
 
 vi.mock("../config.ts", () => ({
@@ -66,10 +62,6 @@ vi.mock("../providers/cline/cline-models.ts", async () => {
 		fetchClineCatalog: (...args: unknown[]) => mockFetchClineCatalog(...args),
 	};
 });
-
-vi.mock("@earendil-works/pi-coding-agent", () => ({
-	readStoredCredential: () => mockReadStoredCredential(),
-}));
 
 vi.mock("../lib/logger.ts", () => ({
 	createLogger: () => ({
@@ -121,7 +113,6 @@ describe("Cline factory wiring", () => {
 		mockGetClineApiKey.mockReturnValue(undefined);
 		mockGetClineShowPaid.mockReturnValue(false);
 		mockGetGlobalFreeOnly.mockReturnValue(true);
-		mockReadStoredCredential.mockReturnValue(undefined);
 		mockFetchClineCatalog.mockResolvedValue({
 			all: [
 				cfg({ id: "free-1" }),
@@ -306,26 +297,5 @@ describe("Cline factory wiring", () => {
 
 		// No modelRegistry on the context -> safe no-op.
 		await expect(handler({}, {})).resolves.toBeUndefined();
-	});
-
-	describe("non-destructive credential inspection", () => {
-		it.each([
-			["no stored credential", undefined],
-			[
-				"valid oauth credential",
-				{ type: "oauth", access: "tok", refresh: "r", expires: 1 },
-			],
-			[
-				"malformed oauth credential",
-				{ type: "oauth", access: "", refresh: "r", expires: 1 },
-			],
-			["api key credential", { type: "api_key", key: "sk" }],
-			["unrecognized credential", { type: "mystery" }],
-		])("registers normally with %s", async (_label, cred) => {
-			mockReadStoredCredential.mockReturnValue(cred);
-			await clineProvider(mockPi);
-			expect(mockRegisterProvider).toHaveBeenCalledTimes(1);
-			expect(mockRegisterProvider.mock.calls[0][0].id).toBe("cline");
-		});
 	});
 });

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -64,10 +64,6 @@ vi.mock("../providers/kilo/kilo-models.ts", async () => {
 	};
 });
 
-vi.mock("@earendil-works/pi-coding-agent", () => ({
-	readStoredCredential: () => undefined,
-}));
-
 vi.mock("../lib/logger.ts", () => ({
 	createLogger: () => ({
 		info: vi.fn(),

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -7,7 +7,7 @@
  *   - participates in the global toggle (registerWithGlobalToggle)
  *   - /toggle-kilo flips show_paid and re-registers the same provider object
  *   - model_select ToS notice + session_start handler
- *   - non-destructive credential migration inspection
+ *   - OAuth-aware ToS suppression through the model registry
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -22,9 +22,6 @@ const mockSaveConfig = vi.hoisted(() =>
 );
 const mockRegisterWithGlobalToggle = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => void>(),
-);
-const mockReadStoredCredential = vi.hoisted(() =>
-	vi.fn<(...args: unknown[]) => unknown>(),
 );
 const mockProvider = vi.hoisted(() => ({
 	id: "kilo",
@@ -47,11 +44,6 @@ vi.mock("../config.ts", () => ({
 vi.mock("../lib/registry.ts", () => ({
 	registerWithGlobalToggle: (...args: unknown[]) =>
 		mockRegisterWithGlobalToggle(...args),
-}));
-
-vi.mock("@earendil-works/pi-coding-agent", () => ({
-	readStoredCredential: (...args: unknown[]) =>
-		mockReadStoredCredential(...args),
 }));
 
 vi.mock("../providers/kilo/kilo-provider.ts", () => ({
@@ -174,8 +166,7 @@ describe("Kilo extension wiring", () => {
 			expect(events).toContain("session_start");
 		});
 
-		it("shows a ToS notice on first Kilo model selection (no stored cred)", async () => {
-			mockReadStoredCredential.mockReturnValue(undefined);
+		it("shows a ToS notice on first Kilo model selection without a model registry", async () => {
 			await kiloProvider(mockPi);
 			const call = mockOn.mock.calls.find((c) => c[0] === "model_select");
 			if (!call) throw new Error("model_select not registered");
@@ -187,27 +178,19 @@ describe("Kilo extension wiring", () => {
 			);
 		});
 
-		it("skips the ToS notice when an OAuth credential is stored", async () => {
-			mockReadStoredCredential.mockReturnValue({
-				type: "oauth",
-				access: "a",
-				refresh: "r",
-				expires: Date.now() + 1000,
-			});
+		it("skips the ToS notice when the current model uses OAuth", async () => {
 			await kiloProvider(mockPi);
 			const call = mockOn.mock.calls.find((c) => c[0] === "model_select");
 			if (!call) throw new Error("model_select not registered");
 			const notify = vi.fn();
-			await call[1]({}, { model: { provider: "kilo" }, ui: { notify } });
+			const isUsingOAuth = vi.fn(() => true);
+			await call[1]({}, {
+				model: { provider: "kilo" },
+				modelRegistry: { isUsingOAuth },
+				ui: { notify },
+			});
+			expect(isUsingOAuth).toHaveBeenCalledWith({ provider: "kilo" });
 			expect(notify).not.toHaveBeenCalled();
-		});
-	});
-
-	describe("credential migration", () => {
-		it("inspects stored credentials without throwing (malformed old cred)", async () => {
-			mockReadStoredCredential.mockReturnValue({ type: "oauth", access: "" });
-			await expect(kiloProvider(mockPi)).resolves.toBeUndefined();
-			expect(mockReadStoredCredential).toHaveBeenCalledWith("kilo");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

The compiled extension import graph was loading the entire `@earendil-works/pi-coding-agent` package (over 1,000 modules) solely because Cline and Kilo performed non-essential `readStoredCredential()` inspections.

This change:

- Removes the startup-only credential inspection from Cline.
- Removes the equivalent Kilo inspection.
- Uses Pi's existing `ctx.modelRegistry.isUsingOAuth(ctx.model)` compatibility helper for Kilo's ToS suppression instead of reading auth storage directly.
- Leaves all type-only `pi-coding-agent` imports intact.
- Preserves the Kilo ToS behavior and native auth lifecycle.

A scratch compiled import comparison showed approximately:

- Before: ~2,002 unique modules, ~1.82–1.92s direct import.
- After: ~855–904 unique modules, ~0.58–0.63s direct import.

The controlled source benchmark remains environment-sensitive; the factory stays network-free and Pi-visible runtime work is unchanged.

## Validation

- Focused tests: 17 passed
- Full suite: 631 passed
- `npm run lint`
- `npm run build`
- `npm run check`
- Warm source benchmark completed
- `git diff --check`
