### PR TITLE
perf: rotate logs without blocking startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Qoder native lifecycle** — Migrated Qoder to Pi's native Provider/ProviderAuth and models-store lifecycle while preserving its OAuth/PAT exchange, COSY signing, static catalog, custom stream, and basic/all filtering. Its legacy cache is now limited to optional stream metadata.
+- **Bounded non-blocking logs** — Added asynchronous size-based rotation for `free.log` (10 MiB default, three backups) without synchronous rotation or startup blocking; `PI_FREE_LOG_MAX_BYTES` controls the threshold.
 - **Compiled startup graph** — Removed startup-only Pi credential inspection and deferred the broad pi-ai compatibility graph. Controlled compiled import-inclusive benchmarks improved from roughly **1.14s to 0.43s p50**, total from **1.18s to 0.47s p50**, and the measured import graph from **904 to 226 modules**. These figures measure the extension benchmark, not a full Pi-host A/B result.
 
 - **Cline native tool-call compatibility** — The custom Cline bridge now advertises the current OpenAI-compatible tool schema and parses streamed `delta.tool_calls` alongside the existing XML and `<function=...>` fallbacks. This prevents reasoning-capable models from stopping after planning text when their actual tool call arrives in the native stream format.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,20 +121,21 @@ export PI_FREE_BENCHMARK_DEBUG=1
 ```bash
 LOG_LEVEL=debug
 PI_FREE_LOG_LEVEL=debug
-PI_FREE_LOG_PATH=/tmp/pi-free.log
+PI_FREE_LOG_PATH=custom-free.log
+PI_FREE_LOG_MAX_BYTES=10485760
 PI_FREE_FILE_LOG=false
 PI_FREE_PROVIDER_CACHE=/tmp/provider-cache.json
 PI_FREE_TELEMETRY_FILE=/tmp/free-telemetry.json
 ```
 
-The telemetry file defaults to `~/.pi/free-telemetry.json`.
+The telemetry file defaults to `~/.pi/free-telemetry.json`. `free.log` rotates asynchronously at the configured size (10 MiB by default) and keeps three backups (`free.log.1` through `.3`). Rotation and the initial log-file check are lazy and do not block extension startup. `PI_FREE_LOG_PATH` accepts a filename within `~/.pi`; it does not accept an arbitrary directory path.
 
 ## File locations
 
 | File | Purpose |
 | --- | --- |
 | `~/.pi/free.json` | pi-free config, flags, and extension-provider keys |
-| `~/.pi/free.log` | Extension log (includes opt-in `benchmark-lookup` diagnostics) |
+| `~/.pi/free.log` and `.1`–`.3` | Rotating extension log (includes opt-in `benchmark-lookup` diagnostics) |
 | `~/.pi/free-telemetry.json` | Local model performance telemetry |
 | `~/.pi/provider-cache.json` | Legacy cache and Ollama compatibility data |
 | `~/.pi/agent/models-store.json` | Pi native provider catalogs |

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -4,8 +4,9 @@
  *
  * File logging:
  * - Default file: ~/.pi/free.log
- * - Override path: PI_FREE_LOG_PATH=/custom/path/free.log
+ * - Override filename: PI_FREE_LOG_PATH=custom-free.log
  * - Disable file logging: PI_FREE_FILE_LOG=false
+ * - Rotate size: PI_FREE_LOG_MAX_BYTES=10485760 (default 10 MiB; 3 backups)
  */
 
 import {
@@ -13,6 +14,7 @@ import {
 	createWriteStream,
 	type WriteStream,
 } from "node:fs";
+import { mkdir as mkdirAsync, rename, rm, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 import { ensureDir, resolveSafeDataFile } from "./paths.ts";
 
@@ -76,16 +78,30 @@ function formatMessage(entry: LogEntry): string {
 
 const LOG_PATH = resolveSafeDataFile(process.env.PI_FREE_LOG_PATH, "free.log");
 const FILE_LOG_ENABLED = process.env.PI_FREE_FILE_LOG !== "false";
+const DEFAULT_MAX_LOG_BYTES = 10 * 1024 * 1024;
+const MAX_LOG_BYTES = parsePositiveInteger(
+	process.env.PI_FREE_LOG_MAX_BYTES,
+	DEFAULT_MAX_LOG_BYTES,
+);
+const LOG_BACKUP_COUNT = 3;
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+	if (!value) return fallback;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 // File logging is buffered through a lazily-opened append stream so startup
-// (which emits many log lines) does not pay a synchronous open+write+close —
-// plus an existsSync — on every single line. The log directory is ensured once,
-// not per line. If a stream cannot be opened (e.g. fs streams are absent under
-// a test mock), we fall back to a single synchronous append per line so logs
-// are never silently dropped.
+// does not pay synchronous open/write/rotation work. The first stream open and
+// every size-based rotation use async fs operations; lines emitted while that
+// work is pending stay in a small in-memory queue. If streams are unavailable
+// (e.g. a minimal test mock), we retain the synchronous fallback.
 let logStream: WriteStream | null = null;
 let logDirEnsured = false;
 let logStreamUnavailable = false;
+let logStreamReady: Promise<void> | null = null;
+let logBytes = 0;
+const queuedLines: string[] = [];
 
 function ensureLogDirOnce(): void {
 	if (logDirEnsured) return;
@@ -93,49 +109,141 @@ function ensureLogDirOnce(): void {
 	logDirEnsured = true;
 }
 
-function getLogStream(): WriteStream | null {
-	if (logStream) return logStream;
-	if (logStreamUnavailable) return null;
-	if (typeof createWriteStream !== "function") {
-		// fs.createWriteStream missing (e.g. a minimal test mock) — use fallback.
-		logStreamUnavailable = true;
-		return null;
+async function ensureLogDirAsync(): Promise<void> {
+	if (logDirEnsured) return;
+	await mkdirAsync(dirname(LOG_PATH), { recursive: true });
+	logDirEnsured = true;
+}
+
+async function moveLog(source: string, target: string): Promise<void> {
+	try {
+		await rm(target, { force: true });
+		await rename(source, target);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
 	}
+}
+
+async function rotateLogFilesIfNeeded(force = false): Promise<void> {
+	let size: number;
+	try {
+		size = (await stat(LOG_PATH)).size;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw err;
+	}
+	if (!force && size < MAX_LOG_BYTES) return;
+
+	for (let index = LOG_BACKUP_COUNT; index >= 1; index--) {
+		const source = index === 1 ? LOG_PATH : `${LOG_PATH}.${index - 1}`;
+		await moveLog(source, `${LOG_PATH}.${index}`);
+	}
+}
+
+function flushQueuedFallback(): void {
+	if (queuedLines.length === 0) return;
+	const lines = queuedLines.splice(0);
 	try {
 		ensureLogDirOnce();
-		const stream = createWriteStream(LOG_PATH, {
-			flags: "a",
-			encoding: "utf8",
-		});
-		stream.on("error", (err) => {
-			console.error("Failed to write to log file:", err);
-			logStreamUnavailable = true;
-			logStream = null;
-		});
-		logStream = stream;
-		return logStream;
+		appendFileSync(LOG_PATH, lines.join(""), "utf8");
 	} catch (err) {
-		console.error("Failed to open log file stream:", err);
-		logStreamUnavailable = true;
-		return null;
+		console.error("Failed to write to log file:", err);
 	}
+}
+
+function attachLogStream(stream: WriteStream, existingBytes: number): void {
+	stream.on("error", (err) => {
+		console.error("Failed to write to log file:", err);
+		logStreamUnavailable = true;
+		logStream = null;
+		flushQueuedFallback();
+	});
+	logStream = stream;
+	logBytes = existingBytes;
+	const pending = queuedLines.splice(0);
+	for (let index = 0; index < pending.length; index++) {
+		const line = pending[index];
+		const bytes = Buffer.byteLength(line, "utf8");
+		if (logBytes > 0 && logBytes + bytes > MAX_LOG_BYTES) {
+			queuedLines.push(...pending.slice(index));
+			break;
+		}
+		stream.write(line);
+		logBytes += bytes;
+	}
+}
+
+async function openLogStream(forceRotate = false): Promise<void> {
+	await ensureLogDirAsync();
+	await rotateLogFilesIfNeeded(forceRotate);
+	let existingBytes = 0;
+	try {
+		existingBytes = (await stat(LOG_PATH)).size;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+	}
+	if (typeof createWriteStream !== "function") {
+		logStreamUnavailable = true;
+		flushQueuedFallback();
+		return;
+	}
+	const stream = createWriteStream(LOG_PATH, {
+		flags: "a",
+		encoding: "utf8",
+	});
+	attachLogStream(stream, existingBytes);
+}
+
+function finishLogStreamOperation(): void {
+	logStreamReady = null;
+	if (logStream && (logBytes >= MAX_LOG_BYTES || queuedLines.length > 0)) {
+		queueMicrotask(() => startLogStream(true));
+	}
+}
+
+function startLogStream(rotationRequested = false): void {
+	if (logStreamReady) return;
+	if (logStreamUnavailable) {
+		flushQueuedFallback();
+		return;
+	}
+	if (logStream && !rotationRequested) return;
+
+	if (logStream && rotationRequested) {
+		const oldStream = logStream;
+		logStream = null;
+		logStreamReady = new Promise<void>((resolve) => oldStream.end(resolve))
+			.then(() => openLogStream(true))
+			.catch((err) => {
+				console.error("Failed to rotate log file:", err);
+				logStreamUnavailable = true;
+				flushQueuedFallback();
+			})
+			.finally(finishLogStreamOperation);
+		return;
+	}
+
+	logStreamReady = openLogStream()
+		.catch((err) => {
+			console.error("Failed to open log file stream:", err);
+			logStreamUnavailable = true;
+			flushQueuedFallback();
+		})
+		.finally(finishLogStreamOperation);
 }
 
 function appendToFile(line: string): void {
 	if (!FILE_LOG_ENABLED) return;
-	const stream = getLogStream();
-	if (stream) {
-		stream.write(`${line}\n`);
+	const formatted = `${line}\n`;
+	const bytes = Buffer.byteLength(formatted, "utf8");
+	if (logStream && logBytes + bytes < MAX_LOG_BYTES) {
+		logStream.write(formatted);
+		logBytes += bytes;
 		return;
 	}
-	// Fallback: a single synchronous append (used only when streams are
-	// unavailable). Still ensures the directory just once.
-	try {
-		ensureLogDirOnce();
-		appendFileSync(LOG_PATH, `${line}\n`, "utf8");
-	} catch (err) {
-		console.error("Failed to write to log file:", err);
-	}
+
+	queuedLines.push(formatted);
+	startLogStream(Boolean(logStream));
 }
 
 function log(

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const MAX_BYTES = 512;
+
+async function waitForLogFlush(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("logger file rotation", () => {
+	it("rotates asynchronously without exceeding the configured size", async () => {
+		const home = await mkdtemp(join(tmpdir(), "pi-free-logger-test-"));
+		try {
+			vi.stubEnv("HOME", home);
+			vi.stubEnv("USERPROFILE", home);
+			vi.stubEnv("PI_FREE_LOG_PATH", "rotation.log");
+			vi.stubEnv("PI_FREE_LOG_MAX_BYTES", String(MAX_BYTES));
+			vi.stubEnv("PI_FREE_LOG_LEVEL", "debug");
+			vi.stubEnv("PI_FREE_FILE_LOG", "true");
+			vi.resetModules();
+
+			const { createLogger } = await import("../lib/logger.ts");
+			const logger = createLogger("rotation-test");
+			for (let index = 0; index < 100; index++) {
+				logger.info("line", { index, payload: "x".repeat(40) });
+			}
+			await waitForLogFlush();
+
+			const logDir = join(home, ".pi");
+			const files = (await readdir(logDir))
+				.filter((file) => file.startsWith("rotation.log"))
+				.sort();
+			expect(files.length).toBeGreaterThan(1);
+			expect(files.length).toBeLessThanOrEqual(4);
+			for (const file of files) {
+				expect((await stat(join(logDir, file))).size).toBeLessThanOrEqual(
+					MAX_BYTES,
+				);
+			}
+			expect(await readFile(join(logDir, files[0]), "utf8")).toContain(
+			"rotation-test",
+		);
+		} finally {
+			await rm(home, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Add asynchronous size-based rotation for `~/.pi/free.log`.
- Default threshold is 10 MiB with three backups (`free.log.1` through `.3`).
- Add `PI_FREE_LOG_MAX_BYTES` configuration.
- Keep the first file check, rotation, and stream setup off the synchronous startup path; log lines are queued briefly while async setup completes.
- Preserve the synchronous append fallback only for environments where streams are unavailable.
- Add configuration documentation and a rotation regression test.

## Validation

- Full suite: 639 passed
- Logger rotation test passed
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`
- Manual 1 KiB rotation smoke test produced bounded current/backup files.
