### PR TITLE
fix: refresh OpenCode free catalog after startup

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,7 +39,7 @@ Run `/toggle-{provider}` to switch between a provider's free/basic view and its 
 | `/toggle-openmodel` | OpenModel | Native |
 | `/toggle-qoder` | Qoder | Legacy |
 | `/toggle-openrouter` | OpenRouter | Pi built-in |
-| `/toggle-opencode` | OpenCode | Pi built-in |
+| `/toggle-opencode-free` | OpenCode Zen free wrapper | Pi built-in catalog + detached Zen refresh |
 | `/toggle-opencode-go` | OpenCode Go | Pi built-in |
 | `/toggle-fastrouter` | FastRouter | Native |
 
@@ -60,7 +60,7 @@ Qoder PAT authentication can also use `QODER_PERSONAL_ACCESS_TOKEN` or its `QODE
 ## Ollama Cloud Refresh
 
 | Command | Description |
-|---|---|
+| --- | --- |
 | `/ollama-cloud-refresh` | Re-fetch Ollama Cloud's catalog and update the provider live. Requires `OLLAMA_API_KEY`. |
 
 Ollama Cloud is a native provider, but this compatibility command and `/api/show` capability reuse continue to use `~/.pi/provider-cache.json`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,7 +22,7 @@ Most pi-free providers now use Pi's native `registerProvider(provider)` surface.
 - retain the previous catalog after an empty or failed refresh; and
 - keep their complete catalog in memory while Pi applies the current free/all filter.
 
-FastRouter and Qoder now use the native provider lifecycle alongside the other migrated providers. Pi owns the OpenCode, OpenCode Go, and OpenRouter built-in catalogs. See [configuration](configuration.md#model-stores-and-caches) for cache locations, including Ollama Cloud's intentional compatibility-cache exception.
+FastRouter and Qoder now use the native provider lifecycle alongside the other migrated providers. Pi owns the OpenCode, OpenCode Go, and OpenRouter built-in catalogs. The `opencode-free` wrapper captures Pi's built-in metadata, then performs one detached `GET /zen/v1/models` refresh after session start so new or retired Zen models are reflected without delaying Pi startup. See [configuration](configuration.md#model-stores-and-caches) for cache locations, including Ollama Cloud's intentional compatibility-cache exception.
 
 ## Coding Index (CI) scores
 

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -11,7 +11,11 @@
  * Usage: /toggle-opencode
  */
 
-import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import type {
+	Api,
+	Model,
+	RefreshModelsContext,
+} from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
 	ProviderModelConfig,
@@ -30,12 +34,15 @@ import {
 import { createToggleState } from "./toggle-state.ts";
 import {
 	OPENCODE_DYNAMIC_API,
+	applyOpenCodeProtocolDefaults,
 	createOpenCodeHeaders,
 	createOpenCodeSessionTracker,
 	createOpenCodeStreamSimple,
+	fetchOpenCodeModelIds,
 	getOpenCodeModelBaseUrl,
 	ensureOpenCodeApiProviderRegistered,
 	isOpenCodeProvider,
+	resolveOpenCodeModelApi,
 } from "../providers/opencode-session.ts";
 
 const _logger = createLogger("built-in-toggle");
@@ -66,6 +73,8 @@ interface BuiltInToggleConfig {
 	getShowPaid: () => boolean;
 	baseUrl: string;
 	api: Api;
+	/** Fetch the public catalog after the initial built-in capture. */
+	refreshEndpoint?: boolean;
 }
 
 const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
@@ -82,6 +91,7 @@ const BUILT_IN_TOGGLE_PROVIDERS: BuiltInToggleConfig[] = [
 		getShowPaid: getOpencodeShowPaid,
 		baseUrl: "https://opencode.ai/zen/v1",
 		api: OPENCODE_DYNAMIC_API,
+		refreshEndpoint: true,
 	},
 	{
 		id: "opencode-go",
@@ -113,6 +123,7 @@ interface BuiltInProviderState {
 	stored: { free: ProviderModelConfig[]; all: ProviderModelConfig[] };
 	reRegister: (models: ProviderModelConfig[]) => void;
 	setModelRegistry: (registry: CurrentModelRegistry) => void;
+	updateModels: (allModels: ProviderModelConfig[]) => void;
 	toggleState: ReturnType<typeof createToggleState<ProviderModelConfig>>;
 }
 
@@ -150,6 +161,8 @@ interface PendingCapture {
  * race two captures (and two re-registrations) for the same provider.
  */
 const pendingCaptures = new Map<string, PendingCapture>();
+/** One detached endpoint refresh per provider; duplicate session events reuse it. */
+const pendingEndpointRefreshes = new Map<string, Promise<void>>();
 let commandsRegisteredFor: ExtensionAPI | undefined;
 let sessionStartRegisteredFor: ExtensionAPI | undefined;
 
@@ -198,6 +211,7 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 					existing.setModelRegistry(ctx.modelRegistry);
 					existing.toggleState.applyCurrent(existing.reRegister);
 					await maybeRestoreSavedModel(pi, config, snapshotFromCtx(ctx));
+					scheduleEndpointRefresh(config, existing);
 					continue;
 				}
 
@@ -231,6 +245,7 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 							`[built-in-toggle] ${config.id}: applied ${applied.mode} mode with ${applied.models.length} models`,
 						);
 						await maybeRestoreSavedModel(pi, config, entry.snapshot);
+						scheduleEndpointRefresh(config, state);
 					} finally {
 						pendingCaptures.delete(config.id);
 					}
@@ -291,8 +306,7 @@ async function maybeRestoreSavedModel(
 			return;
 		}
 		const catalog =
-			snapshot.modelRegistry.getAll?.() ??
-			snapshot.modelRegistry.getAvailable();
+			snapshot.modelRegistry.getAll?.() ?? snapshot.modelRegistry.getAvailable();
 		const model = catalog.find(
 			(m: Model<Api>) => m.provider === config.id && m.id === saved.modelId,
 		);
@@ -357,9 +371,28 @@ function createProviderState(
 ): BuiltInProviderState {
 	const { allModels, baseUrl, api, apiKey, source } = options;
 	let currentModelRegistry = options.modelRegistry;
+	let stateForRefresh: BuiltInProviderState | undefined;
 	const freeModels = allModels.filter((m: ProviderModelConfig) =>
 		isFreeModel({ ...m, provider: config.id }, allModels),
 	);
+
+	const refreshModels = config.refreshEndpoint
+		? async (context: RefreshModelsContext): Promise<ProviderModelConfig[]> => {
+				if (!context.allowNetwork) {
+					return stateForRefresh?.toggleState.getCurrentModels() ?? allModels;
+				}
+				const refreshed = await fetchRefreshedOpenCodeModels(
+					config,
+					stateForRefresh?.stored.all ?? allModels,
+					context.signal,
+				);
+				if (context.signal.aborted || !stateForRefresh) {
+					return stateForRefresh?.toggleState.getCurrentModels() ?? refreshed;
+				}
+				stateForRefresh.updateModels(refreshed);
+				return stateForRefresh.toggleState.getCurrentModels();
+			}
+		: undefined;
 
 	const reRegister = (models: ProviderModelConfig[]) => {
 		// Ensure the opencode-dynamic API is registered in compat's global
@@ -376,6 +409,9 @@ function createProviderState(
 				: {}),
 			models,
 		};
+		if (refreshModels) {
+			Object.assign(providerConfig, { refreshModels });
+		}
 
 		// Event/command contexts expose the current session registry. Using it
 		// avoids calling the stale ExtensionAPI captured before a session switch.
@@ -399,15 +435,32 @@ function createProviderState(
 		initialModels: stored,
 	});
 
+	const updateModels = (nextAllModels: ProviderModelConfig[]): void => {
+		const nextStored = {
+			free: nextAllModels.filter((m: ProviderModelConfig) =>
+				isFreeModel({ ...m, provider: config.id }, nextAllModels),
+			),
+			all: nextAllModels,
+		};
+		toggleState.setModels(nextStored);
+		// Keep the object handed to registerWithGlobalToggle stable. The global
+		// filter retains that reference for the lifetime of the runner.
+		const current = toggleState.getStored();
+		stored.free = current.free;
+		stored.all = current.all;
+	};
+
 	const state: BuiltInProviderState = {
 		stored,
 		reRegister,
 		setModelRegistry: (registry) => {
 			currentModelRegistry = registry;
 		},
+		updateModels,
 		toggleState,
 	};
 	providerStates.set(config.id, state);
+	stateForRefresh = state;
 
 	registerWithGlobalToggle(config.id, stored, reRegister, true);
 
@@ -416,6 +469,95 @@ function createProviderState(
 	);
 
 	return state;
+}
+
+function createDiscoveredOpenCodeModel(
+	id: string,
+	config: BuiltInToggleConfig,
+): ProviderModelConfig {
+	const api = resolveOpenCodeModelApi(id, config.id);
+	const free = id.toLowerCase().includes("free");
+	return {
+		id,
+		name: id,
+		api,
+		baseUrl: getOpenCodeModelBaseUrl(api, config.baseUrl),
+		reasoning: true,
+		input: ["text"],
+		cost: {
+			input: free ? 0 : 1,
+			output: free ? 0 : 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: 200_000,
+		maxTokens: 32_000,
+		headers: createOpenCodeHeaders(getOpenCodeSession()) as Record<
+			string,
+			string
+		>,
+	};
+}
+
+async function fetchRefreshedOpenCodeModels(
+	config: BuiltInToggleConfig,
+	fallbackModels: ProviderModelConfig[],
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
+	const ids = await fetchOpenCodeModelIds(config.baseUrl, signal);
+	const knownById = new Map(fallbackModels.map((model) => [model.id, model]));
+	return applyOpenCodeProtocolDefaults(
+		ids.map(
+			(id) => knownById.get(id) ?? createDiscoveredOpenCodeModel(id, config),
+		),
+		config.id,
+		config.baseUrl,
+	);
+}
+
+/**
+ * Refresh only after the initial capture has registered. Pi's built-in
+ * OpenCode provider is a static catalog, so ModelRegistry.refresh() cannot
+ * discover the public Zen endpoint for our renamed `opencode-free` provider.
+ * Keeping this request detached preserves the fast session_start path.
+ */
+function scheduleEndpointRefresh(
+	config: BuiltInToggleConfig,
+	state: BuiltInProviderState,
+): void {
+	if (!config.refreshEndpoint || pendingEndpointRefreshes.has(config.id)) return;
+
+	let task: Promise<void> | undefined;
+	task = (async () => {
+		try {
+			const refreshed = await fetchRefreshedOpenCodeModels(
+				config,
+				state.stored.all,
+			);
+			state.updateModels(refreshed);
+			const applied = state.toggleState.applyCurrent(state.reRegister);
+			_logger.info(
+				`[built-in-toggle] ${config.id}: endpoint refresh ${applied.models.length}/${refreshed.length} ${applied.mode} models`,
+			);
+		} catch (error) {
+			_logger.warn(`[built-in-toggle] ${config.id}: endpoint refresh failed`, {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
+		} finally {
+			if (pendingEndpointRefreshes.get(config.id) === task) {
+				pendingEndpointRefreshes.delete(config.id);
+			}
+		}
+	})();
+
+	pendingEndpointRefreshes.set(config.id, task);
+	trackDetachedSessionStart(
+		`built-in-toggle-refresh-${config.id}`,
+		task,
+		// The task already logs a credential-free, status-only failure.
+		() => {},
+	);
 }
 
 // =============================================================================

--- a/providers/opencode-session.ts
+++ b/providers/opencode-session.ts
@@ -17,6 +17,7 @@ import type {
 	ProviderConfig,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_FETCH_TIMEOUT_MS } from "../constants.ts";
 
 export const OPENCODE_DYNAMIC_API = "opencode-dynamic" as const;
 
@@ -24,6 +25,59 @@ export const OPENCODE_STATIC_HEADERS = {
 	"User-Agent": "opencode/1.18.18",
 	"x-opencode-client": "cli",
 } as const;
+
+/**
+ * Fetch the public OpenCode Zen catalog. The endpoint intentionally returns
+ * only model ids, so callers merge those ids with Pi's richer built-in model
+ * metadata. Keep this as a small, one-shot request: it runs after session
+ * start and must never become part of extension initialization.
+ */
+export async function fetchOpenCodeModelIds(
+	baseUrl: string,
+	signal?: AbortSignal,
+): Promise<string[]> {
+	const timeoutSignal = AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS);
+	const requestSignal = signal
+		? AbortSignal.any([signal, timeoutSignal])
+		: timeoutSignal;
+	const response = await fetch(`${baseUrl.replace(/\/+$/u, "")}/models`, {
+		headers: {
+			...OPENCODE_STATIC_HEADERS,
+			Accept: "application/json",
+		},
+		signal: requestSignal,
+	});
+	if (!response.ok) {
+		throw new Error(`OpenCode model catalog returned HTTP ${response.status}`);
+	}
+
+	const payload: unknown = await response.json();
+	if (!payload || typeof payload !== "object") {
+		throw new Error("OpenCode model catalog returned an invalid response");
+	}
+	const data = (payload as { data?: unknown }).data;
+	if (!Array.isArray(data)) {
+		throw new Error("OpenCode model catalog returned no model list");
+	}
+
+	const ids = [
+		...new Set(
+			data
+				.filter(
+					(item): item is { id: string } =>
+						!!item &&
+						typeof item === "object" &&
+						typeof (item as { id?: unknown }).id === "string" &&
+						(item as { id: string }).id.length > 0,
+				)
+				.map((item) => item.id),
+		),
+	];
+	if (ids.length === 0) {
+		throw new Error("OpenCode model catalog returned an empty model list");
+	}
+	return ids;
+}
 
 /**
  * OpenCode-native identifier generation.
@@ -596,6 +650,8 @@ export function createOpenCodeStreamSimple(
 			}
 		})();
 
+		// SAFETY: the deferred wrapper implements the async-iterable and result()
+		// surface expected by Pi's AssistantMessageEventStream.
 		return stream as unknown as AssistantMessageEventStream;
 	};
 }

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetGlobalFreeOnly = vi.fn();
 const mockGetOpencodeShowPaid = vi.fn();
@@ -63,9 +63,19 @@ describe("built-in provider toggles", () => {
 	let mockRegisterProvider: ReturnType<typeof vi.fn>;
 	let setupBuiltInProviderToggles: typeof import("../lib/built-in-toggle.ts")["setupBuiltInProviderToggles"];
 
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	beforeEach(async () => {
 		vi.clearAllMocks();
 		vi.resetModules();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("network disabled in built-in-toggle tests");
+			}),
+		);
 		handlers = {};
 		commands = {};
 		mockRegisterProvider = vi.fn();
@@ -136,6 +146,7 @@ describe("built-in provider toggles", () => {
 				api: "opencode-dynamic",
 				apiKey: "$OPENCODE_API_KEY",
 				streamSimple: expect.any(Function),
+				refreshModels: expect.any(Function),
 				models: expect.arrayContaining([
 					expect.objectContaining({
 						id: "free-model",
@@ -193,6 +204,62 @@ describe("built-in provider toggles", () => {
 			"opencode-free",
 			expect.objectContaining({ api: "opencode-dynamic" }),
 		);
+	});
+
+	it("refreshes opencode-free from Zen after session_start without blocking it", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		let resolveFetch: ((response: Response) => void) | undefined;
+		const fetchGate = new Promise<Response>((resolve) => {
+			resolveFetch = resolve;
+		});
+		const fetchMock = vi.fn(() => fetchGate);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const models = [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+
+		await handlers.session_start(
+			{},
+			{ modelRegistry: { getAvailable: () => models } },
+		);
+		// The endpoint is deliberately unresolved, but session_start has already
+		// returned and the initial capture can still register its baseline.
+		await settleDetachedCapture();
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://opencode.ai/zen/v1/models",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+		expect(mockRegisterProvider).toHaveBeenCalledTimes(1);
+
+		resolveFetch?.(
+			new Response(
+				JSON.stringify({
+					data: [{ id: "free-model" }, { id: "new-free-model" }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+		await settleDetachedCapture();
+
+		const lastModels = mockRegisterProvider.mock.calls.at(-1)?.[1]
+			.models as Array<{ id: string }>;
+		expect(lastModels.map((model) => model.id)).toEqual([
+			"free-model",
+			"new-free-model",
+		]);
 	});
 
 	it("registers into the latest registry when session_start fires again mid-capture", async () => {


### PR DESCRIPTION
## Summary

- refresh `opencode-free` from the public OpenCode Zen `/v1/models` endpoint after session start
- keep the request detached so Pi startup remains non-blocking
- preserve Pi metadata for known models and add safe defaults for newly discovered IDs
- expose the refresh through the provider refresh hook while keeping offline refresh network-free
- restore saved built-in-toggle models after late registration

## Validation

- `npm run test:run`
- `npm run lint`
- `npm run check:runtime-imports`
- `npm run build`