### PR TITLE
ci: exclude host peer dependencies from production audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"scripts/check-extensions.mjs"
 	],
 	"scripts": {
-		"audit:prod": "npm audit --omit=dev --audit-level=high",
+		"audit:prod": "npm audit --omit=dev --omit=peer --audit-level=high",
 		"build": "node scripts/build.mjs",
 		"clean": "node scripts/clean.mjs",
 		"check": "node scripts/check-extensions.mjs",


### PR DESCRIPTION
The CI audit was failing on a vulnerability in the host-provided `@earendil-works/pi-coding-agent` peer dependency. pi-free does not ship that dependency; omit peer dependencies from the production audit while continuing to audit shipped production dependencies.