### PR TITLE
perf: detach built-in provider catalog capture from session_start (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Built-in provider toggles no longer block session start** — the first catalog capture for OpenCode / OpenCode Go / OpenRouter (credential resolution can take seconds; observed 2.25s blocking a session resume) now runs detached and is reported under `Detached session_start work` in `/free-startup`. Duplicate `session_start` events reuse the in-flight capture instead of racing a second one; until capture completes the provider shows Pi's unfiltered built-in catalog, and `/toggle-{provider}` still retries capture on demand ([#427](https://github.com/apmantza/pi-free/issues/427)).
+
 ### Changed
 
 - **Lazy pi-ai compat loading removes ~2s from Pi boot** — `@earendil-works/pi-ai/compat` costs ~1.3–1.7s of module-load time and was eagerly value-imported at all seven native provider construction sites (`openAICompletionsApi`/`anthropicMessagesApi`) plus Pi's built-in catalog (`getBuiltinModels`) in the models.dev enrichment fallback. A new `lib/lazy-compat.ts` bridge keeps the sync `stream`/`streamSimple` Provider contract by returning the local compat-free stream shell immediately and piping the real compat stream into it once a single-flight dynamic compat import resolves, with import/call failures surfacing as proper stream error events; the built-in catalog import is likewise deferred to first fallback use, and Cline's legacy compat-API registration now happens on the first Cline agent start instead of at factory time. Boot no longer loads compat at all: dist entry import drops from ~2.2s to ~80ms ([#423](https://github.com/apmantza/pi-free/issues/423)).

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -183,7 +183,10 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 					pending.registry = ctx.modelRegistry;
 					continue;
 				}
-				const entry: PendingCapture = { task: Promise.resolve(), registry: ctx.modelRegistry };
+				const entry: PendingCapture = {
+					task: Promise.resolve(),
+					registry: ctx.modelRegistry,
+				};
 				entry.task = (async () => {
 					try {
 						const state = await tryCaptureProvider(pi, config, ctx);

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -23,7 +23,10 @@ import {
 	isFreeModel,
 	registerWithGlobalToggle,
 } from "./registry.ts";
-import { wrapSessionStartHandler } from "./session-start-metrics.ts";
+import {
+	trackDetachedSessionStart,
+	wrapSessionStartHandler,
+} from "./session-start-metrics.ts";
 import { createToggleState } from "./toggle-state.ts";
 import {
 	OPENCODE_DYNAMIC_API,
@@ -98,6 +101,12 @@ interface BuiltInProviderState {
 }
 
 const providerStates = new Map<string, BuiltInProviderState>();
+/**
+ * In-flight first captures keyed by provider id. Pi can fire session_start
+ * more than once per resume; without this guard the duplicate events would
+ * race two captures (and two re-registrations) for the same provider.
+ */
+const pendingCaptures = new Map<string, Promise<void>>();
 let commandsRegisteredFor: ExtensionAPI | undefined;
 let sessionStartRegisteredFor: ExtensionAPI | undefined;
 
@@ -145,12 +154,37 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 					continue;
 				}
 
-				const state = await tryCaptureProvider(pi, config, ctx);
-				if (!state) continue;
+				// Detach the first capture: resolving OAuth/API credentials and
+				// waiting on Pi's catalog can take seconds and used to block
+				// session start. Until it completes the provider shows Pi's
+				// unfiltered built-in catalog; /toggle-{provider} retries capture
+				// on demand, and duplicate session_start events reuse the
+				// in-flight task instead of racing a second capture.
+				if (pendingCaptures.has(config.id)) continue;
+				const task = (async () => {
+					try {
+						const state = await tryCaptureProvider(pi, config, ctx);
+						if (!state) return;
 
-				const applied = state.toggleState.applyCurrent(state.reRegister);
-				_logger.info(
-					`[built-in-toggle] ${config.id}: applied ${applied.mode} mode with ${applied.models.length} models`,
+						const applied = state.toggleState.applyCurrent(state.reRegister);
+						_logger.info(
+							`[built-in-toggle] ${config.id}: applied ${applied.mode} mode with ${applied.models.length} models`,
+						);
+					} finally {
+						pendingCaptures.delete(config.id);
+					}
+				})();
+				pendingCaptures.set(config.id, task);
+				trackDetachedSessionStart(
+					`built-in-toggle-capture-${config.id}`,
+					task,
+					(err) =>
+						_logger.warn(
+							`[built-in-toggle] ${config.id}: detached capture failed`,
+							{
+								error: err instanceof Error ? err.message : String(err),
+							},
+						),
 				);
 			}
 		}),
@@ -216,7 +250,7 @@ function createProviderState(
 		}
 		const providerConfig = {
 			baseUrl,
-			...(apiKey !== undefined ? { apiKey } : {}),
+			...(apiKey === undefined ? {} : { apiKey }),
 			api: isOpenCodeProvider(config.id) ? OPENCODE_DYNAMIC_API : api,
 			...(isOpenCodeProvider(config.id)
 				? { streamSimple: createOpenCodeStreamSimple(getOpenCodeSession()) }

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -101,12 +101,25 @@ interface BuiltInProviderState {
 }
 
 const providerStates = new Map<string, BuiltInProviderState>();
+
+interface PendingCapture {
+	/** The detached capture task. */
+	task: Promise<void>;
+	/**
+	 * Latest session registry seen by ANY session_start event for this
+	 * provider. Duplicate events update this cell so the in-flight capture
+	 * registers into the CURRENT session's registry, not the one that
+	 * happened to start the capture.
+	 */
+	registry: CurrentModelRegistry;
+}
+
 /**
  * In-flight first captures keyed by provider id. Pi can fire session_start
  * more than once per resume; without this guard the duplicate events would
  * race two captures (and two re-registrations) for the same provider.
  */
-const pendingCaptures = new Map<string, Promise<void>>();
+const pendingCaptures = new Map<string, PendingCapture>();
 let commandsRegisteredFor: ExtensionAPI | undefined;
 let sessionStartRegisteredFor: ExtensionAPI | undefined;
 
@@ -140,6 +153,9 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 	// Capture built-in models on session start and apply initial filter. Avoid
 	// duplicate handlers when the entry point is invoked twice for one runner.
 	if (sessionStartRegisteredFor === pi) return;
+	// A reload creates a new runner; pending captures belong to the previous
+	// runner's session and must not block or shadow the new runner's captures.
+	if (sessionStartRegisteredFor !== undefined) pendingCaptures.clear();
 	sessionStartRegisteredFor = pi;
 	pi.on(
 		"session_start",
@@ -160,12 +176,22 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 				// unfiltered built-in catalog; /toggle-{provider} retries capture
 				// on demand, and duplicate session_start events reuse the
 				// in-flight task instead of racing a second capture.
-				if (pendingCaptures.has(config.id)) continue;
-				const task = (async () => {
+				const pending = pendingCaptures.get(config.id);
+				if (pending) {
+					// Hand the fresh session registry to the in-flight capture so it
+					// registers into the CURRENT session, not the one that started it.
+					pending.registry = ctx.modelRegistry;
+					continue;
+				}
+				const entry: PendingCapture = { task: Promise.resolve(), registry: ctx.modelRegistry };
+				entry.task = (async () => {
 					try {
 						const state = await tryCaptureProvider(pi, config, ctx);
 						if (!state) return;
 
+						// Register into the latest registry seen by any session_start
+						// event while this capture was in flight.
+						state.setModelRegistry(entry.registry);
 						const applied = state.toggleState.applyCurrent(state.reRegister);
 						_logger.info(
 							`[built-in-toggle] ${config.id}: applied ${applied.mode} mode with ${applied.models.length} models`,
@@ -174,17 +200,13 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 						pendingCaptures.delete(config.id);
 					}
 				})();
-				pendingCaptures.set(config.id, task);
+				pendingCaptures.set(config.id, entry);
 				trackDetachedSessionStart(
 					`built-in-toggle-capture-${config.id}`,
-					task,
-					(err) =>
-						_logger.warn(
-							`[built-in-toggle] ${config.id}: detached capture failed`,
-							{
-								error: err instanceof Error ? err.message : String(err),
-							},
-						),
+					entry.task,
+					// session-start-metrics already logs the detached failure; no
+					// second warning here.
+					() => {},
 				);
 			}
 		}),
@@ -311,6 +333,10 @@ function registerToggleCommand(
 	pi.registerCommand(commandName, {
 		description: `Toggle free/paid ${config.id} models`,
 		handler: async (_args, ctx) => {
+			// A detached session-start capture may still be in flight; wait for
+			// it instead of racing a second capture (which would overwrite
+			// provider state and could clobber the view the user is toggling).
+			await pendingCaptures.get(config.id)?.task;
 			let state = providerStates.get(config.id);
 			if (!state) {
 				// Models may have loaded after session_start — try capture again.

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -85,9 +85,7 @@ describe("built-in provider toggles", () => {
 			}),
 		} as unknown as ExtensionAPI;
 
-		({ setupBuiltInProviderToggles } = await import(
-			"../lib/built-in-toggle.ts"
-		));
+		({ setupBuiltInProviderToggles } = await import("../lib/built-in-toggle.ts"));
 	});
 
 	it("applies saved show-paid mode after capturing built-in models", async () => {
@@ -191,6 +189,181 @@ describe("built-in provider toggles", () => {
 		await settleDetachedCapture();
 
 		expect(mockRegisterProvider).toHaveBeenCalledWith(
+			"opencode",
+			expect.objectContaining({ api: "opencode-dynamic" }),
+		);
+	});
+
+	it("registers into the latest registry when session_start fires again mid-capture", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		let resolveKey: ((key: string | undefined) => void) | undefined;
+		const keyGate = new Promise<string | undefined>((resolve) => {
+			resolveKey = resolve;
+		});
+		const models = [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+		const firstRegistry = {
+			getAvailable: () => models,
+			getApiKeyForProvider: () => keyGate,
+			registerProvider: vi.fn(),
+		};
+		const secondRegistry = {
+			getAvailable: () => models,
+			getApiKeyForProvider: () => keyGate,
+			registerProvider: vi.fn(),
+		};
+
+		await handlers.session_start({}, { modelRegistry: firstRegistry });
+		// Pi fires session_start again while the capture is still resolving
+		// credentials; the fresh registry must win.
+		await handlers.session_start({}, { modelRegistry: secondRegistry });
+
+		resolveKey?.(undefined);
+		await settleDetachedCapture();
+
+		expect(firstRegistry.registerProvider).not.toHaveBeenCalled();
+		expect(secondRegistry.registerProvider).toHaveBeenCalledWith(
+			"opencode",
+			expect.objectContaining({ api: "opencode-dynamic" }),
+		);
+	});
+
+	it("toggle waits for an in-flight detached capture instead of racing it", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		let resolveKey: ((key: string | undefined) => void) | undefined;
+		const keyGate = new Promise<string | undefined>((resolve) => {
+			resolveKey = resolve;
+		});
+		const allModels = [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+			{
+				provider: "opencode",
+				id: "paid-model",
+				name: "Paid Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+
+		await handlers.session_start(
+			{},
+			{
+				modelRegistry: {
+					getAvailable: () => allModels,
+					getApiKeyForProvider: () => keyGate,
+					registerProvider: mockRegisterProvider,
+				},
+			},
+		);
+
+		// Toggle while the capture is still pending: it must await the
+		// in-flight capture, not start its own.
+		const notify = vi.fn();
+		const toggleDone = commands["toggle-opencode"]({}, { ui: { notify } });
+		resolveKey?.(undefined);
+		await toggleDone;
+
+		// Exactly one capture: the detached initial apply (free view) plus the
+		// user's toggle to all — no extra racy capture in between.
+		expect(mockRegisterWithGlobalToggle).toHaveBeenCalledTimes(1);
+		expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
+		expect(notify).toHaveBeenCalledWith(
+			"opencode: showing all 2 models",
+			"info",
+		);
+		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
+			"opencode",
+			expect.objectContaining({ models: expect.any(Array) }),
+		);
+		const lastModels = mockRegisterProvider.mock.calls.at(-1)?.[1]
+			.models as Array<{ id: string }>;
+		expect(lastModels.map((m) => m.id).sort()).toEqual([
+			"free-model",
+			"paid-model",
+		]);
+	});
+
+	it("clears stale pending captures when a new runner registers", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		// Hang the first runner's capture forever (credential refresh stall).
+		const hungGate = new Promise<string | undefined>(() => {});
+		const models = [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+		await handlers.session_start(
+			{},
+			{
+				modelRegistry: {
+					getAvailable: () => models,
+					getApiKeyForProvider: () => hungGate,
+					registerProvider: vi.fn(),
+				},
+			},
+		);
+
+		// Extension reload: a new runner registers; the stale pending entry must
+		// not block the new runner's capture.
+		const mockPi2 = {
+			registerCommand: vi.fn((name: string, config: { handler: Function }) => {
+				commands[name] = config.handler;
+			}),
+			registerProvider: mockRegisterProvider,
+			on: vi.fn((event: string, handler: Function) => {
+				handlers[event] = handler;
+			}),
+		} as unknown as ExtensionAPI;
+		setupBuiltInProviderToggles(mockPi2);
+
+		const freshRegistry = {
+			getAvailable: () => models,
+			registerProvider: vi.fn(),
+		};
+		await handlers.session_start({}, { modelRegistry: freshRegistry });
+		await settleDetachedCapture();
+
+		expect(freshRegistry.registerProvider).toHaveBeenCalledWith(
 			"opencode",
 			expect.objectContaining({ api: "opencode-dynamic" }),
 		);

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -297,10 +297,7 @@ describe("built-in provider toggles", () => {
 		// user's toggle to all — no extra racy capture in between.
 		expect(mockRegisterWithGlobalToggle).toHaveBeenCalledTimes(1);
 		expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
-		expect(notify).toHaveBeenCalledWith(
-			"opencode: showing all 2 models",
-			"info",
-		);
+		expect(notify).toHaveBeenCalledWith("opencode: showing all 2 models", "info");
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
 			"opencode",
 			expect.objectContaining({ models: expect.any(Array) }),

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -9,6 +9,16 @@ const mockSaveConfig = vi.fn();
 const mockRegisterWithGlobalToggle = vi.fn();
 const mockProviderRegistry = new Map<string, unknown>();
 
+/**
+ * Session-start capture is detached (fires after the handler returns), so
+ * tests asserting its effects must let the pending task settle first.
+ */
+async function settleDetachedCapture(): Promise<void> {
+	for (let i = 0; i < 10; i += 1) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
 vi.mock("../config.ts", () => ({
 	getOpencodeShowPaid: () => mockGetOpencodeShowPaid(),
 	getOpenrouterApiKey: () => mockGetOpenrouterApiKey(),
@@ -119,6 +129,7 @@ describe("built-in provider toggles", () => {
 				},
 			},
 		);
+		await settleDetachedCapture();
 
 		expect(mockRegisterProvider).toHaveBeenCalledWith(
 			"opencode",
@@ -137,6 +148,51 @@ describe("built-in provider toggles", () => {
 					}),
 				]),
 			}),
+		);
+	});
+
+	it("returns from session_start before the capture completes (detached)", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		let resolveKey: ((key: string | undefined) => void) | undefined;
+		const keyGate = new Promise<string | undefined>((resolve) => {
+			resolveKey = resolve;
+		});
+
+		await handlers.session_start(
+			{},
+			{
+				modelRegistry: {
+					getAvailable: () => [
+						{
+							provider: "opencode",
+							id: "free-model",
+							name: "Free Model",
+							api: "openai-completions",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 4096,
+							baseUrl: "https://example.com",
+						},
+					],
+					// Simulate a slow credential resolution (the real-world
+					// session-start stall this detach fixes).
+					getApiKeyForProvider: () => keyGate,
+				},
+			},
+		);
+
+		// Handler returned, but capture is still waiting on the credential.
+		expect(mockRegisterProvider).not.toHaveBeenCalled();
+
+		resolveKey?.(undefined);
+		await settleDetachedCapture();
+
+		expect(mockRegisterProvider).toHaveBeenCalledWith(
+			"opencode",
+			expect.objectContaining({ api: "opencode-dynamic" }),
 		);
 	});
 
@@ -169,6 +225,7 @@ describe("built-in provider toggles", () => {
 				},
 			},
 		);
+		await settleDetachedCapture();
 
 		expect(registerProvider).toHaveBeenCalledWith(
 			"opencode",
@@ -213,6 +270,7 @@ describe("built-in provider toggles", () => {
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
+		await settleDetachedCapture();
 		await commands["toggle-openrouter"]({}, { ui: { notify: vi.fn() } });
 
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
@@ -289,6 +347,7 @@ describe("built-in provider toggles", () => {
 				},
 			},
 		);
+		await settleDetachedCapture();
 
 		const notify = vi.fn();
 		await commands["toggle-opencode"]({}, { ui: { notify } });


### PR DESCRIPTION
Fixes #427. Follow-up to the #423/#424/#421 session: with startup itself down to ~48ms, log analysis of a slow resume showed the remaining block was the `built-in-toggle` session_start handler — **2250ms** — waiting on credential resolution for the OAuth built-in providers while Pi's store refreshed.

## Change

- **Detach the first capture** of OpenCode / OpenCode Go / OpenRouter from the `session_start` handler: `tryCaptureProvider` + `applyCurrent` now run as a tracked detached task (`built-in-toggle-capture-{id}` via `trackDetachedSessionStart`, visible under `Detached session_start work` in `/free-startup`).
- **Duplicate-event guard**: Pi fires `session_start` more than once per resume; a `pendingCaptures` map makes later events reuse the in-flight capture instead of racing a second capture/re-registration.
- Unchanged: the existing-state fast path (registry swap + reapply, 0–5ms) stays synchronous; `/toggle-{provider}` keeps its on-demand capture fallback.
- Trade-off: until the detached capture completes, a provider shows Pi's unfiltered built-in catalog (brief window, same behavior as before the toggle extension existed).

## Verification

- New test asserts the handler returns **before** a slow credential resolution completes and the capture applies afterwards; settle helper added for the detached path.
- **676/676 tests** · `tsc --noEmit` clean · build + `smoke-compiled` green · dist entry import ~92ms.