### PR TITLE
fix: show StepFun paid models by default

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -147,7 +147,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_show_paid: false,
 	opengateway_show_paid: false,
 	fastrouter_show_paid: false,
-	stepfun_show_paid: false,
+	stepfun_show_paid: true,
 	tokenrouter_show_paid: false,
 	anyapi_show_paid: false,
 	bai_show_paid: false,
@@ -525,7 +525,10 @@ export function getFastrouterShowPaid(): boolean {
 }
 
 export function getStepfunShowPaid(): boolean {
-	return resolveBool("STEPFUN_SHOW_PAID", loadConfigFile().stepfun_show_paid);
+	return resolveBool(
+		"STEPFUN_SHOW_PAID",
+		loadConfigFile().stepfun_show_paid ?? true,
+	);
 }
 
 export function getOllamaShowPaid(): boolean {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,11 +56,12 @@ NVIDIA, Together, Mistral, Groq, Cerebras, xAI, and Hugging Face are Pi-built-in
 {
   "free_only": true,
   "kilo_show_paid": true,
+  "stepfun_show_paid": true,
   "qoder_show_paid": false
 }
 ```
 
-`free_only` controls the global filter. Each provider's `<provider>_show_paid` value controls its provider toggle. Environment flags use the uppercase form, for example `PI_FREE_ONLY`, `KILO_SHOW_PAID`, and `QODER_SHOW_PAID`. The legacy `kilo_free_only` setting is also supported as `PI_FREE_KILO_FREE_ONLY`.
+`free_only` controls the global filter. Each provider's `<provider>_show_paid` value controls its provider toggle. StepFun defaults to showing its paid catalog because the Step Plan catalog has no free models; set `stepfun_show_paid` or `STEPFUN_SHOW_PAID=false` to hide it. Environment flags use the uppercase form, for example `PI_FREE_ONLY`, `KILO_SHOW_PAID`, and `QODER_SHOW_PAID`. The legacy `kilo_free_only` setting is also supported as `PI_FREE_KILO_FREE_ONLY`.
 
 ### Hidden models
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -161,6 +161,22 @@ describe("show-paid getters", () => {
 		expect(getKiloShowPaid()).toBe(false);
 	});
 
+	it("getStepfunShowPaid defaults to true for the paid-only catalog", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		const { getStepfunShowPaid } = await import("../config.ts");
+		expect(getStepfunShowPaid()).toBe(true);
+	});
+
+	it("getStepfunShowPaid respects an explicit false setting", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		const fs = await import("node:fs");
+		const { __mockData } = fs as any;
+		__mockData.set(configPath(), JSON.stringify({ stepfun_show_paid: false }));
+
+		const { getStepfunShowPaid } = await import("../config.ts");
+		expect(getStepfunShowPaid()).toBe(false);
+	});
+
 	it("getKiloShowPaid reads from file", async () => {
 		vi.stubEnv("HOME", "/tmp");
 		const fs = await import("node:fs");


### PR DESCRIPTION
## Summary

StepFun's Step Plan catalog is paid-only. The provider was added with the normal free-only default, so authenticated users fetched models successfully but saw none in the picker until manually toggling the provider.

This follow-up makes StepFun's default paid/all view explicit:

- New configs get `stepfun_show_paid: true`.
- Existing configs without the key also default to `true`.
- Explicit `stepfun_show_paid: false` and `STEPFUN_SHOW_PAID=false` still hide the paid catalog.
- Added regression tests and configuration documentation.

## Validation

- Full suite: 640 passed
- Focused config/StepFun tests: 33 passed
- `npm run lint`
- `npm run build`
- `npm run check`
