### PR TITLE
chore(deps): bump pi packages to 0.84.2, drop unused deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,7 @@
 			"devDependencies": {
 				"@vitest/coverage-v8": "^4.1.10",
 				"@vitest/ui": "^4.1.10",
-				"brace-expansion": "^5.0.9",
-				"protobufjs": "^7.6.5",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.12",
 				"typescript": "^7.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -28,6 +26,8 @@
 		},
 		"node_modules/@anthropic-ai/sdk": {
 			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -47,6 +47,8 @@
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -61,6 +63,8 @@
 		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -74,6 +78,8 @@
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -82,6 +88,8 @@
 		},
 		"node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -92,6 +100,8 @@
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
 			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -115,15 +125,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.975.3",
+			"version": "3.977.7",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+			"integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@aws-sdk/xml-builder": "^3.972.36",
+				"@aws-sdk/types": "^3.974.3",
+				"@aws-sdk/xml-builder": "^3.972.38",
 				"@aws/lambda-invoke-store": "^0.3.0",
-				"@smithy/core": "^3.29.4",
-				"@smithy/signature-v4": "^5.6.5",
+				"@smithy/core": "^3.31.1",
+				"@smithy/signature-v4": "^5.6.12",
 				"@smithy/types": "^4.16.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
@@ -133,13 +145,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.59",
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+			"integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -148,15 +162,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.61",
+			"version": "3.972.70",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+			"integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
-				"@smithy/fetch-http-handler": "^5.6.6",
-				"@smithy/node-http-handler": "^4.9.6",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -165,12 +181,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-			"version": "4.9.8",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
+			"integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.6",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.0",
+				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -178,21 +196,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.973.4",
+			"version": "3.973.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+			"integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/credential-provider-env": "^3.972.59",
-				"@aws-sdk/credential-provider-http": "^3.972.61",
-				"@aws-sdk/credential-provider-login": "^3.972.66",
-				"@aws-sdk/credential-provider-process": "^3.972.59",
-				"@aws-sdk/credential-provider-sso": "^3.973.3",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.65",
-				"@aws-sdk/nested-clients": "^3.997.33",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
-				"@smithy/credential-provider-imds": "^4.4.9",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/credential-provider-env": "^3.972.68",
+				"@aws-sdk/credential-provider-http": "^3.972.70",
+				"@aws-sdk/credential-provider-login": "^3.972.75",
+				"@aws-sdk/credential-provider-process": "^3.972.68",
+				"@aws-sdk/credential-provider-sso": "^3.973.12",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.74",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -201,14 +221,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.66",
+			"version": "3.972.75",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+			"integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/nested-clients": "^3.997.33",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -217,19 +239,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.70",
+			"version": "3.972.79",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+			"integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.59",
-				"@aws-sdk/credential-provider-http": "^3.972.61",
-				"@aws-sdk/credential-provider-ini": "^3.973.4",
-				"@aws-sdk/credential-provider-process": "^3.972.59",
-				"@aws-sdk/credential-provider-sso": "^3.973.3",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.65",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
-				"@smithy/credential-provider-imds": "^4.4.9",
+				"@aws-sdk/credential-provider-env": "^3.972.68",
+				"@aws-sdk/credential-provider-http": "^3.972.70",
+				"@aws-sdk/credential-provider-ini": "^3.973.13",
+				"@aws-sdk/credential-provider-process": "^3.972.68",
+				"@aws-sdk/credential-provider-sso": "^3.973.12",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.74",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -238,13 +262,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.59",
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+			"integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -253,15 +279,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.973.3",
+			"version": "3.973.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+			"integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/nested-clients": "^3.997.33",
-				"@aws-sdk/token-providers": "3.1088.0",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/token-providers": "3.1108.0",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -270,14 +298,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1088.0",
+			"version": "3.1108.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+			"integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/nested-clients": "^3.997.33",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -286,14 +316,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.65",
+			"version": "3.972.74",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+			"integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/nested-clients": "^3.997.33",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -302,12 +334,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.29",
+			"version": "3.972.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
+			"integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -316,12 +350,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.24",
+			"version": "3.972.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
+			"integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -330,15 +366,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.41",
+			"version": "3.972.50",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
+			"integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
-				"@smithy/fetch-http-handler": "^5.6.6",
-				"@smithy/signature-v4": "^5.6.5",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/signature-v4": "^5.6.12",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -347,16 +385,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.33",
+			"version": "3.997.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+			"integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.3",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.41",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.29.4",
-				"@smithy/fetch-http-handler": "^5.6.6",
-				"@smithy/node-http-handler": "^4.9.6",
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.44",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -365,12 +405,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.9.8",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
+			"integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.6",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.0",
+				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -378,12 +420,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.41",
+			"version": "3.996.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+			"integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/signature-v4": "^5.6.5",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/signature-v4": "^5.6.12",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -393,6 +437,8 @@
 		},
 		"node_modules/@aws-sdk/token-providers": {
 			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -408,7 +454,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.974.2",
+			"version": "3.974.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+			"integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -420,7 +468,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.8",
+			"version": "3.965.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
+			"integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -431,7 +481,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.36",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+			"integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -444,6 +496,8 @@
 		},
 		"node_modules/@aws/lambda-invoke-store": {
 			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
@@ -488,6 +542,8 @@
 		},
 		"node_modules/@babel/runtime": {
 			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -519,22 +575,21 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
-			"integrity": "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+			"integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
 				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
-				"@earendil-works/pi-telemetry": "^0.84.0",
+				"@earendil-works/pi-telemetry": "^0.84.2",
 				"@google/genai": "1.52.0",
-				"@mistralai/mistralai": "2.2.6",
 				"@opentelemetry/api": "1.9.0",
 				"@smithy/node-http-handler": "4.7.3",
 				"http-proxy-agent": "7.0.2",
 				"https-proxy-agent": "7.0.6",
-				"openai": "6.26.0",
+				"openai": "6.40.0",
 				"partial-json": "0.1.7",
 				"typebox": "1.3.7"
 			},
@@ -546,18 +601,18 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.0.tgz",
-			"integrity": "sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+			"integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.84.0",
-				"@earendil-works/pi-ai": "^0.84.0",
-				"@earendil-works/pi-client": "^0.84.0",
-				"@earendil-works/pi-protocol": "^0.84.0",
-				"@earendil-works/pi-tui": "^0.84.0",
+				"@earendil-works/pi-agent-core": "^0.84.2",
+				"@earendil-works/pi-ai": "^0.84.2",
+				"@earendil-works/pi-client": "^0.84.2",
+				"@earendil-works/pi-protocol": "^0.84.2",
+				"@earendil-works/pi-tui": "^0.84.2",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -1048,13 +1103,13 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.84.0",
-				"@earendil-works/pi-telemetry": "^0.84.0",
+				"@earendil-works/pi-ai": "^0.84.2",
+				"@earendil-works/pi-telemetry": "^0.84.2",
 				"diff": "8.0.4",
 				"ignore": "7.0.5",
 				"typebox": "1.3.7",
@@ -1065,21 +1120,20 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
 				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
-				"@earendil-works/pi-telemetry": "^0.84.0",
+				"@earendil-works/pi-telemetry": "^0.84.2",
 				"@google/genai": "1.52.0",
-				"@mistralai/mistralai": "2.2.6",
 				"@opentelemetry/api": "1.9.0",
 				"@smithy/node-http-handler": "4.7.3",
 				"http-proxy-agent": "7.0.2",
 				"https-proxy-agent": "7.0.6",
-				"openai": "6.26.0",
+				"openai": "6.40.0",
 				"partial-json": "0.1.7",
 				"typebox": "1.3.7"
 			},
@@ -1091,20 +1145,20 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.0.tgz",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@earendil-works/pi-protocol": "^0.84.0"
+				"@earendil-works/pi-protocol": "^0.84.2"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.0.tgz",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1115,8 +1169,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -1124,8 +1178,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1351,27 +1405,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.40.0",
-				"ws": "^8.18.0",
-				"zod": "^3.25.0 || ^4.0.0",
-				"zod-to-json-schema": "^3.25.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.9.0"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1393,16 +1426,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
@@ -2189,14 +2212,11 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+			"integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
 			"license": "Apache-2.0",
 			"peer": true,
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -2532,30 +2552,10 @@
 				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-			"version": "3.25.2",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-			"license": "ISC",
-			"peer": true,
-			"peerDependencies": {
-				"zod": "^3.25.28 || ^4"
-			}
-		},
 		"node_modules/@earendil-works/pi-telemetry": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
-			"integrity": "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+			"integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -2563,9 +2563,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
-			"integrity": "sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==",
+			"version": "0.84.2",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+			"integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -3052,6 +3052,8 @@
 		},
 		"node_modules/@google/genai": {
 			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -3099,25 +3101,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@mistralai/mistralai": {
-			"version": "2.2.6",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.40.0",
-				"ws": "^8.18.0",
-				"zod": "^3.25.0 || ^4.0.0",
-				"zod-to-json-schema": "^3.25.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.9.0"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
@@ -3142,18 +3125,12 @@
 		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.43.0",
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@oxc-project/types": {
@@ -3171,42 +3148,69 @@
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/base64": {
 			"version": "1.1.2",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/codegen": {
 			"version": "2.0.5",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/eventemitter": {
 			"version": "1.1.1",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/fetch": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.1"
 			}
 		},
 		"node_modules/@protobufjs/float": {
 			"version": "1.0.2",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/pool": {
 			"version": "1.1.0",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@protobufjs/utf8": {
 			"version": "1.1.2",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.1.5",
@@ -3487,11 +3491,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.29.6",
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
+			"integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3499,12 +3505,14 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.11",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+			"integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.6",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3512,12 +3520,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.6.8",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+			"integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.6",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3526,6 +3536,8 @@
 		},
 		"node_modules/@smithy/is-array-buffer": {
 			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3537,6 +3549,8 @@
 		},
 		"node_modules/@smithy/node-http-handler": {
 			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3549,12 +3563,14 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.6.7",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+			"integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.29.6",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3562,7 +3578,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.16.1",
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+			"integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3574,6 +3592,8 @@
 		},
 		"node_modules/@smithy/util-buffer-from": {
 			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3586,6 +3606,8 @@
 		},
 		"node_modules/@smithy/util-utf8": {
 			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3632,14 +3654,19 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "26.1.1",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+			"integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -4133,6 +4160,8 @@
 		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4159,16 +4188,10 @@
 				"js-tokens": "^10.0.0"
 			}
 		},
-		"node_modules/balanced-match": {
-			"version": "4.0.4",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"funding": [
 				{
 					"type": "github",
@@ -4188,6 +4211,8 @@
 		},
 		"node_modules/bignumber.js": {
 			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4196,24 +4221,15 @@
 		},
 		"node_modules/bowser": {
 			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/brace-expansion": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause",
 			"peer": true
 		},
@@ -4232,6 +4248,8 @@
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4240,6 +4258,8 @@
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4264,6 +4284,8 @@
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4333,6 +4355,8 @@
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -4354,6 +4378,8 @@
 		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -4386,6 +4412,8 @@
 		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4411,7 +4439,9 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.2.0",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+			"integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4425,6 +4455,8 @@
 		},
 		"node_modules/gcp-metadata": {
 			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4438,6 +4470,8 @@
 		},
 		"node_modules/get-east-asian-width": {
 			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4448,7 +4482,9 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.9.0",
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+			"integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -4465,6 +4501,8 @@
 		},
 		"node_modules/google-logging-utils": {
 			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"engines": {
@@ -4490,6 +4528,8 @@
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4502,6 +4542,8 @@
 		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4560,6 +4602,8 @@
 		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4568,6 +4612,8 @@
 		},
 		"node_modules/json-schema-to-ts": {
 			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4580,6 +4626,8 @@
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4590,6 +4638,8 @@
 		},
 		"node_modules/jws": {
 			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4868,7 +4918,10 @@
 		},
 		"node_modules/long": {
 			"version": "5.3.2",
-			"license": "Apache-2.0"
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -4908,6 +4961,8 @@
 		},
 		"node_modules/marked": {
 			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -4927,6 +4982,8 @@
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -4949,6 +5006,9 @@
 		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
 			"funding": [
 				{
 					"type": "github",
@@ -4967,6 +5027,8 @@
 		},
 		"node_modules/node-fetch": {
 			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4995,12 +5057,11 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "6.26.0",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+			"integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
 			"license": "Apache-2.0",
 			"peer": true,
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -5016,6 +5077,8 @@
 		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -5028,6 +5091,8 @@
 		},
 		"node_modules/partial-json": {
 			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -5083,8 +5148,11 @@
 		},
 		"node_modules/protobufjs": {
 			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -5104,6 +5172,8 @@
 		},
 		"node_modules/retry": {
 			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -5144,6 +5214,8 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -5165,7 +5237,6 @@
 			"version": "7.8.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
 			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5269,6 +5340,8 @@
 		},
 		"node_modules/ts-algebra": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -5277,9 +5350,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.23.10",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.10.tgz",
-			"integrity": "sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==",
+			"version": "4.23.12",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+			"integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5337,7 +5410,10 @@
 		},
 		"node_modules/undici-types": {
 			"version": "8.3.0",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/vite": {
 			"version": "8.1.5",
@@ -5505,6 +5581,8 @@
 		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -5527,7 +5605,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.21.1",
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -5544,22 +5624,6 @@
 				"utf-8-validate": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/zod": {
-			"version": "4.4.3",
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.25.2",
-			"license": "ISC",
-			"peer": true,
-			"peerDependencies": {
-				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -78,9 +78,7 @@
 	"devDependencies": {
 		"@vitest/coverage-v8": "^4.1.10",
 		"@vitest/ui": "^4.1.10",
-		"brace-expansion": "^5.0.9",
-		"protobufjs": "^7.6.5",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.12",
 		"typescript": "^7.0.2",
 		"vitest": "^4.1.10"
 	},


### PR DESCRIPTION
Follow-up to #425 (merged).

- **`@earendil-works/{pi-ai,pi-coding-agent,pi-tui}`**: 0.84.0 → **0.84.2** (lockfile-resolved peer installs). Peer range stays `>=0.81.0` and the trio stays **peer-only** — an earlier revision of this PR pinned them as devDependencies, which broke the `Production source install` job (`npm ci --omit=dev` drops devDeps but keeps peers, and `scripts/smoke-pi-loader.mjs` resolves `@earendil-works/pi-coding-agent`).
- **`tsx`**: 4.23.1 → 4.23.12 (patch).
- **Removed** unused devDependencies `brace-expansion` and `protobufjs` — zero source/script references. The `overrides` entries that motivated them stay in place and keep governing the transitive tree (also clears the protobufjs install-script warning).

**Verified:** `check-lockfile-sync` ✓ · `check-runtime-imports` ✓ · `tsc --noEmit` clean · **675/675 tests** · build clean · dist entry import ~99ms · **local repro of the failing CI job passes** (`npm ci --omit=dev` in a clean copy → build + all three smoke scripts green).