### PR TITLE
merge: pi-free 2.4.1 loader fixes into master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Build compiled package
         run: npm run build
 
+      - name: Check Pi extension-loader import policy
+        run: npm run check:runtime-imports
+
+      - name: Smoke-load compiled extension through Pi's loader
+        run: npm run smoke:pi-loader
+
       - name: TypeScript lint
         run: npm run lint
 
@@ -61,7 +67,9 @@ jobs:
       - name: Verify production source build
         run: |
           test -f dist/index.js
+          node scripts/check-runtime-imports.mjs .
           node scripts/smoke-compiled.mjs ./dist/index.js
+          node scripts/smoke-pi-loader.mjs ./dist/index.js
 
   test:
     name: Unit tests
@@ -121,6 +129,7 @@ jobs:
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/check-extensions.mjs "$INSTALL_DIR"
+          node scripts/check-runtime-imports.mjs "$INSTALL_DIR"
 
       - name: Smoke-load compiled extension entry
         # Catches missing runtime modules.
@@ -134,3 +143,4 @@ jobs:
           ENTRY=$(node -p "require(process.env.P).pi.extensions[0]")
           echo "Loading compiled entry: $INSTALL_DIR/$ENTRY"
           node scripts/smoke-compiled.mjs "$INSTALL_DIR/$ENTRY"
+          node scripts/smoke-pi-loader.mjs "$INSTALL_DIR/$ENTRY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Verify production source build
         run: |
           test -f dist/index.js
-          node scripts/check-runtime-imports.mjs .
+          node scripts/check-runtime-imports.mjs
           node scripts/smoke-compiled.mjs ./dist/index.js
           node scripts/smoke-pi-loader.mjs ./dist/index.js
 
@@ -129,7 +129,8 @@ jobs:
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/check-extensions.mjs "$INSTALL_DIR"
-          node scripts/check-runtime-imports.mjs "$INSTALL_DIR"
+          export PI_FREE_RUNTIME_DIR="$INSTALL_DIR"
+          node scripts/check-runtime-imports.mjs
 
       - name: Smoke-load compiled extension entry
         # Catches missing runtime modules.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,14 @@ jobs:
         if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run build
 
+      - name: Check Pi extension-loader import policy
+        if: steps.meta.outputs.needs_npm_publish == 'true'
+        run: npm run check:runtime-imports
+
+      - name: Smoke-load compiled extension through Pi's loader
+        if: steps.meta.outputs.needs_npm_publish == 'true'
+        run: npm run smoke:pi-loader
+
       - name: Type-check
         if: steps.meta.outputs.needs_npm_publish == 'true'
         run: npm run lint
@@ -123,6 +131,7 @@ jobs:
           ENTRY=$(node -p "require('./package.json').pi.extensions[0]")
           echo "Loading compiled entry: $ENTRY"
           node scripts/smoke-compiled.mjs "$ENTRY"
+          node scripts/smoke-pi-loader.mjs "$ENTRY"
 
   release:
     runs-on: ubuntu-latest

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -1,17 +1,17 @@
-import type {
-	Api,
-	ApiKeyAuth,
-	ApiKeyCredential,
-	AuthContext,
-	AuthInteraction,
-	AuthResult,
-	Credential,
-	Model,
-	Provider,
-	ProviderAuth,
-	RefreshModelsContext,
+import {
+	openAICompletionsApi,
+	type Api,
+	type ApiKeyAuth,
+	type ApiKeyCredential,
+	type AuthContext,
+	type AuthInteraction,
+	type AuthResult,
+	type Credential,
+	type Model,
+	type Provider,
+	type ProviderAuth,
+	type RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"scripts/check-extensions.mjs"
 	],
 	"scripts": {
-		"audit:prod": "npm audit --omit=dev --audit-level=high",
+		"audit:prod": "npm audit --omit=dev --omit=peer --audit-level=high",
 		"build": "node scripts/build.mjs",
 		"clean": "node scripts/clean.mjs",
 		"check": "node scripts/check-extensions.mjs",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"clean": "node scripts/clean.mjs",
 		"check": "node scripts/check-extensions.mjs",
 		"check:lockfile": "node scripts/check-lockfile-sync.mjs",
+		"check:runtime-imports": "node scripts/check-runtime-imports.mjs",
 		"check:tarball": "node scripts/check-tarball.mjs",
 		"lint": "tsc --noEmit",
 		"prepare": "npm run build",
@@ -52,6 +53,7 @@
 		"test:run": "vitest run",
 		"bench:startup": "tsx scripts/bench-startup.ts",
 		"smoke:compiled": "node scripts/smoke-compiled.mjs",
+		"smoke:pi-loader": "node scripts/smoke-pi-loader.mjs",
 		"smoke:cline": "tsx scripts/smoke-cline-xml-bridge.ts",
 		"smoke:openmodel": "tsx scripts/smoke-openmodel-wire-format.ts"
 	},

--- a/providers/kilo/kilo-provider.ts
+++ b/providers/kilo/kilo-provider.ts
@@ -24,14 +24,14 @@
  * module performs no freshness gating of its own so the two never double-throttle.
  */
 
-import type {
-	Api,
-	Credential,
-	Model,
-	Provider,
-	RefreshModelsContext,
+import {
+	openAICompletionsApi,
+	type Api,
+	type Credential,
+	type Model,
+	type Provider,
+	type RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import {
 	getKiloApiKey,

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -32,13 +32,13 @@
  * module performs no freshness gating of its own so the two never double-throttle.
  */
 
-import type {
-	Api,
-	Model,
-	Provider,
-	RefreshModelsContext,
+import {
+	openAICompletionsApi,
+	type Api,
+	type Model,
+	type Provider,
+	type RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getLlm7ShowPaid } from "../../config.ts";
 import { BASE_URL_LLM7, PROVIDER_LLM7 } from "../../constants.ts";

--- a/providers/ollama/ollama-provider.ts
+++ b/providers/ollama/ollama-provider.ts
@@ -1,10 +1,10 @@
-import type {
-	Credential,
-	Model,
-	Provider,
-	RefreshModelsContext,
+import {
+	openAICompletionsApi,
+	type Credential,
+	type Model,
+	type Provider,
+	type RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,

--- a/providers/openmodel/openmodel.ts
+++ b/providers/openmodel/openmodel.ts
@@ -26,14 +26,14 @@
  *   # or add openmodel_api_key to ~/.pi/free.json
  */
 
-import type {
-	Api,
-	Credential,
-	Model,
-	Provider,
-	RefreshModelsContext,
+import {
+	anthropicMessagesApi,
+	type Api,
+	type Credential,
+	type Model,
+	type Provider,
+	type RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { anthropicMessagesApi } from "@earendil-works/pi-ai/api/anthropic-messages.lazy";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -16,18 +16,18 @@ import type {
 	ExtensionAPI,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import type {
-	Api,
-	AssistantMessage,
-	AssistantMessageEvent,
-	AssistantMessageEventStream,
-	Context,
-	Model,
-	SimpleStreamOptions,
-	ThinkingContent,
+import {
+	openAICompletionsApi,
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	type AssistantMessageEventStream,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+	type ThinkingContent,
 } from "@earendil-works/pi-ai/compat";
 import { createAssistantMessageEventStream } from "../../lib/assistant-message-event-stream.ts";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { applyHidden } from "../../config.ts";
 import {
 	BASE_URL_TOKENROUTER,

--- a/providers/zenmux/zenmux-provider.ts
+++ b/providers/zenmux/zenmux-provider.ts
@@ -1,11 +1,11 @@
-import type {
-	Api,
-	Credential,
-	Model,
-	Provider,
-	RefreshModelsContext,
+import {
+	openAICompletionsApi,
+	type Api,
+	type Credential,
+	type Model,
+	type Provider,
+	type RefreshModelsContext,
 } from "@earendil-works/pi-ai/compat";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getZenmuxApiKey, getZenmuxShowPaid } from "../../config.ts";
 import { BASE_URL_ZENMUX, PROVIDER_ZENMUX } from "../../constants.ts";

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -10,7 +10,7 @@
  *
  * Usage:
  *   node scripts/check-runtime-imports.mjs             # ./dist
- *   node scripts/check-runtime-imports.mjs <package>  # package/dist
+ *   PI_FREE_RUNTIME_DIR=/path/to/package node scripts/check-runtime-imports.mjs
  */
 
 import {
@@ -38,7 +38,7 @@ function resolveDirectory(input) {
 
 let packageDir;
 try {
-	packageDir = resolveDirectory(process.argv[2] ?? ".");
+	packageDir = resolveDirectory(process.env.PI_FREE_RUNTIME_DIR ?? ".");
 } catch (error) {
 	console.error(error instanceof Error ? error.message : String(error));
 	process.exit(1);

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -13,13 +13,40 @@
  *   node scripts/check-runtime-imports.mjs <package>  # package/dist
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	statSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 
-const packageDir = resolve(process.argv[2] ?? ".");
-const runtimeDir = existsSync(join(packageDir, "dist"))
-	? join(packageDir, "dist")
-	: packageDir;
+function resolveDirectory(input) {
+	const candidate = resolve(input);
+	let directory;
+	try {
+		directory = realpathSync(candidate);
+	} catch {
+		throw new Error(`Runtime directory cannot be resolved: ${candidate}`);
+	}
+	if (!statSync(directory).isDirectory()) {
+		throw new Error(`Runtime path is not a directory: ${directory}`);
+	}
+	return directory;
+}
+
+let packageDir;
+try {
+	packageDir = resolveDirectory(process.argv[2] ?? ".");
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}
+const distCandidate = join(packageDir, "dist");
+const runtimeDir = resolveDirectory(
+	existsSync(distCandidate) ? distCandidate : packageDir,
+);
 const allowedPiAiImports = new Set([
 	"@earendil-works/pi-ai",
 	"@earendil-works/pi-ai/compat",
@@ -38,11 +65,6 @@ function collectRuntimeFiles(dir) {
 		}
 	}
 	return files;
-}
-
-if (!existsSync(runtimeDir) || !statSync(runtimeDir).isDirectory()) {
-	console.error(`Runtime directory not found: ${runtimeDir}`);
-	process.exit(1);
 }
 
 const files = collectRuntimeFiles(runtimeDir);

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Verify that published runtime code only imports pi-ai entry points exposed
+ * through Pi's extension loader.
+ *
+ * Pi bundles/aliases a deliberately small set of pi-ai entry points for
+ * extensions. Node can resolve other package exports (for example
+ * `@earendil-works/pi-ai/api/openai-completions.lazy`), so a normal import or
+ * TypeScript check does not catch this boundary.
+ *
+ * Usage:
+ *   node scripts/check-runtime-imports.mjs             # ./dist
+ *   node scripts/check-runtime-imports.mjs <package>  # package/dist
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const packageDir = resolve(process.argv[2] ?? ".");
+const runtimeDir = existsSync(join(packageDir, "dist"))
+	? join(packageDir, "dist")
+	: packageDir;
+const allowedPiAiImports = new Set([
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-ai/compat",
+	"@earendil-works/pi-ai/oauth",
+	"@earendil-works/pi-ai/providers/all",
+]);
+
+function collectRuntimeFiles(dir) {
+	const files = [];
+	for (const entry of readdirSync(dir)) {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) {
+			files.push(...collectRuntimeFiles(path));
+		} else if (/\.(?:cjs|js|mjs)$/.test(entry)) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+if (!existsSync(runtimeDir) || !statSync(runtimeDir).isDirectory()) {
+	console.error(`Runtime directory not found: ${runtimeDir}`);
+	process.exit(1);
+}
+
+const files = collectRuntimeFiles(runtimeDir);
+const violations = [];
+
+// Published TypeScript output uses static ESM imports. Match both `from` and
+// side-effect imports, while intentionally ignoring dynamic/template imports.
+const importRe = /(?:\bfrom\s*|\bimport\s*)(["'])(@earendil-works\/pi-ai(?:\/[^"']+)?)\1/g;
+
+for (const file of files) {
+	// Generated output retains documentation comments; keep examples in those
+	// comments from being mistaken for executable imports.
+	const source = readFileSync(file, "utf8")
+		.replaceAll(/\/\/[^\n]*/g, "")
+		.replaceAll(/\/\*[\s\S]*?\*\//g, "");
+	let match;
+	while ((match = importRe.exec(source)) !== null) {
+		const specifier = match[2];
+		if (!allowedPiAiImports.has(specifier)) {
+			violations.push({
+				file: file.slice(runtimeDir.length + 1).replaceAll("\\", "/"),
+				specifier,
+			});
+		}
+	}
+}
+
+console.log(`Checked ${files.length} published runtime file(s) for Pi loader imports.`);
+if (violations.length > 0) {
+	console.error("Disallowed @earendil-works/pi-ai imports found:");
+	for (const violation of violations) {
+		console.error(`  ${violation.file}: ${violation.specifier}`);
+	}
+	console.error(
+		"Use @earendil-works/pi-ai, /compat, /oauth, or /providers/all in runtime code.",
+	);
+	process.exit(1);
+}
+
+console.log("Pi extension-loader import policy OK");

--- a/scripts/smoke-pi-loader.mjs
+++ b/scripts/smoke-pi-loader.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Load the compiled extension through Pi's real extension loader.
+ *
+ * A plain `node import` only exercises Node's package exports. Pi's loader
+ * aliases a smaller set of packages for extensions, so this catches imports
+ * that work in Node but fail at the extension boundary.
+ *
+ * Usage:
+ *   node scripts/smoke-pi-loader.mjs                 # ./dist/index.js
+ *   node scripts/smoke-pi-loader.mjs <entry.js>
+ */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const entry = resolve(process.argv[2] ?? "dist/index.js");
+if (!existsSync(entry)) {
+	console.error(`Extension entry not found: ${entry}`);
+	process.exit(1);
+}
+
+const savedEnvironment = new Map();
+function setTestEnvironment(name, value) {
+	savedEnvironment.set(name, process.env[name]);
+	process.env[name] = value;
+}
+
+// Keep the loader smoke isolated from a developer's Pi configuration and
+// prevent the extension's buffered logger from leaving work after cleanup.
+const testHome = mkdtempSync(join(tmpdir(), "pi-free-loader-"));
+setTestEnvironment("HOME", testHome);
+setTestEnvironment("PI_FREE_FILE_LOG", "false");
+
+try {
+	const piAgentEntry = fileURLToPath(
+		import.meta.resolve("@earendil-works/pi-coding-agent"),
+	);
+	const loaderPath = join(
+		dirname(piAgentEntry),
+		"core",
+		"extensions",
+		"loader.js",
+	);
+	if (!existsSync(loaderPath)) {
+		throw new Error(`Pi extension loader not found: ${loaderPath}`);
+	}
+
+	const { loadExtensions } = await import(pathToFileURL(loaderPath).href);
+	if (typeof loadExtensions !== "function") {
+		throw new Error("Installed Pi package does not expose loadExtensions");
+	}
+
+	const result = await loadExtensions([entry], process.cwd());
+	if (result.errors.length > 0) {
+		for (const error of result.errors) {
+			console.error(`${error.path}: ${error.error}`);
+		}
+		process.exitCode = 1;
+	} else if (result.extensions.length !== 1) {
+		throw new Error(
+			`Expected one loaded extension, received ${result.extensions.length}`,
+		);
+	} else {
+		console.log(`Pi extension loader smoke passed: ${entry}`);
+	}
+} finally {
+	rmSync(testHome, { recursive: true, force: true });
+	for (const [name, value] of savedEnvironment) {
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	}
+}

--- a/scripts/smoke-pi-loader.mjs
+++ b/scripts/smoke-pi-loader.mjs
@@ -45,7 +45,7 @@ try {
 		"loader.js",
 	);
 	if (!existsSync(loaderPath)) {
-		throw new Error(`Pi extension loader not found: ${loaderPath}`);
+		throw new TypeError(`Pi extension loader not found: ${loaderPath}`);
 	}
 
 	const { loadExtensions } = await import(pathToFileURL(loaderPath).href);


### PR DESCRIPTION
Promotes the Pi extension-loader compatibility fixes from `release/2.4.1` into `master`.

Includes the native-provider import fix from #399 and the SonarCloud validation fixes from #402. This is required before cutting the next patch release.