### PR TITLE
perf: defer pi-ai compatibility graph

### DIFF
--- a/lib/assistant-message-event-stream.ts
+++ b/lib/assistant-message-event-stream.ts
@@ -1,0 +1,98 @@
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+} from "@earendil-works/pi-ai/compat";
+
+/**
+ * Push-based async stream used by custom providers.
+ *
+ * This mirrors pi-ai's public AssistantMessageEventStream contract without
+ * importing the compatibility entrypoint (or an unexported pi-ai module).
+ */
+export class EventStream<T, R = T> implements AsyncIterable<T> {
+	private queue: T[] = [];
+	private waiting: Array<(result: IteratorResult<T>) => void> = [];
+	private done = false;
+	private finalResultPromise: Promise<R>;
+	private resolveFinalResult!: (result: R) => void;
+	private readonly isComplete: (event: T) => boolean;
+	private readonly extractResult: (event: T) => R;
+
+	constructor(
+		isComplete: (event: T) => boolean,
+		extractResult: (event: T) => R,
+	) {
+		this.isComplete = isComplete;
+		this.extractResult = extractResult;
+		this.finalResultPromise = new Promise<R>((resolve) => {
+			this.resolveFinalResult = resolve;
+		});
+	}
+
+	push(event: T): void {
+		if (this.done) return;
+
+		if (this.isComplete(event)) {
+			this.done = true;
+			this.resolveFinalResult(this.extractResult(event));
+		}
+
+		const waiter = this.waiting.shift();
+		if (waiter) {
+			waiter({ value: event, done: false });
+		} else {
+			this.queue.push(event);
+		}
+	}
+
+	end(result?: R): void {
+		this.done = true;
+		if (result !== undefined) this.resolveFinalResult(result);
+
+		while (this.waiting.length > 0) {
+			const waiter = this.waiting.shift();
+			waiter?.({ value: undefined as never, done: true });
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<T> {
+		while (true) {
+			if (this.queue.length > 0) {
+				yield this.queue.shift() as T;
+			} else if (this.done) {
+				return;
+			} else {
+				const result = await new Promise<IteratorResult<T>>((resolve) =>
+					this.waiting.push(resolve),
+				);
+				if (result.done) return;
+				yield result.value;
+			}
+		}
+	}
+
+	result(): Promise<R> {
+		return this.finalResultPromise;
+	}
+}
+
+/** Public-provider-compatible stream factory for custom wire protocols. */
+export class AssistantMessageEventStream extends EventStream<
+	AssistantMessageEvent,
+	AssistantMessage
+> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type for final result");
+			},
+		);
+	}
+}
+
+export function createAssistantMessageEventStream(): AssistantMessageEventStream {
+	return new AssistantMessageEventStream();
+}

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -11,7 +11,7 @@ import type {
 	ProviderAuth,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -38,6 +38,7 @@
 
 import type {
 	Api,
+	AssistantMessageEventStream,
 	Model,
 	Provider,
 	RefreshModelsContext,
@@ -182,7 +183,13 @@ export function createClineProvider(): ClineNativeProvider {
 		model: ClineModel,
 		context: Parameters<typeof streamClineXml>[1],
 		options: Parameters<typeof streamClineXml>[2],
-	) => streamClineXml(model, context, options, buildClineHeaders());
+	): AssistantMessageEventStream =>
+		streamClineXml(
+			model,
+			context,
+			options,
+			buildClineHeaders(),
+		) as unknown as AssistantMessageEventStream;
 
 	const provider: Provider<"cline-xml-tools"> = {
 		id: PROVIDER_CLINE,

--- a/providers/cline/cline-xml-bridge.ts
+++ b/providers/cline/cline-xml-bridge.ts
@@ -9,7 +9,7 @@ import type {
 	ToolResultMessage,
 	Usage,
 } from "@earendil-works/pi-ai/compat";
-import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
+import { createAssistantMessageEventStream } from "../../lib/assistant-message-event-stream.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { BASE_URL_CLINE, PROVIDER_CLINE } from "../../constants.ts";
 

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -31,7 +31,7 @@ import type {
 	Provider,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import {
 	getKiloApiKey,

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -38,7 +38,7 @@ import type {
 	Provider,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getLlm7ShowPaid } from "../../config.ts";
 import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";

--- a/providers/ollama/ollama-provider.ts
+++ b/providers/ollama/ollama-provider.ts
@@ -4,7 +4,7 @@ import type {
 	Provider,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -13,7 +13,6 @@ import type {
 	ProviderHeaders,
 	SimpleStreamOptions,
 } from "@earendil-works/pi-ai/compat";
-import { registerApiProvider } from "@earendil-works/pi-ai/compat";
 import type {
 	ProviderConfig,
 	ProviderModelConfig,
@@ -583,35 +582,46 @@ export function createOpenCodeStreamSimple(
 // Registering the API here ensures the compat path also works.
 
 let _apiProviderRegistrationSourceId: string | undefined;
+let _apiProviderRegistrationPromise: Promise<void> | undefined;
 
 /**
  * Register the opencode-dynamic API in compat's global API registry
  * so that fallback code paths (compat streamSimple) can resolve it.
  * Safe to call multiple times — registers once per tracker instance.
+ *
+ * The registry is only needed after Pi has captured a built-in OpenCode
+ * catalog. Defer loading the compatibility entrypoint until this path is
+ * actually used; the normal OpenCode stream imports its API subpaths lazily.
  */
 export function ensureOpenCodeApiProviderRegistered(
 	tracker: OpenCodeSessionTracker,
 ): void {
-	if (_apiProviderRegistrationSourceId) return;
+	if (_apiProviderRegistrationSourceId || _apiProviderRegistrationPromise) return;
 
 	const streamFn = createOpenCodeStreamSimple(tracker);
 	const sourceId = `pi-free-opencode-${randomBytes(4).toString("hex")}`;
-
-	// registerApiProvider expects { api, stream, streamSimple }. Both
-	// stream and streamSimple return async-iterable streams; using the
-	// same implementation for both is safe — the compat wrappers only
-	// validate model.api and forward the call.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	registerApiProvider(
-		{
-			api: OPENCODE_DYNAMIC_API,
-			stream: streamFn as any,
-			streamSimple: streamFn,
-		},
-		sourceId,
-	);
-
-	_apiProviderRegistrationSourceId = sourceId;
+	_apiProviderRegistrationPromise = import("@earendil-works/pi-ai/compat")
+		.then(({ registerApiProvider }) => {
+			// registerApiProvider expects { api, stream, streamSimple }. Both
+			// stream and streamSimple return async-iterable streams; using the
+			// same implementation for both is safe — the compat wrappers only
+			// validate model.api and forward the call.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			registerApiProvider(
+				{
+					api: OPENCODE_DYNAMIC_API,
+					stream: streamFn as any,
+					streamSimple: streamFn,
+				},
+				sourceId,
+			);
+			_apiProviderRegistrationSourceId = sourceId;
+		})
+		.catch(() => {
+			// The normal OpenCode path does not require compat registration, so a
+			// failed optional fallback import must not break the built-in toggle.
+			_apiProviderRegistrationPromise = undefined;
+		});
 }
 
 /**

--- a/providers/openmodel/openmodel.ts
+++ b/providers/openmodel/openmodel.ts
@@ -33,7 +33,7 @@ import type {
 	Provider,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { anthropicMessagesApi } from "@earendil-works/pi-ai/compat";
+import { anthropicMessagesApi } from "@earendil-works/pi-ai/api/anthropic-messages.lazy";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/qoder/stream.ts
+++ b/providers/qoder/stream.ts
@@ -13,7 +13,7 @@
 import type {
 	Api,
 	AssistantMessage,
-	AssistantMessageEventStream,
+	AssistantMessageEventStream as PiAssistantMessageEventStream,
 	Context,
 	Model,
 	SimpleStreamOptions,
@@ -22,7 +22,9 @@ import type {
 	ThinkingContent,
 	ToolCall,
 } from "@earendil-works/pi-ai/compat";
-import * as PiAi from "@earendil-works/pi-ai/compat";
+import {
+	AssistantMessageEventStream as LocalAssistantMessageEventStream,
+} from "../../lib/assistant-message-event-stream.ts";
 import { BASE_URL_QODER } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getCachedModelConfig, staticModels } from "./models.ts";
@@ -44,7 +46,7 @@ interface ToolCallState {
 
 interface StreamState {
 	output: AssistantMessage;
-	stream: AssistantMessageEventStream;
+	stream: LocalAssistantMessageEventStream;
 	contentBlockIndex: number;
 	thinkingBlockIndex: number;
 	toolCallsState: ToolCallState[];
@@ -447,13 +449,8 @@ export function streamQoder(
 	model: Model<Api>,
 	context: Context,
 	options?: SimpleStreamOptions,
-): AssistantMessageEventStream {
-	const StreamCtor = (
-		PiAi as unknown as {
-			AssistantMessageEventStream: new () => AssistantMessageEventStream;
-		}
-	).AssistantMessageEventStream;
-	const stream = new StreamCtor();
+): PiAssistantMessageEventStream {
+	const stream = new LocalAssistantMessageEventStream();
 
 	const output: AssistantMessage = {
 		role: "assistant",
@@ -482,12 +479,12 @@ export function streamQoder(
 	// Run async — AssistantMessageEventStream is a push-based pull stream
 	runStream(output, stream, model, context, options);
 
-	return stream;
+	return stream as unknown as PiAssistantMessageEventStream;
 }
 
 async function runStream(
 	output: AssistantMessage,
-	stream: AssistantMessageEventStream,
+	stream: LocalAssistantMessageEventStream,
 	model: Model<Api>,
 	context: Context,
 	options: SimpleStreamOptions | undefined,

--- a/providers/qoder/thinking-parser.ts
+++ b/providers/qoder/thinking-parser.ts
@@ -12,10 +12,10 @@
 
 import type {
 	AssistantMessage,
-	AssistantMessageEventStream,
 	TextContent,
 	ThinkingContent,
 } from "@earendil-works/pi-ai/compat";
+import type { AssistantMessageEventStream } from "../../lib/assistant-message-event-stream.ts";
 
 const THINKING_TAG_VARIANTS: Array<{ open: string; close: string }> = [
 	{ open: "<thinking>", close: "</thinking>" },

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -26,8 +26,8 @@ import type {
 	SimpleStreamOptions,
 	ThinkingContent,
 } from "@earendil-works/pi-ai/compat";
-import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import { createAssistantMessageEventStream } from "../../lib/assistant-message-event-stream.ts";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { applyHidden } from "../../config.ts";
 import {
 	BASE_URL_TOKENROUTER,
@@ -443,7 +443,7 @@ function streamWithTokenRouterHighLoadRetry(
 		}
 	})();
 
-	return output;
+	return output as unknown as AssistantMessageEventStream;
 }
 
 export function streamSimpleTokenRouter(

--- a/providers/zenmux/zenmux-provider.ts
+++ b/providers/zenmux/zenmux-provider.ts
@@ -5,7 +5,7 @@ import type {
 	Provider,
 	RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/compat";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
 import { BASE_URL_ZENMUX, PROVIDER_ZENMUX } from "../../constants.ts";

--- a/tests/qoder-stream.test.ts
+++ b/tests/qoder-stream.test.ts
@@ -25,7 +25,7 @@ const mockLogger = vi.hoisted(() => ({
 
 const mockGetCachedModelConfig = vi.hoisted(() => vi.fn());
 
-vi.mock("@earendil-works/pi-ai/compat", async () => {
+vi.mock("../lib/assistant-message-event-stream.ts", async () => {
 	class MockStream implements MockStreamShape {
 		events: AssistantMessageEvent[] = [];
 		ended = false;


### PR DESCRIPTION
## Summary

After PR #385 removed the `pi-coding-agent` root graph, startup was still loading the `@earendil-works/pi-ai/compat` entrypoint through provider API factories, custom stream factories, Qoder, and OpenCode fallback registration.

This change:

- Uses supported narrow `pi-ai` lazy API exports for OpenAI Completions and Anthropic Messages.
- Adds a local provider-compatible assistant event stream for custom wire providers, preserving `push`, `end`, async iteration, and `result()` semantics.
- Removes runtime compat loading from Cline, TokenRouter, Qoder, and native API factories.
- Defers OpenCode's compat registry import until its fallback registration path is actually used.
- Keeps all pi-ai compatibility imports used only for types erased at runtime.

Import-graph measurements on the compiled entry:

- Before: 904 unique module files, including 660 TypeBox and 163 pi-ai modules.
- After: 226 unique module files; no `compat.js` or TypeBox modules load during extension import.
- Direct repeated import timing after: approximately 215–400ms in the current environment.

## Validation

- Full suite: 634 passed
- Qoder, Cline, TokenRouter, and OpenCode focused tests passed
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`
