### PR TITLE
fix: default DeepInfra to the free-only model view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **DeepInfra now defaults to the free-only model view** — it was the only public-catalog freemium provider seeded with `deepinfra_show_paid: true` (a leftover of its original trial-credit posture), so fresh installs saw the full paid catalog while Novita, SambaNova, and every other public-catalog provider defaulted to free models. The template default and the config getter's fallback are now `false`, matching the consistent free-by-default principle; an explicit `/toggle-deepinfra` choice still persists and wins.
+
 ### Added
 
 - **Requesty provider** — new native OpenAI-compatible gateway (router.requesty.ai/v1) with a public ~670-model catalog fetched without a credential. Requesty exposes per-model pricing inline in `/models`, so the standard cost-based free detection applies: 11 free models (NVIDIA Nemotron 3 family, Poolside Laguna, Gemma 4, Leanstral, Ling) are shown by default and `/toggle-requesty` reveals the paid catalog. Capability flags (`supports_reasoning`, `supports_vision`, `context_window`, `max_output_tokens`) map straight onto model metadata; non-chat endpoints and NVIDIA content-safety classifiers are filtered out. Chat requires `REQUESTY_API_KEY` (or `requesty_api_key` in `~/.pi/free.json`).

--- a/config.ts
+++ b/config.ts
@@ -166,7 +166,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	zenmux_show_paid: false,
 	crofai_show_paid: false,
 	llm7_show_paid: false,
-	deepinfra_show_paid: true,
+	deepinfra_show_paid: false,
 	sambanova_show_paid: false,
 	novita_show_paid: false,
 	routeway_show_paid: false,
@@ -510,12 +510,11 @@ export function getLlm7ShowPaid(): boolean {
 }
 
 export function getDeepinfraShowPaid(): boolean {
-	// Default to showing all models (paid view) when unconfigured, matching
-	// the provider's trial-credit posture. `?? true` makes the persisted
-	// free toggle (deepinfra_show_paid: false) still win on restart.
+	// Default to the free-only view like every other public-catalog freemium
+	// provider (Novita has the same trial-credit posture and defaults free).
 	return resolveBool(
 		"DEEPINFRA_SHOW_PAID",
-		loadConfigFile().deepinfra_show_paid ?? true,
+		loadConfigFile().deepinfra_show_paid,
 	);
 }
 


### PR DESCRIPTION
## Context

Audit of public-catalog providers found one inconsistency: **DeepInfra** was seeded `deepinfra_show_paid: true` — a leftover of its original trial-credit posture (documented in #149) — making it the only public-catalog freemium provider that booted to the full paid catalog. Novita, which has the same $-credit posture and public catalog, already defaults to free-only.

## Change

- Config template: `deepinfra_show_paid: false`
- Getter fallback: drop the `?? true` override for unconfigured legacy files
- Explicit `/toggle-deepinfra` choices still persist and win (unchanged)

## Also verified in this audit
- No provider-id or baseUrl collisions between pi's 41 built-in providers and the 19 pi-free registers (`opencode-free` is the deliberate distinct-id shadow of built-in `opencode`, #441)
- All other public-catalog providers (Kilo, Cline, ZenMux, CrofAI, DeepInfra, Novita, Routeway, SambaNova, OpenModel, FastRouter, LLM7, Requesty) default to free-only

700 tests pass.