### PR TITLE
fix: log automatic provider notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Quiet automatic provider notices** — Routine free-model terms notices are now recorded through pi-free's structured logger instead of being sent to Pi's terminal UI; explicit command results and authentication prompts remain visible.
+
 ## [2.4.3] - 2026-08-04
 
 ### Fixed

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -279,10 +279,10 @@ export function registerNativeOpenAIProvider(
 			if (tosShown || ctx.model?.provider !== options.providerId) return;
 			tosShown = true;
 			if (options.suppressTosWhenKey && options.getApiKey()) return;
-			ctx.ui.notify(
-				`Using ${options.providerId} free models. Terms: ${options.tosUrl}`,
-				"info",
-			);
+			_logger.debug("Free-model terms notice", {
+				provider: options.providerId,
+				termsUrl: options.tosUrl,
+			});
 		});
 	}
 	registerNativeProviderRefresh(pi, options.providerId);

--- a/provider-helper.ts
+++ b/provider-helper.ts
@@ -398,10 +398,10 @@ export function setupProvider(
 			tosShown = true;
 			if (config.hasKey) return;
 			if (isCurrentModelOAuth(ctx)) return;
-			ctx.ui.notify(
-				`Using ${providerId} free models. Set API key for paid access. Terms: ${tosUrl}`,
-				"info",
-			);
+			_logger.debug("Free-model terms notice", {
+				provider: providerId,
+				termsUrl: tosUrl,
+			});
 		});
 	}
 }

--- a/providers/kilo/kilo.ts
+++ b/providers/kilo/kilo.ts
@@ -25,6 +25,7 @@ import {
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
+import { createLogger } from "../../lib/logger.ts";
 import { logWarning } from "../../lib/util.ts";
 import { isCurrentModelOAuth } from "../../provider-helper.ts";
 import { createKiloProvider } from "./kilo-provider.ts";
@@ -32,6 +33,8 @@ import { createKiloProvider } from "./kilo-provider.ts";
 // =============================================================================
 // XML leak detection and auto-retry
 // =============================================================================
+
+const _logger = createLogger("kilo");
 
 // NOTE: the "<invoke" / "<antml:tool_use>" needles are built via concatenation
 // purely so this source file does not contain a literal token that the agent
@@ -171,10 +174,12 @@ export default async function kiloProvider(pi: ExtensionAPI) {
 		if (isCurrentModelOAuth(ctx)) return;
 		const paidCount = stored.all.length - stored.free.length;
 		if (paidCount > 0) {
-			ctx.ui.notify(
-				`Kilo: ${stored.free.length} free models shown. Use /toggle-kilo or /login kilo for ${paidCount} paid models. Terms: ${URL_KILO_TOS}`,
-				"info",
-			);
+			_logger.debug("Free-model terms notice", {
+				provider: PROVIDER_KILO,
+				freeModelCount: stored.free.length,
+				paidModelCount: paidCount,
+				termsUrl: URL_KILO_TOS,
+			});
 		}
 	});
 

--- a/providers/llm7/llm7.ts
+++ b/providers/llm7/llm7.ts
@@ -56,11 +56,14 @@ import {
 	registerNativeProviderRefresh,
 	registerNativeProviderToggle,
 } from "../../lib/native-provider.ts";
+import { createLogger } from "../../lib/logger.ts";
 import { createLlm7Provider } from "./llm7-provider.ts";
 
 // =============================================================================
 // Extension entry point
 // =============================================================================
+
+const _logger = createLogger("llm7");
 
 export default async function llm7Provider(pi: ExtensionAPI) {
 	const { provider, stored } = createLlm7Provider();
@@ -98,10 +101,10 @@ export default async function llm7Provider(pi: ExtensionAPI) {
 		if (tosShown || ctx.model?.provider !== PROVIDER_LLM7) return;
 		tosShown = true;
 		if (getLlm7ApiKey()) return;
-		ctx.ui.notify(
-			"Using llm7 free models. Set API key for paid access. Terms: https://llm7.io/",
-			"info",
-		);
+		_logger.debug("Free-model terms notice", {
+			provider: PROVIDER_LLM7,
+			termsUrl: "https://llm7.io/",
+		});
 	});
 
 	registerNativeProviderRefresh(pi, PROVIDER_LLM7);

--- a/providers/openmodel/openmodel.ts
+++ b/providers/openmodel/openmodel.ts
@@ -598,10 +598,10 @@ export default function openmodelProvider(pi: ExtensionAPI): Promise<void> {
 	pi.on("model_select", (_event, ctx) => {
 		if (tosShown || ctx.model?.provider !== PROVIDER_OPENMODEL) return;
 		tosShown = true;
-		ctx.ui.notify(
-			"Using openmodel free models. Set API key for paid access. Terms: https://docs.openmodel.ai/en/docs",
-			"info",
-		);
+			_logger.debug("Free-model terms notice", {
+			provider: PROVIDER_OPENMODEL,
+			termsUrl: "https://docs.openmodel.ai/en/docs",
+		});
 	});
 	return Promise.resolve();
 }

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -33,6 +33,12 @@ const mockStored = vi.hoisted(() => ({
 	free: [] as unknown[],
 	all: [] as unknown[],
 }));
+const mockLogger = vi.hoisted(() => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+}));
 
 vi.mock("../config.ts", () => ({
 	getKiloApiKey: () => mockGetKiloApiKey(),
@@ -55,12 +61,7 @@ vi.mock("../providers/kilo/kilo-provider.ts", () => ({
 }));
 
 vi.mock("../lib/logger.ts", () => ({
-	createLogger: () => ({
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-		debug: vi.fn(),
-	}),
+	createLogger: () => mockLogger,
 }));
 
 import kiloProvider from "../providers/kilo/kilo.ts";
@@ -166,15 +167,16 @@ describe("Kilo extension wiring", () => {
 			expect(events).toContain("session_start");
 		});
 
-		it("shows a ToS notice on first Kilo model selection without a model registry", async () => {
+		it("logs a ToS event on first Kilo model selection without a model registry", async () => {
 			await kiloProvider(mockPi);
 			const call = mockOn.mock.calls.find((c) => c[0] === "model_select");
 			if (!call) throw new Error("model_select not registered");
 			const notify = vi.fn();
 			await call[1]({}, { model: { provider: "kilo" }, ui: { notify } });
-			expect(notify).toHaveBeenCalledWith(
-				expect.stringContaining("free models shown"),
-				"info",
+			expect(notify).not.toHaveBeenCalled();
+			expect(mockLogger.debug).toHaveBeenCalledWith(
+				"Free-model terms notice",
+				expect.objectContaining({ provider: "kilo", termsUrl: expect.any(String) }),
 			);
 		});
 

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -25,6 +25,12 @@ const mockRegisterWithGlobalToggle = vi.hoisted(() =>
 	vi.fn<(...args: unknown[]) => void>(),
 );
 const mockFetch = vi.hoisted(() => vi.fn());
+const mockLogger = vi.hoisted(() => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+}));
 
 let capturedToggleArgs: unknown[][] = [];
 
@@ -53,12 +59,7 @@ vi.mock("../provider-helper.ts", async () => {
 });
 
 vi.mock("../lib/logger.ts", () => ({
-	createLogger: () => ({
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn(),
-		debug: vi.fn(),
-	}),
+	createLogger: () => mockLogger,
 }));
 
 import llm7Provider from "../providers/llm7/llm7.ts";
@@ -226,12 +227,13 @@ describe("LLM7 factory wiring", () => {
 		expect(handler).toBeDefined();
 		const notify = vi.fn();
 
-		// Keyless: notice fires with the Terms link.
+		// Keyless: notice is logged instead of sent to Pi's terminal UI.
 		await handler({}, { model: { provider: "llm7" }, ui: { notify } });
-		expect(notify).toHaveBeenCalledWith(
-			expect.stringContaining("https://llm7.io/"),
-			"info",
-		);
+		expect(notify).not.toHaveBeenCalled();
+		expect(mockLogger.debug).toHaveBeenCalledWith("Free-model terms notice", {
+			provider: "llm7",
+			termsUrl: "https://llm7.io/",
+		});
 
 		// Only once per session.
 		notify.mockClear();


### PR DESCRIPTION
Stop unsolicited pi-free terms/model-selection notices from reaching Pi's terminal UI. Record them as debug events through the existing structured logger while preserving explicit command output and authentication prompts. Includes regression coverage.