### PR TITLE
feat: add Requesty native provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Requesty provider** — new native OpenAI-compatible gateway (router.requesty.ai/v1) with a public ~670-model catalog fetched without a credential. Requesty exposes per-model pricing inline in `/models`, so the standard cost-based free detection applies: 11 free models (NVIDIA Nemotron 3 family, Poolside Laguna, Gemma 4, Leanstral, Ling) are shown by default and `/toggle-requesty` reveals the paid catalog. Capability flags (`supports_reasoning`, `supports_vision`, `context_window`, `max_output_tokens`) map straight onto model metadata; non-chat endpoints and NVIDIA content-safety classifiers are filtered out. Chat requires `REQUESTY_API_KEY` (or `requesty_api_key` in `~/.pi/free.json`).
 - **OpenRouter's built-in catalog now refreshes from the live endpoint** — Pi ships a static OpenRouter catalog that only updates with a Pi release, so models added upstream stayed invisible until then. After session start, pi-free now performs one detached fetch of OpenRouter's public `GET /api/v1/models` endpoint and re-registers the captured catalog in place: known model IDs keep Pi's curated metadata, while newer models are synthesized from the endpoint's pricing, context-window, modality, and reasoning data. The refresh is deduplicated per process and never blocks startup; `/toggle-openrouter` free/paid filtering keeps working on the refreshed view.
 
 ### Fixed

--- a/agents.md
+++ b/agents.md
@@ -69,6 +69,7 @@ index.ts                          ← Extension entry point (piFreeEntry)
       ├─ qoder/                   ← Qoder/Cosy OAuth and streaming provider
       ├─ bai/bai.ts               ← BAI gateway provider
       ├─ fastrouter/              ← FastRouter native provider (public catalog + API-key chat)
+      ├─ requesty/requesty.ts     ← Requesty native provider (public catalog + inline pricing)
       └─ stepfun/                 ← StepFun Step Plan native provider (OpenAI-compatible chat)
 
 tests/                            ← Vitest test suite
@@ -182,9 +183,9 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | Category | Providers | Auth | Notes |
 | ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
 | ✅ Free / free-tier | kilo, cline, llm7, openmodel, tokenrouter, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
-| 🔄 Freemium | anyapi, ollama-cloud, sambanova | API key | Free allowance with limits |
+| 🔄 Freemium | anyapi, ollama-cloud, sambanova, requesty | API key | Free allowance with limits |
 | 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
-| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
+| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, OpenModel, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, Requesty, StepFun, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
 | 🔧 Built-in | opencode-free, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---

--- a/config.ts
+++ b/config.ts
@@ -23,6 +23,7 @@ import {
 	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_FASTROUTER,
+	PROVIDER_REQUESTY,
 	PROVIDER_STEPFUN,
 	PROVIDER_KILO,
 	PROVIDER_OLLAMA,
@@ -47,6 +48,7 @@ export {
 	PROVIDER_BAI,
 	PROVIDER_CLINE,
 	PROVIDER_FASTROUTER,
+	PROVIDER_REQUESTY,
 	PROVIDER_STEPFUN,
 	PROVIDER_KILO,
 	PROVIDER_OPENCODE,
@@ -98,6 +100,7 @@ interface PiFreeConfig {
 	routeway_api_key?: string;
 	opengateway_api_key?: string;
 	fastrouter_api_key?: string;
+	requesty_api_key?: string;
 	stepfun_api_key?: string;
 	tokenrouter_api_key?: string;
 	anyapi_api_key?: string;
@@ -120,6 +123,7 @@ interface PiFreeConfig {
 	routeway_show_paid?: boolean;
 	opengateway_show_paid?: boolean;
 	fastrouter_show_paid?: boolean;
+	requesty_show_paid?: boolean;
 	stepfun_show_paid?: boolean;
 	tokenrouter_show_paid?: boolean;
 	anyapi_show_paid?: boolean;
@@ -144,6 +148,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_api_key: "",
 	opengateway_api_key: "",
 	fastrouter_api_key: "",
+	requesty_api_key: "",
 	stepfun_api_key: "",
 	tokenrouter_api_key: "",
 	anyapi_api_key: "",
@@ -167,6 +172,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	routeway_show_paid: false,
 	opengateway_show_paid: false,
 	fastrouter_show_paid: false,
+	requesty_show_paid: false,
 	stepfun_show_paid: true,
 	tokenrouter_show_paid: false,
 	anyapi_show_paid: false,
@@ -429,6 +435,11 @@ const PROVIDER_META: readonly ProviderMeta[] = [
 		showPaidKey: "fastrouter_show_paid",
 	},
 	{
+		id: PROVIDER_REQUESTY,
+		prefix: "REQUESTY",
+		showPaidKey: "requesty_show_paid",
+	},
+	{
 		id: PROVIDER_STEPFUN,
 		prefix: "STEPFUN",
 		showPaidKey: "stepfun_show_paid",
@@ -559,6 +570,13 @@ export function getFastrouterShowPaid(): boolean {
 	);
 }
 
+export function getRequestyShowPaid(): boolean {
+	return resolveBool(
+		"REQUESTY_SHOW_PAID",
+		loadConfigFile().requesty_show_paid,
+	);
+}
+
 export function getStepfunShowPaid(): boolean {
 	return resolveBool(
 		"STEPFUN_SHOW_PAID",
@@ -653,6 +671,10 @@ export function getOpengatewayApiKey(): string | undefined {
 
 export function getFastrouterApiKey(): string | undefined {
 	return resolve("FASTROUTER_API_KEY", loadConfigFile().fastrouter_api_key);
+}
+
+export function getRequestyApiKey(): string | undefined {
+	return resolve("REQUESTY_API_KEY", loadConfigFile().requesty_api_key);
 }
 
 export function getStepfunApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -24,6 +24,7 @@ export const PROVIDER_BAI = "bai";
 export const PROVIDER_OPENMODEL = "openmodel";
 export const PROVIDER_QODER = "qoder";
 export const PROVIDER_FASTROUTER = "fastrouter";
+export const PROVIDER_REQUESTY = "requesty";
 export const PROVIDER_STEPFUN = "stepfun";
 
 // Built-in pi providers that pi-free wraps with toggles
@@ -63,6 +64,7 @@ export const BASE_URL_TOKENROUTER = "https://api.tokenrouter.com/v1";
 export const BASE_URL_ANYAPI = "https://api.anyapi.ai/v1";
 export const BASE_URL_BAI = "https://api.b.ai/v1";
 export const BASE_URL_FASTROUTER = "https://api.fastrouter.ai/api/v1";
+export const BASE_URL_REQUESTY = "https://router.requesty.ai/v1";
 /** StepFun Step Plan OpenAI-compatible Chat Completions API base URL. */
 export const BASE_URL_STEPFUN = "https://api.stepfun.ai/step_plan/v1";
 /**

--- a/index.ts
+++ b/index.ts
@@ -53,6 +53,7 @@ import kilo from "./providers/kilo/kilo.ts";
 import llm7 from "./providers/llm7/llm7.ts";
 import deepinfra from "./providers/deepinfra/deepinfra.ts";
 import fastrouter from "./providers/fastrouter/fastrouter.ts";
+import requesty from "./providers/requesty/requesty.ts";
 import stepfun from "./providers/stepfun/stepfun.ts";
 import sambanova from "./providers/sambanova/sambanova.ts";
 import novita from "./providers/novita/novita.ts";
@@ -85,6 +86,7 @@ const UNIQUE_PROVIDERS: ReadonlyArray<(pi: ExtensionAPI) => Promise<void>> = [
 	sambanova,
 	novita,
 	fastrouter,
+	requesty,
 	stepfun,
 	routeway,
 	opengateway,

--- a/providers/requesty/requesty-auth.ts
+++ b/providers/requesty/requesty-auth.ts
@@ -1,0 +1,48 @@
+/**
+ * Requesty native authentication.
+ *
+ * Requesty's model catalog (router.requesty.ai/v1/models) is public, so
+ * native auth resolves even when no key is configured. Chat requests use the
+ * configured key; the gateway rejects unauthenticated completions.
+ */
+
+import type {
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	ProviderAuth,
+} from "@earendil-works/pi-ai/compat";
+import { getRequestyApiKey } from "../../config.ts";
+
+async function resolveRequestyApiKey(input: {
+	ctx: AuthContext;
+	credential?: ApiKeyCredential;
+	signal?: AbortSignal;
+}): Promise<AuthResult | undefined> {
+	const key = input.credential?.key ?? getRequestyApiKey();
+	if (!key) {
+		return { auth: {}, source: "public catalog (no account)" };
+	}
+	return {
+		auth: { apiKey: key },
+		source: input.credential?.key ? "stored API key" : "REQUESTY_API_KEY",
+	};
+}
+
+export const requestyApiKeyAuth: ApiKeyAuth = {
+	name: "Requesty API key",
+	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+		const key = await interaction.prompt({
+			type: "secret",
+			message: "Requesty API key",
+		});
+		return { type: "api_key", key };
+	},
+	resolve: resolveRequestyApiKey,
+};
+
+export const requestyAuth: ProviderAuth = {
+	apiKey: requestyApiKeyAuth,
+};

--- a/providers/requesty/requesty-models.ts
+++ b/providers/requesty/requesty-models.ts
@@ -1,0 +1,119 @@
+/**
+ * Requesty's public model catalog (router.requesty.ai/v1/models).
+ *
+ * The schema is Requesty-specific — flat `input_price`/`output_price` numbers,
+ * a `context_window` field, and `supports_*` capability flags — so it is
+ * mapped here instead of through the shared OpenRouter-compatible fetcher.
+ * Pricing is exposed inline for every model, which feeds pi-free's
+ * cost-based free-model detection (Route A) without any curated list.
+ */
+
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import { BASE_URL_REQUESTY, DEFAULT_FETCH_TIMEOUT_MS, PROVIDER_REQUESTY } from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+
+const _logger = createLogger("requesty-models");
+
+interface RequestyCatalogModel {
+	id?: unknown;
+	api?: unknown;
+	input_price?: unknown;
+	output_price?: unknown;
+	cached_price?: unknown;
+	caching_price?: unknown;
+	context_window?: unknown;
+	max_output_tokens?: unknown;
+	supports_reasoning?: unknown;
+	supports_tool_calling?: unknown;
+	supports_vision?: unknown;
+	description?: unknown;
+}
+
+/** Fallback context window for entries that omit `context_window`. */
+const FALLBACK_CONTEXT_WINDOW = 128_000;
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Map one catalog entry to the pi-free model config shape. Returns undefined
+ * for non-chat endpoints and unusable entries rather than guessing.
+ */
+export function mapRequestyModel(
+	entry: RequestyCatalogModel,
+): ProviderModelConfig | undefined {
+	if (typeof entry.id !== "string" || entry.id.length === 0) return undefined;
+	// The /models endpoint also serves image-generation and other api types;
+	// only chat completions are usable as an agent model.
+	if (entry.api !== "chat") return undefined;
+	// NVIDIA NIM guard classifiers are served through the chat surface but
+	// cannot hold a conversation.
+	if (entry.id.includes("content-safety")) return undefined;
+
+	const inputPrice = asNumber(entry.input_price);
+	const outputPrice = asNumber(entry.output_price);
+
+	return {
+		id: entry.id,
+		name: entry.id,
+		reasoning: entry.supports_reasoning === true,
+		input: entry.supports_vision === true ? ["text", "image"] : ["text"],
+		cost: {
+			input: inputPrice ?? 0,
+			output: outputPrice ?? 0,
+			cacheRead: asNumber(entry.cached_price) ?? 0,
+			cacheWrite: asNumber(entry.caching_price) ?? 0,
+		},
+		contextWindow:
+			asNumber(entry.context_window) ?? FALLBACK_CONTEXT_WINDOW,
+		maxTokens: asNumber(entry.max_output_tokens) || 4_096,
+	};
+}
+
+/**
+ * Fetch the complete public catalog. The key is optional for /models; it is
+ * only passed when configured so public discovery works for logged-out users.
+ */
+export async function fetchRequestyModels(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
+	const headers: Record<string, string> = {
+		Accept: "application/json",
+	};
+	if (apiKey) {
+		headers.Authorization = `Bearer ${apiKey}`;
+	}
+	const response = await fetchWithRetry(
+		`${BASE_URL_REQUESTY}/models`,
+		{
+			headers,
+			signal,
+		},
+		1,
+		1_000,
+		DEFAULT_FETCH_TIMEOUT_MS,
+	);
+	if (!response.ok) {
+		throw new Error(`Requesty catalog returned HTTP ${response.status}`);
+	}
+	const payload: unknown = await response.json();
+	const entries =
+		payload &&
+		typeof payload === "object" &&
+		Array.isArray((payload as { data?: unknown }).data)
+			? ((payload as { data: unknown[] }).data as RequestyCatalogModel[])
+			: [];
+	const models: ProviderModelConfig[] = [];
+	for (const entry of entries) {
+		const mapped = mapRequestyModel(entry);
+		if (mapped) models.push(mapped);
+	}
+	if (models.length === 0) {
+		_logger.warn("Requesty catalog returned no usable chat models");
+	}
+	return applyHidden(models, PROVIDER_REQUESTY);
+}

--- a/providers/requesty/requesty.ts
+++ b/providers/requesty/requesty.ts
@@ -1,0 +1,32 @@
+/**
+ * Requesty native provider.
+ *
+ * The factory is synchronous and network-free. Pi restores the catalog from
+ * its native models store, then nudges the normal asynchronous refresh at
+ * session start. Requesty's public /models endpoint is fetched without a
+ * credential; chat requests use REQUESTY_API_KEY when configured. Pricing is
+ * inline in the catalog, so the standard cost-based free-model detection
+ * applies and `/toggle-requesty` switches between the 12-model free view and
+ * the full ~670-model catalog.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getRequestyApiKey, getRequestyShowPaid } from "../../config.ts";
+import { BASE_URL_REQUESTY, PROVIDER_REQUESTY } from "../../constants.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
+import { requestyAuth } from "./requesty-auth.ts";
+import { fetchRequestyModels } from "./requesty-models.ts";
+
+export default function requestyProvider(pi: ExtensionAPI): Promise<void> {
+	registerNativeOpenAIProvider(pi, {
+		providerId: PROVIDER_REQUESTY,
+		name: "Requesty",
+		baseUrl: BASE_URL_REQUESTY,
+		auth: requestyAuth,
+		getApiKey: getRequestyApiKey,
+		getShowPaid: getRequestyShowPaid,
+		allowUnauthenticated: true,
+		fetchModels: (apiKey, signal) => fetchRequestyModels(apiKey, signal),
+	});
+	return Promise.resolve();
+}

--- a/tests/requesty-provider.test.ts
+++ b/tests/requesty-provider.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Requesty provider tests.
+ *
+ * Covers the catalog mapper (schema-specific flat pricing, capability flags,
+ * non-chat filtering) and the public-catalog fetch path with an optional key.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { mapRequestyModel } from "../providers/requesty/requesty-models.ts";
+
+function catalogEntry(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "nvidia/nemotron-3-super-120b-a12b",
+		api: "chat",
+		input_price: 0,
+		output_price: 0,
+		cached_price: 0,
+		caching_price: 0,
+		context_window: 131072,
+		max_output_tokens: 65536,
+		supports_reasoning: true,
+		supports_tool_calling: true,
+		supports_vision: false,
+		...overrides,
+	};
+}
+
+describe("mapRequestyModel", () => {
+	it("maps a free chat model with inline zero pricing", () => {
+		const model = mapRequestyModel(catalogEntry());
+		expect(model).toBeDefined();
+		expect(model?.id).toBe("nvidia/nemotron-3-super-120b-a12b");
+		expect(model?.cost.input).toBe(0);
+		expect(model?.cost.output).toBe(0);
+		expect(model?.reasoning).toBe(true);
+		expect(model?.contextWindow).toBe(131072);
+		expect(model?.maxTokens).toBe(65536);
+	});
+
+	it("maps paid pricing and vision support", () => {
+		const model = mapRequestyModel(
+			catalogEntry({
+				id: "google/gemini-3.1-flash-image",
+				input_price: 4.5e-7,
+				output_price: 1.8e-6,
+				cached_price: 1e-8,
+				caching_price: 2e-8,
+				supports_vision: true,
+				supports_reasoning: false,
+			}),
+		);
+		expect(model?.cost).toEqual({
+			input: 4.5e-7,
+			output: 1.8e-6,
+			cacheRead: 1e-8,
+			cacheWrite: 2e-8,
+		});
+		expect(model?.input).toEqual(["text", "image"]);
+		expect(model?.reasoning).toBe(false);
+	});
+
+	it("falls back when context_window is missing", () => {
+		const model = mapRequestyModel(
+			catalogEntry({ context_window: undefined }),
+		);
+		expect(model?.contextWindow).toBeGreaterThan(0);
+	});
+
+	it("filters out non-chat api entries", () => {
+		expect(mapRequestyModel(catalogEntry({ api: "image" }))).toBeUndefined();
+	});
+
+	it("filters out NVIDIA content-safety classifiers", () => {
+		expect(
+			mapRequestyModel(
+				catalogEntry({ id: "nvidia/nemotron-3.5-content-safety" }),
+			),
+		).toBeUndefined();
+	});
+
+	it("filters out entries without an id", () => {
+		expect(mapRequestyModel(catalogEntry({ id: undefined }))).toBeUndefined();
+	});
+});
+
+describe("fetchRequestyModels", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("fetches the public catalog without a key and maps chat models", async () => {
+		const { fetchRequestyModels } = await import(
+			"../providers/requesty/requesty-models.ts"
+		);
+		const fetchMock = vi.fn(async () => ({
+			ok: true,
+			json: async () => ({
+				data: [
+					catalogEntry(),
+					catalogEntry({ api: "image", id: "x/image" }),
+					catalogEntry({ id: "nvidia/nemotron-3.5-content-safety" }),
+				],
+			}),
+		}));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const models = await fetchRequestyModels("");
+		expect(models).toHaveLength(1);
+		expect(models[0].id).toBe("nvidia/nemotron-3-super-120b-a12b");
+		const [url, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+		expect(url).toBe("https://router.requesty.ai/v1/models");
+		expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+	});
+
+	it("sends the bearer header when a key is configured", async () => {
+		const { fetchRequestyModels } = await import(
+			"../providers/requesty/requesty-models.ts"
+		);
+		const fetchMock = vi.fn(async () => ({
+			ok: true,
+			json: async () => ({ data: [] }),
+		}));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await fetchRequestyModels("test-key");
+		const [, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+		expect((init.headers as Record<string, string>).Authorization).toBe(
+			"Bearer test-key",
+		);
+	});
+});


### PR DESCRIPTION
## What

New native OpenAI-compatible provider for **Requesty** (`router.requesty.ai/v1`), selected from a models.dev gap analysis (free models + not built-in to Pi).

## Design

- Follows the FastRouter pattern: `registerNativeOpenAIProvider` with **public catalog** (anonymous auth resolves so logged-out users see models) + API-key chat
- Requesty's `/models` schema is its own (flat `input_price`/`output_price`, `context_window`, `supports_*` flags) → custom mapper instead of the shared OpenRouter fetcher
- Inline pricing feeds pi-free's Route A free detection — no curated list: **11 free models** by default (NVIDIA Nemotron-3 family, Poolside Laguna, Gemma 4, Leanstral, Ling), `/toggle-requesty` reveals all ~670
- Filters: non-chat api types and NVIDIA content-safety classifiers dropped; missing `context_window` falls back to 128k
- Capability flags map onto metadata: `supports_reasoning`, `supports_vision`, `max_output_tokens`
- Chat auth: `REQUESTY_API_KEY` env or `requesty_api_key` in `~/.pi/free.json`

## Verification

- Live catalog probe: 667 chat models mapped, 11 detected free via Route A ✅
- 8 new tests (mapper + fetch path); suite: 700 passed / 2 skipped
- Chat-completion smoke test pending maintainer API key

## Docs
AGENTS.md tree + provider tables updated; CHANGELOG entry added.