### PR TITLE
release: 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.1] - 2026-08-16
 
 ### Fixed
+
+- **OpenCode free tier no longer rate-limited by Pi's third-party client identity** — Pi's runtime stamps every opencode/opencode-go request with its own attribution identity (`x-opencode-client: pi` + a UUID session, `provider-attribution.js`), which OpenCode's backend treats as a foreign client and drops to the fallback rate limit (`FreeUsageLimitError`, 429) — while the same models work in the real opencode app. pi-free's fixes never reached the wire because Pi registers a built-in `opencode` provider, so the built-in-toggle capture was skipped, our stream wrapper (the only place CLI-faithful headers are injected) never ran, and Pi strips `model.headers` before dispatch. The free tier is now registered under the distinct id **`opencode-free`** (`captureFrom: "opencode"` captures Pi's built-in catalog but re-registers it under the new id): Pi has no built-in provider with that id, so OUR provider — with the CLI identity (`x-opencode-client: cli`, `ses_`/`prt_` ULIDs, `opencode/1.18.18`) and the header wrapper — is the one Pi dispatches through, and the attribution merge lets our model headers override its stamp. The toggle command is now `/toggle-opencode-free` ([#441](https://github.com/apmantza/pi-free/issues/441)).
 
 - **OpenCode wire headers aligned with the current CLI (v1.18.18)** — reverse-engineered from `packages/opencode/src/session/llm/request.ts`: `User-Agent` bumped `1.15.5 → 1.18.18`, `x-opencode-request` now uses the CLI's `prt_` PartID prefix (was `msg_`), `x-opencode-project` is now sent (was missing), and the session/request ULIDs replicate the CLI's `descending()`/`ascending()` encoding exactly. This keeps pi-free speaking the official CLI wire dialect (forward-compat if the Zen backend's `checkHeaders` gate is re-enabled); note the deployed gate is currently disabled, so today's free-tier freeze is IP-based, not header-based ([#440](https://github.com/apmantza/pi-free/issues/440)).
 

--- a/agents.md
+++ b/agents.md
@@ -20,7 +20,7 @@ A **Pi extension** (`@earendil-works/pi-coding-agent`) that registers free and p
 index.ts                          ← Extension entry point (piFreeEntry)
   ├─ lib/registry.ts              ← Global provider registry + isFreeModel detection
   ├─ lib/toggle-state.ts          ← Generic toggle state machine (free ↔ all)
-  ├─ lib/built-in-toggle.ts       ← Toggles for Pi's built-in providers (opencode, opencode-go, openrouter)
+  ├─ lib/built-in-toggle.ts       ← Toggles for Pi's built-in providers (opencode-free, opencode-go, openrouter)
   ├─ lib/quota-monitor.ts         ← Rate-limit header extraction → status bar
   ├─ lib/startup-timing.ts        ← Startup, cache/network, and session-start timing observability
   ├─ lib/session-start-metrics.ts ← Monotonic handler + detached session-start timing
@@ -184,7 +184,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova | API key | Free allowance with limits |
 | 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
 | 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
-| 🔧 Built-in | opencode, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
+| 🔧 Built-in | opencode-free, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [

--- a/tests/opencode-session-integration.test.ts
+++ b/tests/opencode-session-integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -78,27 +78,41 @@ describe("opencode-session fallback resolution", () => {
 	});
 
 	it("encodes ses descending and prt ascending with the same ms base", () => {
-		// The CLI's identifier.ts encodes `~timestamp<<12|counter` (descending)
-		// and `timestamp<<12|counter` (ascending). Two ids created in the same
-		// millisecond must share the same timestamp base, with the per-call
-		// counter advancing in the low 12 bits — ses first (counter=1), then
-		// prt (counter=2). A bug that swapped the directions (or dropped the
-		// complement) would fail here even though the shape assertions pass.
-		const tracker = createOpenCodeSessionTracker();
-		const session = tracker.getSessionId().slice(4); // strip ses_
-		const request = tracker.nextRequestId().slice(4); // strip prt_
+		// Freeze the clock so both ids land in the same millisecond. Without
+		// this the assertions are timing-sensitive: if Date.now() ticks between
+		// the getSessionId() and nextRequestId() calls, the ULID counter resets
+		// and the ms bases differ by 1 (flaky on loaded CI runners, e.g.
+		// 176323391n vs 176323390n). The implementation mirrors the CLI, which
+		// has the same reset-on-ms-tick behavior — only the test needs a stable
+		// clock.
+		const frozenNow = 1_700_000_000_000;
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(frozenNow);
+		try {
+			// The CLI's identifier.ts encodes `~timestamp<<12|counter` (descending)
+			// and `timestamp<<12|counter` (ascending). Two ids created in the same
+			// millisecond must share the same timestamp base, with the per-call
+			// counter advancing in the low 12 bits — ses first (counter=1), then
+			// prt (counter=2). A bug that swapped the directions (or dropped the
+			// complement) would fail here even though the shape assertions pass.
+			const tracker = createOpenCodeSessionTracker();
+			const session = tracker.getSessionId().slice(4); // strip ses_
+			const request = tracker.nextRequestId().slice(4); // strip prt_
 
-		const sesComplement = ~BigInt(`0x${session.slice(0, 12)}`) & 0xffffffffffffn;
-		const prtTime = BigInt(`0x${request.slice(0, 12)}`);
+			const sesComplement = ~BigInt(`0x${session.slice(0, 12)}`) &
+				0xffffffffffffn;
+			const prtTime = BigInt(`0x${request.slice(0, 12)}`);
 
-		// Same timestamp base (high 36 bits = milliseconds).
-		expect(prtTime >> 12n).toBe(sesComplement >> 12n);
-		// Counter advanced monotonically within the same ms (ses=1, prt=2).
-		expect(prtTime & 0xfffn).toBe((sesComplement & 0xfffn) + 1n);
+			// Same timestamp base (high 36 bits = milliseconds).
+			expect(prtTime >> 12n).toBe(sesComplement >> 12n);
+			// Counter advanced monotonically within the same ms (ses=1, prt=2).
+			expect(prtTime & 0xfffn).toBe((sesComplement & 0xfffn) + 1n);
 
-		// Random suffixes are full-length (14 base62 chars) on both.
-		expect(session.slice(12)).toHaveLength(14);
-		expect(request.slice(12)).toHaveLength(14);
+			// Random suffixes are full-length (14 base62 chars) on both.
+			expect(session.slice(12)).toHaveLength(14);
+			expect(request.slice(12)).toHaveLength(14);
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 
 	it("resolves pi-ai subpaths when loaded from an isolated directory", () => {


### PR DESCRIPTION
## Release 2.5.1

- **Fixed**: OpenCode free tier no longer rate-limited — registered as `opencode-free` so our CLI-faithful header wrapper runs (Pi's `x-opencode-client: pi` stamp was triggering `FreeUsageLimitError`) ([#441](https://github.com/apmantza/pi-free/issues/441))
- Changelog moved from Unreleased, version bumped
- agents.md updated for the rename