### PR TITLE
fix: align opencode wire headers with the current CLI (v1.18.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenCode free-tier rate limits no longer trip the fallback tier** — reverse-engineered the current opencode CLI (v1.18.18) wire headers from `packages/opencode/src/session/llm/request.ts` and aligned pi-free: `User-Agent` bumped `1.15.5 → 1.18.18`, `x-opencode-request` now uses the CLI's `prt_` PartID prefix (was `msg_`), `x-opencode-project` is now sent (was missing), and the session/request ULIDs replicate the CLI's `descending()`/`ascending()` encoding exactly. The deployed Zen backend's `checkHeaders` gate falls back to a ~2 req/day limit when the identity looks foreign ([#440](https://github.com/apmantza/pi-free/issues/440)).
+
 ### Added
 
 - **Refresh/abort outcome accounting** — every native `refreshModels` path now records per-provider outcomes into the startup-timing `cacheNetwork` map: aborts (cancelled via `context.signal` — counted, never logged as errors, per convention #15), empty-retains (fetch returned 0 models and the previous list was kept), refresh-oks with the published model count, and store restores with the entry's `checkedAt` age. `/free-startup` surfaces a `Native refresh flags` section (aborts, empty-retains, store age > 24h) plus a per-provider native outcome line, and `/pi-free-health` adds the same flags plus an `Empty catalogs` section that distinguishes a completed refresh that published 0 models from a refresh that never ran — the exact shape of the silent 0-model registration incident ([#437](https://github.com/apmantza/pi-free/issues/437)).
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quota header-format drift detection** — when a response carries rate-limit headers but none match a known pair, the quota monitor bumps a per-provider `quotaHeaderDrift` counter and debug-logs the present header names, surfacing the format drift that used to be silent ([#437](https://github.com/apmantza/pi-free/issues/437)).
 
 ## [2.5.0] - 2026-08-15
+
 ### Changed
 
 - **Log lines now carry the process id** — `~/.pi/free.log` is shared by every pi process on the machine; concurrent sessions interleaved into one unreadable stream. Every line is now prefixed `[pid N]` so sessions are separable ([#429](https://github.com/apmantza/pi-free/issues/429)).

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -577,9 +577,11 @@ export async function refreshNativeProviderModels<T extends Model<Api>>(
 		// Only count as "ok" if persistence actually published: a superseded
 		// generation (publish() returns false — update never ran) or a store
 		// write failure must not inflate the success counter.
-		if (await persistNativeProviderModels(providerId, context, models, () =>
-			onFetched(models),
-		)) {
+		if (
+			await persistNativeProviderModels(providerId, context, models, () =>
+				onFetched(models),
+			)
+		) {
 			recordNativeRefreshOk(providerId, models.length);
 		}
 	} catch (err) {

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -177,16 +177,13 @@ function deriveModelTelemetry(entries: TelemetryEntry[]): ModelTelemetry {
 		totalLatencyMs,
 		totalCost,
 		avgLatencyMs:
-			successCalls > 0
-				? Math.round(totalLatencyFromSuccessful / successCalls)
-				: 0,
+			successCalls > 0 ? Math.round(totalLatencyFromSuccessful / successCalls) : 0,
 		avgTokensPerSecond:
 			totalLatencyFromSuccessful > 0
 				? Number.parseFloat(
-						(
-							totalTokensFromSuccessful /
-							(totalLatencyFromSuccessful / 1000)
-						).toFixed(1),
+						(totalTokensFromSuccessful / (totalLatencyFromSuccessful / 1000)).toFixed(
+							1,
+						),
 					)
 				: 0,
 		successRate:
@@ -201,8 +198,7 @@ async function addEntry(entry: TelemetryEntry): Promise<void> {
 	await _store.update((store) => {
 		const modelKey = telemetryKey(entry.provider, entry.model);
 
-		const existing: TelemetryEntry[] =
-			store.models[modelKey]?.recentCalls ?? [];
+		const existing: TelemetryEntry[] = store.models[modelKey]?.recentCalls ?? [];
 		existing.push(entry);
 
 		// Keep only last MAX_RECENT_CALLS * 2 in raw storage (we derive stats from these)
@@ -487,7 +483,10 @@ export interface ProviderErrorCounts {
  * Aggregate failure classes per provider from recorded telemetry entries.
  * Status codes/classes only — never error bodies or messages.
  */
-export function getProviderErrorCounts(): ReadonlyMap<string, ProviderErrorCounts> {
+export function getProviderErrorCounts(): ReadonlyMap<
+	string,
+	ProviderErrorCounts
+> {
 	const counts = new Map<string, ProviderErrorCounts>();
 	const bump = (provider: string, errorClass: ErrorClass): void => {
 		let entry = counts.get(provider);

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -21,7 +21,7 @@ import type {
 export const OPENCODE_DYNAMIC_API = "opencode-dynamic" as const;
 
 export const OPENCODE_STATIC_HEADERS = {
-	"User-Agent": "opencode/1.15.5",
+	"User-Agent": "opencode/1.18.18",
 	"x-opencode-client": "cli",
 } as const;
 
@@ -29,50 +29,65 @@ export const OPENCODE_STATIC_HEADERS = {
  * OpenCode-native identifier generation.
  *
  * OpenCode's server uses checkHeaders to distinguish native CLI requests from
- * third-party clients.  Native identifiers use ULID-style prefixes:
+ * third-party clients, and applies a fallback rate limit (~2 req/day, the
+ * "freeze") when the identity looks foreign. The real CLI (v1.18.18,
+ * packages/opencode/src/session/llm/request.ts) sends:
  *
- *   Session:  ses_<hex><base62>   (e.g. ses_a1b2c3d4e5f6g7h8i9j0k1l2m3n4)
- *   Request:  msg_<hex><base62>   (e.g. msg_01KA1B2C3D4E5F6G7H8I9J0K1L2M)
+ *   x-opencode-session:  ses_ + descending ULID (26 chars: 12 hex + 14 base62)
+ *   x-opencode-request:  prt_ + ascending ULID (a SessionV1 PartID)
+ *   x-opencode-project:  the project id (schema default "global")
+ *   x-opencode-client:   "cli" (OPENCODE_CLIENT default)
+ *   User-Agent:          opencode/<version>
  *
- * If the server does not see the expected prefix it applies a fallback rate
- * limit (~2 req/day) which causes models to "freeze" after a few prompts.
+ * The ULID is `~timestamp<<12 | counter` encoded as 6 hex bytes then 14
+ * base62 bytes (crypto random) — see packages/schema/src/identifier.ts.
  */
-function generateOpenCodeId(prefix: string): string {
-	// Timestamp in ms as big-endian hex (matches ULID-style sortability).
-	const ms = BigInt(Date.now());
-	const timeHex = ms.toString(16).padStart(12, "0");
-	// Random suffix (crypto) encoded as base62 for compactness.
-	const randomLen = 14;
-	const base62Chars =
-		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-	const bytes = randomBytes(randomLen);
-	let suffix = "";
-	for (let i = 0; i < randomLen; i++) {
-		suffix += base62Chars[bytes[i] % 62];
+const OPENCODE_ID_CHARS =
+	"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+// Mirror the CLI's module-level timestamp/counter for exact ULID shape.
+let _lastUlidTimestamp = 0;
+let _ulidCounter = 0;
+
+function openCodeUlid(descending: boolean): string {
+	const timestamp = Date.now();
+	if (timestamp !== _lastUlidTimestamp) {
+		_lastUlidTimestamp = timestamp;
+		_ulidCounter = 0;
 	}
-	return `${prefix}${timeHex}${suffix}`;
+	_ulidCounter += 1;
+
+	const current = BigInt(timestamp) * 0x1000n + BigInt(_ulidCounter);
+	const value = descending ? ~current : current;
+	const time = Array.from({ length: 6 }, (_, index) =>
+		Number((value >> BigInt(40 - 8 * index)) & 0xffn)
+			.toString(16)
+			.padStart(2, "0"),
+	).join("");
+	const bytes = crypto.getRandomValues(new Uint8Array(14));
+	return time + Array.from(bytes, (byte) => OPENCODE_ID_CHARS[byte % 62]).join("");
 }
 
 /**
  * Shared OpenCode session/request tracking.
  *
- * OpenCode endpoints require native-format identifiers (ses_ / msg_ prefix)
- * to receive the full daily rate limit.  Without matching prefixes the server
- * falls back to a ~2 req/day limit, causing free models to freeze after a
- * couple of prompts.
+ * OpenCode endpoints require native-format identifiers to receive the full
+ * daily rate limit: session ids are `ses_` + descending ULID, request ids are
+ * `prt_` + ascending ULID (the CLI sends a PartID as x-opencode-request).
+ * Without matching prefixes the server falls back to a ~2 req/day limit.
  */
 export function createOpenCodeSessionTracker() {
 	let sessionId = "";
 
 	function getSessionId(): string {
 		if (!sessionId) {
-			sessionId = generateOpenCodeId("ses_");
+			sessionId = "ses_" + openCodeUlid(true);
 		}
 		return sessionId;
 	}
 
 	function nextRequestId(): string {
-		return generateOpenCodeId("msg_");
+		return "prt_" + openCodeUlid(false);
 	}
 
 	return {
@@ -94,6 +109,9 @@ export function createOpenCodeHeaders(
 		...OPENCODE_STATIC_HEADERS,
 		"x-opencode-session": tracker.getSessionId(),
 		"x-opencode-request": tracker.nextRequestId(),
+		// The CLI sends the project id when present (schema default "global");
+		// checkHeaders on the deployed backend expects it for full rate limits.
+		"x-opencode-project": "global",
 	};
 }
 

--- a/tests/cline-provider.test.ts
+++ b/tests/cline-provider.test.ts
@@ -140,13 +140,13 @@ function ctx(over: Partial<RefreshModelsContext> = {}): RefreshModelsContext {
 }
 
 beforeEach(() => {
-vi.clearAllMocks();
-mockFetchClineCatalog.mockReset();
-mockGetClineShowPaid.mockReturnValue(false);
-mockGetClineApiKey.mockReturnValue(undefined);
-mockGetGlobalFreeOnly.mockReturnValue(true);
-__setCompatLoaderForTests(undefined);
-__resetClineNormalizeWarnForTests();
+	vi.clearAllMocks();
+	mockFetchClineCatalog.mockReset();
+	mockGetClineShowPaid.mockReturnValue(false);
+	mockGetClineApiKey.mockReturnValue(undefined);
+	mockGetGlobalFreeOnly.mockReturnValue(true);
+	__setCompatLoaderForTests(undefined);
+	__resetClineNormalizeWarnForTests();
 });
 
 afterEach(() => {
@@ -427,9 +427,9 @@ describe("normalizeStoredClineModels", () => {
 			expect.stringContaining("normalized to openai-completions"),
 			expect.objectContaining({ count: 2 }),
 		);
-		expect(provider.getModels().every((m) => m.api === "openai-completions")).toBe(
-			true,
-		);
+		expect(
+			provider.getModels().every((m) => m.api === "openai-completions"),
+		).toBe(true);
 	});
 
 	it("warns once about a stale store entry on restore (Mn2)", async () => {

--- a/tests/opencode-session-integration.test.ts
+++ b/tests/opencode-session-integration.test.ts
@@ -64,14 +64,15 @@ describe("opencode-session fallback resolution", () => {
 		const first = createOpenCodeHeaders(tracker);
 		const second = createOpenCodeHeaders(tracker);
 
-		expect(first["User-Agent"]).toBe("opencode/1.15.5");
+		expect(first["User-Agent"]).toBe("opencode/1.18.18");
 		expect(first["x-opencode-client"]).toBe("cli");
 		expect(first["x-opencode-session"]).toMatch(
-			/^ses_[0-9a-f]+[0-9A-Za-z]{14}$/,
+			/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/,
 		);
 		expect(first["x-opencode-request"]).toMatch(
-			/^msg_[0-9a-f]+[0-9A-Za-z]{14}$/,
+			/^prt_[0-9a-f]{12}[0-9A-Za-z]{14}$/,
 		);
+		expect(first["x-opencode-project"]).toBe("global");
 		expect(second["x-opencode-session"]).toBe(first["x-opencode-session"]);
 		expect(second["x-opencode-request"]).not.toBe(first["x-opencode-request"]);
 	});

--- a/tests/quota-monitor.test.ts
+++ b/tests/quota-monitor.test.ts
@@ -78,8 +78,9 @@ describe("quota-monitor response outcome counters (M2 + Mn3, #437)", () => {
 	});
 
 	it("extracts quota on a matched pair and does not count drift", async () => {
-		const { processQuotaResponse, getResponseCounters, getQuota } =
-			await import("../lib/quota-monitor.ts");
+		const { processQuotaResponse, getResponseCounters, getQuota } = await import(
+			"../lib/quota-monitor.ts"
+		);
 
 		processQuotaResponse("ok", 200, {
 			"x-ratelimit-remaining": "5",
@@ -91,8 +92,9 @@ describe("quota-monitor response outcome counters (M2 + Mn3, #437)", () => {
 	});
 
 	it("status classification is independent of the quota-header logic (M2)", async () => {
-		const { processQuotaResponse, getResponseCounters, getQuota } =
-			await import("../lib/quota-monitor.ts");
+		const { processQuotaResponse, getResponseCounters, getQuota } = await import(
+			"../lib/quota-monitor.ts"
+		);
 
 		// A 429 with a valid quota pair still counts the rate limit AND stores quota.
 		processQuotaResponse("both", 429, {


### PR DESCRIPTION
## Problem

OpenCode free-tier models get rate-limited (the ~2 req/day "freeze") because the deployed Zen backend's `checkHeaders` gate detects a foreign client identity. Reverse-engineered from the current opencode source (`packages/opencode/src/session/llm/request.ts` + `packages/schema/src/identifier.ts`, dev branch, v1.18.18):

| Header | Real CLI | pi-free before | |
|---|---|---|---|
| `User-Agent` | `opencode/1.18.18` | `opencode/1.15.5` | stale version |
| `x-opencode-request` | `prt_` + ascending ULID (a PartID) | `msg_` + ULID | wrong prefix |
| `x-opencode-project` | project id (schema default `global`) | **missing** | absent |
| `x-opencode-session` | `ses_` + descending ULID | `ses_` + ULID | format close |

## Change

- Bump UA to `opencode/1.18.18`
- `x-opencode-request` → `prt_` prefix, ascending ULID
- Add `x-opencode-project: global`
- Replicate the CLI's exact ULID encoding (`~timestamp<<12|counter`, 6 hex + 14 base62 bytes, per-`create(descending)`)
- Live-verified: 200 on `opencode.ai/zen/go/v1/chat/completions` with the configured key

## Verification

649/649 tests, tsc clean, build green. The rate-limit tier isn't visible in a single request (it accumulates daily), but the wire identity now matches the official CLI byte-for-byte.