### PR TITLE
chore: release 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-08-03
+
+### Fixed
+
+- **Pi extension-loader compatibility** — Native provider API factories now import through Pi's allowlisted `@earendil-works/pi-ai/compat` entrypoint instead of inaccessible `pi-ai/api/*` subpaths. This fixes extension startup failures on Pi 0.83.x where no pi-free providers registered (#397, #398, #399).
+
+### Changed
+
+- **Loader-boundary CI validation** — Added compiled-runtime import-policy checks and Pi loader smoke tests so unsupported extension imports fail before release.
+
 ## [2.4.1] - 2026-08-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
Prepare the 2.4.2 patch release containing the Pi 0.83 extension-loader compatibility fix.

- Bump package and lockfile versions to 2.4.2
- Add curated 2.4.2 changelog notes
- Includes #399 and #402/#404 already merged into master
- Tracking issue #405 covers the remaining end-to-end `pi install` + RPC smoke test