### PR TITLE
feat: add native StepFun provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Free and paid AI model providers for [Pi](https://pi.dev). Access models from mu
 
 When you install pi-free, it:
 
-1. Registers native providers such as Kilo, Cline, LLM7, FastRouter, Ollama Cloud, OpenModel, and more.
+1. Registers native providers such as Kilo, Cline, LLM7, FastRouter, Ollama Cloud, OpenModel, StepFun, and more.
 2. Keeps Qoder on its legacy provider surface and supports Pi's built-in OpenCode, OpenCode Go, and OpenRouter integrations.
 3. Uses Pi's native model and auth stores for migrated providers; remaining legacy catalogs use their documented cache paths.
 4. Applies the global free-only filter by default, while preserving provider-specific paid/trial behavior.
@@ -72,8 +72,8 @@ First run creates `~/.pi/free.json`. Add extension-provider keys there or use th
 | --- | --- |
 | Free/free-tier | Kilo, Cline, LLM7, OpenModel, TokenRouter, Qoder basic tier, and eligible models from other catalogs |
 | Freemium | AnyAPI, Ollama Cloud, SambaNova |
-| Paid/trial | ZenMux, CrofAI, DeepInfra trial, Novita, Routeway, OpenGateway, B.AI, and paid catalog entries from other providers |
-| Native | FastRouter |
+| Paid/trial | ZenMux, CrofAI, DeepInfra trial, Novita, Routeway, OpenGateway, B.AI, StepFun, and paid catalog entries from other providers |
+| Native | FastRouter, StepFun |
 | Built-in | OpenCode, OpenCode Go, OpenRouter |
 
 Provider availability, authentication, and exact API-key names are maintained in [docs/providers.md](docs/providers.md). pi-free does not publish model counts because provider catalogs change.

--- a/agents.md
+++ b/agents.md
@@ -68,7 +68,8 @@ index.ts                          ← Extension entry point (piFreeEntry)
       ├─ openmodel/openmodel.ts   ← OpenModel Anthropic-compatible gateway
       ├─ qoder/                   ← Qoder/Cosy OAuth and streaming provider
       ├─ bai/bai.ts               ← BAI gateway provider
-      └─ fastrouter/              ← FastRouter native provider (public catalog + API-key chat)
+      ├─ fastrouter/              ← FastRouter native provider (public catalog + API-key chat)
+      └─ stepfun/                 ← StepFun Step Plan native provider (OpenAI-compatible chat)
 
 tests/                            ← Vitest test suite
 ```
@@ -102,7 +103,7 @@ For a new OpenAI-compatible native provider, use `registerNativeOpenAIProvider()
 
 ### Native `Provider` providers
 
-Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, OpenModel, and FastRouter use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
+Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, OpenModel, FastRouter, and StepFun use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
 
 ```
 providers/kilo/kilo-provider.ts   ← createKiloProvider(): assembles the Provider
@@ -183,8 +184,8 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
 | ✅ Free / free-tier | kilo, cline, llm7, openmodel, tokenrouter, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova | API key | Free allowance with limits |
-| 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
-| 🔧 Native | fastrouter | API key or none | Public catalog; Pi owns store refresh |
+| 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
+| 🔧 Native | fastrouter, stepfun | API key or none | Public catalog; Pi owns store refresh |
 | 🔧 Built-in | opencode, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---
@@ -211,7 +212,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 8. **Error handling is graceful** — providers that fail at startup are silently skipped
 9. **Model filtering is provider-specific** — native providers filter complete catalogs with `filterModels`; catalog fetchers may apply provider-specific modality or quality filters (NVIDIA retains its own 70B threshold)
 10. **All pi-free-registered catalogs use `enhanceWithCI()`** before registration to add CI scores
-11. **Legacy network-fetching extension providers are cache-first** (1h TTL via `lib/provider-cache.ts`); native providers, including FastRouter, use Pi's models store + `refreshModels` instead. Pi's built-in OpenCode, OpenCode Go, and OpenRouter providers are not managed by either extension cache.
+11. **Legacy network-fetching extension providers are cache-first** (1h TTL via `lib/provider-cache.ts`); native providers, including FastRouter and StepFun, use Pi's models store + `refreshModels` instead. Pi's built-in OpenCode, OpenCode Go, and OpenRouter providers are not managed by either extension cache.
 12. **Startup and session-start work are observable and bounded** — legacy `loadCachedOrFetchModels` network attempts use `STARTUP_FETCH_DEADLINE_MS` (8s, override `PI_FREE_STARTUP_FETCH_TIMEOUT_MS`) via `withFetchDeadline` in `lib/util.ts`; failed and timed-out attempts are counted with duration and per-provider status. Native providers, including FastRouter, restore from Pi's store and their session-start refresh nudges and detached probes are measured without making intentionally background work block the event. `/free-startup` exposes the post-finalize handler/task timings.
 13. **Compiled packaging is not shipped yet** — the proposed plain-TypeScript `dist` strategy, peer externalization, JSON asset layout, and validation plan live in [`docs/build-strategy.md`](docs/build-strategy.md). Keep source-mode loading until an import-inclusive benchmark justifies the change.
 14. **Health output is credential-free** — `/pi-free-health` reports provider counts, timing/failure labels, and the configured log path; it must not print API keys, OAuth tokens, model payloads, or raw log contents.

--- a/config.ts
+++ b/config.ts
@@ -23,6 +23,7 @@ import {
 	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_FASTROUTER,
+	PROVIDER_STEPFUN,
 	PROVIDER_KILO,
 	PROVIDER_OLLAMA,
 	PROVIDER_OPENCODE,
@@ -44,6 +45,7 @@ export {
 	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_FASTROUTER,
+	PROVIDER_STEPFUN,
 	PROVIDER_KILO,
 	PROVIDER_OPENCODE,
 	PROVIDER_OPENROUTER,
@@ -78,6 +80,7 @@ interface PiFreeConfig {
 	routeway_api_key?: string;
 	opengateway_api_key?: string;
 	fastrouter_api_key?: string;
+	stepfun_api_key?: string;
 	tokenrouter_api_key?: string;
 	anyapi_api_key?: string;
 	bai_api_key?: string;
@@ -99,6 +102,7 @@ interface PiFreeConfig {
 	routeway_show_paid?: boolean;
 	opengateway_show_paid?: boolean;
 	fastrouter_show_paid?: boolean;
+	stepfun_show_paid?: boolean;
 	tokenrouter_show_paid?: boolean;
 	anyapi_show_paid?: boolean;
 	bai_show_paid?: boolean;
@@ -120,6 +124,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_api_key: "",
 	opengateway_api_key: "",
 	fastrouter_api_key: "",
+	stepfun_api_key: "",
 	tokenrouter_api_key: "",
 	anyapi_api_key: "",
 	bai_api_key: "",
@@ -142,6 +147,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_show_paid: false,
 	opengateway_show_paid: false,
 	fastrouter_show_paid: false,
+	stepfun_show_paid: false,
 	tokenrouter_show_paid: false,
 	anyapi_show_paid: false,
 	bai_show_paid: false,
@@ -400,6 +406,11 @@ const PROVIDER_META: readonly ProviderMeta[] = [
 		prefix: "FASTROUTER",
 		showPaidKey: "fastrouter_show_paid",
 	},
+	{
+		id: PROVIDER_STEPFUN,
+		prefix: "STEPFUN",
+		showPaidKey: "stepfun_show_paid",
+	},
 	{ id: PROVIDER_OLLAMA, prefix: "OLLAMA", showPaidKey: "ollama_show_paid" },
 	{
 		id: PROVIDER_OPENROUTER,
@@ -513,6 +524,10 @@ export function getFastrouterShowPaid(): boolean {
 	);
 }
 
+export function getStepfunShowPaid(): boolean {
+	return resolveBool("STEPFUN_SHOW_PAID", loadConfigFile().stepfun_show_paid);
+}
+
 export function getOllamaShowPaid(): boolean {
 	return resolveBool("OLLAMA_SHOW_PAID", loadConfigFile().ollama_show_paid);
 }
@@ -586,6 +601,10 @@ export function getOpengatewayApiKey(): string | undefined {
 
 export function getFastrouterApiKey(): string | undefined {
 	return resolve("FASTROUTER_API_KEY", loadConfigFile().fastrouter_api_key);
+}
+
+export function getStepfunApiKey(): string | undefined {
+	return resolve("STEPFUN_API_KEY", loadConfigFile().stepfun_api_key);
 }
 
 export function getTokenrouterApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -24,6 +24,7 @@ export const PROVIDER_BAI = "bai";
 export const PROVIDER_OPENMODEL = "openmodel";
 export const PROVIDER_QODER = "qoder";
 export const PROVIDER_FASTROUTER = "fastrouter";
+export const PROVIDER_STEPFUN = "stepfun";
 
 // Built-in pi providers that pi-free wraps with toggles
 export const PROVIDER_OPENROUTER = "openrouter";
@@ -47,6 +48,8 @@ export const BASE_URL_TOKENROUTER = "https://api.tokenrouter.com/v1";
 export const BASE_URL_ANYAPI = "https://api.anyapi.ai/v1";
 export const BASE_URL_BAI = "https://api.b.ai/v1";
 export const BASE_URL_FASTROUTER = "https://api.fastrouter.ai/api/v1";
+/** StepFun Step Plan OpenAI-compatible Chat Completions API base URL. */
+export const BASE_URL_STEPFUN = "https://api.stepfun.ai/step_plan/v1";
 /**
  * OpenModel is registered with `api: "anthropic-messages"`. The pi-ai
  * Anthropic SDK appends `/v1/messages` to `baseURL`, so the base must

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,7 @@ Run `/toggle-{provider}` to switch between a provider's free/basic view and its 
 | `/toggle-tokenrouter` | TokenRouter | Native |
 | `/toggle-anyapi` | AnyAPI | Native |
 | `/toggle-bai` | B.AI | Native |
+| `/toggle-stepfun` | StepFun | Native |
 | `/toggle-openmodel` | OpenModel | Native |
 | `/toggle-qoder` | Qoder | Legacy |
 | `/toggle-openrouter` | OpenRouter | Pi built-in |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ These are the pi-free config keys and their environment variables:
 | `tokenrouter_api_key` | `TOKENROUTER_API_KEY` |
 | `anyapi_api_key` | `ANYAPI_API_KEY` |
 | `bai_api_key` | `BAI_API_KEY` |
+| `stepfun_api_key` | `STEPFUN_API_KEY` |
 | `openmodel_api_key` | `OPENMODEL_API_KEY` |
 
 ```bash
@@ -40,6 +41,7 @@ Example file:
   "cline_api_key": "...",
   "ollama_api_key": "...",
   "anyapi_api_key": "...",
+  "stepfun_api_key": "...",
   "openmodel_api_key": "..."
 }
 ```

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -171,6 +171,16 @@ export BAI_API_KEY="..."
 
 Or set `bai_api_key`. Toggle with `/toggle-bai`.
 
+### StepFun
+
+StepFun Step Plan is an OpenAI-compatible paid provider. Pi uses the Chat Completions endpoint at `https://api.stepfun.ai/step_plan/v1/chat/completions`; the same Step Plan base also exposes the Anthropic-compatible Messages endpoint at `/messages` for clients such as Claude Code:
+
+```bash
+export STEPFUN_API_KEY="..."
+```
+
+Or set `stepfun_api_key`. Toggle with `/toggle-stepfun`.
+
 ## Qoder (legacy, intentionally unmigrated)
 
 Qoder remains on pi-free's legacy provider surface. It has a basic Community/free tier and premium models that consume plan credits. The provider uses a static curated catalog plus its own one-hour cache at `~/.pi/agent/qoder-models-cache.json`; it does not use Pi's native models-store refresh lifecycle.

--- a/index.ts
+++ b/index.ts
@@ -47,6 +47,7 @@ import kilo from "./providers/kilo/kilo.ts";
 import llm7 from "./providers/llm7/llm7.ts";
 import deepinfra from "./providers/deepinfra/deepinfra.ts";
 import fastrouter from "./providers/fastrouter/fastrouter.ts";
+import stepfun from "./providers/stepfun/stepfun.ts";
 import sambanova from "./providers/sambanova/sambanova.ts";
 import novita from "./providers/novita/novita.ts";
 import routeway from "./providers/routeway/routeway.ts";
@@ -78,6 +79,7 @@ const UNIQUE_PROVIDERS: ReadonlyArray<(pi: ExtensionAPI) => Promise<void>> = [
 	sambanova,
 	novita,
 	fastrouter,
+	stepfun,
 	routeway,
 	opengateway,
 	tokenRouter,

--- a/providers/stepfun/stepfun-auth.ts
+++ b/providers/stepfun/stepfun-auth.ts
@@ -1,0 +1,10 @@
+import { getStepfunApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+/** StepFun API-key authentication for both catalog refresh and chat requests. */
+export const stepfunAuth = createNativeApiKeyAuth({
+	name: "StepFun API key",
+	prompt: "StepFun API key",
+	source: "STEPFUN_API_KEY",
+	getApiKey: getStepfunApiKey,
+});

--- a/providers/stepfun/stepfun-models.ts
+++ b/providers/stepfun/stepfun-models.ts
@@ -1,0 +1,32 @@
+/** StepFun's OpenAI-compatible model catalog. */
+
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import { BASE_URL_STEPFUN, PROVIDER_STEPFUN } from "../../constants.ts";
+import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
+
+/**
+ * Fetch StepFun's authenticated `/models` catalog.
+ *
+ * StepFun's Step Plan endpoint follows the OpenAI model-list shape. The
+ * shared mapper preserves any pricing/capability metadata exposed by the
+ * endpoint and applies models.dev enrichment without introducing a second
+ * cache or freshness policy.
+ */
+export async function fetchStepfunModels(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
+	const models = await fetchOpenAICompatibleModels(
+		PROVIDER_STEPFUN,
+		BASE_URL_STEPFUN,
+		apiKey,
+		{
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		},
+		undefined,
+		signal,
+	);
+	return applyHidden(models, PROVIDER_STEPFUN);
+}

--- a/providers/stepfun/stepfun.ts
+++ b/providers/stepfun/stepfun.ts
@@ -1,0 +1,32 @@
+/**
+ * StepFun Step Plan native provider.
+ *
+ * StepFun exposes an OpenAI-compatible Chat Completions API at the supplied
+ * `/step_plan/v1` base URL. Pi owns authentication, model-store persistence,
+ * refresh scheduling, and request streaming through the native provider
+ * lifecycle.
+ *
+ * Setup:
+ *   STEPFUN_API_KEY=...
+ *   # or add stepfun_api_key to ~/.pi/free.json
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getStepfunApiKey, getStepfunShowPaid } from "../../config.ts";
+import { BASE_URL_STEPFUN, PROVIDER_STEPFUN } from "../../constants.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
+import { stepfunAuth } from "./stepfun-auth.ts";
+import { fetchStepfunModels } from "./stepfun-models.ts";
+
+export default function stepfunProvider(pi: ExtensionAPI): Promise<void> {
+	registerNativeOpenAIProvider(pi, {
+		providerId: PROVIDER_STEPFUN,
+		name: "StepFun",
+		baseUrl: BASE_URL_STEPFUN,
+		auth: stepfunAuth,
+		getApiKey: getStepfunApiKey,
+		getShowPaid: getStepfunShowPaid,
+		fetchModels: (apiKey, signal) => fetchStepfunModels(apiKey, signal),
+	});
+	return Promise.resolve();
+}

--- a/tests/stepfun.test.ts
+++ b/tests/stepfun.test.ts
@@ -1,0 +1,100 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getApiKey: vi.fn((): string | undefined => undefined),
+	fetchModels: vi.fn(async (_args: unknown) => [{ id: "step-3.7-flash" }]),
+	applyHidden: vi.fn((models: unknown[]) => models),
+	registerNativeOpenAIProvider: vi.fn(),
+}));
+
+vi.mock("../config.ts", () => ({
+	getStepfunApiKey: () => mocks.getApiKey(),
+	getStepfunShowPaid: () => false,
+	applyHidden: (models: unknown[], _providerId?: string) =>
+		mocks.applyHidden(models),
+}));
+vi.mock("../lib/util.ts", () => ({
+	fetchOpenAICompatibleModels: (...args: unknown[]) =>
+		mocks.fetchModels(args),
+}));
+vi.mock("../lib/native-provider.ts", () => ({
+	createNativeApiKeyAuth: (options: {
+		name: string;
+		prompt: string;
+		source: string;
+		getApiKey: () => string | undefined;
+	}) => ({
+		apiKey: {
+			name: options.name,
+			async login(interaction: { prompt: (input: unknown) => Promise<string> }) {
+				return { type: "api_key", key: await interaction.prompt({}) };
+			},
+			async resolve(input: { credential?: { key?: string } }) {
+				const key = input.credential?.key ?? options.getApiKey();
+				return key
+					? { auth: { apiKey: key }, source: options.source }
+					: undefined;
+			},
+		},
+	}),
+	registerNativeOpenAIProvider: (...args: unknown[]) =>
+		mocks.registerNativeOpenAIProvider(...args),
+}));
+
+import stepfunProvider from "../providers/stepfun/stepfun.ts";
+import { stepfunAuth } from "../providers/stepfun/stepfun-auth.ts";
+import { fetchStepfunModels } from "../providers/stepfun/stepfun-models.ts";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.getApiKey.mockReturnValue(undefined);
+});
+
+describe("StepFun native provider", () => {
+	it("resolves stored and ambient API keys without exposing them", async () => {
+		mocks.getApiKey.mockReturnValue("ambient-test-key");
+		expect(
+			await stepfunAuth.apiKey?.resolve({
+				ctx: {} as never,
+				credential: { type: "api_key", key: "stored-test-key" },
+			}),
+		).toMatchObject({ auth: { apiKey: "stored-test-key" } });
+		expect(
+			await stepfunAuth.apiKey?.resolve({ ctx: {} as never }),
+		).toMatchObject({ auth: { apiKey: "ambient-test-key" } });
+	});
+
+	it("does not resolve auth when no key is configured", async () => {
+		expect(await stepfunAuth.apiKey?.resolve({ ctx: {} as never })).toBeUndefined();
+	});
+
+	it("registers StepFun through the native OpenAI lifecycle", () => {
+		const pi = {} as ExtensionAPI;
+		stepfunProvider(pi);
+
+		expect(mocks.registerNativeOpenAIProvider).toHaveBeenCalledWith(
+			pi,
+			expect.objectContaining({
+				providerId: "stepfun",
+				name: "StepFun",
+				baseUrl: "https://api.stepfun.ai/step_plan/v1",
+			}),
+		);
+	});
+
+	it("fetches and hides models using Pi's native refresh inputs", async () => {
+		const signal = new AbortController().signal;
+		const models = await fetchStepfunModels("test-key", signal);
+
+		expect(mocks.fetchModels).toHaveBeenCalledWith([
+			"stepfun",
+			"https://api.stepfun.ai/step_plan/v1",
+			"test-key",
+			expect.objectContaining({ contextWindow: 128_000, maxTokens: 16_384 }),
+			undefined,
+			signal,
+		]);
+		expect(mocks.applyHidden).toHaveBeenCalledWith(models);
+	});
+});


### PR DESCRIPTION
## Summary

- Add StepFun as a native OpenAI-compatible provider using the Step Plan base URL:
  `https://api.stepfun.ai/step_plan/v1`
- Discover models through the authenticated `/models` endpoint and send Pi chat requests through `/chat/completions`.
- Add native Pi models-store/auth lifecycle, free/paid filtering, hidden-model handling, and Coding Index enrichment.
- Resolve `STEPFUN_API_KEY` before `stepfun_api_key` from `~/.pi/free.json`.
- Document the Step Plan Messages endpoint (`/messages`) for Claude-compatible clients; pi-free uses the OpenAI Chat Completions surface for Pi models.

## Validation

- `npm run lint`
- Full test suite: 638 passed
- `npm run build`
- `npm run check`
- `git diff --check`

No live credential was used or persisted; tests use mocked credentials and network responses.
