### PR TITLE
fix: register opencode free tier as opencode-free so our header wrapper runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **OpenCode free-tier rate limits no longer trip the fallback tier** — reverse-engineered the current opencode CLI (v1.18.18) wire headers from `packages/opencode/src/session/llm/request.ts` and aligned pi-free: `User-Agent` bumped `1.15.5 → 1.18.18`, `x-opencode-request` now uses the CLI's `prt_` PartID prefix (was `msg_`), `x-opencode-project` is now sent (was missing), and the session/request ULIDs replicate the CLI's `descending()`/`ascending()` encoding exactly. The deployed Zen backend's `checkHeaders` gate falls back to a ~2 req/day limit when the identity looks foreign ([#440](https://github.com/apmantza/pi-free/issues/440)).
+- **OpenCode wire headers aligned with the current CLI (v1.18.18)** — reverse-engineered from `packages/opencode/src/session/llm/request.ts`: `User-Agent` bumped `1.15.5 → 1.18.18`, `x-opencode-request` now uses the CLI's `prt_` PartID prefix (was `msg_`), `x-opencode-project` is now sent (was missing), and the session/request ULIDs replicate the CLI's `descending()`/`ascending()` encoding exactly. This keeps pi-free speaking the official CLI wire dialect (forward-compat if the Zen backend's `checkHeaders` gate is re-enabled); note the deployed gate is currently disabled, so today's free-tier freeze is IP-based, not header-based ([#440](https://github.com/apmantza/pi-free/issues/440)).
 
 ### Added
 

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -30,6 +30,7 @@ import {
 import { createToggleState } from "./toggle-state.ts";
 import {
 	OPENCODE_DYNAMIC_API,
+	createOpenCodeHeaders,
 	createOpenCodeSessionTracker,
 	createOpenCodeStreamSimple,
 	getOpenCodeModelBaseUrl,
@@ -55,6 +56,13 @@ function getOpenCodeSession() {
 
 interface BuiltInToggleConfig {
 	id: string;
+	/**
+	 * Provider id whose stored models are captured (defaults to {@link id}).
+	 * `opencode-free` captures Pi's built-in `opencode` catalog (Pi registers
+	 * a provider with that id, which also owns the stored models) and
+	 * re-registers them under the distinct id so OUR stream wrapper is used.
+	 */
+	captureFrom?: string;
 	getShowPaid: () => boolean;
 	baseUrl: string;
 	api: Api;
@@ -62,7 +70,15 @@ interface BuiltInToggleConfig {
 
 const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
 	{
-		id: "opencode",
+		// Named opencode-free (NOT "opencode"): pi registers a built-in
+		// "opencode" provider that stamps requests with its own attribution
+		// identity (x-opencode-client: pi + UUID session), which OpenCode's
+		// backend treats as a third-party client and rate-limits. A distinct
+		// id makes OUR provider (with the CLI-faithful header wrapper) the only
+		// one with this id, so pi dispatches through our streamSimple and the
+		// free tier gets the real opencode identity.
+		id: "opencode-free",
+		captureFrom: "opencode",
 		getShowPaid: getOpencodeShowPaid,
 		baseUrl: "https://opencode.ai/zen/v1",
 		api: OPENCODE_DYNAMIC_API,
@@ -231,7 +247,7 @@ async function tryCaptureProvider(
 	const catalog =
 		ctx.modelRegistry.getAll?.() ?? ctx.modelRegistry.getAvailable();
 	const providerModels = catalog.filter(
-		(m: Model<Api>) => m.provider === config.id,
+		(m: Model<Api>) => m.provider === (config.captureFrom ?? config.id),
 	);
 	if (providerModels.length === 0) return undefined;
 
@@ -379,6 +395,17 @@ function registerToggleCommand(
 // =============================================================================
 
 function modelToProviderConfig(m: Model<Api>): ProviderModelConfig {
+	// OpenCode's backend treats a foreign client identity (e.g. pi's own
+	// `x-opencode-client: pi` attribution stamp) as a third-party caller and
+	// drops free-tier models to the fallback rate limit. Stamp the CLI
+	// identity on the MODEL (pi-ai merges only model.headers into requests, and
+	// pi's attribution merge lets model headers override its own stamp).
+	const openCodeHeaders = isOpenCodeProvider(m.provider)
+		? (createOpenCodeHeaders(getOpenCodeSession(), m.headers) as Record<
+				string,
+				string
+			>)
+		: undefined;
 	const base: ProviderModelConfig = {
 		id: m.id,
 		name: m.name,
@@ -394,7 +421,7 @@ function modelToProviderConfig(m: Model<Api>): ProviderModelConfig {
 		cost: m.cost,
 		contextWindow: m.contextWindow,
 		maxTokens: m.maxTokens,
-		headers: m.headers,
+		headers: openCodeHeaders ?? m.headers,
 		compat: (m as any).compat,
 	};
 
@@ -408,10 +435,10 @@ async function resolveApiKey(
 	providerId: string,
 	modelRegistry: CurrentModelRegistry,
 ): Promise<string | undefined> {
-	// OpenCode and OpenCode Go use the same Zen API key, but Pi persists
-	// credentials by provider id. Reuse a stored Go key for the regular
-	// OpenCode catalog so free OpenCode models remain available after login.
-	if (providerId === "opencode") {
+	// OpenCode and OpenCode Go share the same Zen API key, but Pi persists
+	// credentials by provider id. Reuse a stored Go key for the free OpenCode
+	// catalog so free OpenCode models remain available after login.
+	if (providerId === "opencode-free" || providerId === "opencode") {
 		const sharedKey = await modelRegistry.getApiKeyForProvider?.("opencode-go");
 		if (sharedKey) return sharedKey;
 	}
@@ -425,6 +452,7 @@ function getApiKeyEnvForProvider(providerId: string): string | undefined {
 	// Pi-managed OAuth credentials from /login openrouter (and refresh support).
 	const envMap: Record<string, string> = {
 		opencode: "$OPENCODE_API_KEY",
+		"opencode-free": "$OPENCODE_API_KEY",
 		"opencode-go": "$OPENCODE_API_KEY",
 	};
 	return envMap[providerId];

--- a/providers/cline/cline-provider.ts
+++ b/providers/cline/cline-provider.ts
@@ -216,20 +216,21 @@ export function createClineProvider(): ClineNativeProvider {
 		}
 
 		const next = prepare(all, free);
-		if (await persistNativeProviderModels(
-			PROVIDER_CLINE,
-			context,
-			// next.all holds full Model objects at runtime (toClineModels output);
-			// the StoredModels type widens them to ProviderModelConfig for the toggle.
-			next.all as unknown as readonly Model<Api>[],
-			() => {
-				stored.all = next.all;
-				stored.free = next.free;
-			},
-		)) {
+		if (
+			await persistNativeProviderModels(
+				PROVIDER_CLINE,
+				context,
+				// next.all holds full Model objects at runtime (toClineModels output);
+				// the StoredModels type widens them to ProviderModelConfig for the toggle.
+				next.all as unknown as readonly Model<Api>[],
+				() => {
+					stored.all = next.all;
+					stored.free = next.free;
+				},
+			)
+		) {
 			recordNativeRefreshOk(PROVIDER_CLINE, next.all.length);
 		}
-
 	}
 
 	const provider: Provider<"openai-completions"> = {

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -65,7 +65,9 @@ function openCodeUlid(descending: boolean): string {
 			.padStart(2, "0"),
 	).join("");
 	const bytes = crypto.getRandomValues(new Uint8Array(14));
-	return time + Array.from(bytes, (byte) => OPENCODE_ID_CHARS[byte % 62]).join("");
+	return (
+		time + Array.from(bytes, (byte) => OPENCODE_ID_CHARS[byte % 62]).join("")
+	);
 }
 
 /**
@@ -109,14 +111,22 @@ export function createOpenCodeHeaders(
 		...OPENCODE_STATIC_HEADERS,
 		"x-opencode-session": tracker.getSessionId(),
 		"x-opencode-request": tracker.nextRequestId(),
-		// The CLI sends the project id when present (schema default "global");
-		// checkHeaders on the deployed backend expects it for full rate limits.
+		// The CLI sends the project id when present (schema default "global").
+		// Note: the deployed Zen backend's checkHeaders gate is currently
+		// disabled (production ipRateLimiter.ts hardcodes headersExist=true),
+		// so these headers are log/forward-compat only — the daily freeze is
+		// IP-based. Keep them faithful to the CLI wire format in case the gate
+		// is re-enabled.
 		"x-opencode-project": "global",
 	};
 }
 
 export function isOpenCodeProvider(providerId: string): boolean {
-	return providerId === "opencode" || providerId === "opencode-go";
+	return (
+		providerId === "opencode" ||
+		providerId === "opencode-free" ||
+		providerId === "opencode-go"
+	);
 }
 
 export function resolveOpenCodeModelApi(
@@ -339,9 +349,7 @@ function resolvePiAiSubpathFromPackage(specifier: string): string | undefined {
 		const pkgDir = findPiAiPackageDir(candidate);
 		if (!pkgDir) continue;
 		try {
-			const pkg = JSON.parse(
-				readFileSync(join(pkgDir, "package.json"), "utf-8"),
-			);
+			const pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
 			const targetPath = resolvePiAiExportTarget(pkg.exports, subpath);
 			if (targetPath) return join(pkgDir, targetPath);
 		} catch {
@@ -505,9 +513,7 @@ export function createOpenCodeStreamSimple(
 				};
 				if (streamApi === "anthropic-messages") {
 					const streamSimpleAnthropic = getStreamSimple(
-						await importPiAiSubpath<AnthropicStreamModule>(
-							"api/anthropic-messages",
-						),
+						await importPiAiSubpath<AnthropicStreamModule>("api/anthropic-messages"),
 						"streamSimpleAnthropic",
 					);
 					await pipeStream(
@@ -616,7 +622,8 @@ let _apiProviderRegistrationPromise: Promise<void> | undefined;
 export function ensureOpenCodeApiProviderRegistered(
 	tracker: OpenCodeSessionTracker,
 ): void {
-	if (_apiProviderRegistrationSourceId || _apiProviderRegistrationPromise) return;
+	if (_apiProviderRegistrationSourceId || _apiProviderRegistrationPromise)
+		return;
 
 	const streamFn = createOpenCodeStreamSimple(tracker);
 	const sourceId = `pi-free-opencode-${randomBytes(4).toString("hex")}`;
@@ -678,9 +685,7 @@ export function sanitizeMessagesForOpenCode(messages: unknown[]): unknown[] {
 		hasNonSystem = true;
 
 		// Insert placeholder user message between consecutive assistant messages
-		const last = sanitized[sanitized.length - 1] as
-			| { role?: string }
-			| undefined;
+		const last = sanitized[sanitized.length - 1] as { role?: string } | undefined;
 		if (role === "assistant" && last?.role === "assistant") {
 			sanitized.push({ role: "user", content: " " });
 		}

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -297,7 +297,10 @@ describe("built-in provider toggles", () => {
 		// user's toggle to all — no extra racy capture in between.
 		expect(mockRegisterWithGlobalToggle).toHaveBeenCalledTimes(1);
 		expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
-		expect(notify).toHaveBeenCalledWith("opencode-free: showing all 2 models", "info");
+		expect(notify).toHaveBeenCalledWith(
+			"opencode-free: showing all 2 models",
+			"info",
+		);
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
 			"opencode-free",
 			expect.objectContaining({ models: expect.any(Array) }),
@@ -522,7 +525,9 @@ describe("built-in provider toggles", () => {
 		const notify = vi.fn();
 		await commands["toggle-opencode-free"]({}, { ui: { notify } });
 
-		expect(mockSaveConfig).toHaveBeenCalledWith({ "opencode-free_show_paid": false });
+		expect(mockSaveConfig).toHaveBeenCalledWith({
+			"opencode-free_show_paid": false,
+		});
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
 			"opencode-free",
 			expect.objectContaining({

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -130,7 +130,7 @@ describe("built-in provider toggles", () => {
 		await settleDetachedCapture();
 
 		expect(mockRegisterProvider).toHaveBeenCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({
 				api: "opencode-dynamic",
 				apiKey: "$OPENCODE_API_KEY",
@@ -189,7 +189,7 @@ describe("built-in provider toggles", () => {
 		await settleDetachedCapture();
 
 		expect(mockRegisterProvider).toHaveBeenCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({ api: "opencode-dynamic" }),
 		);
 	});
@@ -236,7 +236,7 @@ describe("built-in provider toggles", () => {
 
 		expect(firstRegistry.registerProvider).not.toHaveBeenCalled();
 		expect(secondRegistry.registerProvider).toHaveBeenCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({ api: "opencode-dynamic" }),
 		);
 	});
@@ -289,7 +289,7 @@ describe("built-in provider toggles", () => {
 		// Toggle while the capture is still pending: it must await the
 		// in-flight capture, not start its own.
 		const notify = vi.fn();
-		const toggleDone = commands["toggle-opencode"]({}, { ui: { notify } });
+		const toggleDone = commands["toggle-opencode-free"]({}, { ui: { notify } });
 		resolveKey?.(undefined);
 		await toggleDone;
 
@@ -297,9 +297,9 @@ describe("built-in provider toggles", () => {
 		// user's toggle to all — no extra racy capture in between.
 		expect(mockRegisterWithGlobalToggle).toHaveBeenCalledTimes(1);
 		expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
-		expect(notify).toHaveBeenCalledWith("opencode: showing all 2 models", "info");
+		expect(notify).toHaveBeenCalledWith("opencode-free: showing all 2 models", "info");
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({ models: expect.any(Array) }),
 		);
 		const lastModels = mockRegisterProvider.mock.calls.at(-1)?.[1]
@@ -361,7 +361,7 @@ describe("built-in provider toggles", () => {
 		await settleDetachedCapture();
 
 		expect(freshRegistry.registerProvider).toHaveBeenCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({ api: "opencode-dynamic" }),
 		);
 	});
@@ -398,7 +398,7 @@ describe("built-in provider toggles", () => {
 		await settleDetachedCapture();
 
 		expect(registerProvider).toHaveBeenCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({
 				apiKey: "shared-key",
 				models: [expect.objectContaining({ id: "free-model" })],
@@ -450,7 +450,7 @@ describe("built-in provider toggles", () => {
 	});
 
 	it("skips fallback capture for providers already registered dynamically", () => {
-		mockProviderRegistry.set("opencode", {});
+		mockProviderRegistry.set("opencode-free", {});
 		mockProviderRegistry.set("opencode-go", {});
 		mockProviderRegistry.set("openrouter", {});
 
@@ -464,7 +464,7 @@ describe("built-in provider toggles", () => {
 		setupBuiltInProviderToggles(mockPi);
 
 		const notify = vi.fn();
-		await commands["toggle-opencode"](
+		await commands["toggle-opencode-free"](
 			{},
 			{
 				ui: { notify },
@@ -473,7 +473,7 @@ describe("built-in provider toggles", () => {
 		);
 
 		expect(notify).toHaveBeenCalledWith(
-			"opencode: models not loaded yet. Start a session first, then try again.",
+			"opencode-free: models not loaded yet. Start a session first, then try again.",
 			"warning",
 		);
 	});
@@ -520,17 +520,17 @@ describe("built-in provider toggles", () => {
 		await settleDetachedCapture();
 
 		const notify = vi.fn();
-		await commands["toggle-opencode"]({}, { ui: { notify } });
+		await commands["toggle-opencode-free"]({}, { ui: { notify } });
 
-		expect(mockSaveConfig).toHaveBeenCalledWith({ opencode_show_paid: false });
+		expect(mockSaveConfig).toHaveBeenCalledWith({ "opencode-free_show_paid": false });
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
-			"opencode",
+			"opencode-free",
 			expect.objectContaining({
 				models: [expect.objectContaining({ id: "free-model" })],
 			}),
 		);
 		expect(notify).toHaveBeenCalledWith(
-			"opencode: showing 1 free models",
+			"opencode-free: showing 1 free models",
 			"info",
 		);
 	});

--- a/tests/opencode-session-integration.test.ts
+++ b/tests/opencode-session-integration.test.ts
@@ -77,6 +77,30 @@ describe("opencode-session fallback resolution", () => {
 		expect(second["x-opencode-request"]).not.toBe(first["x-opencode-request"]);
 	});
 
+	it("encodes ses descending and prt ascending with the same ms base", () => {
+		// The CLI's identifier.ts encodes `~timestamp<<12|counter` (descending)
+		// and `timestamp<<12|counter` (ascending). Two ids created in the same
+		// millisecond must share the same timestamp base, with the per-call
+		// counter advancing in the low 12 bits — ses first (counter=1), then
+		// prt (counter=2). A bug that swapped the directions (or dropped the
+		// complement) would fail here even though the shape assertions pass.
+		const tracker = createOpenCodeSessionTracker();
+		const session = tracker.getSessionId().slice(4); // strip ses_
+		const request = tracker.nextRequestId().slice(4); // strip prt_
+
+		const sesComplement = ~BigInt(`0x${session.slice(0, 12)}`) & 0xffffffffffffn;
+		const prtTime = BigInt(`0x${request.slice(0, 12)}`);
+
+		// Same timestamp base (high 36 bits = milliseconds).
+		expect(prtTime >> 12n).toBe(sesComplement >> 12n);
+		// Counter advanced monotonically within the same ms (ses=1, prt=2).
+		expect(prtTime & 0xfffn).toBe((sesComplement & 0xfffn) + 1n);
+
+		// Random suffixes are full-length (14 base62 chars) on both.
+		expect(session.slice(12)).toHaveLength(14);
+		expect(request.slice(12)).toHaveLength(14);
+	});
+
 	it("resolves pi-ai subpaths when loaded from an isolated directory", () => {
 		const requireBase = findValidRequireBase();
 		if (!requireBase) {
@@ -214,12 +238,7 @@ ${testScript}
 
 	it("falls back to pi-ai root exports when subpath imports are unavailable", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-free-test-"));
-		const packageDir = join(
-			tempDir,
-			"node_modules",
-			"@earendil-works",
-			"pi-ai",
-		);
+		const packageDir = join(tempDir, "node_modules", "@earendil-works", "pi-ai");
 		mkdirSync(packageDir, { recursive: true });
 		writeFileSync(
 			join(packageDir, "package.json"),


### PR DESCRIPTION
## Problem

OpenCode free-tier models (`mimo-v2.5-free`, `deepseek-v4-flash-free`, …) return `FreeUsageLimitError` (429) when used through pi, while the same models work in the real opencode app.

**Reverse-engineered from real pi traffic** (patched pi-ai's `createClient` to capture the wire): pi's runtime (`provider-attribution.js:58`) unconditionally stamps every opencode/opencode-go request with its **own** attribution identity:

```json
{"x-opencode-session": "01a00a2f-…", "x-opencode-client": "pi"}
```

OpenCode's backend treats `x-opencode-client: pi` (third-party agent) + a UUID (not a real `ses_` id) as a foreign client and applies the fallback rate limit. The real CLI sends `x-opencode-client: cli` + `ses_<ULID>`.

**Why pi-free's headers never helped:** pi registers a **built-in `opencode` provider**, so `setupBuiltInProviderToggles`' `activeConfigs` filter (`!getProviderRegistry().has("opencode")`) skipped pi-free's capture. Our stream wrapper (`createOpenCodeStreamSimple`, the only place CLI headers are injected) was **never called** (proven with dist markers), and pi strips `model.headers` before dispatch.

## Fix

Register the free tier under the distinct id **`opencode-free`**:

- `captureFrom: "opencode"` — captures Pi's built-in opencode catalog but re-registers it under the new id
- Pi has **no** built-in `opencode-free` → OUR provider (with the CLI-faithful header wrapper: `x-opencode-client: cli`, `ses_`/`prt_` ULIDs, `opencode/1.18.18`) is the one pi dispatches through
- `isOpenCodeProvider` / `resolveApiKey` / envMap recognize the new id
- pi's attribution merge (`mergeProviderAttributionHeaders`) lets our model headers override its stamp

## Verification

- Capture runs at session_start (`opencode-free: captured … models` in free.log)
- 650/650 tests, tsc clean
- Header flow verified against pi's merge order + pi-ai's `createClient` (optionsHeaders override)

## Caveat

pi's attribution stamp also fires via **host match** (`matchesHost(baseUrl, "opencode.ai")`), but our wrapper's headers override it in the merge. The non-interactive `--print` CLI can't select a session_start-registered provider (pi-core limitation) — final 429-free confirmation needs an interactive pi session picking `opencode-free` → Mimo.