### PR TITLE
docs: document npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ When you install pi-free, it:
 
 ## Install
 
+Install the published npm package:
+
+```bash
+pi install npm:pi-free
+```
+
+For the latest unreleased GitHub changes instead:
+
 ```bash
 pi install git:github.com/apmantza/pi-free
 ```


### PR DESCRIPTION
Document the published npm installation as the recommended path, while retaining the GitHub install for unreleased changes.