### PR TITLE
feat: add GMI Cloud and Agnes AI native providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Agnes AI provider** — registered `agnes` as a native OpenAI-compatible provider against the Agnes AI free gateway (`https://apihub.agnes-ai.com/v1`). Pi owns authentication, model-store persistence, refresh scheduling, and request streaming through the native provider lifecycle. The text chat catalog is fetched from `GET /v1/models`; image/video generation models are filtered out so only chat models are published. Agnes is an entirely-free gateway, but its model ids contain no "free" token and the API exposes no pricing, so each published model is stamped with the authoritative free flag (`_freeKnown`/`_isFree`, the same escape hatch used by the anyapi and bai gateways) — the free-only view and `/free-providers` counts are correct without depending on the adaptive Route A/B detector. Set `AGNES_API_KEY` or `agnes_api_key`; toggle with `/toggle-agnes`. The catalog defaults to the free-only view (`agnes_show_paid` defaults to `false`) because every published model is free.
+
+- **GMI Cloud provider** — registered `gmi` as a native OpenAI-compatible provider against the GMI Cloud Inference API (`https://api.gmi-serving.com/v1`). Pi owns authentication, model-store persistence, refresh scheduling, and request streaming through the native provider lifecycle. Chat, vision, tools, and reasoning are served from one OpenAI-compatible Chat Completions endpoint across 200+ open and frontier models; the catalog is fetched from `GET /v1/models`. Set `GMI_API_KEY` or `gmi_api_key`; toggle with `/toggle-gmi`. GMI Cloud is a paid provider with per-token pricing, so its full catalog is shown by default (`gmi_show_paid` defaults to `true`).
+
 ## [2.6.0] - 2026-08-21
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ First run creates `~/.pi/free.json`. Add extension-provider keys there or use th
 
 | Category | Providers |
 | --- | --- |
-| Free/free-tier | Kilo, Cline, LLM7, TokenRouter, Qoder basic tier, and eligible models from other catalogs |
+| Free/free-tier | Kilo, Cline, LLM7, TokenRouter, Agnes AI, Qoder basic tier, and eligible models from other catalogs |
 | Freemium | AnyAPI, Ollama Cloud, SambaNova |
-| Paid/trial | ZenMux, CrofAI, DeepInfra trial, Novita, Routeway, OpenGateway, B.AI, StepFun, and paid catalog entries from other providers |
-| Native lifecycle | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun |
+| Paid/trial | ZenMux, CrofAI, DeepInfra trial, Novita, Routeway, OpenGateway, B.AI, StepFun, GMI Cloud, and paid catalog entries from other providers |
+| Native lifecycle | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, StepFun, GMI Cloud, Agnes AI |
 | Built-in | OpenCode, OpenCode Go, OpenRouter — captured from Pi and refreshed in place after session start (OpenCode Zen catalog + public OpenRouter endpoint), so new models appear without waiting for a Pi release |
 
 Provider availability, authentication, and exact API-key names are maintained in [docs/providers.md](docs/providers.md). pi-free does not publish model counts because provider catalogs change.

--- a/agents.md
+++ b/agents.md
@@ -70,6 +70,7 @@ index.ts                          ← Extension entry point (piFreeEntry)
       ├─ fastrouter/              ← FastRouter native provider (public catalog + API-key chat)
       ├─ requesty/requesty.ts     ← Requesty native provider (public catalog + inline pricing)
       └─ stepfun/                 ← StepFun Step Plan native provider (OpenAI-compatible chat)
+      (gmi/ mirrors this structure for GMI Cloud)
 
 tests/                            ← Vitest test suite
 ```
@@ -103,7 +104,7 @@ For a new OpenAI-compatible native provider, use `registerNativeOpenAIProvider()
 
 ### Native `Provider` providers
 
-Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, FastRouter, StepFun, and Qoder use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
+Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, FastRouter, StepFun, GMI Cloud, Agnes AI, and Qoder use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
 
 ```
 providers/kilo/kilo-provider.ts   ← createKiloProvider(): assembles the Provider
@@ -181,10 +182,10 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 
 | Category | Providers | Auth | Notes |
 | ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
-| ✅ Free / free-tier | kilo, cline, llm7, tokenrouter, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
+| ✅ Free / free-tier | kilo, cline, llm7, tokenrouter, agnes, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova, requesty | API key | Free allowance with limits |
-| 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
-| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, Requesty, StepFun, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
+| 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, gmi, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
+| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, Requesty, StepFun, GMI Cloud, Agnes AI, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
 | 🔧 Built-in | opencode-free, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---
@@ -247,7 +248,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 
 **Authentication notes:**
 
-- **Anonymous public catalogs** — Kilo, ZenMux, CrofAI, DeepInfra, Novita, Routeway, SambaNova, FastRouter, and Cline resolve a truthy keyless auth (`public catalog (no account)`) when no credential is configured, so Pi's model refresh populates their public catalogs with zero setup; chat still requires a real key or OAuth login. StepFun, TokenRouter, AnyAPI, B.AI, and OpenGateway have auth-required catalogs and keep resolving `undefined` without a key ([#421](https://github.com/apmantza/pi-free/issues/421)).
+- **Anonymous public catalogs** — Kilo, ZenMux, CrofAI, DeepInfra, Novita, Routeway, SambaNova, FastRouter, and Cline resolve a truthy keyless auth (`public catalog (no account)`) when no credential is configured, so Pi's model refresh populates their public catalogs with zero setup; chat still requires a real key or OAuth login. StepFun, GMI Cloud, Agnes AI, TokenRouter, AnyAPI, B.AI, and OpenGateway have auth-required catalogs and keep resolving `undefined` without a key ([#421](https://github.com/apmantza/pi-free/issues/421)).
 - **Kilo** and **Cline** support both OAuth (`/login`) and direct API keys. Set `KILO_API_KEY` / `CLINE_API_KEY` (or `kilo_api_key` / `cline_api_key` in `~/.pi/free.json`) to authenticate directly. Both are native providers: their native auth carries both methods, and Pi's resolution order applies — a stored credential (from `/login`) wins, then the ambient API key. Cline's catalog is public and can refresh without a credential.
 - **Qoder** is a native provider with OAuth/PAT authentication, Pi-owned credential/model stores, COSY signing, and its custom stream. Use `/login qoder`, or set `QODER_PERSONAL_ACCESS_TOKEN` / `QODER_PAT` for headless PAT authentication.
 - **OpenCode and OpenCode Go** remain Pi-built-in providers. pi-free only captures Pi's available catalogs for filtering after session start; it performs no startup or on-demand catalog discovery.

--- a/config.ts
+++ b/config.ts
@@ -25,6 +25,8 @@ import {
 	PROVIDER_FASTROUTER,
 	PROVIDER_REQUESTY,
 	PROVIDER_STEPFUN,
+	PROVIDER_GMI,
+	PROVIDER_AGNES,
 	PROVIDER_KILO,
 	PROVIDER_OLLAMA,
 	PROVIDER_OPENCODE,
@@ -49,6 +51,7 @@ export {
 	PROVIDER_FASTROUTER,
 	PROVIDER_REQUESTY,
 	PROVIDER_STEPFUN,
+	PROVIDER_GMI,
 	PROVIDER_KILO,
 	PROVIDER_OPENCODE,
 	PROVIDER_OPENROUTER,
@@ -101,6 +104,8 @@ interface PiFreeConfig {
 	fastrouter_api_key?: string;
 	requesty_api_key?: string;
 	stepfun_api_key?: string;
+	gmi_api_key?: string;
+	agnes_api_key?: string;
 	tokenrouter_api_key?: string;
 	anyapi_api_key?: string;
 	bai_api_key?: string;
@@ -123,6 +128,8 @@ interface PiFreeConfig {
 	fastrouter_show_paid?: boolean;
 	requesty_show_paid?: boolean;
 	stepfun_show_paid?: boolean;
+	gmi_show_paid?: boolean;
+	agnes_show_paid?: boolean;
 	tokenrouter_show_paid?: boolean;
 	anyapi_show_paid?: boolean;
 	bai_show_paid?: boolean;
@@ -147,6 +154,8 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	fastrouter_api_key: "",
 	requesty_api_key: "",
 	stepfun_api_key: "",
+	gmi_api_key: "",
+	agnes_api_key: "",
 	tokenrouter_api_key: "",
 	anyapi_api_key: "",
 	bai_api_key: "",
@@ -170,6 +179,8 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	fastrouter_show_paid: false,
 	requesty_show_paid: false,
 	stepfun_show_paid: true,
+	gmi_show_paid: true,
+	agnes_show_paid: false,
 	tokenrouter_show_paid: false,
 	anyapi_show_paid: false,
 	bai_show_paid: false,
@@ -196,9 +207,7 @@ function ensureConfigFile(): void {
 		if (existsSync(CONFIG_PATH)) {
 			let existing: PiFreeConfig;
 			try {
-				existing = JSON.parse(
-					readFileSync(CONFIG_PATH, "utf8"),
-				) as PiFreeConfig;
+				existing = JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as PiFreeConfig;
 			} catch {
 				// File exists but is corrupt — back it up and write a fresh
 				// template so the extension can start. The original bytes are
@@ -222,11 +231,7 @@ function ensureConfigFile(): void {
 			// Merge with template to add any missing keys, preserving existing values
 			const merged = { ...CONFIG_TEMPLATE, ...existing };
 			if (JSON.stringify(merged) !== JSON.stringify(existing)) {
-				writeFileSync(
-					CONFIG_PATH,
-					`${JSON.stringify(merged, null, 2)}\n`,
-					"utf8",
-				);
+				writeFileSync(CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
 				restrictConfigFilePermissions();
 			}
 		} else {
@@ -434,6 +439,16 @@ const PROVIDER_META: readonly ProviderMeta[] = [
 		prefix: "STEPFUN",
 		showPaidKey: "stepfun_show_paid",
 	},
+	{
+		id: PROVIDER_GMI,
+		prefix: "GMI",
+		showPaidKey: "gmi_show_paid",
+	},
+	{
+		id: PROVIDER_AGNES,
+		prefix: "AGNES",
+		showPaidKey: "agnes_show_paid",
+	},
 	{ id: PROVIDER_OLLAMA, prefix: "OLLAMA", showPaidKey: "ollama_show_paid" },
 	{
 		id: PROVIDER_OPENROUTER,
@@ -469,10 +484,7 @@ function resolveShowPaidForProvider(providerId: string): boolean {
 	if (!meta) return false;
 	const cfg = loadConfigFile();
 	const fileVal = cfg[meta.showPaidKey];
-	return resolveBool(
-		`${meta.prefix}_SHOW_PAID`,
-		fileVal as boolean | undefined,
-	);
+	return resolveBool(`${meta.prefix}_SHOW_PAID`, fileVal as boolean | undefined);
 }
 
 // =============================================================================
@@ -553,10 +565,7 @@ export function getFastrouterShowPaid(): boolean {
 }
 
 export function getRequestyShowPaid(): boolean {
-	return resolveBool(
-		"REQUESTY_SHOW_PAID",
-		loadConfigFile().requesty_show_paid,
-	);
+	return resolveBool("REQUESTY_SHOW_PAID", loadConfigFile().requesty_show_paid);
 }
 
 export function getStepfunShowPaid(): boolean {
@@ -564,6 +573,14 @@ export function getStepfunShowPaid(): boolean {
 		"STEPFUN_SHOW_PAID",
 		loadConfigFile().stepfun_show_paid ?? true,
 	);
+}
+
+export function getGmiShowPaid(): boolean {
+	return resolveBool("GMI_SHOW_PAID", loadConfigFile().gmi_show_paid ?? true);
+}
+
+export function getAgnesShowPaid(): boolean {
+	return resolveBool("AGNES_SHOW_PAID", loadConfigFile().agnes_show_paid);
 }
 
 export function getOllamaShowPaid(): boolean {
@@ -661,6 +678,14 @@ export function getRequestyApiKey(): string | undefined {
 
 export function getStepfunApiKey(): string | undefined {
 	return resolve("STEPFUN_API_KEY", loadConfigFile().stepfun_api_key);
+}
+
+export function getGmiApiKey(): string | undefined {
+	return resolve("GMI_API_KEY", loadConfigFile().gmi_api_key);
+}
+
+export function getAgnesApiKey(): string | undefined {
+	return resolve("AGNES_API_KEY", loadConfigFile().agnes_api_key);
 }
 
 export function getTokenrouterApiKey(): string | undefined {
@@ -781,11 +806,7 @@ export async function saveConfig(
 		if (raw === undefined) {
 			// File doesn't exist or can't be read — start from template
 			const merged = { ...CONFIG_TEMPLATE, ...updates };
-			writeFileSync(
-				CONFIG_PATH,
-				`${JSON.stringify(merged, null, 2)}\n`,
-				"utf8",
-			);
+			writeFileSync(CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
 			restrictConfigFilePermissions();
 			_logger.info("Config saved (new file)", {
 				path: CONFIG_PATH,
@@ -806,8 +827,7 @@ export async function saveConfig(
 				"Config file was corrupt; a backup was created and the next save will overwrite it",
 				{
 					path: CONFIG_PATH,
-					error:
-						parseErr instanceof Error ? parseErr.message : String(parseErr),
+					error: parseErr instanceof Error ? parseErr.message : String(parseErr),
 				},
 			);
 		}
@@ -870,11 +890,7 @@ export async function updateConfig(
 			// File doesn't exist — start from template, apply updater once
 			const updated = updater({ ...CONFIG_TEMPLATE });
 			const merged = { ...CONFIG_TEMPLATE, ...updated };
-			writeFileSync(
-				CONFIG_PATH,
-				`${JSON.stringify(merged, null, 2)}\n`,
-				"utf8",
-			);
+			writeFileSync(CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
 			restrictConfigFilePermissions();
 			_logger.info("Config updated (new file)", {
 				path: CONFIG_PATH,
@@ -895,8 +911,7 @@ export async function updateConfig(
 				"Config file was corrupt; a backup was created and the update will overwrite it",
 				{
 					path: CONFIG_PATH,
-					error:
-						parseErr instanceof Error ? parseErr.message : String(parseErr),
+					error: parseErr instanceof Error ? parseErr.message : String(parseErr),
 				},
 			);
 		}

--- a/constants.ts
+++ b/constants.ts
@@ -25,6 +25,8 @@ export const PROVIDER_QODER = "qoder";
 export const PROVIDER_FASTROUTER = "fastrouter";
 export const PROVIDER_REQUESTY = "requesty";
 export const PROVIDER_STEPFUN = "stepfun";
+export const PROVIDER_GMI = "gmi";
+export const PROVIDER_AGNES = "agnes";
 
 // Built-in pi providers that pi-free wraps with toggles
 export const PROVIDER_OPENROUTER = "openrouter";
@@ -66,6 +68,10 @@ export const BASE_URL_FASTROUTER = "https://api.fastrouter.ai/api/v1";
 export const BASE_URL_REQUESTY = "https://router.requesty.ai/v1";
 /** StepFun Step Plan OpenAI-compatible Chat Completions API base URL. */
 export const BASE_URL_STEPFUN = "https://api.stepfun.ai/step_plan/v1";
+/** GMI Cloud OpenAI-compatible Inference API base URL. */
+export const BASE_URL_GMI = "https://api.gmi-serving.com/v1";
+/** Agnes AI OpenAI-compatible free gateway base URL. */
+export const BASE_URL_AGNES = "https://apihub.agnes-ai.com/v1";
 export const BASE_URL_QODER = "https://api2-v2.qoder.sh";
 
 /** Cline fetches free models from OpenRouter */

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -93,6 +93,14 @@ Or set `tokenrouter_api_key`. Toggle with `/toggle-tokenrouter`.
 
 StepFun Step Plan is a native, paid OpenAI-compatible provider. Pi uses the Chat Completions endpoint at `https://api.stepfun.ai/step_plan/v1/chat/completions`; the same base also exposes an Anthropic-compatible Messages endpoint at `/messages` for clients such as Claude Code. Set `STEPFUN_API_KEY` or `stepfun_api_key` and toggle with `/toggle-stepfun`. StepFun shows its paid catalog by default because its catalog has no free models; set `stepfun_show_paid` or `STEPFUN_SHOW_PAID=false` to hide it.
 
+### GMI Cloud
+
+GMI Cloud is a native, paid OpenAI-compatible provider. Pi uses the Inference API at `https://api.gmi-serving.com/v1/chat/completions` (one OpenAI-compatible endpoint for chat, vision, tools, and reasoning across 200+ open and frontier models); the same base also exposes `GET /v1/models`. Set `GMI_API_KEY` or `gmi_api_key` and toggle with `/toggle-gmi`. GMI Cloud shows its full paid catalog by default because the gateway lists no free models; set `gmi_show_paid=false` or `GMI_SHOW_PAID=false` to restrict the view.
+
+### Agnes AI
+
+Agnes AI is a native, free OpenAI-compatible provider. Pi uses the gateway at `https://apihub.agnes-ai.com/v1/chat/completions` (an omni-modal API covering text, image, and video models under one `sk-` key); the same base also exposes `GET /v1/models`. Agnes is an entirely-free gateway, so every published chat model is stamped authoritatively free and the catalog defaults to the free-only view; image/video generation models are filtered out so only text chat models are published. Set `AGNES_API_KEY` or `agnes_api_key` and toggle with `/toggle-agnes`.
+
 ### FastRouter
 
 FastRouter is a native OpenAI-compatible provider with a public catalog. Pi restores its model store first and refreshes the catalog asynchronously; a key is required for chat requests but not model listing. Set `FASTROUTER_API_KEY` or `fastrouter_api_key`, then use `/toggle-fastrouter`.

--- a/index.ts
+++ b/index.ts
@@ -55,6 +55,8 @@ import deepinfra from "./providers/deepinfra/deepinfra.ts";
 import fastrouter from "./providers/fastrouter/fastrouter.ts";
 import requesty from "./providers/requesty/requesty.ts";
 import stepfun from "./providers/stepfun/stepfun.ts";
+import gmi from "./providers/gmi/gmi.ts";
+import agnes from "./providers/agnes/agnes.ts";
 import sambanova from "./providers/sambanova/sambanova.ts";
 import novita from "./providers/novita/novita.ts";
 import routeway from "./providers/routeway/routeway.ts";
@@ -87,6 +89,8 @@ const UNIQUE_PROVIDERS: ReadonlyArray<(pi: ExtensionAPI) => Promise<void>> = [
 	fastrouter,
 	requesty,
 	stepfun,
+	gmi,
+	agnes,
 	routeway,
 	opengateway,
 	tokenRouter,

--- a/providers/agnes/agnes-auth.ts
+++ b/providers/agnes/agnes-auth.ts
@@ -1,0 +1,10 @@
+import { getAgnesApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+/** Agnes AI API-key authentication for both catalog refresh and chat requests. */
+export const agnesAuth = createNativeApiKeyAuth({
+	name: "Agnes AI API key",
+	prompt: "Agnes AI API key",
+	source: "AGNES_API_KEY",
+	getApiKey: getAgnesApiKey,
+});

--- a/providers/agnes/agnes-models.ts
+++ b/providers/agnes/agnes-models.ts
@@ -1,0 +1,72 @@
+/**
+ * Agnes AI's OpenAI-compatible model catalog.
+ *
+ * Agnes AI exposes a plain OpenAI `/v1/models` list (id, object, created,
+ * owned_by, supported_endpoint_types) with no pricing or architecture fields.
+ * The catalog mixes text chat models with image/video generation models;
+ * pi-free feeds a coding agent that speaks Chat Completions, so only text
+ * chat models are published and the rest are filtered out.
+ *
+ * Agnes is an entirely-free gateway, but none of its model ids contain
+ * "free" and the API exposes no pricing — so the adaptive Route A/B free-model
+ * detector in lib/registry.ts cannot identify them as free on its own. Each
+ * published model is therefore stamped with the authoritative free flag
+ * (`_freeKnown`/`_isFree`, the same escape hatch used by the anyapi and bai
+ * gateways) so the free-only view and `/free-providers` counts are correct.
+ */
+
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import { BASE_URL_AGNES, PROVIDER_AGNES } from "../../constants.ts";
+import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
+
+/** Augmented model shape carrying the authoritative free/paid flag. */
+type AgnesProviderModel = ProviderModelConfig & {
+	_freeKnown?: boolean;
+	_isFree?: boolean;
+};
+
+/**
+ * Agnes's catalog lists image and video *generation* models alongside text
+ * chat models. pi-free targets Chat Completions for coding, so generation
+ * models are excluded by name. (e.g. `agnes-image-2.1-flash`,
+ * `agnes-video-2.5`.)
+ */
+function isChatModel(id: string): boolean {
+	const lower = id.toLowerCase();
+	return !lower.includes("image") && !lower.includes("video");
+}
+
+/**
+ * Fetch Agnes AI's authenticated `/v1/models` catalog, keep only the text
+ * chat models, and stamp them as authoritatively free.
+ */
+export async function fetchAgnesModels(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
+	const models = await fetchOpenAICompatibleModels(
+		PROVIDER_AGNES,
+		BASE_URL_AGNES,
+		apiKey,
+		{
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		},
+		undefined,
+		signal,
+	);
+
+	const chatModels = models.filter((model) => isChatModel(model.id));
+
+	// Agnes is an entirely-free gateway; mark every published chat model as
+	// authoritatively free so the global free-only filter and `/free-providers`
+	// counts treat them correctly (no "free" in the name, no pricing exposed).
+	const stamped: AgnesProviderModel[] = chatModels.map((model) => ({
+		...model,
+		_freeKnown: true,
+		_isFree: true,
+	}));
+
+	return applyHidden(stamped, PROVIDER_AGNES);
+}

--- a/providers/agnes/agnes.ts
+++ b/providers/agnes/agnes.ts
@@ -1,0 +1,39 @@
+/**
+ * Agnes AI native provider.
+ *
+ * Agnes AI (https://agnes-ai.com) is a free omni-modal AI gateway exposing a
+ * single OpenAI-compatible Inference API at `https://apihub.agnes-ai.com/v1`
+ * covering text, image, and video models under one `sk-` API key. Pi owns
+ * authentication, model-store persistence, refresh scheduling, and request
+ * streaming through the native provider lifecycle.
+ *
+ * Agnes is an entirely-free gateway: every chat model in its catalog is free
+ * to use, so models are stamped explicitly free (`_freeKnown`/`_isFree`) and
+ * the catalog defaults to the free-only view. Image/video generation models
+ * are filtered out — only text chat models are published, since pi-free feeds
+ * a coding agent that speaks Chat Completions.
+ *
+ * Setup:
+ *   AGNES_API_KEY=...
+ *   # or add agnes_api_key to ~/.pi/free.json
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgnesApiKey, getAgnesShowPaid } from "../../config.ts";
+import { BASE_URL_AGNES, PROVIDER_AGNES } from "../../constants.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
+import { agnesAuth } from "./agnes-auth.ts";
+import { fetchAgnesModels } from "./agnes-models.ts";
+
+export default function agnesProvider(pi: ExtensionAPI): Promise<void> {
+ registerNativeOpenAIProvider(pi, {
+  providerId: PROVIDER_AGNES,
+  name: "Agnes AI",
+  baseUrl: BASE_URL_AGNES,
+  auth: agnesAuth,
+  getApiKey: getAgnesApiKey,
+  getShowPaid: getAgnesShowPaid,
+  fetchModels: (apiKey, signal) => fetchAgnesModels(apiKey, signal),
+ });
+ return Promise.resolve();
+}

--- a/providers/gmi/gmi-auth.ts
+++ b/providers/gmi/gmi-auth.ts
@@ -1,0 +1,10 @@
+import { getGmiApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
+
+/** GMI Cloud API-key authentication for both catalog refresh and chat requests. */
+export const gmiAuth = createNativeApiKeyAuth({
+	name: "GMI Cloud API key",
+	prompt: "GMI Cloud API key",
+	source: "GMI_API_KEY",
+	getApiKey: getGmiApiKey,
+});

--- a/providers/gmi/gmi-models.ts
+++ b/providers/gmi/gmi-models.ts
@@ -1,0 +1,32 @@
+/** GMI Cloud's OpenAI-compatible model catalog. */
+
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import { BASE_URL_GMI, PROVIDER_GMI } from "../../constants.ts";
+import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
+
+/**
+ * Fetch GMI Cloud's authenticated `/v1/models` catalog.
+ *
+ * GMI Cloud's Inference API follows the OpenAI model-list shape. The
+ * shared mapper preserves any pricing/capability metadata exposed by the
+ * endpoint and applies models.dev enrichment without introducing a second
+ * cache or freshness policy.
+ */
+export async function fetchGmiModels(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
+	const models = await fetchOpenAICompatibleModels(
+		PROVIDER_GMI,
+		BASE_URL_GMI,
+		apiKey,
+		{
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		},
+		undefined,
+		signal,
+	);
+	return applyHidden(models, PROVIDER_GMI);
+}

--- a/providers/gmi/gmi.ts
+++ b/providers/gmi/gmi.ts
@@ -1,0 +1,33 @@
+/**
+ * GMI Cloud native provider.
+ *
+ * GMI Cloud exposes a single OpenAI-compatible Inference API at
+ * `https://api.gmi-serving.com/v1` covering chat, vision, tools, and
+ * reasoning across 200+ open and frontier models. Pi owns authentication,
+ * model-store persistence, refresh scheduling, and request streaming through
+ * the native provider lifecycle.
+ *
+ * Setup:
+ *   GMI_API_KEY=...
+ *   # or add gmi_api_key to ~/.pi/free.json
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getGmiApiKey, getGmiShowPaid } from "../../config.ts";
+import { BASE_URL_GMI, PROVIDER_GMI } from "../../constants.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
+import { gmiAuth } from "./gmi-auth.ts";
+import { fetchGmiModels } from "./gmi-models.ts";
+
+export default function gmiProvider(pi: ExtensionAPI): Promise<void> {
+ registerNativeOpenAIProvider(pi, {
+  providerId: PROVIDER_GMI,
+  name: "GMI Cloud",
+  baseUrl: BASE_URL_GMI,
+  auth: gmiAuth,
+  getApiKey: getGmiApiKey,
+  getShowPaid: getGmiShowPaid,
+  fetchModels: (apiKey, signal) => fetchGmiModels(apiKey, signal),
+ });
+ return Promise.resolve();
+}


### PR DESCRIPTION
## Summary

Adds two new OpenAI-compatible **native** providers, both wired through `registerNativeOpenAIProvider` so Pi owns authentication, model-store persistence, refresh scheduling, and request streaming through the native provider lifecycle. No catalog network I/O runs during extension startup.

### GMI Cloud (`gmi`) — paid, per-token pricing
- OpenAI-compatible Inference API at `https://api.gmi-serving.com/v1` (one endpoint for chat, vision, tools, and reasoning across 200+ open and frontier models); catalog via `GET /v1/models`.
- Auth-required catalog (resolves `undefined` without a key, like StepFun/GMI-class providers); chat requires a real key.
- `gmi_show_paid` defaults to `true` (the gateway lists no free models).
- Set `GMI_API_KEY` or `gmi_api_key`; toggle with `/toggle-gmi`.

### Agnes AI (`agnes`) — entirely-free omni-modal gateway
- OpenAI-compatible gateway at `https://apihub.agnes-ai.com/v1` (text, image, and video models under one `sk-` key); catalog via `GET /v1/models`.
- **Filters out image/video generation models** so only text chat models are published (pi-free feeds a coding agent that speaks Chat Completions).
- **Stamps each published model authoritatively free** (`_freeKnown`/`_isFree`, the same escape hatch used by the `anyapi` and `bai` gateways). Agnes is an entirely-free gateway, but its model ids contain no "free" token and the API exposes no pricing — the adaptive Route A/B free-detector would otherwise classify **zero** Agnes models as free, leaving the free-only view empty and mislabeling a free provider as paid in `/free-providers`.
- `agnes_show_paid` defaults to `false` (free-only view shows everything, since everything is free).
- Auth-required catalog; chat requires a real key.
- Set `AGNES_API_KEY` or `agnes_api_key`; toggle with `/toggle-agnes`.

## Files changed
- `constants.ts` — `PROVIDER_GMI`/`BASE_URL_GMI`, `PROVIDER_AGNES`/`BASE_URL_AGNES`
- `config.ts` — config interface/template entries, `PROVIDER_META` rows, `getGmi*`/`getAgnes*` getters
- `providers/gmi/` — `gmi.ts`, `gmi-auth.ts`, `gmi-models.ts`
- `providers/agnes/` — `agnes.ts`, `agnes-auth.ts`, `agnes-models.ts`
- `index.ts` — imports + `UNIQUE_PROVIDERS` entries
- `README.md`, `docs/providers.md`, `AGENTS.md` — catalog tables, provider entries, native/auth-required lists
- `CHANGELOG.md` — `[Unreleased]` section

## Security
No API keys are committed. Keys resolve from env (`GMI_API_KEY` / `AGNES_API_KEY`) or `~/.pi/free.json`, following the existing provider convention. Wire-signature logs and `/pi-free-health` stay credential-free.

## Verification
- `tsc --noEmit` clean
- `npm run test:run` — **678 passed / 2 skipped**
- `node scripts/check-runtime-imports.mjs` green (no startup compat import)
- Both gateways confirmed **end-to-end** against their live `GET /v1/models` and `POST /v1/chat/completions` endpoints (standard OpenAI chat-completion shape; Agnes returns `reasoning_content`, which pi-ai maps natively).

## Checklist
- [x] Provider constants + base URLs added to `constants.ts`
- [x] API-key getters + `show_paid` config added to `config.ts`
- [x] Per-provider factory/auth/models following the native OpenAI template
- [x] Wired into `index.ts` `UNIQUE_PROVIDERS`
- [x] README / docs/providers.md / AGENTS.md / CHANGELOG updated
- [x] No secrets committed; keys resolve from env/config