### PR TITLE
docs: refresh roadmap and banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **StepFun native provider** — Added the paid StepFun Step Plan provider using Pi's native model store and refresh lifecycle. Chat requests use the OpenAI-compatible endpoint at `https://api.stepfun.ai/step_plan/v1/chat/completions`; `STEPFUN_API_KEY` and `stepfun_api_key` are supported, and paid models are shown by default.
+
 ### Changed
+
+- **Compiled startup graph** — Removed startup-only Pi credential inspection and deferred the broad pi-ai compatibility graph. Controlled compiled import-inclusive benchmarks improved from roughly **1.14s to 0.43s p50**, total from **1.18s to 0.47s p50**, and the measured import graph from **904 to 226 modules**. These figures measure the extension benchmark, not a full Pi-host A/B result.
 
 - **Cline native tool-call compatibility** — The custom Cline bridge now advertises the current OpenAI-compatible tool schema and parses streamed `delta.tool_calls` alongside the existing XML and `<function=...>` fallbacks. This prevents reasoning-capable models from stopping after planning text when their actual tool call arrives in the native stream format.
 - **Telemetry latency uses a monotonic clock** — `startModelCall`/`recordModelCall` now measure elapsed latency with `performance.now()` instead of `Date.now()`, matching the startup-timing module. Wall-clock skew from NTP adjustments or system suspend can no longer corrupt recorded per-call latency; `Date.now()` is retained only for the stored entry timestamp. The 10-minute implausible-latency guard remains as a sanity backstop.
 - **Telemetry disk writes are debounced** — `recordModelCall` no longer performs one synchronous `writeFileSync` of the whole telemetry store on every `turn_end`. The JSON store (`lib/json-persistence.ts`) gained an optional `debounceMs` (telemetry uses 1500ms) that updates the in-memory cache immediately — so `/free-telemetry` always shows current data — while coalescing the disk flush into a single write once the burst settles. `clearTelemetry` flushes immediately so the explicit `/clear-free-telemetry` action is durable. Removes the per-turn event-loop block from chatty sessions; probe-cache and config keep synchronous writes.
 - **Benchmark debug logging routed through the structured logger** — Coding Index match diagnostics (`PI_FREE_BENCHMARK_DEBUG=1`) now flow through `createLogger("benchmark-lookup")` to `~/.pi/free.log` via the buffered async stream, instead of a parallel `appendFileSync`-based pipe-delimited `~/.pi/modelmatch.log`. Eliminates the per-model synchronous file writes when debug logging is enabled and consolidates diagnostics into the single extension log. The unused `getMatchingStats`/`getMatchLogPath`/`clearMatchLog` helpers were removed.
+- **Compiled startup entry** — npm and Pi now load the generated `dist/index.js` entry, with peer dependencies externalized and build-time packaging checks covering Git installs and tarballs.
 
 ## [2.3.0] - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,18 @@ First run creates `~/.pi/free.json`. Add extension-provider keys there or use th
 | Free/free-tier | Kilo, Cline, LLM7, OpenModel, TokenRouter, Qoder basic tier, and eligible models from other catalogs |
 | Freemium | AnyAPI, Ollama Cloud, SambaNova |
 | Paid/trial | ZenMux, CrofAI, DeepInfra trial, Novita, Routeway, OpenGateway, B.AI, StepFun, and paid catalog entries from other providers |
-| Native | FastRouter, StepFun |
+| Native lifecycle | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun |
 | Built-in | OpenCode, OpenCode Go, OpenRouter |
 
 Provider availability, authentication, and exact API-key names are maintained in [docs/providers.md](docs/providers.md). pi-free does not publish model counts because provider catalogs change.
 
 ### Catalog and credential storage
 
-Migrated native providers use Pi's `~/.pi/agent/models-store.json` and `~/.pi/agent/auth.json`. Remaining legacy network catalogs use `~/.pi/provider-cache.json`; Ollama Cloud uses that cache for capability reuse and its compatibility refresh command. Qoder is intentionally unmigrated and uses its own `~/.pi/agent/qoder-models-cache.json`. `/free-startup` also reports per-provider fetch attempts and post-start session work.
+Migrated native providers use Pi's `~/.pi/agent/models-store.json` and `~/.pi/agent/auth.json`. Qoder is intentionally unmigrated and uses its own `~/.pi/agent/qoder-models-cache.json`; Ollama Cloud retains `~/.pi/provider-cache.json` only for capability reuse and its compatibility refresh command. `/free-startup` also reports per-provider fetch attempts and post-start session work.
+
+### Startup packaging
+
+Pi and npm load the compiled `dist/` entry. The compiled import-inclusive benchmark improved from roughly **1.14s to 0.43s p50** (total from **1.18s to 0.47s p50**) after reducing the measured import graph from **904 to 226 modules**. These are controlled extension benchmarks, not a full Pi-host A/B result; host startup also includes Pi and its peer dependencies.
 
 ## Docs
 
@@ -90,7 +94,7 @@ Migrated native providers use Pi's `~/.pi/agent/models-store.json` and `~/.pi/ag
 | Slash commands | [docs/commands.md](docs/commands.md) |
 | Configuration & logging | [docs/configuration.md](docs/configuration.md) |
 | Features deep dive | [docs/features.md](docs/features.md) |
-| Proposed compiled packaging | [docs/build-strategy.md](docs/build-strategy.md) |
+| Compiled packaging | [docs/build-strategy.md](docs/build-strategy.md) |
 | Adding new providers | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 ## License

--- a/agents.md
+++ b/agents.md
@@ -6,7 +6,7 @@
 
 A **Pi extension** (`@earendil-works/pi-coding-agent`) that registers free and paid AI model providers with Pi's model picker. It shows free models by default and lets users toggle per-provider between free-only and all-models view via `/toggle-{provider}` commands.
 
-**Package:** `pi-free` v2.2.10
+**Package:** `pi-free` v2.3.0
 **Author:** Apostolos Mantzaris  
 **License:** MIT  
 **Repo:** `github.com/apmantza/pi-free`  
@@ -95,11 +95,11 @@ No dynamic catalog discovery runs during extension startup.
 Provider setup has two lifecycle patterns:
 
 - **Native providers** register a Pi `Provider` object (usually through `lib/native-provider.ts`). They expose the complete catalog from `getModels()`, apply free/paid and hidden-model policy in `filterModels`, and implement `refreshModels(context)` so Pi owns the models store, credentials, refresh timing, abort signal, and offline initialization.
-- **Legacy providers** may still fetch a catalog during setup and use `createReRegister`, `setupProvider`, and `lib/provider-cache.ts`. Qoder intentionally remains on this surface for now; built-in catalogs are owned by Pi and FastRouter uses the native lifecycle.
+- **Legacy provider:** Qoder still fetches and registers through its legacy surface. Built-in catalogs are owned by Pi; all other pi-free providers, including FastRouter and StepFun, use the native lifecycle.
 
 For a new OpenAI-compatible native provider, use `registerNativeOpenAIProvider()` with a `ProviderAuth`, a catalog fetcher, and `getShowPaid`. For a custom wire protocol, assemble the public `Provider` interface directly, following OpenModel or Cline. Do not add a second freshness policy or copy native catalogs into `provider-cache.json`.
 
-**Cache-first loading.** Legacy network-fetching extension providers register from the disk cache (`~/.pi/provider-cache.json`, 1-hour TTL via `lib/provider-cache.ts`) first and only hit the network on a cold or stale cache. Built-in OpenCode, OpenCode Go, and OpenRouter catalogs are owned by Pi; FastRouter is native and refreshes asynchronously through Pi's model store. **Native providers** use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`; remaining legacy providers use `lib/provider-cache.ts` (see below). Ollama Cloud additionally retains that cache only for `/api/show` capability reuse and its manual refresh compatibility path.
+**Cache-first loading.** Qoder's legacy catalog uses its own cache at `~/.pi/agent/qoder-models-cache.json`. Built-in OpenCode, OpenCode Go, and OpenRouter catalogs are owned by Pi. **Native providers** use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`; Ollama Cloud additionally retains `~/.pi/provider-cache.json` only for `/api/show` capability reuse and its manual refresh compatibility path.
 
 ### Native `Provider` providers
 
@@ -185,7 +185,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | ✅ Free / free-tier | kilo, cline, llm7, openmodel, tokenrouter, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova | API key | Free allowance with limits |
 | 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
-| 🔧 Native | fastrouter, stepfun | API key or none | Public catalog; Pi owns store refresh |
+| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun | API key, OAuth, or none | Pi owns catalog refresh and native stores |
 | 🔧 Built-in | opencode, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---
@@ -204,7 +204,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 
 1. **TypeScript only** — no transpilation needed (Pi runs `.ts` directly with Node)
 2. **ES modules** (`"type": "module"` in package.json)
-3. **No build step** — `tsconfig.json` has `"noEmit": true`
+3. **Source development has no emit step** — `tsconfig.json` has `"noEmit": true`; release and Git installs build the published `dist/` entry
 4. **Node >= 20.0.0** required
 5. **Provider IDs are constants** in `constants.ts` — always import from there
 6. **API keys are getters** in `config.ts` — re-read on every call for runtime changes
@@ -214,7 +214,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 10. **All pi-free-registered catalogs use `enhanceWithCI()`** before registration to add CI scores
 11. **Legacy network-fetching extension providers are cache-first** (1h TTL via `lib/provider-cache.ts`); native providers, including FastRouter and StepFun, use Pi's models store + `refreshModels` instead. Pi's built-in OpenCode, OpenCode Go, and OpenRouter providers are not managed by either extension cache.
 12. **Startup and session-start work are observable and bounded** — legacy `loadCachedOrFetchModels` network attempts use `STARTUP_FETCH_DEADLINE_MS` (8s, override `PI_FREE_STARTUP_FETCH_TIMEOUT_MS`) via `withFetchDeadline` in `lib/util.ts`; failed and timed-out attempts are counted with duration and per-provider status. Native providers, including FastRouter, restore from Pi's store and their session-start refresh nudges and detached probes are measured without making intentionally background work block the event. `/free-startup` exposes the post-finalize handler/task timings.
-13. **Compiled packaging is not shipped yet** — the proposed plain-TypeScript `dist` strategy, peer externalization, JSON asset layout, and validation plan live in [`docs/build-strategy.md`](docs/build-strategy.md). Keep source-mode loading until an import-inclusive benchmark justifies the change.
+13. **Compiled packaging is shipped** — npm and Pi load `dist/index.js`, generated from the TypeScript source with peer dependencies externalized. The validation plan and packaging details live in [`docs/build-strategy.md`](docs/build-strategy.md).
 14. **Health output is credential-free** — `/pi-free-health` reports provider counts, timing/failure labels, and the configured log path; it must not print API keys, OAuth tokens, model payloads, or raw log contents.
 
 ---

--- a/banner.svg
+++ b/banner.svg
@@ -79,7 +79,7 @@
 
   <g transform="translate(370, 200)">
     <rect x="0" y="0" width="100" height="28" rx="6" fill="#7c3aed" opacity="0.15" stroke="#7c3aed" stroke-width="0.5" stroke-opacity="0.3"/>
-    <text x="50" y="18" font-family="system-ui, sans-serif" font-size="11" fill="#a78bfa" text-anchor="middle" font-weight="600">Dynamic</text>
+    <text x="50" y="18" font-family="system-ui, sans-serif" font-size="11" fill="#a78bfa" text-anchor="middle" font-weight="600">Native</text>
   </g>
 
   <g transform="translate(480, 200)">
@@ -93,12 +93,12 @@
     <rect x="0" y="0" width="250" height="200" rx="12" fill="none" stroke="url(#accent)" stroke-width="0.5" opacity="0.1"/>
     <text x="20" y="26" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#c4b5fd">Providers</text>
     <text x="20" y="46" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Kilo · Cline · OpenCode</text>
-    <text x="20" y="66" font-family="system-ui, sans-serif" font-size="11" fill="#a78bfa">OpenModel · AgentRouter</text>
+    <text x="20" y="66" font-family="system-ui, sans-serif" font-size="11" fill="#a78bfa">OpenModel · StepFun · Qoder</text>
     <text x="20" y="86" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Ollama Cloud · SambaNova</text>
-    <text x="20" y="106" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">LLM7 · Novita</text>
+    <text x="20" y="106" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">LLM7 · Novita · FastRouter</text>
     <text x="20" y="126" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">ZenMux · CrofAI · DeepInfra</text>
-    <text x="20" y="146" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Together · TokenRouter · FastRouter</text>
-    <text x="20" y="166" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">+ dynamic (Mistral, Groq, …)</text>
+    <text x="20" y="146" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">TokenRouter · AnyAPI · B.AI</text>
+    <text x="20" y="166" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Routeway · OpenGateway · OpenRouter</text>
   </g>
 
   <g transform="translate(970, 45)">
@@ -112,7 +112,7 @@
     <text x="20" y="118" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Model health probes</text>
     <text x="20" y="136" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Thinking level maps</text>
     <text x="20" y="154" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">404/403 auto-hide on probe</text>
-    <text x="20" y="172" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">+ dynamic built-in fetch</text>
+    <text x="20" y="172" font-family="system-ui, sans-serif" font-size="11" fill="#8b9aaa">Pi-owned native model stores</text>
   </g>
 
   <!-- Bottom tagline -->

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,7 +43,7 @@ Run `/toggle-{provider}` to switch between a provider's free/basic view and its 
 | `/toggle-opencode-go` | OpenCode Go | Pi built-in |
 | `/toggle-fastrouter` | FastRouter | Native |
 
-Native providers retain their complete catalog and let Pi apply the current filter. Qoder and remaining legacy providers re-register the selected model list.
+Native providers retain their complete catalog and let Pi apply the current filter. Qoder is the remaining legacy provider and re-registers its selected model list.
 
 ## Authentication Commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,10 +85,10 @@ Migrated native providers restore and persist catalogs through Pi's model lifecy
 - `~/.pi/agent/models-store.json` — Pi-owned native provider catalogs.
 - `~/.pi/agent/auth.json` — Pi-owned native credentials, including Kilo and Cline OAuth/API-key credentials.
 
-Remaining legacy network catalogs use the pi-free cache:
+The remaining legacy catalog is Qoder's and uses its own cache:
 
-- `~/.pi/provider-cache.json` — one-hour cache used by legacy catalog fetches.
 - `~/.pi/agent/qoder-models-cache.json` — Qoder's separate legacy model/config cache; Qoder intentionally remains unmigrated.
+- `~/.pi/provider-cache.json` — retained by native Ollama Cloud only for `/api/show` capability reuse and `/ollama-cloud-refresh` compatibility.
 
 Ollama Cloud is native but intentionally retains `~/.pi/provider-cache.json` for `/api/show` capability reuse and `/ollama-cloud-refresh`. This does not replace its Pi native model store.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -99,6 +99,14 @@ export OPENMODEL_API_KEY="..."
 
 Or set `openmodel_api_key`. Toggle with `/toggle-openmodel`.
 
+### StepFun
+
+StepFun Step Plan is a native, paid OpenAI-compatible provider. Pi uses the Chat Completions endpoint at `https://api.stepfun.ai/step_plan/v1/chat/completions`; the same base also exposes an Anthropic-compatible Messages endpoint at `/messages` for clients such as Claude Code. Set `STEPFUN_API_KEY` or `stepfun_api_key` and toggle with `/toggle-stepfun`. StepFun shows its paid catalog by default because its catalog has no free models; set `stepfun_show_paid` or `STEPFUN_SHOW_PAID=false` to hide it.
+
+### FastRouter
+
+FastRouter is a native OpenAI-compatible provider with a public catalog. Pi restores its model store first and refreshes the catalog asynchronously; a key is required for chat requests but not model listing. Set `FASTROUTER_API_KEY` or `fastrouter_api_key`, then use `/toggle-fastrouter`.
+
 ## Paid and trial providers
 
 ### ZenMux
@@ -171,16 +179,6 @@ export BAI_API_KEY="..."
 
 Or set `bai_api_key`. Toggle with `/toggle-bai`.
 
-### StepFun
-
-StepFun Step Plan is an OpenAI-compatible paid provider. Pi uses the Chat Completions endpoint at `https://api.stepfun.ai/step_plan/v1/chat/completions`; the same Step Plan base also exposes the Anthropic-compatible Messages endpoint at `/messages` for clients such as Claude Code:
-
-```bash
-export STEPFUN_API_KEY="..."
-```
-
-Or set `stepfun_api_key`. Toggle with `/toggle-stepfun`.
-
 ## Qoder (legacy, intentionally unmigrated)
 
 Qoder remains on pi-free's legacy provider surface. It has a basic Community/free tier and premium models that consume plan credits. The provider uses a static curated catalog plus its own one-hour cache at `~/.pi/agent/qoder-models-cache.json`; it does not use Pi's native models-store refresh lifecycle.
@@ -216,16 +214,6 @@ These are Pi-built-in providers wrapped by pi-free for filtering. Pi owns their 
 /toggle-opencode
 /toggle-opencode-go
 ```
-
-### FastRouter (native)
-
-FastRouter uses Pi's native provider lifecycle. Its model catalog is publicly discoverable, so model listing does not require a key; Pi restores the native model store first and refreshes the public catalog asynchronously at session start. Set `FASTROUTER_API_KEY` or `fastrouter_api_key` for chat requests:
-
-```bash
-export FASTROUTER_API_KEY="..."
-```
-
-Toggle with `/toggle-fastrouter`.
 
 ### Other Pi-built-in providers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,10 +1,10 @@
 # Roadmap — pi-free forward assessment
 
-> Updated after the observability → startup-perf → built-in-audit → native-provider
-> migration arc (PRs #350–#362). Supersedes the recommendations in
-> `docs/opps.md`, which remains historical context for *why* the native-provider
-> migration exists. This is a planning document, not a record of shipped model
-> counts or provider promotions.
+> Updated after the observability → native-provider → compiled-startup arc
+> (PRs #350–#388). Supersedes the recommendations in `docs/opps.md`, which
+> remains historical context for *why* the native-provider migration exists.
+> This is a planning document, not a record of shipped model counts or provider
+> promotions.
 
 ---
 
@@ -14,14 +14,15 @@ Merged and in production:
 
 | PR | What | Evidence it worked |
 | --- | --- | --- |
-| #350 | Startup observability (`lib/startup-timing.ts`, `/free-startup`) | Production logs: measured Kilo at 7.0s of 7.0s startup, 4/4 startups |
-| #351 | 8s startup fetch deadline + buffered async logging | Cold worst case 66s → 8s bound; warm logging cost ~15–20ms → ~0ms |
-| #352 | Built-in alignment: retired `together` + 5 superseded dynamic fetchers | Audit verified against Pi 0.83 compiled dist (42 built-ins); −463 net lines |
-| #353 | Kilo → native `createProvider` + `auth` + `refreshModels` | Native store owns the catalog; OAuth credentials are reused without migration |
-| #354–#362 | Cline plus the remaining 12 static providers → native lifecycle; `filterModels` capstone and native cleanup | 14 of 15 static providers now use Pi's native provider/model-store lifecycle; Qoder intentionally remains legacy |
-| Follow-up | Session-start and fetch observability | `/free-startup` now reports per-provider attempts, failures, handler durations, and detached post-handler work; background work remains non-blocking |
+| #350 | Startup observability (`lib/startup-timing.ts`, `/free-startup`) | Production logs expose factory, provider, and detached session-start timings |
+| #351 | 8s startup fetch deadline + buffered async logging | Cold network work is bounded; warm logging is effectively non-blocking |
+| #352 | Built-in alignment and retired duplicate fetchers | Pi-owned built-ins no longer have duplicate pi-free catalog discovery |
+| #353–#386 | Native provider lifecycle, filtering, and startup import-graph cleanup | All pi-free providers except Qoder use Pi's native lifecycle; compiled import p50 improved ~1.14s → ~0.43s and total p50 ~1.18s → ~0.47s; measured graph 904 → 226 modules |
+| #387–#388 | StepFun native provider and paid-by-default behavior | StepFun uses Pi's native model store and OpenAI Chat Completions at `api.stepfun.ai/step_plan/v1` |
+| #380–#384 | Generic DeepSeek/Cline DSML and custom-tool schema compatibility | Registered extension-tool schemas are preserved; mixed DSML forms are normalized without provider-specific allowlists |
+| Follow-up | Session-start and fetch observability | `/free-startup` reports per-provider attempts, failures, handler durations, and detached post-handler work; background work remains non-blocking |
 
-Current focus: **Qoder remains the only static legacy provider**; any future migration is a separate protocol/auth project. The proposed compiled packaging work is documented in [`build-strategy.md`](build-strategy.md) and is not shipped.
+Current focus: **Qoder remains the only static legacy provider**; any future migration is a separate protocol/auth project. Compiled `dist/` packaging is shipped and is the Pi/npm entry. The startup numbers above are controlled compiled extension benchmarks; a full Pi-host A/B result has not been claimed.
 
 ---
 
@@ -123,16 +124,18 @@ specialized legacy surfaces by design.
   only if users miss them. Requires a pricing check per native catalog first
   (Route A/B detection depends on it; opencode-go's native catalog has zero
   free models, illustrating the risk).
-+ **Compiled packaging** — evaluate the proposed plain-TypeScript `dist`
-  strategy in [`docs/build-strategy.md`](build-strategy.md) only after an
-  import-inclusive benchmark shows a user-visible benefit.
-+ **opps.md item E**: preventive XML-tool-leak stripping via
-  `before_provider_headers` for known-leaky Kilo models (detect-before-leak
-  instead of detect-after). Quality-of-life.
-+ **Banner refresh** (lists retired providers; PNG not regenerable in-agent).
-+ **Orphan cleanup**: old per-provider entries in users'
-  `~/.pi/provider-cache.json` for migrated providers (Kilo already gone on
-  the test machine; cosmetic).
++ **Qoder native migration** — requires a dedicated plan for PAT exchange,
+  COSY signing, the static catalog, and its custom stream.
++ **Free-filter toggle ports** for Pi-built-in Mistral, Groq, Cerebras, xAI, and
+  Hugging Face catalogs — only if users request them. pi-free would layer a
+  filter/toggle over Pi's catalog without duplicating discovery; pricing
+  metadata must be checked first to avoid false free classifications.
++ **Preventive XML-tool-leak handling** — the Cline bridge now recovers known
+  XML/DSML and native tool-call forms reactively. A future `before_provider_headers`
+  compatibility hook could prevent leaks for known model families, but needs
+  reliable model-specific evidence before adding request complexity.
++ **Orphan cleanup** — old per-provider entries in users' `~/.pi/provider-cache.json`
+  are cosmetic leftovers from the native migrations.
 
 ---
 
@@ -171,11 +174,10 @@ specialized legacy surfaces by design.
 
 ---
 
-## Suggested decision points
+## Suggested next decisions
 
-1. After Cline: cut 2.3.0 immediately, or batch with early Phase 1?
-   (Recommendation: cut immediately — the Kilo win deserves a release.)
-2. Phase 1 scope: forced march vs migrate-on-touch? (Recommendation:
-   migrate-on-touch, with llm7 first as the keyless-pattern proof.)
-3. `filterModels` capstone trigger: "≥ N native providers" — propose N = 8
-   (majority of the 15 toggle-participating providers).
+1. Cut the next release with the merged StepFun, DSML, schema, and startup work.
+2. Revisit Qoder only when its authentication and custom-stream compatibility can
+   be migrated without reintroducing startup network work.
+3. Consider built-in free-filter ports or preventive XML leak handling only when
+   user demand and model-specific evidence justify the maintenance cost.


### PR DESCRIPTION
## Summary

- Refresh roadmap status through PR #388.
- Document the merged compiled startup packaging and measured extension benchmark improvement.
- Document StepFun's native provider and paid-by-default behavior.
- Clarify Qoder as the sole remaining legacy provider.
- Refresh provider/banner text and unreleased release notes.

## Validation

- `npm run lint`
- `npm run check`
- `git diff --check`

Documentation/assets only; no runtime code changes.
