### PR TITLE
chore: prepare 2.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.3] - 2026-08-04
+
+### Fixed
+
+- **Cline custom API registration** — Register the `cline-xml-tools` compatibility API so Pi's default agent stream path reaches the existing XML bridge instead of failing with `No API provider registered for api: cline-xml-tools` ([#409](https://github.com/apmantza/pi-free/issues/409), [#410](https://github.com/apmantza/pi-free/pull/410)).
+
 ## [2.4.2] - 2026-08-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
Release 2.4.3 with the Cline cline-xml-tools compatibility fix from #410. Fixes #409 in the published package.