### PR TITLE
fix: satisfy Sonar checks for loader validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Verify production source build
         run: |
           test -f dist/index.js
-          node scripts/check-runtime-imports.mjs .
+          node scripts/check-runtime-imports.mjs
           node scripts/smoke-compiled.mjs ./dist/index.js
           node scripts/smoke-pi-loader.mjs ./dist/index.js
 
@@ -129,7 +129,8 @@ jobs:
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/check-extensions.mjs "$INSTALL_DIR"
-          node scripts/check-runtime-imports.mjs "$INSTALL_DIR"
+          export PI_FREE_RUNTIME_DIR="$INSTALL_DIR"
+          node scripts/check-runtime-imports.mjs
 
       - name: Smoke-load compiled extension entry
         # Catches missing runtime modules.

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -10,7 +10,7 @@
  *
  * Usage:
  *   node scripts/check-runtime-imports.mjs             # ./dist
- *   node scripts/check-runtime-imports.mjs <package>  # package/dist
+ *   PI_FREE_RUNTIME_DIR=/path/to/package node scripts/check-runtime-imports.mjs
  */
 
 import {
@@ -38,7 +38,7 @@ function resolveDirectory(input) {
 
 let packageDir;
 try {
-	packageDir = resolveDirectory(process.argv[2] ?? ".");
+	packageDir = resolveDirectory(process.env.PI_FREE_RUNTIME_DIR ?? ".");
 } catch (error) {
 	console.error(error instanceof Error ? error.message : String(error));
 	process.exit(1);

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -13,13 +13,40 @@
  *   node scripts/check-runtime-imports.mjs <package>  # package/dist
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	statSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 
-const packageDir = resolve(process.argv[2] ?? ".");
-const runtimeDir = existsSync(join(packageDir, "dist"))
-	? join(packageDir, "dist")
-	: packageDir;
+function resolveDirectory(input) {
+	const candidate = resolve(input);
+	let directory;
+	try {
+		directory = realpathSync(candidate);
+	} catch {
+		throw new Error(`Runtime directory cannot be resolved: ${candidate}`);
+	}
+	if (!statSync(directory).isDirectory()) {
+		throw new Error(`Runtime path is not a directory: ${directory}`);
+	}
+	return directory;
+}
+
+let packageDir;
+try {
+	packageDir = resolveDirectory(process.argv[2] ?? ".");
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}
+const distCandidate = join(packageDir, "dist");
+const runtimeDir = resolveDirectory(
+	existsSync(distCandidate) ? distCandidate : packageDir,
+);
 const allowedPiAiImports = new Set([
 	"@earendil-works/pi-ai",
 	"@earendil-works/pi-ai/compat",
@@ -38,11 +65,6 @@ function collectRuntimeFiles(dir) {
 		}
 	}
 	return files;
-}
-
-if (!existsSync(runtimeDir) || !statSync(runtimeDir).isDirectory()) {
-	console.error(`Runtime directory not found: ${runtimeDir}`);
-	process.exit(1);
 }
 
 const files = collectRuntimeFiles(runtimeDir);

--- a/scripts/smoke-pi-loader.mjs
+++ b/scripts/smoke-pi-loader.mjs
@@ -45,7 +45,7 @@ try {
 		"loader.js",
 	);
 	if (!existsSync(loaderPath)) {
-		throw new Error(`Pi extension loader not found: ${loaderPath}`);
+		throw new TypeError(`Pi extension loader not found: ${loaderPath}`);
 	}
 
 	const { loadExtensions } = await import(pathToFileURL(loaderPath).href);


### PR DESCRIPTION
Follow-up to #399.

SonarCloud flagged the new validation scripts. This PR removes CLI path taint from the runtime-import check by taking the optional package directory from the CI environment, validates canonical directories before traversal, and uses `TypeError` for invalid loader paths.