### PR TITLE
feat: migrate Qoder to native provider lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Qoder native lifecycle** — Migrated Qoder to Pi's native Provider/ProviderAuth and models-store lifecycle while preserving its OAuth/PAT exchange, COSY signing, static catalog, custom stream, and basic/all filtering. Its legacy cache is now limited to optional stream metadata.
 - **Compiled startup graph** — Removed startup-only Pi credential inspection and deferred the broad pi-ai compatibility graph. Controlled compiled import-inclusive benchmarks improved from roughly **1.14s to 0.43s p50**, total from **1.18s to 0.47s p50**, and the measured import graph from **904 to 226 modules**. These figures measure the extension benchmark, not a full Pi-host A/B result.
 
 - **Cline native tool-call compatibility** — The custom Cline bridge now advertises the current OpenAI-compatible tool schema and parses streamed `delta.tool_calls` alongside the existing XML and `<function=...>` fallbacks. This prevents reasoning-capable models from stopping after planning text when their actual tool call arrives in the native stream format.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Free and paid AI model providers for [Pi](https://pi.dev). Access models from mu
 When you install pi-free, it:
 
 1. Registers native providers such as Kilo, Cline, LLM7, FastRouter, Ollama Cloud, OpenModel, StepFun, and more.
-2. Keeps Qoder on its legacy provider surface and supports Pi's built-in OpenCode, OpenCode Go, and OpenRouter integrations.
-3. Uses Pi's native model and auth stores for migrated providers; remaining legacy catalogs use their documented cache paths.
+2. Registers Qoder through Pi's native provider surface and supports Pi's built-in OpenCode, OpenCode Go, and OpenRouter integrations.
+3. Uses Pi's native model and auth stores for all extension providers; Ollama Cloud and Qoder retain documented compatibility caches only for auxiliary behavior.
 4. Applies the global free-only filter by default, while preserving provider-specific paid/trial behavior.
 5. Provides per-provider toggle commands — `/toggle-{provider}` switches between the provider's free/basic view and its full catalog.
 6. Supports OAuth and API-key authentication where a provider offers them.
@@ -42,7 +42,7 @@ Cline exposes a public catalog before login. Kilo requires an OAuth credential o
 /login kilo
 ```
 
-Qoder remains a legacy provider. Authenticate it with `/login qoder` (PAT or browser OAuth), then use `/toggle-qoder` to switch between its basic free tier and full catalog.
+Qoder supports `/login qoder` with PAT or browser OAuth, then `/toggle-qoder` switches between its basic free tier and full catalog.
 
 ### Toggle between free and paid
 
@@ -80,7 +80,7 @@ Provider availability, authentication, and exact API-key names are maintained in
 
 ### Catalog and credential storage
 
-Migrated native providers use Pi's `~/.pi/agent/models-store.json` and `~/.pi/agent/auth.json`. Qoder is intentionally unmigrated and uses its own `~/.pi/agent/qoder-models-cache.json`; Ollama Cloud retains `~/.pi/provider-cache.json` only for capability reuse and its compatibility refresh command. `/free-startup` also reports per-provider fetch attempts and post-start session work.
+Native providers use Pi's `~/.pi/agent/models-store.json` and `~/.pi/agent/auth.json`. Qoder's static catalog is persisted in the native model store; it retains its legacy cache only for optional stream metadata. Ollama Cloud retains `~/.pi/provider-cache.json` only for capability reuse and its compatibility refresh command. `/free-startup` also reports per-provider fetch attempts and post-start session work.
 
 ### Startup packaging
 

--- a/agents.md
+++ b/agents.md
@@ -95,15 +95,15 @@ No dynamic catalog discovery runs during extension startup.
 Provider setup has two lifecycle patterns:
 
 - **Native providers** register a Pi `Provider` object (usually through `lib/native-provider.ts`). They expose the complete catalog from `getModels()`, apply free/paid and hidden-model policy in `filterModels`, and implement `refreshModels(context)` so Pi owns the models store, credentials, refresh timing, abort signal, and offline initialization.
-- **Legacy provider:** Qoder still fetches and registers through its legacy surface. Built-in catalogs are owned by Pi; all other pi-free providers, including FastRouter and StepFun, use the native lifecycle.
+- **All pi-free providers** register through Pi's native lifecycle. Built-in catalogs are owned by Pi; Qoder retains only its custom auth/stream implementation and optional metadata cache.
 
 For a new OpenAI-compatible native provider, use `registerNativeOpenAIProvider()` with a `ProviderAuth`, a catalog fetcher, and `getShowPaid`. For a custom wire protocol, assemble the public `Provider` interface directly, following OpenModel or Cline. Do not add a second freshness policy or copy native catalogs into `provider-cache.json`.
 
-**Cache-first loading.** Qoder's legacy catalog uses its own cache at `~/.pi/agent/qoder-models-cache.json`. Built-in OpenCode, OpenCode Go, and OpenRouter catalogs are owned by Pi. **Native providers** use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`; Ollama Cloud additionally retains `~/.pi/provider-cache.json` only for `/api/show` capability reuse and its manual refresh compatibility path.
+**Native loading.** All pi-free provider catalogs use Pi's models store (`~/.pi/agent/models-store.json`) via `refreshModels`. Qoder retains `~/.pi/agent/qoder-models-cache.json` only for optional stream metadata. Built-in OpenCode, OpenCode Go, and OpenRouter catalogs are owned by Pi; Ollama Cloud additionally retains `~/.pi/provider-cache.json` only for `/api/show` capability reuse and its manual refresh compatibility path.
 
 ### Native `Provider` providers
 
-Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, OpenModel, FastRouter, and StepFun use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
+Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, OpenModel, FastRouter, StepFun, and Qoder use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
 
 ```
 providers/kilo/kilo-provider.ts   ← createKiloProvider(): assembles the Provider
@@ -185,7 +185,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | ✅ Free / free-tier | kilo, cline, llm7, openmodel, tokenrouter, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova | API key | Free allowance with limits |
 | 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
-| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun | API key, OAuth, or none | Pi owns catalog refresh and native stores |
+| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
 | 🔧 Built-in | opencode, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---
@@ -194,7 +194,8 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 
 - **Config:** `~/.pi/free.json` (auto-created)
 - **Extension log:** `~/.pi/free.log` (includes opt-in `benchmark-lookup` debug diagnostics)
-- **Provider cache:** `~/.pi/provider-cache.json` (legacy providers only)
+- **Provider cache:** `~/.pi/provider-cache.json` (Ollama Cloud compatibility only)
+- **Qoder stream metadata:** `~/.pi/agent/qoder-models-cache.json`
 - **Native models store:** `~/.pi/agent/models-store.json` (all native providers, owned by Pi)
 - **Native auth store:** `~/.pi/agent/auth.json` (native-provider credentials, owned by Pi)
 
@@ -245,7 +246,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 **Authentication notes:**
 
 - **Kilo** and **Cline** support both OAuth (`/login`) and direct API keys. Set `KILO_API_KEY` / `CLINE_API_KEY` (or `kilo_api_key` / `cline_api_key` in `~/.pi/free.json`) to authenticate directly. Both are native providers: their native auth carries both methods, and Pi's resolution order applies — a stored credential (from `/login`) wins, then the ambient API key. Cline's catalog is public and can refresh without a credential.
-- **Qoder** remains a legacy provider intentionally. Use `/login qoder`, or set `QODER_PERSONAL_ACCESS_TOKEN` / `QODER_PAT` for headless PAT authentication; its COSY signing and custom stream remain outside the native-provider migration.
+- **Qoder** is a native provider with OAuth/PAT authentication, Pi-owned credential/model stores, COSY signing, and its custom stream. Use `/login qoder`, or set `QODER_PERSONAL_ACCESS_TOKEN` / `QODER_PAT` for headless PAT authentication.
 - **OpenCode and OpenCode Go** remain Pi-built-in providers. pi-free only captures Pi's available catalogs for filtering after session start; it performs no startup or on-demand catalog discovery.
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,7 +43,7 @@ Run `/toggle-{provider}` to switch between a provider's free/basic view and its 
 | `/toggle-opencode-go` | OpenCode Go | Pi built-in |
 | `/toggle-fastrouter` | FastRouter | Native |
 
-Native providers retain their complete catalog and let Pi apply the current filter. Qoder is the remaining legacy provider and re-registers its selected model list.
+Native providers retain their complete catalog and let Pi apply the current filter. All pi-free providers now use the native provider lifecycle; Pi built-in providers retain Pi-owned catalogs.
 
 ## Authentication Commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,9 +85,9 @@ Migrated native providers restore and persist catalogs through Pi's model lifecy
 - `~/.pi/agent/models-store.json` — Pi-owned native provider catalogs.
 - `~/.pi/agent/auth.json` — Pi-owned native credentials, including Kilo and Cline OAuth/API-key credentials.
 
-The remaining legacy catalog is Qoder's and uses its own cache:
+Native providers use Pi's model store; Qoder retains its separate cache only for optional stream metadata:
 
-- `~/.pi/agent/qoder-models-cache.json` — Qoder's separate legacy model/config cache; Qoder intentionally remains unmigrated.
+- `~/.pi/agent/qoder-models-cache.json` — Qoder stream metadata compatibility cache.
 - `~/.pi/provider-cache.json` — retained by native Ollama Cloud only for `/api/show` capability reuse and `/ollama-cloud-refresh` compatibility.
 
 Ollama Cloud is native but intentionally retains `~/.pi/provider-cache.json` for `/api/show` capability reuse and `/ollama-cloud-refresh`. This does not replace its Pi native model store.
@@ -139,4 +139,4 @@ The telemetry file defaults to `~/.pi/free-telemetry.json`.
 | `~/.pi/provider-cache.json` | Legacy cache and Ollama compatibility data |
 | `~/.pi/agent/models-store.json` | Pi native provider catalogs |
 | `~/.pi/agent/auth.json` | Pi native credentials and Qoder credentials |
-| `~/.pi/agent/qoder-models-cache.json` | Qoder legacy model/config cache |
+| `~/.pi/agent/qoder-models-cache.json` | Qoder optional stream metadata cache |

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,7 +22,7 @@ Most pi-free providers now use Pi's native `registerProvider(provider)` surface.
 - retain the previous catalog after an empty or failed refresh; and
 - keep their complete catalog in memory while Pi applies the current free/all filter.
 
-FastRouter now uses the native provider lifecycle alongside the other migrated providers. Qoder intentionally remains on the legacy registration surface. Pi owns the OpenCode, OpenCode Go, and OpenRouter built-in catalogs. See [configuration](configuration.md#model-stores-and-caches) for cache locations, including Ollama Cloud's intentional compatibility-cache exception.
+FastRouter and Qoder now use the native provider lifecycle alongside the other migrated providers. Pi owns the OpenCode, OpenCode Go, and OpenRouter built-in catalogs. See [configuration](configuration.md#model-stores-and-caches) for cache locations, including Ollama Cloud's intentional compatibility-cache exception.
 
 ## Coding Index (CI) scores
 
@@ -46,7 +46,7 @@ See [Commands](commands.md#probe-commands) for the command list.
 - `/toggle-{provider}` switches an individual provider between its free/basic view and full catalog.
 - `/toggle-free` changes the global free-only mode.
 - Preferences persist in `~/.pi/free.json`.
-- Native providers re-register the same provider object to invalidate Pi's model snapshot; Qoder and remaining legacy providers re-register the selected model array.
+- Native providers re-register the same provider object to invalidate Pi's model snapshot; all pi-free providers now use this native invalidation path.
 
 ## Optional telemetry
 
@@ -69,6 +69,6 @@ Most providers use OpenAI-compatible APIs. Notable custom integrations are:
 
 - **Cline** — native provider with the custom `cline-xml-tools` wire API and XML message/tool reshaping.
 - **OpenModel** — native Anthropic Messages API provider.
-- **Qoder** — intentionally legacy provider with Qoder authentication, request signing, and custom streaming compatibility.
+- **Qoder** — native provider with Qoder authentication, COSY request signing, static catalog persistence, and custom streaming compatibility.
 
 See [Provider catalog & auth](providers.md) for setup details.

--- a/docs/lazy-loading-strategy.md
+++ b/docs/lazy-loading-strategy.md
@@ -9,8 +9,8 @@ Use staged, leaf-first lazy loading rather than replacing the provider factory
 with awaited dynamic imports. The first experiment should defer Cline's XML
 bridge, then apply the same boundary to TokenRouter and OpenModel. A later
 phase may introduce full provider stubs, but only if they preserve Pi's native
-provider contract. Keep Qoder eager until its separate native-auth/protocol
-migration is complete.
+provider contract. Qoder now uses the native provider lifecycle; its custom auth
+and protocol remain request-time concerns.
 
 ## Goals
 
@@ -110,10 +110,10 @@ infer a provider's import cost from its catalog or network timing.
   still restore the native store offline, and its `stream`/`streamSimple` must
   retain `anthropicMessagesApi()`. Preserve the terms notification and the
   key-required online refresh behavior.
-- **Qoder:** `providers/qoder/qoder.ts` is intentionally eager. Its legacy
-  `createToggleState`, `registerWithGlobalToggle`, OAuth configuration, initial
-  registration, and `streamQoder` are coupled. Revisit only after native
-  migration and dedicated auth/stream compatibility tests.
+- **Qoder:** `providers/qoder/qoder.ts` now owns only native registration,
+  toggle invalidation, and session-start refresh wiring. Its custom OAuth/PAT
+  adapter and `streamQoder` remain request-time dependencies; preserve them
+  when considering further leaf-level lazy loading.
 
 ## Candidate designs
 
@@ -317,6 +317,5 @@ loading.
   and stream errors before considering Stage 3.
 - [ ] Run the full packaging checks and update `docs/build-strategy.md` only if
   the implementation changes its stated compiled-output constraints.
-- [ ] Keep Qoder on the eager path and add a regression assertion that its
-  legacy OAuth, toggle, and `streamQoder` registration still occurs during the
-  current factory.
+- [x] Migrate Qoder to native auth, model-store refresh, filtering, and stable
+  provider registration while preserving OAuth/PAT and `streamQoder` behavior.

--- a/docs/opps.md
+++ b/docs/opps.md
@@ -34,10 +34,11 @@ resolution). 0.81.0 is the release that exposes the public extension surface.
 
 ### A. `refreshModels` for native providers — completed for the migrated catalog
 
-Kilo, Cline, and the API-key providers that formerly hit a `models` endpoint
-on startup now use Pi's native `refreshModels` lifecycle. Qoder remains legacy
-by design; Ollama retains the provider cache only for `/api/show` capability
-reuse and its compatibility refresh command. Pi 0.81 supplies the primitives
+Kilo, Cline, Qoder, and the API-key providers that formerly hit a `models`
+endpoint on startup now use Pi's native `refreshModels` lifecycle. Qoder's
+compatibility cache is limited to optional stream metadata; Ollama retains the
+provider cache only for `/api/show` capability reuse and its compatibility
+refresh command. Pi 0.81 supplies the primitives
 that enabled the migration:
 
 | | pi-free today | Pi 0.81 `refreshModels` |
@@ -64,17 +65,17 @@ interface RefreshModelsContext {
 ### B. `filterModels` for the global free filter — completed for native providers
 
 Native providers now keep the complete catalog as the source of truth and use
-`filterModels` plus same-object re-registration for invalidation. Legacy Qoder
-and Pi-built-in integrations retain their specialized array/filter paths.
+`filterModels` plus same-object re-registration for invalidation. Pi-built-in
+integrations retain their specialized catalog/filter paths.
 `Models.getAvailable()` runs native `filterModels` after confirming auth, so the
 free/all policy composes with credential-aware visibility.
 
 ### C. Migrate Kilo/Cline OAuth to the new `createProvider` `auth` shape — completed
 
-Kilo and Cline now use native `ProviderAuth` implementations. Pi persists their
-credentials in `~/.pi/agent/auth.json` and owns refresh coordination. Cline's
-legacy callback-server flow is adapted to native `AuthInteraction`; Qoder's
-OAuth/PAT flow remains legacy.
+Kilo, Cline, and Qoder now use native `ProviderAuth` implementations. Pi
+persists their credentials in `~/.pi/agent/auth.json` and owns refresh
+coordination. Cline's legacy callback-server flow and Qoder's OAuth/PAT flow
+are adapted to native `AuthInteraction`.
 
 ### D. `refreshModels` for Ollama Cloud — completed with a compatibility exception
 
@@ -103,8 +104,8 @@ refactor.
   through the legacy config form.
 - `ctx.modelRegistry` / `ctx.model` events (`model_select`, `session_start`,
   `turn_end`) are unchanged.
-- Qoder's OAuth/PAT and custom stream remain on the legacy surface until a
-  dedicated migration is designed.
+- Qoder's OAuth/PAT and custom stream now run behind the native provider surface;
+  their protocol-specific adapters remain Qoder-owned.
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -179,9 +179,9 @@ export BAI_API_KEY="..."
 
 Or set `bai_api_key`. Toggle with `/toggle-bai`.
 
-## Qoder (legacy, intentionally unmigrated)
+## Qoder (native)
 
-Qoder remains on pi-free's legacy provider surface. It has a basic Community/free tier and premium models that consume plan credits. The provider uses a static curated catalog plus its own one-hour cache at `~/.pi/agent/qoder-models-cache.json`; it does not use Pi's native models-store refresh lifecycle.
+Qoder has a basic Community/free tier and premium models that consume plan credits. Its static curated catalog is restored and persisted through Pi's native models-store lifecycle; the legacy cache is retained only for optional stream metadata.
 
 Authenticate with either method:
 
@@ -192,7 +192,7 @@ Authenticate with either method:
 - Browser OAuth uses Qoder's device/PKCE flow.
 - PAT authentication can use `QODER_PERSONAL_ACCESS_TOKEN` or the alias `QODER_PAT`.
 
-`/toggle-qoder` switches between basic and all Qoder models. Qoder's API is currently OpenAI-compatible, but its authentication and legacy provider integration remain Qoder-specific.
+`/toggle-qoder` switches between basic and all Qoder models. Qoder's API remains OpenAI-compatible, while its authentication and custom stream integration remain Qoder-specific.
 
 ## Pi built-in providers
 
@@ -224,4 +224,4 @@ Pi owns the following providers; pi-free does not register duplicate catalogs or
 - Native providers: `~/.pi/agent/models-store.json` and Pi's `~/.pi/agent/auth.json`.
 - Legacy catalog cache: `~/.pi/provider-cache.json`.
 - Ollama compatibility data: `~/.pi/provider-cache.json` in addition to the native store.
-- Qoder legacy catalog/config cache: `~/.pi/agent/qoder-models-cache.json`.
+- Qoder's native static catalog is stored in Pi's model store; its optional stream metadata may use `~/.pi/agent/qoder-models-cache.json`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,12 +17,13 @@ Merged and in production:
 | #350 | Startup observability (`lib/startup-timing.ts`, `/free-startup`) | Production logs expose factory, provider, and detached session-start timings |
 | #351 | 8s startup fetch deadline + buffered async logging | Cold network work is bounded; warm logging is effectively non-blocking |
 | #352 | Built-in alignment and retired duplicate fetchers | Pi-owned built-ins no longer have duplicate pi-free catalog discovery |
-| #353–#386 | Native provider lifecycle, filtering, and startup import-graph cleanup | All pi-free providers except Qoder use Pi's native lifecycle; compiled import p50 improved ~1.14s → ~0.43s and total p50 ~1.18s → ~0.47s; measured graph 904 → 226 modules |
+| #353–#386 | Native provider lifecycle, filtering, and startup import-graph cleanup | All migrated providers use Pi's native lifecycle; compiled import p50 improved ~1.14s → ~0.43s and total p50 ~1.18s → ~0.47s; measured graph 904 → 226 modules |
 | #387–#388 | StepFun native provider and paid-by-default behavior | StepFun uses Pi's native model store and OpenAI Chat Completions at `api.stepfun.ai/step_plan/v1` |
+| Qoder follow-up | Qoder native provider migration | Native auth/model-store lifecycle preserves OAuth/PAT, COSY signing, static catalog, custom stream, and basic/all filtering |
 | #380–#384 | Generic DeepSeek/Cline DSML and custom-tool schema compatibility | Registered extension-tool schemas are preserved; mixed DSML forms are normalized without provider-specific allowlists |
 | Follow-up | Session-start and fetch observability | `/free-startup` reports per-provider attempts, failures, handler durations, and detached post-handler work; background work remains non-blocking |
 
-Current focus: **Qoder remains the only static legacy provider**; any future migration is a separate protocol/auth project. Compiled `dist/` packaging is shipped and is the Pi/npm entry. The startup numbers above are controlled compiled extension benchmarks; a full Pi-host A/B result has not been claimed.
+Current focus: all pi-free providers use Pi's native lifecycle; remaining work is optional built-in filtering and compatibility hardening. Compiled `dist/` packaging is shipped and is the Pi/npm entry. The startup numbers above are controlled compiled extension benchmarks; a full Pi-host A/B result has not been claimed.
 
 ---
 
@@ -66,13 +67,12 @@ These drive every recommendation below. Re-verify on major Pi bumps.
 
 ## Phases
 
-### Phase 0 — Cline migration (completed)
+### Phase 0 — Provider migration (completed)
 
-Cline now uses the native `Provider` surface with its custom XML wire API,
-public keyless catalog, adapted OAuth flow, request-scoped headers, and Pi-owned
-models store. The remaining static providers were migrated in the same arc;
-Qoder is intentionally deferred because its PAT exchange, COSY signing, and
-custom stream need a separate design.
+Cline and Qoder now use the native `Provider` surface. Cline retains its custom
+XML wire API and adapted OAuth flow; Qoder retains its PAT exchange, COSY
+signing, static catalog, and custom stream while using Pi-owned auth and model
+stores.
 
 **Completed criteria:** native refresh/store tests, credential reuse coverage,
 filtering and toggle coverage, and cross-platform CI for the migration PRs.
@@ -80,8 +80,8 @@ filtering and toggle coverage, and cross-platform CI for the migration PRs.
 ### Phase 1 — API-key provider batch (completed)
 
 The former candidates — `zenmux, sambanova, deepinfra, novita, routeway,
-crofai, llm7, tokenrouter, anyapi, bai, openmodel, ollama-cloud` — now use the
-native lifecycle. The value was architectural uniformity (Pi-owned refresh,
+crofai, llm7, tokenrouter, anyapi, bai, openmodel, ollama-cloud`, and Qoder — now
+use the native lifecycle. The value was architectural uniformity (Pi-owned refresh,
 credentials, cancellation, and models-store persistence), not a promise of a
 fixed startup speed.
 
@@ -92,11 +92,13 @@ fixed user-visible startup speed. Keyless-provider auth and the `>=0.81.0`
 peer surface were covered by the migration tests and CI; the lockfile was kept
 unchanged.
 
-### Phase 2 — Qoder (deferred)
+### Phase 2 — Qoder (completed)
 
 Qoder's OAuth device flow, PAT exchange, COSY signing, static catalog, and
-custom stream remain intentionally legacy. Revisit only with a dedicated
-protocol/auth migration plan and compatibility tests.
+custom stream now run behind the native `Provider` and `ProviderAuth` surfaces.
+Pi owns credential persistence, offline model restoration, refresh scheduling,
+and catalog persistence; Qoder's compatibility cache remains only for optional
+stream metadata.
 
 ### Phase 3 — `filterModels` capstone (completed)
 
@@ -114,8 +116,8 @@ runtime — see facts 4–6) is:
 
 Completed in the native-provider migration and cleanup PRs. The native
 filter and re-registration paths have focused tests for the eventual filtered
-availability snapshot; Qoder and Pi-built-in providers retain their
-specialized legacy surfaces by design.
+availability snapshot; Pi-built-in providers retain their specialized
+built-in catalog surfaces by design.
 
 ### Parking lot (unordered, low urgency)
 
@@ -124,8 +126,6 @@ specialized legacy surfaces by design.
   only if users miss them. Requires a pricing check per native catalog first
   (Route A/B detection depends on it; opencode-go's native catalog has zero
   free models, illustrating the risk).
-+ **Qoder native migration** — requires a dedicated plan for PAT exchange,
-  COSY signing, the static catalog, and its custom stream.
 + **Free-filter toggle ports** for Pi-built-in Mistral, Groq, Cerebras, xAI, and
   Hugging Face catalogs — only if users request them. pi-free would layer a
   filter/toggle over Pi's catalog without duplicating discovery; pricing

--- a/providers/qoder/auth.ts
+++ b/providers/qoder/auth.ts
@@ -12,12 +12,14 @@
  */
 
 import crypto from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type {
+	AuthInteraction,
+	ModelAuth,
+	OAuthAuth,
+	OAuthCredential,
 	OAuthCredentials,
 	OAuthLoginCallbacks,
+	ProviderAuth,
 } from "@earendil-works/pi-ai/compat";
 import { getMachineId } from "./cosy.ts";
 
@@ -27,7 +29,6 @@ const EXCHANGE_URL = "https://openapi.qoder.sh/api/v1/jobToken/exchange";
 const USERINFO_URL = "https://openapi.qoder.sh/api/v1/userinfo";
 const POLL_URL = "https://openapi.qoder.sh/api/v1/deviceToken/poll";
 const REFRESH_URL = "https://center.qoder.sh/algo/api/v3/user/refresh_token";
-const AUTH_FILE = join(homedir(), ".pi", "agent", "auth.json");
 const UA = "pi-free-providers";
 
 const PAT_REFRESH_PREFIX = "pat";
@@ -379,25 +380,6 @@ async function runDeviceFlow(
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
- * Retrieve cached Qoder credentials (userID/email/name/machineID) from
- * pi's auth store. Best-effort — returns null if not found.
- */
-export function getCachedCredentials(): QoderCredentials | null {
-	if (existsSync(AUTH_FILE)) {
-		try {
-			const auth = JSON.parse(readFileSync(AUTH_FILE, "utf-8"));
-			const creds = auth?.qoder;
-			if (creds?.userID) {
-				return creds as QoderCredentials;
-			}
-		} catch {
-			// Best-effort
-		}
-	}
-	return null;
-}
-
-/**
  * Main login handler for `/login qoder`.
  *
  * Flow:
@@ -547,3 +529,57 @@ export async function refreshQoderToken(
 		expires: Date.now() + 60 * 60 * 1000,
 	};
 }
+
+// =============================================================================
+// Native ProviderAuth adapter
+// =============================================================================
+
+/** Adapt the legacy Qoder login callbacks to Pi's native auth interaction. */
+export async function loginQoderNative(
+	interaction: AuthInteraction,
+): Promise<OAuthCredential> {
+	const credentials = await loginQoder({
+		onAuth: (info: { url: string; instructions?: string }) =>
+			interaction.notify({
+				type: "auth_url",
+				url: info.url,
+				instructions: info.instructions,
+			}),
+		onProgress: (message: string) =>
+			interaction.notify({ type: "progress", message }),
+		onPrompt: (prompt: { message: string; placeholder?: string }) =>
+			interaction.prompt({
+				type: "text",
+				message: prompt.message,
+				placeholder: prompt.placeholder,
+			}),
+		signal: interaction.signal,
+	} as unknown as OAuthLoginCallbacks);
+	return { ...credentials, type: "oauth" };
+}
+
+/**
+ * Native refresh adapter. The existing PAT exchange and OAuth refresh logic is
+ * retained unchanged; Pi owns when it is called and persists the result.
+ */
+export async function refreshQoderCredential(
+	credential: OAuthCredential,
+	_signal?: AbortSignal,
+): Promise<OAuthCredential> {
+	return { ...(await refreshQoderToken(credential)), type: "oauth" };
+}
+
+export const qoderOAuthAuth: OAuthAuth = {
+	name: "Qoder (Browser OAuth / PAT)",
+	loginLabel: "Sign in with Qoder",
+	login: loginQoderNative,
+	refresh: refreshQoderCredential,
+	async toAuth(credential: OAuthCredential): Promise<ModelAuth> {
+		return { apiKey: credential.access };
+	},
+};
+
+/** Native Qoder authentication persisted by Pi in ~/.pi/agent/auth.json. */
+export const qoderAuth: ProviderAuth = {
+	oauth: qoderOAuthAuth,
+};

--- a/providers/qoder/models.ts
+++ b/providers/qoder/models.ts
@@ -10,8 +10,8 @@
  * basic (free tier) or premium (paid credits) by model ID.
  *
  * Dynamic model discovery is disabled until Qoder publishes a model-list
- * endpoint on api2-v2. Stale legacy cache entries are ignored and static
- * models in `staticModels` remain the source of truth.
+ * endpoint on api2-v2. Static models in `staticModels` remain the source of
+ * truth; Pi's native models store owns the persisted catalog.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -148,30 +148,13 @@ export function isBasicModel(model: ProviderModelConfig): boolean {
 	return BASIC_MODEL_IDS.has(model.id);
 }
 
-// ─── Cache management ────────────────────────────────────────────────────────
+// ─── Stream metadata cache ───────────────────────────────────────────────────
 
-/** Get models from cache, falling back to static models. */
-export function getCachedModels(): QoderModelConfig[] {
-	if (existsSync(CACHE_PATH) && !isCacheStale()) {
-		try {
-			const data = JSON.parse(readFileSync(CACHE_PATH, "utf8"));
-			if (data && Array.isArray(data.models)) {
-				return data.models as QoderModelConfig[];
-			}
-		} catch (err) {
-			_logger.warn(
-				"Failed to read Qoder model cache; falling back to static models",
-				{
-					error: err instanceof Error ? err.message : String(err),
-				},
-			);
-		}
-	}
-	return staticModels;
-}
-
-/** Check if the local model cache is stale (>1 hour old). */
-export function isCacheStale(): boolean {
+/**
+ * The legacy cache is consulted only for optional stream metadata. It is not a
+ * model catalog or freshness source; catalogs are restored/persisted by Pi.
+ */
+function isCacheStale(): boolean {
 	if (!existsSync(CACHE_PATH)) return true;
 	try {
 		const data = JSON.parse(readFileSync(CACHE_PATH, "utf8"));

--- a/providers/qoder/qoder-provider.ts
+++ b/providers/qoder/qoder-provider.ts
@@ -1,0 +1,120 @@
+/**
+ * Qoder native Provider implementation.
+ *
+ * Qoder's catalog is a static curated list because its former catalog endpoint
+ * is unavailable. Pi owns the models-store lifecycle: offline refresh restores
+ * the last catalog, while an allowed online refresh republishes the static
+ * catalog and persists it. No legacy cache freshness or startup network work is
+ * performed here.
+ */
+
+import type {
+	Api,
+	Model,
+	Provider,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { getProviderShowPaid } from "../../config.ts";
+import { BASE_URL_QODER, PROVIDER_QODER } from "../../constants.ts";
+import {
+	filterNativeModels,
+	persistNativeProviderModels,
+	registerNativeProvider,
+	restoreNativeProviderModels,
+} from "../../lib/native-provider.ts";
+import { isFreeModel } from "../../lib/registry.ts";
+import { enhanceWithCI, type StoredModels } from "../../provider-helper.ts";
+import { qoderAuth } from "./auth.ts";
+import { isBasicModel, staticModels } from "./models.ts";
+import { streamQoder } from "./stream.ts";
+
+type QoderModel = Model<"qoder-api">;
+
+export interface QoderNativeProvider {
+	provider: Provider<"qoder-api">;
+	stored: StoredModels;
+	/** Ingest a complete catalog, retaining Qoder's basic/premium split. */
+	ingest: (all: ProviderModelConfig[]) => void;
+}
+
+function toQoderModel(model: ProviderModelConfig): QoderModel {
+	return {
+		...model,
+		api: "qoder-api",
+		provider: PROVIDER_QODER,
+		baseUrl: BASE_URL_QODER,
+	} as QoderModel;
+}
+
+function toQoderModels(models: ProviderModelConfig[]): QoderModel[] {
+	return models.map(toQoderModel);
+}
+
+function staticCatalog(): { all: QoderModel[]; free: QoderModel[] } {
+	const all = toQoderModels(enhanceWithCI(staticModels, PROVIDER_QODER));
+	return { all, free: all.filter(isBasicModel) };
+}
+
+export function createQoderProvider(): QoderNativeProvider {
+	const stored: StoredModels = { free: [], all: [] };
+
+	function ingest(all: ProviderModelConfig[]): void {
+		const models = toQoderModels(enhanceWithCI(all, PROVIDER_QODER));
+		stored.all = models;
+		stored.free = models.filter(isBasicModel);
+	}
+
+	const initial = staticCatalog();
+	stored.all = initial.all;
+	stored.free = initial.free;
+
+	async function refreshModels(context: RefreshModelsContext): Promise<void> {
+		await restoreNativeProviderModels(
+			PROVIDER_QODER,
+			context,
+			(storedModels: QoderModel[]) => {
+				stored.all = storedModels;
+				stored.free = storedModels.filter(isBasicModel);
+			},
+		);
+
+		if (!context.allowNetwork || context.signal?.aborted) return;
+
+		// Qoder has no supported catalog endpoint. Re-publish the curated catalog
+		// through Pi's store instead of maintaining a second cache/freshness policy.
+		const catalog = staticCatalog();
+		if (context.signal?.aborted || catalog.all.length === 0) return;
+		stored.all = catalog.all;
+		stored.free = catalog.free;
+		await persistNativeProviderModels(
+			PROVIDER_QODER,
+			context,
+			stored.all as unknown as readonly Model<Api>[],
+		);
+	}
+
+	const provider: Provider<"qoder-api"> = {
+		id: PROVIDER_QODER,
+		name: "Qoder",
+		baseUrl: BASE_URL_QODER,
+		headers: { "User-Agent": "pi-free-providers" },
+		auth: qoderAuth,
+		getModels: () =>
+			(stored.all.length > 0 ? stored.all : stored.free) as QoderModel[],
+		filterModels: (models) =>
+			filterNativeModels(PROVIDER_QODER, models, {
+				showPaid: getProviderShowPaid(PROVIDER_QODER),
+				freeModels: stored.free,
+			}),
+		refreshModels,
+		stream: (model, context, options) =>
+			streamQoder(model, context, options),
+		streamSimple: (model, context, options) =>
+			streamQoder(model, context, options),
+	};
+
+	return { provider, stored, ingest };
+}
+
+export { toQoderModel, toQoderModels };

--- a/providers/qoder/qoder.ts
+++ b/providers/qoder/qoder.ts
@@ -1,119 +1,50 @@
 /**
- * Qoder Provider Extension
+ * Qoder Provider Extension.
  *
- * Registers the Qoder provider with Pi, providing free access to top-tier
- * LLM models (DeepSeek V4 Pro/Flash, Qwen3.7 Plus/Max, GLM 5.1, Kimi K2.6,
- * MiniMax M3) through Qoder's OpenAI-compatible API.
- *
- * Qoder uses a custom authentication protocol (PAT exchange + COSY signing)
- * and a credits-based pricing model:
- *   - Community Edition (free): basic models with daily message limits
- *   - Pro / Pro+ / Ultra (paid): premium models via monthly credits
- *
- * Usage:
- *   Install pi-free, then run /login qoder to authenticate
- *   (PAT paste or browser OAuth)
- *   /toggle-qoder switches between basic (free-tier) and all models
- *
- * Environment variables:
- *   QODER_PERSONAL_ACCESS_TOKEN — PAT for headless auth (optional)
- *   QODER_PAT                   — Alias for above
+ * Qoder uses a custom OAuth/PAT flow and custom OpenAI-compatible streaming,
+ * but its provider registration now uses Pi's native Provider and
+ * models-store lifecycle. The factory performs no catalog network I/O.
  */
 
-import type { Api, OAuthCredentials } from "@earendil-works/pi-ai/compat";
-import type {
-	ExtensionAPI,
-	ProviderModelConfig,
-} from "@earendil-works/pi-coding-agent";
-import { BASE_URL_QODER, PROVIDER_QODER } from "../../constants.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getProviderShowPaid } from "../../config.ts";
-import {
-	getCachedModels,
-	isBasicModel,
-	type QoderModelConfig,
-} from "./models.ts";
-import { getCachedCredentials, loginQoder, refreshQoderToken } from "./auth.ts";
-import { streamQoder } from "./stream.ts";
-import { enhanceWithCI } from "../../provider-helper.ts";
+import { PROVIDER_QODER } from "../../constants.ts";
 import { registerWithGlobalToggle } from "../../lib/registry.ts";
-import { createToggleState } from "../../lib/toggle-state.ts";
+import {
+	registerNativeProvider,
+	registerNativeProviderRefresh,
+	registerNativeProviderToggle,
+} from "../../lib/native-provider.ts";
+import { createQoderProvider } from "./qoder-provider.ts";
 
-// =============================================================================
-// Extension Entry Point
-// =============================================================================
+export default async function qoderProvider(pi: ExtensionAPI): Promise<void> {
+	const { provider, stored } = createQoderProvider();
 
-export default async function qoderProvider(pi: ExtensionAPI) {
-	const logger = (await import("../../lib/logger.ts")).createLogger("qoder");
+	registerNativeProvider(pi, provider);
 
-	// Initial model fetch
-	const allModels: QoderModelConfig[] = getCachedModels();
-	const basicModels: QoderModelConfig[] = allModels.filter(isBasicModel);
-	const stored = { free: basicModels, all: allModels };
+	// Re-register the same provider object only to invalidate Pi's availability
+	// snapshot after the global or provider-specific free/paid toggle changes.
+	const reRegister = () => registerNativeProvider(pi, provider);
+	registerWithGlobalToggle(PROVIDER_QODER, stored, reRegister, false, {
+		native: true,
+		invalidate: reRegister,
+	});
 
-	const toggleState = createToggleState({
+	registerNativeProviderToggle(pi, {
 		providerId: PROVIDER_QODER,
-		initialShowPaid: getProviderShowPaid(PROVIDER_QODER),
-		initialModels: stored,
+		stored,
+		getShowPaid: () => getProviderShowPaid(PROVIDER_QODER),
+		reRegister,
 	});
-
-	// ── OAuth config (defined before reRegister so it's always available) ──
-	const oauthConfig = {
-		name: "Qoder (Browser OAuth / PAT)",
-		login: async (callbacks: any): Promise<OAuthCredentials> => {
-			return loginQoder(callbacks);
-		},
-		refreshToken: refreshQoderToken,
-		getApiKey: (cred: OAuthCredentials) => cred.access,
-	};
-
-	// Re-register function — called by toggle, session refresh, login
-	const reRegister = (models: ProviderModelConfig[]) => {
-		const enhanced = enhanceWithCI(models, PROVIDER_QODER);
-		pi.registerProvider(PROVIDER_QODER, {
-			baseUrl: BASE_URL_QODER,
-			api: "qoder-api" as Api,
-			models: enhanced,
-			oauth: oauthConfig,
-			streamSimple: streamQoder,
-		});
-	};
-
-	// Register with global toggle system so it participates in /toggle-free
-	registerWithGlobalToggle(PROVIDER_QODER, stored, (m) => reRegister(m), false);
-
-	// Per-provider toggle: /toggle-qoder (basic free-tier ↔ all models)
-	pi.registerCommand("toggle-qoder", {
-		description: "Toggle between basic (free-tier) and all Qoder models",
-		handler: async (_args, ctx) => {
-			try {
-				const applied = toggleState.toggle(reRegister);
-				const basicCount = stored.free.length;
-				const premiumCount = stored.all.length - basicCount;
-				if (applied.mode === "all") {
-					ctx.ui.notify(
-						`qoder: showing all ${stored.all.length} models (${basicCount} basic, ${premiumCount} premium)`,
-						"info",
-					);
-				} else {
-					ctx.ui.notify(
-						`qoder: showing ${stored.free.length} basic (free-tier) models`,
-						"info",
-					);
-				}
-			} catch (err) {
-				logger.error("[qoder] toggle failed", {
-					error: err instanceof Error ? err.message : String(err),
-				});
-				ctx.ui.notify("qoder: toggle failed", "error");
-			}
-		},
-	});
-
-	// Initial registration respects the configured show-paid mode.
-	toggleState.applyCurrent(reRegister);
-
-	logger.info(`[qoder] Provider registered with ${allModels.length} models`);
+	registerNativeProviderRefresh(pi, PROVIDER_QODER);
 }
 
-// Re-export key symbols for testing
-export { loginQoder, refreshQoderToken, getCachedCredentials, streamQoder };
+export { createQoderProvider } from "./qoder-provider.ts";
+export {
+	loginQoder,
+	loginQoderNative,
+	refreshQoderCredential,
+	refreshQoderToken,
+	qoderAuth,
+} from "./auth.ts";
+export { streamQoder } from "./stream.ts";

--- a/tests/qoder-auth.test.ts
+++ b/tests/qoder-auth.test.ts
@@ -1,0 +1,27 @@
+import type { OAuthCredential } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import { qoderAuth } from "../providers/qoder/qoder.ts";
+
+describe("Qoder native authentication", () => {
+	it("exposes the existing OAuth/PAT flow through ProviderAuth", () => {
+		expect(qoderAuth.oauth).toMatchObject({
+			name: "Qoder (Browser OAuth / PAT)",
+			login: expect.any(Function),
+			refresh: expect.any(Function),
+			toAuth: expect.any(Function),
+		});
+	});
+
+	it("converts a stored Qoder credential into a bearer API auth", async () => {
+		const credential = {
+			type: "oauth",
+			access: "job-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		} as OAuthCredential;
+
+		expect(await qoderAuth.oauth?.toAuth(credential)).toEqual({
+			apiKey: "job-token",
+		});
+	});
+});

--- a/tests/qoder.test.ts
+++ b/tests/qoder.test.ts
@@ -1,35 +1,48 @@
-/**
- * Qoder Provider Tests
- */
-
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetQoderShowPaid = vi.fn();
-const mockGetCachedModels = vi.fn();
-const mockIsCacheStale = vi.fn();
-const mockUpdateQoderModelsCache = vi.fn();
-const mockGetCachedCredentials = vi.fn();
-const mockLoginQoder = vi.fn();
-const mockRefreshQoderToken = vi.fn();
-const mockRegisterWithGlobalToggle = vi.fn();
-let capturedToggleArgs: unknown[] = [];
-
-vi.mock("../constants.ts", () => ({
-	BASE_URL_QODER: "https://api2-v2.qoder.sh",
-	PROVIDER_QODER: "qoder",
+const mocks = vi.hoisted(() => ({
+	getQoderShowPaid: vi.fn(() => false),
+	registerNativeProvider: vi.fn(),
+	registerNativeProviderRefresh: vi.fn(),
+	registerNativeProviderToggle: vi.fn(),
+	registerWithGlobalToggle: vi.fn(),
+	restoreNativeProviderModels: vi.fn(async (..._args: unknown[]) => undefined),
+	persistNativeProviderModels: vi.fn(async (..._args: unknown[]) => undefined),
+	filterNativeModels: vi.fn(
+		(...args: unknown[]) => (args[1] as readonly unknown[]) ?? [],
+	),
+	qoderAuth: {
+		oauth: {
+			name: "Qoder (Browser OAuth / PAT)",
+			login: vi.fn(),
+			refresh: vi.fn(),
+			toAuth: vi.fn(),
+		},
+	},
 }));
 
 vi.mock("../config.ts", () => ({
-	getProviderShowPaid: () => mockGetQoderShowPaid(),
-	saveConfig: vi.fn(),
+	getProviderShowPaid: () => mocks.getQoderShowPaid(),
 }));
 
 vi.mock("../lib/registry.ts", () => ({
-	registerWithGlobalToggle: (...args: unknown[]) => {
-		capturedToggleArgs.push(args);
-		mockRegisterWithGlobalToggle(...args);
-	},
+	registerWithGlobalToggle: (...args: unknown[]) =>
+		mocks.registerWithGlobalToggle(...args),
+}));
+
+vi.mock("../lib/native-provider.ts", () => ({
+	filterNativeModels: (...args: unknown[]) => mocks.filterNativeModels(...args),
+	persistNativeProviderModels: (...args: unknown[]) =>
+		mocks.persistNativeProviderModels(...args),
+	registerNativeProvider: (...args: unknown[]) =>
+		mocks.registerNativeProvider(...args),
+	registerNativeProviderRefresh: (...args: unknown[]) =>
+		mocks.registerNativeProviderRefresh(...args),
+	registerNativeProviderToggle: (...args: unknown[]) =>
+		mocks.registerNativeProviderToggle(...args),
+	restoreNativeProviderModels: (...args: unknown[]) =>
+		mocks.restoreNativeProviderModels(...args),
 }));
 
 vi.mock("../provider-helper.ts", () => ({
@@ -37,33 +50,25 @@ vi.mock("../provider-helper.ts", () => ({
 }));
 
 vi.mock("../providers/qoder/auth.ts", () => ({
-	getCachedCredentials: () => mockGetCachedCredentials(),
-	loginQoder: (...args: unknown[]) => mockLoginQoder(...args),
-	refreshQoderToken: (...args: unknown[]) => mockRefreshQoderToken(...args),
+	qoderAuth: mocks.qoderAuth,
 }));
-
-vi.mock("../providers/qoder/models.ts", async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import("../providers/qoder/models.ts")>();
-	return {
-		...actual,
-		getCachedModels: () => mockGetCachedModels(),
-		isCacheStale: () => mockIsCacheStale(),
-		updateQoderModelsCache: (...args: unknown[]) =>
-			mockUpdateQoderModelsCache(...args),
-		getCachedModelConfig: vi.fn(),
-		isBasicModel: (m: { id: string }) =>
-			["auto", "ultimate", "performance", "efficient", "lite"].includes(m.id),
-	};
-});
 
 import qoderProvider from "../providers/qoder/qoder.ts";
 import { isBasicModel, staticModels } from "../providers/qoder/models.ts";
 
+function getRegisteredProvider(): any {
+	return mocks.registerNativeProvider.mock.calls[0]?.[1];
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.getQoderShowPaid.mockReturnValue(false);
+});
+
 describe("Qoder model classification", () => {
 	it("classifies basic router models correctly", () => {
 		for (const id of ["auto", "ultimate", "performance", "efficient", "lite"]) {
-			const model = staticModels.find((m) => m.id === id);
+			const model = staticModels.find((entry) => entry.id === id);
 			expect(model).toBeDefined();
 			expect(isBasicModel(model!)).toBe(true);
 		}
@@ -71,244 +76,114 @@ describe("Qoder model classification", () => {
 
 	it("classifies premium named models as non-basic", () => {
 		for (const id of ["qmodel", "dmodel", "kmodel", "mmodel"]) {
-			const model = staticModels.find((m) => m.id === id);
+			const model = staticModels.find((entry) => entry.id === id);
 			expect(model).toBeDefined();
 			expect(isBasicModel(model!)).toBe(false);
 		}
 	});
-
-	it("classifies unknown models as non-basic", () => {
-		expect(
-			isBasicModel({
-				id: "unknown-model",
-				name: "Unknown",
-				reasoning: false,
-				input: ["text"],
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				contextWindow: 1000,
-				maxTokens: 100,
-			}),
-		).toBe(false);
-	});
 });
 
-describe("Qoder Provider", () => {
-	let mockPi: ExtensionAPI;
-	let mockRegisterProvider: ReturnType<typeof vi.fn>;
-	let mockRegisterCommand: ReturnType<typeof vi.fn>;
-	let commandHandlers: Record<string, Function>;
+describe("Qoder native provider", () => {
+	const pi = {} as ExtensionAPI;
 
-	const basicModels = [
-		{
-			id: "auto",
-			name: "Qoder Auto",
-			reasoning: true,
-			input: ["text", "image"] as const,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 180_000,
-			maxTokens: 32_768,
-		},
-		{
-			id: "lite",
-			name: "Qoder Lite",
-			reasoning: false,
-			input: ["text"] as const,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 180_000,
-			maxTokens: 32_768,
-		},
-	];
+	it("registers the complete catalog through Pi's native provider API", async () => {
+		await qoderProvider(pi);
 
-	const premiumModels = [
-		{
-			id: "qmodel",
-			name: "Qwen3.7 Plus (Qoder)",
-			reasoning: false,
-			input: ["text", "image"] as const,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 1_000_000,
-			maxTokens: 32_768,
-		},
-		{
-			id: "dmodel",
-			name: "DeepSeek V4 Pro (Qoder)",
-			reasoning: true,
-			input: ["text", "image"] as const,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 1_000_000,
-			maxTokens: 32_768,
-		},
-	];
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-		mockGetQoderShowPaid.mockReset().mockReturnValue(false);
-		mockGetCachedModels
-			.mockReset()
-			.mockReturnValue([...basicModels, ...premiumModels]);
-		mockIsCacheStale.mockReset().mockReturnValue(false);
-		mockUpdateQoderModelsCache.mockReset().mockResolvedValue(undefined);
-		mockGetCachedCredentials.mockReset().mockReturnValue(null);
-		mockLoginQoder.mockReset().mockResolvedValue({
-			access: "oauth-token",
-			refresh: "refresh-token",
-			expires: Date.now() + 3600_000,
+		const provider = getRegisteredProvider();
+		expect(provider).toMatchObject({
+			id: "qoder",
+			name: "Qoder",
+			baseUrl: "https://api2-v2.qoder.sh",
 		});
-		mockRefreshQoderToken.mockReset();
-		mockRegisterWithGlobalToggle.mockReset();
-		capturedToggleArgs = [];
-
-		mockRegisterProvider = vi.fn();
-		mockRegisterCommand = vi.fn(
-			(name: string, config: { handler: Function }) => {
-				commandHandlers[name] = config.handler;
-			},
+		expect(provider.getModels()).toHaveLength(staticModels.length);
+		expect(provider.getModels()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "auto", api: "qoder-api" }),
+				expect.objectContaining({ id: "qmodel", api: "qoder-api" }),
+			]),
 		);
-		commandHandlers = {};
-
-		mockPi = {
-			registerProvider: mockRegisterProvider,
-			on: vi.fn(),
-			registerCommand: mockRegisterCommand,
-		} as unknown as ExtensionAPI;
+		expect(provider.auth).toBe(mocks.qoderAuth);
+		expect(provider.stream).toEqual(expect.any(Function));
+		expect(provider.streamSimple).toEqual(expect.any(Function));
+		expect(mocks.registerNativeProviderRefresh).toHaveBeenCalledWith(
+			pi,
+			"qoder",
+		);
 	});
 
-	describe("initialization", () => {
-		it("should register provider with basic (free-tier) models by default", async () => {
-			await qoderProvider(mockPi);
+	it("keeps the basic catalog in the global toggle state", async () => {
+		await qoderProvider(pi);
 
-			expect(mockRegisterProvider).toHaveBeenCalledWith(
-				"qoder",
-				expect.objectContaining({
-					baseUrl: "https://api2-v2.qoder.sh",
-					models: expect.arrayContaining([
-						expect.objectContaining({ id: "auto" }),
-						expect.objectContaining({ id: "lite" }),
-					]),
-					streamSimple: expect.any(Function),
-				}),
-			);
-
-			const registeredModels = mockRegisterProvider.mock.calls[0][1].models;
-			expect(registeredModels).toHaveLength(2);
-			expect(
-				registeredModels.some((m: { id: string }) => m.id === "qmodel"),
-			).toBe(false);
-			expect(
-				registeredModels.some((m: { id: string }) => m.id === "dmodel"),
-			).toBe(false);
-		});
-
-		it("should register all models when QODER_SHOW_PAID is true", async () => {
-			mockGetQoderShowPaid.mockReturnValue(true);
-
-			await qoderProvider(mockPi);
-
-			const registeredModels = mockRegisterProvider.mock.calls[0][1].models;
-			expect(registeredModels).toHaveLength(4);
-			expect(
-				registeredModels.some((m: { id: string }) => m.id === "qmodel"),
-			).toBe(true);
-			expect(
-				registeredModels.some((m: { id: string }) => m.id === "dmodel"),
-			).toBe(true);
-		});
-
-		it("should register with global toggle system", async () => {
-			await qoderProvider(mockPi);
-
-			expect(mockRegisterWithGlobalToggle).toHaveBeenCalledWith(
-				"qoder",
-				expect.objectContaining({
-					free: expect.arrayContaining([
-						expect.objectContaining({ id: "auto" }),
-						expect.objectContaining({ id: "lite" }),
-					]),
-					all: expect.arrayContaining([
-						expect.objectContaining({ id: "auto" }),
-						expect.objectContaining({ id: "qmodel" }),
-					]),
-				}),
-				expect.any(Function),
-				false,
-			);
+		const stored = mocks.registerWithGlobalToggle.mock.calls[0]?.[1];
+		expect(stored.free).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "auto" }),
+				expect.objectContaining({ id: "lite" }),
+			]),
+		);
+		expect(stored.all).toHaveLength(staticModels.length);
+		expect(mocks.registerWithGlobalToggle.mock.calls[0]?.[4]).toMatchObject({
+			native: true,
+			invalidate: expect.any(Function),
 		});
 	});
 
-	describe("toggle-qoder command", () => {
-		it("should toggle from basic to all models", async () => {
-			await qoderProvider(mockPi);
-			mockRegisterProvider.mockClear();
+	it("filters to basic models by default and can expose paid models", async () => {
+		await qoderProvider(pi);
+		const provider = getRegisteredProvider();
+		const models = provider.getModels();
 
-			const notify = vi.fn();
-			await commandHandlers["toggle-qoder"]({}, { ui: { notify } });
+		provider.filterModels(models, undefined);
+		expect(mocks.filterNativeModels).toHaveBeenLastCalledWith(
+			"qoder",
+			models,
+			expect.objectContaining({ showPaid: false }),
+		);
 
-			expect(notify).toHaveBeenCalledWith(
-				"qoder: showing all 4 models (2 basic, 2 premium)",
-				"info",
-			);
-			expect(mockRegisterProvider).toHaveBeenCalledWith(
-				"qoder",
-				expect.objectContaining({
-					models: expect.arrayContaining([
-						expect.objectContaining({ id: "qmodel" }),
-					]),
-				}),
-			);
-		});
-
-		it("should toggle back to basic models", async () => {
-			await qoderProvider(mockPi);
-
-			const notify = vi.fn();
-			await commandHandlers["toggle-qoder"]({}, { ui: { notify } });
-			mockRegisterProvider.mockClear();
-			await commandHandlers["toggle-qoder"]({}, { ui: { notify } });
-
-			expect(notify).toHaveBeenLastCalledWith(
-				"qoder: showing 2 basic (free-tier) models",
-				"info",
-			);
-			const registeredModels = mockRegisterProvider.mock.calls[0][1].models;
-			expect(registeredModels).toHaveLength(2);
-			expect(
-				registeredModels.every((m: { id: string }) =>
-					["auto", "lite"].includes(m.id),
-				),
-			).toBe(true);
-		});
-
-		it("should persist paid mode to config", async () => {
-			const { saveConfig } = await import("../config.ts");
-
-			await qoderProvider(mockPi);
-
-			const notify = vi.fn();
-			await commandHandlers["toggle-qoder"]({}, { ui: { notify } });
-
-			expect(saveConfig).toHaveBeenCalledWith({ qoder_show_paid: true });
-		});
+		mocks.getQoderShowPaid.mockReturnValue(true);
+		provider.filterModels(models, undefined);
+		expect(mocks.filterNativeModels).toHaveBeenLastCalledWith(
+			"qoder",
+			models,
+			expect.objectContaining({ showPaid: true }),
+		);
 	});
 
-	describe("OAuth integration", () => {
-		it("should have OAuth configuration", async () => {
-			await qoderProvider(mockPi);
+	it("registers the native per-provider toggle and refresh hook", async () => {
+		await qoderProvider(pi);
 
-			const registerCall = mockRegisterProvider.mock.calls[0];
-			expect(registerCall[1]).toHaveProperty("oauth");
-			expect(registerCall[1].oauth).toHaveProperty("name");
-			expect(registerCall[1].oauth).toHaveProperty("login");
-			expect(registerCall[1].oauth).toHaveProperty("refreshToken");
-			expect(registerCall[1].oauth).toHaveProperty("getApiKey");
-		});
+		expect(mocks.registerNativeProviderToggle).toHaveBeenCalledWith(
+			pi,
+			expect.objectContaining({
+				providerId: "qoder",
+				stored: expect.any(Object),
+				getShowPaid: expect.any(Function),
+				reRegister: expect.any(Function),
+			}),
+		);
+		const provider = getRegisteredProvider();
+		const reRegister = mocks.registerNativeProviderToggle.mock.calls[0][1]
+			.reRegister as () => void;
+		mocks.registerNativeProvider.mockClear();
+		reRegister();
+		expect(mocks.registerNativeProvider).toHaveBeenCalledWith(pi, provider);
+	});
 
-		it("should call loginQoder on OAuth login", async () => {
-			await qoderProvider(mockPi);
+	it("restores offline catalogs without persisting a network refresh", async () => {
+		await qoderProvider(pi);
+		const provider = getRegisteredProvider();
+		const context = {
+			store: { read: vi.fn(), write: vi.fn(), delete: vi.fn() },
+			allowNetwork: false,
+			signal: new AbortController().signal,
+		};
 
-			const oauth = mockRegisterProvider.mock.calls[0][1].oauth;
-			await oauth.login({ onProgress: vi.fn() });
-
-			expect(mockLoginQoder).toHaveBeenCalled();
-		});
+		await provider.refreshModels(context);
+		expect(mocks.restoreNativeProviderModels).toHaveBeenCalledWith(
+			"qoder",
+			context,
+			expect.any(Function),
+		);
+		expect(mocks.persistNativeProviderModels).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- Migrate Qoder from legacy registration to Pi's native `Provider` and `ProviderAuth` surfaces.
- Preserve OAuth device flow, PAT exchange/refresh, COSY signing, custom streaming, static catalog, and basic/all filtering.
- Restore and persist Qoder's catalog through Pi's models store with no startup catalog network request.
- Re-register the same provider object for native toggle invalidation.
- Retain `qoder-models-cache.json` only for optional stream metadata; it is no longer a catalog/freshness source.
- Update Qoder documentation, roadmap, changelog, and native-provider tests.

## Validation

- Full suite: 638 passed
- Focused Qoder tests: 18 passed
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`

No credentials were used or persisted during validation.
