### PR TITLE
fix: Cline free list matches recommended-models ids exactly (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cline free list no longer zero-prices paid dated model variants** — the free-to-try matcher fuzzy-aliased catalog ids by stripping date suffixes, so `deepseek/deepseek-v4-flash-0731` inherited free pricing from `deepseek/deepseek-v4-flash` while the API actually bills it (402 insufficient credits at request time). Matching is now exact against Cline's authoritative `recommended-models` free list — both endpoints use provider-qualified ids, so the aliasing bought nothing and cost broken free models ([#431](https://github.com/apmantza/pi-free/issues/431)).
+
+### Fixed
+
 - **Built-in provider toggles no longer block session start** — the first catalog capture for OpenCode / OpenCode Go / OpenRouter (credential resolution can take seconds; observed 2.25s blocking a session resume) now runs detached and is reported under `Detached session_start work` in `/free-startup`. Duplicate `session_start` events reuse the in-flight capture instead of racing a second one; until capture completes the provider shows Pi's unfiltered built-in catalog, and `/toggle-{provider}` still retries capture on demand ([#427](https://github.com/apmantza/pi-free/issues/427)).
 
 ### Changed

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -133,52 +133,11 @@ function modelFromRecommended(
 	};
 }
 
-// Cline's free endpoint can use a provider-qualified ID while the catalog
-// uses the leaf ID (or vice versa). It also occasionally gives a dated
-// catalog entry for an otherwise identical recommended model, for example
-// `deepseek-v4-flash` -> `deepseek-v4-flash-0731`.
-//
-// Keep this deliberately narrow: only valid date-shaped release suffixes are
-// removed, and two provider-qualified IDs must have the same qualifier. This
-// avoids turning similarly named paid variants (such as `-pro`) into free ones.
-const CLINE_RELEASE_DATE_SUFFIX =
-	/(?:-(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])|-(?:19|20)\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])|-(?:19|20)\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]))$/;
-
-function splitClineModelId(id: string): {
-	qualifier?: string;
-	leaf: string;
-} {
-	const separator = id.lastIndexOf("/");
-	return separator < 0
-		? { leaf: id }
-		: { qualifier: id.slice(0, separator), leaf: id.slice(separator + 1) };
-}
-
-function stripClineReleaseDateSuffix(id: string): string {
-	return id.replace(CLINE_RELEASE_DATE_SUFFIX, "");
-}
-
-function isClineFreeToTryId(
-	modelId: string,
-	freeToTryIds: ReadonlySet<string>,
-): boolean {
-	if (freeToTryIds.has(modelId)) return true;
-
-	const model = splitClineModelId(modelId);
-	const normalizedModelLeaf = stripClineReleaseDateSuffix(model.leaf);
-	for (const freeToTryId of freeToTryIds) {
-		const free = splitClineModelId(freeToTryId);
-		if (model.qualifier && free.qualifier && model.qualifier !== free.qualifier) {
-			continue;
-		}
-		if (
-			normalizedModelLeaf === stripClineReleaseDateSuffix(free.leaf)
-		) {
-			return true;
-		}
-	}
-	return false;
-}
+// Cline's recommended-models `free` list is the authoritative free-to-try
+// source, and both it and the catalog use provider-qualified IDs. Match
+// exactly: fuzzy aliasing (e.g. stripping date suffixes) turned genuinely
+// paid dated variants like `deepseek/deepseek-v4-flash-0731` into free
+// models that then fail with 402 insufficient credits at request time.
 
 function modelFromCatalog(
 	info: ClineRaw,
@@ -188,7 +147,7 @@ function modelFromCatalog(
 		info.supported_parameters?.includes("include_reasoning") ||
 		info.supported_parameters?.includes("reasoning")
 	);
-	const isFreeToTry = isClineFreeToTryId(info.id, freeToTryIds);
+	const isFreeToTry = freeToTryIds.has(info.id);
 	const inputCost = isFreeToTry ? 0 : parsePricing(info.pricing?.prompt);
 	const outputCost = isFreeToTry ? 0 : parsePricing(info.pricing?.completion);
 	const cacheRead = isFreeToTry

--- a/providers/cline/cline-models.ts
+++ b/providers/cline/cline-models.ts
@@ -306,9 +306,7 @@ export async function fetchClineCatalog(options?: {
  * Adds the provider id, the custom wire api, and the gateway baseUrl that the
  * legacy registerProvider config form used to supply implicitly.
  */
-export function toClineModel(
-	m: ProviderModelConfig,
-): Model<"cline-xml-tools"> {
+export function toClineModel(m: ProviderModelConfig): Model<"cline-xml-tools"> {
 	return {
 		...m,
 		api: "cline-xml-tools",

--- a/tests/cline-models.test.ts
+++ b/tests/cline-models.test.ts
@@ -45,13 +45,13 @@ afterEach(() => {
 	vi.unstubAllGlobals();
 });
 
-describe("Cline free-to-try catalog aliases", () => {
-	it("applies free pricing before native free splitting for qualified and leaf date aliases", async () => {
+describe("Cline free-to-try catalog matching", () => {
+	it("marks only exact free-to-try ids free; dated variants stay paid", async () => {
 		const freeId = "deepseek/deepseek-v4-flash";
 		const datedQualifiedId = "deepseek/deepseek-v4-flash-0731";
 		const datedLeafId = "deepseek-v4-flash-0731";
 		const paidVariantId = "deepseek/deepseek-v4-flash-pro";
-		const otherProviderId = "other/deepseek-v4-flash-0731";
+		const otherProviderId = "other/deepseek-v4-flash";
 
 		stubClineEndpoints(
 			[freeId],
@@ -67,19 +67,17 @@ describe("Cline free-to-try catalog aliases", () => {
 		const { all, free } = await fetchClineCatalog();
 		const byId = new Map(all.map((model) => [model.id, model]));
 
-		for (const id of [freeId, datedQualifiedId, datedLeafId]) {
-			expect(byId.get(id)).toMatchObject({
-				cost: { input: 0, output: 0 },
-				name: expect.not.stringContaining("💰"),
-			});
-		}
+		// Exact match is free.
+		expect(byId.get(freeId)).toMatchObject({
+			cost: { input: 0, output: 0 },
+			name: expect.not.stringContaining("💰"),
+		});
+		expect(free.map((model) => model.id)).toEqual([freeId]);
 
-		expect(free.map((model) => model.id)).toEqual([
-			freeId,
-			datedQualifiedId,
-			datedLeafId,
-		]);
-		expect(byId.get(paidVariantId)?.cost.input).toBeGreaterThan(0);
-		expect(byId.get(otherProviderId)?.cost.input).toBeGreaterThan(0);
+		// Dated/leaf/other-provider variants are paid — the old fuzzy aliasing
+		// zero-priced dated variants that return 402 at request time.
+		for (const id of [datedQualifiedId, datedLeafId, paidVariantId, otherProviderId]) {
+			expect(byId.get(id)?.cost.input).toBeGreaterThan(0);
+		}
 	});
 });

--- a/tests/cline-models.test.ts
+++ b/tests/cline-models.test.ts
@@ -76,7 +76,12 @@ describe("Cline free-to-try catalog matching", () => {
 
 		// Dated/leaf/other-provider variants are paid — the old fuzzy aliasing
 		// zero-priced dated variants that return 402 at request time.
-		for (const id of [datedQualifiedId, datedLeafId, paidVariantId, otherProviderId]) {
+		for (const id of [
+			datedQualifiedId,
+			datedLeafId,
+			paidVariantId,
+			otherProviderId,
+		]) {
 			expect(byId.get(id)?.cost.input).toBeGreaterThan(0);
 		}
 	});


### PR DESCRIPTION
Fixes #431.

The free-to-try matcher fuzzy-aliased catalog ids by stripping date-shaped suffixes, so `deepseek/deepseek-v4-flash-0731` inherited free pricing from `deepseek/deepseek-v4-flash` — while the API actually bills it (**402 insufficient credits**, verified live; genuinely free models like `nvidia/nemotron-3.5-lightning` stream fine at cost 0 with the same token).

## Change

- Exact membership against Cline's authoritative `recommended-models` free list; deleted the `CLINE_RELEASE_DATE_SUFFIX` / `splitClineModelId` / `stripClineReleaseDateSuffix` aliasing helpers (~45 lines). Both endpoints use provider-qualified ids (verified against the live payloads), so the aliasing had no legitimate job.
- Test rewritten: exact id free; dated qualified, dated leaf, `-pro`, and other-provider variants all stay paid.

## Verification

679/679 tests, `tsc --noEmit` clean.

Note: after merge, users' cached model stores keep the stale zero-pricing until Pi's next catalog refresh.