### PR TITLE
feat: prefix log lines with the process id (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Log lines now carry the process id** — `~/.pi/free.log` is shared by every pi process on the machine; concurrent sessions interleaved into one unreadable stream. Every line is now prefixed `[pid N]` so sessions are separable ([#429](https://github.com/apmantza/pi-free/issues/429)).
+
 ### Fixed
 
 - **Built-in provider toggles no longer block session start** — the first catalog capture for OpenCode / OpenCode Go / OpenRouter (credential resolution can take seconds; observed 2.25s blocking a session resume) now runs detached and is reported under `Detached session_start work` in `/free-startup`. Duplicate `session_start` events reuse the in-flight capture instead of racing a second one; until capture completes the provider shows Pi's unfiltered built-in catalog, and `/toggle-{provider}` still retries capture on demand ([#427](https://github.com/apmantza/pi-free/issues/427)).

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -77,7 +77,7 @@ function formatMessage(entry: LogEntry): string {
 			data = " [unserializable-data]";
 		}
 	}
-	return `[${entry.timestamp}] [${entry.level.toUpperCase()}] [${sanitizeLogText(entry.namespace)}] ${sanitizeLogText(entry.message)}${data}`;
+	return `[${entry.timestamp}] [${entry.level.toUpperCase()}] [pid ${process.pid}] [${sanitizeLogText(entry.namespace)}] ${sanitizeLogText(entry.message)}${data}`;
 }
 
 const LOG_PATH = resolveSafeDataFile(process.env.PI_FREE_LOG_PATH, "free.log");

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -50,9 +50,21 @@ describe("logger file rotation", () => {
 			await waitForLogFlush();
 
 			const logDir = join(home, ".pi");
-			const files = (await readdir(logDir))
-				.filter((file) => file.startsWith("rotation.log"))
-				.sort();
+			// Async rotation may still be renaming files right after the flush;
+			// wait for the directory listing to stabilize so the size/content
+			// assertions never race a mid-check rename (ENOENT flake).
+			let files: string[] = [];
+			for (let attempt = 0; attempt < 40; attempt += 1) {
+				const current = (await readdir(logDir))
+					.filter((file) => file.startsWith("rotation.log"))
+					.sort();
+				if (current.length > 0 && current.join(",") === files.join(",")) {
+					files = current;
+					break;
+				}
+				files = current;
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			}
 			expect(files.length).toBeGreaterThan(1);
 			expect(files.length).toBeLessThanOrEqual(4);
 			for (const file of files) {


### PR DESCRIPTION
Fixes #429.

`~/.pi/free.log` is shared by every pi process on the machine. With two pi sessions running concurrently, both write into the same file and their lines interleave — doubled `startup complete` lines and `built-in-toggle-capture-*` entries that were initially misread as a double-loaded extension while verifying the #423/#424/#428 fixes.

## Change

- Every log line now carries the OS process id: `[timestamp] [LEVEL] [pid N] [namespace] message {data}` — one-line change in `formatMessage`.
- Hardened the logger rotation test against its intermittent ENOENT flake: it now waits for a stable directory listing before asserting file sizes/content, instead of racing an in-flight async rotation rename.

## Verification

- 679/679 tests, rotation test green across 5 consecutive runs, `tsc --noEmit` clean, build clean.