### PR TITLE
ci: verify pi install loads pi-free

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,12 @@ jobs:
           TARBALL=$(ls pi-free-*.tgz)
           npm install -g "$TARBALL"
 
+      - name: Install pi-free through Pi and verify RPC commands
+        shell: bash
+        run: |
+          TARBALL=$(ls pi-free-*.tgz)
+          npm run smoke:pi-install -- "$PWD/$TARBALL"
+
       - name: Verify published relative imports resolve
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
 		"LICENSE",
 		"CHANGELOG.md",
 		"banner.svg",
-		"scripts/check-extensions.mjs"
+		"scripts/check-extensions.mjs",
+		"scripts/pi-install-smoke.mjs",
+		"scripts/rpc-load-check.mjs"
 	],
 	"scripts": {
 		"audit:prod": "npm audit --omit=dev --omit=peer --audit-level=high",
@@ -54,6 +56,7 @@
 		"bench:startup": "tsx scripts/bench-startup.ts",
 		"smoke:compiled": "node scripts/smoke-compiled.mjs",
 		"smoke:pi-loader": "node scripts/smoke-pi-loader.mjs",
+		"smoke:pi-install": "node scripts/pi-install-smoke.mjs",
 		"smoke:cline": "tsx scripts/smoke-cline-xml-bridge.ts",
 		"smoke:openmodel": "tsx scripts/smoke-openmodel-wire-format.ts"
 	},

--- a/scripts/check-tarball.mjs
+++ b/scripts/check-tarball.mjs
@@ -87,6 +87,8 @@ const required = [
 	"package/CHANGELOG.md",
 	"package/LICENSE",
 	"package/scripts/check-extensions.mjs",
+	"package/scripts/pi-install-smoke.mjs",
+	"package/scripts/rpc-load-check.mjs",
 ];
 
 for (const file of required) {
@@ -101,7 +103,7 @@ const forbiddenPatterns = [
 	/^package\/.+\.tgz$/,
 	/^package\/.+\.env(?:\..*)?$/,
 	/^package\/(?:\.env(?:\..*)?|npm-debug\.log|yarn-error\.log)$/,
-	/^package\/scripts\/(?!check-extensions\.mjs$).+/,
+	/^package\/scripts\/(?!check-extensions\.mjs$|pi-install-smoke\.mjs$|rpc-load-check\.mjs$).+/,
 ];
 
 const forbidden = entries.filter((entry) =>

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * End-to-end local package smoke test.
+ *
+ * Installs the supplied tarball through Pi's package manager in an isolated
+ * HOME, then uses Pi's RPC mode to prove the extension was loaded. No model
+ * request is made.
+ *
+ * Usage:
+ *   node scripts/pi-install-smoke.mjs ./pi-free-<version>.tgz
+ */
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const tarball = process.argv[2] && resolve(process.argv[2]);
+if (!tarball || !existsSync(tarball)) {
+	console.error("Usage: node scripts/pi-install-smoke.mjs <pi-free-tarball>");
+	process.exit(1);
+}
+
+function scrubSecrets(environment) {
+	for (const name of Object.keys(environment)) {
+		if (/(?:API_KEY|APIKEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET)$/i.test(name)) {
+			delete environment[name];
+		}
+	}
+	// Pi needs a provider to initialize RPC, but this value is deliberately fake.
+	environment.ANTHROPIC_API_KEY = "sk-ant-dummy-pi-free-install-smoke";
+}
+
+function run(args, options, timeoutMs = 120_000) {
+	return new Promise((resolveRun, rejectRun) => {
+		const child = spawn(process.execPath, args, options);
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				// The process may already have exited.
+			}
+		}, timeoutMs);
+
+		child.once("error", rejectRun);
+		child.once("close", (code, signal) => {
+			clearTimeout(timer);
+			if (timedOut) {
+				rejectRun(new Error(`Node timed out after ${timeoutMs}ms`));
+			} else if (code !== 0) {
+				rejectRun(
+					new Error(
+						`Node exited with code ${code ?? "unknown"}${signal ? ` (${signal})` : ""}`,
+					),
+				);
+			} else {
+				resolveRun();
+			}
+		});
+	});
+}
+
+const testRoot = mkdtempSync(join(tmpdir(), "pi-free-install-smoke-"));
+const home = join(testRoot, "home");
+const project = join(testRoot, "project");
+mkdirSync(home);
+mkdirSync(project);
+
+const environment = { ...process.env };
+scrubSecrets(environment);
+// Pi and npm both consult HOME on POSIX; Node uses USERPROFILE for os.homedir()
+// on Windows. Set both so the test cannot read or modify the runner's config.
+environment.HOME = home;
+environment.USERPROFILE = home;
+environment.NPM_CONFIG_USERCONFIG = join(testRoot, "npmrc");
+environment.NPM_CONFIG_CACHE = join(testRoot, "npm-cache");
+environment.PI_FREE_FILE_LOG = "false";
+delete environment.PI_CODING_AGENT_DIR;
+delete environment.PI_CODING_AGENT_SESSION_DIR;
+delete environment.PI_PACKAGE_DIR;
+
+const piModule = fileURLToPath(
+	import.meta.resolve("@earendil-works/pi-coding-agent"),
+);
+const piCli = join(dirname(piModule), "cli.js");
+const rpcDriver = join(dirname(fileURLToPath(import.meta.url)), "rpc-load-check.mjs");
+const piOptions = { cwd: project, env: environment, stdio: "inherit" };
+
+try {
+	// Pi treats a bare local path as a source extension, not an npm package.
+	// Use npm's package@file tarball form so Pi installs the artifact and then
+	// records the installed package name in its extension settings.
+	const installSpec = `npm:pi-free@${pathToFileURL(tarball).href}`;
+	console.log(`Installing ${tarball} through Pi (${piCli})`);
+	await run([piCli, "install", installSpec], piOptions);
+	console.log("Launching Pi RPC load check");
+	await run([rpcDriver], piOptions, 45_000);
+	console.log("Pi install smoke passed");
+} catch (error) {
+	console.error(`Pi install smoke failed: ${error.message}`);
+	process.exitCode = 1;
+} finally {
+	rmSync(testRoot, { recursive: true, force: true });
+}

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -50,10 +50,10 @@ function run(args, options, timeoutMs = 120_000) {
 			if (timedOut) {
 				rejectRun(new Error(`Node timed out after ${timeoutMs}ms`));
 			} else if (code !== 0) {
+				const signalSuffix = signal ? " (" + String(signal) + ")" : "";
+				const exitCode = code ?? "unknown";
 				rejectRun(
-					new Error(
-						`Node exited with code ${code ?? "unknown"}${signal ? ` (${signal})` : ""}`,
-					),
+					new Error(`Node exited with code ${exitCode}${signalSuffix}`),
 				);
 			} else {
 				resolveRun();

--- a/scripts/rpc-load-check.mjs
+++ b/scripts/rpc-load-check.mjs
@@ -7,22 +7,13 @@
  * and fails on extension errors, timeouts, or missing pi-free commands.
  *
  * Usage:
- *   node scripts/rpc-load-check.mjs [path-to-pi-bin]
+ *   node scripts/rpc-load-check.mjs
  */
 import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
-const suppliedPi = process.argv[2];
-
-function commandForPi(piPath) {
-	if (!piPath) return undefined;
-	if (/\.m?js$/i.test(piPath)) {
-		return { command: process.execPath, args: [piPath] };
-	}
-	return { command: piPath, args: [] };
-}
 
 function resolveInstalledPi() {
 	const piModule = fileURLToPath(
@@ -31,7 +22,7 @@ function resolveInstalledPi() {
 	return { command: process.execPath, args: [join(dirname(piModule), "cli.js")] };
 }
 
-const piCommand = commandForPi(suppliedPi) ?? resolveInstalledPi();
+const piCommand = resolveInstalledPi();
 const pi = spawn(
 	piCommand.command,
 	[...piCommand.args, "--mode", "rpc", "--no-session"],

--- a/scripts/rpc-load-check.mjs
+++ b/scripts/rpc-load-check.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * RPC load check -- positively verify pi-free loaded, headless and model-free.
+ *
+ * The caller is responsible for providing an isolated HOME. This script starts
+ * Pi in RPC mode, requests the command registry (which never calls a model),
+ * and fails on extension errors, timeouts, or missing pi-free commands.
+ *
+ * Usage:
+ *   node scripts/rpc-load-check.mjs [path-to-pi-bin]
+ */
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
+const suppliedPi = process.argv[2];
+
+function commandForPi(piPath) {
+	if (!piPath) return undefined;
+	if (/\.m?js$/i.test(piPath)) {
+		return { command: process.execPath, args: [piPath] };
+	}
+	return { command: piPath, args: [] };
+}
+
+function resolveInstalledPi() {
+	const piModule = fileURLToPath(
+		import.meta.resolve("@earendil-works/pi-coding-agent"),
+	);
+	return { command: process.execPath, args: [join(dirname(piModule), "cli.js")] };
+}
+
+const piCommand = commandForPi(suppliedPi) ?? resolveInstalledPi();
+const pi = spawn(
+	piCommand.command,
+	[...piCommand.args, "--mode", "rpc", "--no-session"],
+	{
+		stdio: ["pipe", "pipe", "inherit"],
+		env: {
+			...process.env,
+			// RPC startup needs a configured provider, but get_commands never calls it.
+			ANTHROPIC_API_KEY:
+				process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-load-check",
+		},
+		shell: false,
+	},
+);
+
+let buffer = "";
+const extensionErrors = [];
+let finished = false;
+let timer;
+
+function finish(code, message) {
+	if (finished) return;
+	finished = true;
+	clearTimeout(timer);
+	if (message) console.log(message);
+	try {
+		pi.kill("SIGKILL");
+	} catch {
+		// The process may already have exited.
+	}
+	process.exit(code);
+}
+
+timer = setTimeout(
+	() => finish(2, "TIMEOUT waiting for get_commands response"),
+	30_000,
+);
+
+function handleLine(line) {
+	let message;
+	try {
+		message = JSON.parse(line);
+	} catch {
+		return;
+	}
+
+	if (
+		(message.type === "event" && message.event === "extension_error") ||
+		message.type === "extension_error"
+	) {
+		extensionErrors.push(message);
+		console.log("extension_error:", JSON.stringify(message).slice(0, 500));
+	}
+
+	if (message.type !== "response" || message.command !== "get_commands") return;
+
+	const commands = message.data?.commands ?? [];
+	const names = new Set(commands.map((command) => command.name));
+	const missing = expectedCommands.filter((name) => !names.has(name));
+	console.log(`Pi reported ${commands.length} command(s): ${[...names].join(", ")}`);
+
+	if (extensionErrors.length > 0) {
+		finish(1, `FAIL: ${extensionErrors.length} extension_error event(s)`);
+	} else if (missing.length > 0) {
+		finish(1, `FAIL: missing pi-free command(s): ${missing.join(", ")}`);
+	} else {
+		finish(0, "PASS: pi-free loaded and registered the expected commands");
+	}
+}
+
+pi.stdout.on("data", (data) => {
+	buffer += data.toString();
+	let newline;
+	while ((newline = buffer.indexOf("\n")) >= 0) {
+		const line = buffer.slice(0, newline).replace(/\r$/, "");
+		buffer = buffer.slice(newline + 1);
+		if (line.trim()) handleLine(line);
+	}
+});
+
+pi.on("error", (error) => finish(1, `FAIL: could not start Pi: ${error.message}`));
+pi.on("exit", (code) => {
+	if (!finished) {
+		finish(
+			extensionErrors.length > 0 ? 1 : 2,
+			`Pi exited before get_commands (code ${code ?? "unknown"})`,
+		);
+	}
+});
+
+// Allow Pi to finish loading extensions before querying the registry.
+setTimeout(() => {
+	try {
+		pi.stdin.write(`${JSON.stringify({ type: "get_commands" })}\n`);
+	} catch (error) {
+		finish(1, `FAIL: could not send get_commands: ${error.message}`);
+	}
+}, 2_500);


### PR DESCRIPTION
Closes #405.

Adds a pi-lens-style end-to-end smoke test that:
- packs and installs the local tarball through Pi's own `pi install` path;
- isolates HOME/USERPROFILE and removes real credentials;
- starts `pi --mode rpc --no-session`;
- asserts `toggle-free`, `free-providers`, and `pi-free-health` register;
- fails on extension errors, timeouts, or missing commands.

Also verifies the smoke drivers are included in the tarball. Local Windows validation passed with Pi 0.83.0.