### PR TITLE
chore: release 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-08-02
+
+### Fixed
+
+- **OpenCode built-in model toggles** — Free OpenCode models are now captured from Pi's full catalog, re-registered through the current session registry, and made available when the shared credential is stored under `opencode-go` (#393, #395).
+
 ## [2.4.0] - 2026-08-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-free",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-free",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
## Release 2.4.1

### Fixed
- Restore free OpenCode models and built-in toggles after session reloads.
- Reuse shared `opencode-go` credentials for the regular OpenCode provider.

### Validation
- `npm run check:lockfile`
- `npm run lint`
- `npm run test:run` (640 passed)
- `npm run build`

After merge, the release workflow will create tag `v2.4.1` and publish the package.