### PR TITLE
chore: prepare 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-02
+
 ### Added
 
 - **StepFun native provider** — Added the paid StepFun Step Plan provider using Pi's native model store and refresh lifecycle. Chat requests use the OpenAI-compatible endpoint at `https://api.stepfun.ai/step_plan/v1/chat/completions`; `STEPFUN_API_KEY` and `stepfun_api_key` are supported, and paid models are shown by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-free",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-free",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## Release 2.4.0

Promotes the accumulated Unreleased changes since 2.3.0:

- StepFun native provider
- Qoder native lifecycle migration
- Compiled startup/import graph optimization
- Non-blocking rotating logs
- DSML and custom-tool schema compatibility improvements

## Validation

- `npm run check:lockfile`
- `npm run audit:prod` — 0 vulnerabilities
- `npm run build`
- `npm run lint`
- Full tests: 639 passed
- `npm publish --dry-run`
- Tarball verification
- Compiled entry smoke-load
