### PR TITLE
fix: dispatch drive-pi-ai by model.api

### DIFF
--- a/scripts/drive-pi-ai.ts
+++ b/scripts/drive-pi-ai.ts
@@ -230,8 +230,13 @@ async function main(): Promise<number> {
 				],
 			};
 
-	const { lazyOpenAICompletionsApi } = await import("../lib/lazy-compat.ts");
-	const api = lazyOpenAICompletionsApi();
+	const { lazyOpenAICompletionsApi, lazyAnthropicMessagesApi } = await import("../lib/lazy-compat.ts");
+	// Dispatch by the model's wire api — openai-completions for most gateways,
+	// anthropic-messages for Anthropic-compatible ones (e.g. OpenModel).
+	const api =
+		model.api === "anthropic-messages"
+			? lazyAnthropicMessagesApi()
+			: lazyOpenAICompletionsApi();
 
 	const maxEvents = Number(args["max-events"] ?? 4_000) || 4_000;
 	let text = "";


### PR DESCRIPTION
## Bug

The harness always drove `lazyOpenAICompletionsApi()` regardless of `model.api`. For Anthropic-compatible providers (OpenModel, `api: "anthropic-messages"`) that POSTs OpenAI-style `/chat/completions` to a gateway that has no such route — producing a misleading `404 route not found` instead of the provider's real wire behavior.

## Fix

Dispatch by `model.api`: `anthropic-messages` → `lazyAnthropicMessagesApi()`, everything else → `lazyOpenAICompletionsApi()`. Verified live: OpenModel now surfaces its genuine upstream response (`402 insufficient balance` on a paid model id) through the correct Anthropic-messages path.