### PR TITLE
fix: register Cline XML API fallback

### DIFF
--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -39,9 +39,11 @@
 import type {
 	Api,
 	AssistantMessageEventStream,
+	Context,
 	Model,
 	Provider,
 	RefreshModelsContext,
+	StreamOptions,
 } from "@earendil-works/pi-ai/compat";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { getClineShowPaid } from "../../config.ts";
@@ -107,6 +109,40 @@ export function buildClineHeaders(): Record<string, string> {
 		"X-CORE-VERSION": CLINE_EXTENSION_VERSION,
 		"X-Is-Multiroot": "false",
 	};
+}
+
+/**
+ * Register the Cline wire API for Pi's legacy/default agent stream path.
+ *
+ * Native ModelRuntime requests call the Provider object directly, but older
+ * Pi agent sessions still dispatch through pi-ai/compat's global API registry.
+ * Cline's custom API is not built into pi-ai, so without this fallback those
+ * sessions fail before the XML bridge can handle the request.
+ */
+export async function registerClineXmlApiProvider(): Promise<void> {
+	const { registerApiProvider } = await import(
+		"@earendil-works/pi-ai/compat"
+	);
+	const stream = (
+		model: Model<"cline-xml-tools">,
+		context: Context,
+		options?: StreamOptions,
+	) =>
+		streamClineXml(
+			model,
+			context,
+			options,
+			buildClineHeaders(),
+		) as unknown as AssistantMessageEventStream;
+
+	registerApiProvider(
+		{
+			api: "cline-xml-tools",
+			stream,
+			streamSimple: stream,
+		},
+		"pi-free-cline",
+	);
 }
 
 // =============================================================================

--- a/providers/cline/cline.ts
+++ b/providers/cline/cline.ts
@@ -32,13 +32,18 @@ import {
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
-import { createClineProvider, rotateClineTaskId } from "./cline-provider.ts";
+import {
+	createClineProvider,
+	registerClineXmlApiProvider,
+	rotateClineTaskId,
+} from "./cline-provider.ts";
 
 // =============================================================================
 // Extension entry point
 // =============================================================================
 
 export default async function clineProvider(pi: ExtensionAPI) {
+	await registerClineXmlApiProvider();
 	const { provider, stored } = createClineProvider();
 
 	// Register the native provider. The factory performs NO network I/O: models
@@ -53,7 +58,7 @@ export default async function clineProvider(pi: ExtensionAPI) {
 		registerNativeProvider(pi, provider);
 	};
 
-	const hasClineKey = !!getClineApiKey();
+	const hasClineKey = Boolean(getClineApiKey());
 	registerWithGlobalToggle(PROVIDER_CLINE, stored, reRegister, hasClineKey, {
 		native: true,
 		invalidate: reRegister,

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -6,6 +6,7 @@
  * refresh nudge.
  */
 
+import { getApiProvider } from "@earendil-works/pi-ai/compat";
 import type {
 	ModelsStoreEntry,
 	ProviderModelsStore,
@@ -137,6 +138,10 @@ describe("Cline factory wiring", () => {
 	it("factory is network-free: registers the native provider empty", async () => {
 		await clineProvider(mockPi);
 
+		// The custom API must also be available to Pi's compat/default agent
+		// stream path, which otherwise throws before reaching the XML bridge.
+		expect(getApiProvider("cline-xml-tools")).toBeDefined();
+
 		// The factory never fetches: models load via refreshModels.
 		expect(mockFetchClineCatalog).not.toHaveBeenCalled();
 
@@ -147,6 +152,27 @@ describe("Cline factory wiring", () => {
 		expect(provider.getModels()).toEqual([]);
 		expect(provider.auth.apiKey).toBeDefined();
 		expect(provider.auth.oauth).toBeDefined();
+
+		// The registry entry delegates to the same bridge, not a generic API.
+		const compatProvider = getApiProvider("cline-xml-tools");
+		expect(compatProvider).toBeDefined();
+		const compatResult = await compatProvider!.streamSimple(
+			{
+				id: "compat-model",
+				name: "Compat Model",
+				api: "cline-xml-tools",
+				provider: "cline",
+			} as never,
+			{
+				systemPrompt: "system",
+				messages: [],
+				tools: [],
+			} as never,
+			{},
+		).result();
+		expect(compatResult.errorMessage).toContain(
+			"No Cline access token found",
+		);
 
 		// Lifecycle handlers + toggle command registered.
 		expect(mockOn).toHaveBeenCalledWith(


### PR DESCRIPTION
Fixes #409. Register Cline's custom cline-xml-tools API with pi-ai's compat registry so legacy/default Pi agent stream paths reach the existing XML bridge instead of failing with 'No API provider registered'. Adds regression coverage.