### PR TITLE
feat: Venice AI provider; GMI catalog dedupe; Agnes doc correction

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -105,7 +105,7 @@ For a new OpenAI-compatible native provider, use `registerNativeOpenAIProvider()
 
 ### Native `Provider` providers
 
-Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, FastRouter, StepFun, GMI Cloud, Agnes AI, and Qoder use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
+Kilo, Cline, LLM7, ZenMux, TokenRouter, Ollama Cloud, B.AI, AnyAPI, CrofAI, SambaNova, Novita, DeepInfra, Routeway, OpenGateway, FastRouter, StepFun, GMI Cloud, Agnes AI, Venice AI, and Qoder use Pi's modern provider API (Pi `>=0.81.0`). Instead of the legacy `registerProvider(id, { baseUrl, apiKey, models, oauth })` form, each builds a native pi-ai `Provider` object and registers it via the single-argument `registerProvider(provider)`. Pi then owns credential refresh, background model refresh (4h throttle, abortable), and offline initialization — so these extension factories perform no catalog network I/O on startup.
 
 ```
 providers/kilo/kilo-provider.ts   ← createKiloProvider(): assembles the Provider
@@ -186,7 +186,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | ✅ Free / free-tier | kilo, cline, llm7, tokenrouter, agnes, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova, requesty | API key | Free allowance with limits |
 | 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, gmi, venice, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
-| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, Requesty, StepFun, GMI Cloud, Agnes AI, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
+| 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, Requesty, StepFun, GMI Cloud, Agnes AI, Venice AI, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
 | 🔧 Built-in | opencode-free, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -53,6 +53,7 @@ index.ts                          ← Extension entry point (piFreeEntry)
       ├─ cline/cline-auth.ts      ← native ProviderAuth (API key + OAuth callback-server flow)
       ├─ cline/cline-models.ts    ← public catalog fetch + Model conversion
       ├─ novita/novita.ts         ← Novita AI (paid credits)
+      ├─ venice/venice.ts         ← Venice AI (paid, public catalog)
       ├─ ollama/ollama.ts         ← Ollama Cloud (usage-based free tier, 403 probing)
       ├─ routeway/routeway.ts     ← RouteWay AI (paid)
       ├─ opengateway/opengateway.ts ← Gitlawb OpenGateway (paid + promotional free models)
@@ -184,7 +185,7 @@ Debug logging writes to `~/.pi/free.log` under the `benchmark-lookup` namespace:
 | ----------- | -------------------------------------------------- | ----------------- | -------------------------------- |
 | ✅ Free / free-tier | kilo, cline, llm7, tokenrouter, agnes, qoder basic | OAuth, API key, or none | Free models or tier; toggles can expose paid models |
 | 🔄 Freemium | anyapi, ollama-cloud, sambanova, requesty | API key | Free allowance with limits |
-| 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, gmi, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
+| 💳 Paid / trial | zenmux, crofai, deepinfra, novita, routeway, opengateway, bai, stepfun, gmi, venice, qoder premium | API key, OAuth, or credits | Paid access, trial credit, or premium tier |
 | 🔧 Native | Kilo, Cline, LLM7, Ollama Cloud, AnyAPI, SambaNova, TokenRouter, ZenMux, CrofAI, DeepInfra, Novita, Routeway, OpenGateway, B.AI, FastRouter, Requesty, StepFun, GMI Cloud, Agnes AI, Qoder | API key, OAuth, or none | Pi owns catalog refresh and native stores |
 | 🔧 Built-in | opencode-free, opencode-go, openrouter | Built-in Pi auth | Built-in toggles; Pi owns catalogs |
 

--- a/config.ts
+++ b/config.ts
@@ -43,6 +43,7 @@ import {
 	PROVIDER_DEEPINFRA,
 	PROVIDER_SAMBANOVA,
 	PROVIDER_NOVITA,
+	PROVIDER_VENICE,
 } from "./constants.ts";
 export {
 	PROVIDER_ANYAPI,
@@ -99,6 +100,7 @@ interface PiFreeConfig {
 	deepinfra_api_key?: string;
 	sambanova_api_key?: string;
 	novita_api_key?: string;
+	venice_api_key?: string;
 	routeway_api_key?: string;
 	opengateway_api_key?: string;
 	fastrouter_api_key?: string;
@@ -123,6 +125,7 @@ interface PiFreeConfig {
 	deepinfra_show_paid?: boolean;
 	sambanova_show_paid?: boolean;
 	novita_show_paid?: boolean;
+	venice_show_paid?: boolean;
 	routeway_show_paid?: boolean;
 	opengateway_show_paid?: boolean;
 	fastrouter_show_paid?: boolean;
@@ -149,6 +152,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	deepinfra_api_key: "",
 	sambanova_api_key: "",
 	novita_api_key: "",
+	venice_api_key: "",
 	routeway_api_key: "",
 	opengateway_api_key: "",
 	fastrouter_api_key: "",
@@ -174,6 +178,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	deepinfra_show_paid: false,
 	sambanova_show_paid: false,
 	novita_show_paid: false,
+	venice_show_paid: false,
 	routeway_show_paid: false,
 	opengateway_show_paid: false,
 	fastrouter_show_paid: false,
@@ -407,6 +412,7 @@ const PROVIDER_META: readonly ProviderMeta[] = [
 		showPaidKey: "sambanova_show_paid",
 	},
 	{ id: PROVIDER_NOVITA, prefix: "NOVITA", showPaidKey: "novita_show_paid" },
+	{ id: PROVIDER_VENICE, prefix: "VENICE", showPaidKey: "venice_show_paid" },
 	{
 		id: PROVIDER_ROUTEWAY,
 		prefix: "ROUTEWAY",
@@ -529,6 +535,10 @@ export function getSambanovaShowPaid(): boolean {
 
 export function getNovitaShowPaid(): boolean {
 	return resolveBool("NOVITA_SHOW_PAID", loadConfigFile().novita_show_paid);
+}
+
+export function getVeniceShowPaid(): boolean {
+	return resolveBool("VENICE_SHOW_PAID", loadConfigFile().venice_show_paid);
 }
 
 export function getRoutewayShowPaid(): boolean {
@@ -658,6 +668,10 @@ export function getSambanovaApiKey(): string | undefined {
 
 export function getNovitaApiKey(): string | undefined {
 	return resolve("NOVITA_API_KEY", loadConfigFile().novita_api_key);
+}
+
+export function getVeniceApiKey(): string | undefined {
+	return resolve("VENICE_API_KEY", loadConfigFile().venice_api_key);
 }
 
 export function getRoutewayApiKey(): string | undefined {

--- a/constants.ts
+++ b/constants.ts
@@ -27,6 +27,7 @@ export const PROVIDER_REQUESTY = "requesty";
 export const PROVIDER_STEPFUN = "stepfun";
 export const PROVIDER_GMI = "gmi";
 export const PROVIDER_AGNES = "agnes";
+export const PROVIDER_VENICE = "venice";
 
 // Built-in pi providers that pi-free wraps with toggles
 export const PROVIDER_OPENROUTER = "openrouter";
@@ -72,6 +73,8 @@ export const BASE_URL_STEPFUN = "https://api.stepfun.ai/step_plan/v1";
 export const BASE_URL_GMI = "https://api.gmi-serving.com/v1";
 /** Agnes AI OpenAI-compatible free gateway base URL. */
 export const BASE_URL_AGNES = "https://apihub.agnes-ai.com/v1";
+/** Venice AI OpenAI-compatible inference API base URL. */
+export const BASE_URL_VENICE = "https://api.venice.ai/api/v1";
 export const BASE_URL_QODER = "https://api2-v2.qoder.sh";
 
 /** Cline fetches free models from OpenRouter */

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -103,7 +103,7 @@ Agnes AI is a native OpenAI-compatible provider mixing free and paid chat models
 
 ### Venice AI
 
-Venice AI is a native, paid OpenAI-compatible provider. Pi uses the inference API at `https://api.venice.ai/api/v1/chat/completions` (100+ text models billed in USD or DIEM per million tokens); the same base also exposes `GET /models?type=text`. The model catalog is public, so models appear before login, but chat requires `VENICE_API_KEY` or `venice_api_key`; toggle with `/toggle-venice`. **Balance gate:** Venice requires a positive account balance for all inference — including `$0`-listed models, which answer HTTP 402 on unfunded keys — so the catalog publishes no usable free models and Venice contributes nothing to the free-only view until that changes.
+Venice AI is a native OpenAI-compatible provider mixing free-classified and paid chat models. Pi uses the inference API at `https://api.venice.ai/api/v1/chat/completions` (100+ text models billed in USD or DIEM per million tokens); the same base also exposes `GET /models?type=text`. The model catalog is public, so models appear before login, but chat requires `VENICE_API_KEY` or `venice_api_key`; toggle with `/toggle-venice`. Free/paid classification follows the published pricing (zero-priced models count as free). **Balance gate:** Venice requires a positive account balance for all inference — including zero-priced models, which answer HTTP 402 on unfunded keys — so a model classified as free can still fail at request time until the account is funded.
 
 ### FastRouter
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -101,6 +101,10 @@ GMI Cloud is a native, paid OpenAI-compatible provider. Pi uses the Inference AP
 
 Agnes AI is a native OpenAI-compatible provider mixing free and paid chat models. Pi uses the gateway at `https://apihub.agnes-ai.com/v1/chat/completions` (an omni-modal API covering text, image, and video models under one `sk-` key); the same base also exposes `GET /v1/models`. Per the Agnes pricing docs, the flash-class models (`agnes-2.0-flash`, `agnes-2.5-flash`) are free while the pro models (`agnes-2.5-pro`, `agnes-2.5-pro-alpha`) are billed at list price. The `/v1/models` endpoint exposes no pricing, so the free flash models are stamped authoritatively free and the paid pro models are left to the default paid classification; image/video generation models are filtered out so only text chat models are published. Set `AGNES_API_KEY` or `agnes_api_key` and toggle with `/toggle-agnes`. The catalog defaults to the free-only view (the two free flash models); `/toggle-agnes` reveals the paid pro models.
 
+### Venice AI
+
+Venice AI is a native, paid OpenAI-compatible provider. Pi uses the inference API at `https://api.venice.ai/api/v1/chat/completions` (100+ text models billed in USD or DIEM per million tokens); the same base also exposes `GET /models?type=text`. The model catalog is public, so models appear before login, but chat requires `VENICE_API_KEY` or `venice_api_key`; toggle with `/toggle-venice`. **Balance gate:** Venice requires a positive account balance for all inference — including `$0`-listed models, which answer HTTP 402 on unfunded keys — so the catalog publishes no usable free models and Venice contributes nothing to the free-only view until that changes.
+
 ### FastRouter
 
 FastRouter is a native OpenAI-compatible provider with a public catalog. Pi restores its model store first and refreshes the catalog asynchronously; a key is required for chat requests but not model listing. Set `FASTROUTER_API_KEY` or `fastrouter_api_key`, then use `/toggle-fastrouter`.

--- a/index.ts
+++ b/index.ts
@@ -59,6 +59,7 @@ import gmi from "./providers/gmi/gmi.ts";
 import agnes from "./providers/agnes/agnes.ts";
 import sambanova from "./providers/sambanova/sambanova.ts";
 import novita from "./providers/novita/novita.ts";
+import venice from "./providers/venice/venice.ts";
 import routeway from "./providers/routeway/routeway.ts";
 import opengateway from "./providers/opengateway/opengateway.ts";
 import tokenRouter from "./providers/tokenrouter/tokenrouter.ts";
@@ -86,6 +87,7 @@ const UNIQUE_PROVIDERS: ReadonlyArray<(pi: ExtensionAPI) => Promise<void>> = [
 	deepinfra,
 	sambanova,
 	novita,
+	venice,
 	fastrouter,
 	requesty,
 	stepfun,

--- a/providers/agnes/agnes-models.ts
+++ b/providers/agnes/agnes-models.ts
@@ -32,8 +32,8 @@ import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
 
 /** Augmented model shape carrying the authoritative free/paid flag. */
 type AgnesProviderModel = ProviderModelConfig & {
-	_freeKnown?: boolean;
-	_isFree?: boolean;
+ _freeKnown?: boolean;
+ _isFree?: boolean;
 };
 
 /**
@@ -43,8 +43,8 @@ type AgnesProviderModel = ProviderModelConfig & {
  * `agnes-video-2.5`.)
  */
 function isChatModel(id: string): boolean {
-	const lower = id.toLowerCase();
-	return !lower.includes("image") && !lower.includes("video");
+ const lower = id.toLowerCase();
+ return !lower.includes("image") && !lower.includes("video");
 }
 
 /**
@@ -56,8 +56,8 @@ function isChatModel(id: string): boolean {
  * text-chat model ids only. Update this set if Agnes changes its free tier.
  */
 const FREE_CHAT_MODEL_IDS: ReadonlySet<string> = new Set([
-	"agnes-2.0-flash",
-	"agnes-2.5-flash",
+ "agnes-2.0-flash",
+ "agnes-2.5-flash",
 ]);
 
 /**
@@ -65,31 +65,31 @@ const FREE_CHAT_MODEL_IDS: ReadonlySet<string> = new Set([
  * chat models, and stamp the free flash models as authoritatively free.
  */
 export async function fetchAgnesModels(
-	apiKey: string,
-	signal?: AbortSignal,
+ apiKey: string,
+ signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
-	const models = await fetchOpenAICompatibleModels(
-		PROVIDER_AGNES,
-		BASE_URL_AGNES,
-		apiKey,
-		{
-			contextWindow: 128_000,
-			maxTokens: 16_384,
-		},
-		undefined,
-		signal,
-	);
+ const models = await fetchOpenAICompatibleModels(
+  PROVIDER_AGNES,
+  BASE_URL_AGNES,
+  apiKey,
+  {
+   contextWindow: 128_000,
+   maxTokens: 16_384,
+  },
+  undefined,
+  signal,
+ );
 
-	const chatModels = models.filter((model) => isChatModel(model.id));
+ const chatModels = models.filter((model) => isChatModel(model.id));
 
-	const stamped: AgnesProviderModel[] = chatModels.map((model) => {
-		if (!FREE_CHAT_MODEL_IDS.has(model.id)) return model;
-		return {
-			...model,
-			_freeKnown: true,
-			_isFree: true,
-		};
-	});
+ const stamped: AgnesProviderModel[] = chatModels.map((model) => {
+  if (!FREE_CHAT_MODEL_IDS.has(model.id)) return model;
+  return {
+   ...model,
+   _freeKnown: true,
+   _isFree: true,
+  };
+ });
 
-	return applyHidden(stamped, PROVIDER_AGNES);
+ return applyHidden(stamped, PROVIDER_AGNES);
 }

--- a/providers/agnes/agnes.ts
+++ b/providers/agnes/agnes.ts
@@ -7,11 +7,15 @@
  * authentication, model-store persistence, refresh scheduling, and request
  * streaming through the native provider lifecycle.
  *
- * Agnes is an entirely-free gateway: every chat model in its catalog is free
- * to use, so models are stamped explicitly free (`_freeKnown`/`_isFree`) and
- * the catalog defaults to the free-only view. Image/video generation models
- * are filtered out — only text chat models are published, since pi-free feeds
- * a coding agent that speaks Chat Completions.
+ * Agnes is a freemium gateway, not an entirely-free one: per the Agnes
+ * pricing docs only the flash-class chat models (agnes-2.0-flash,
+ * agnes-2.5-flash) are free; the pro models are billed at list price.
+ * The free flash models are stamped authoritatively free (`_freeKnown`/
+ * `_isFree`) in agnes-models.ts so the free-only view and `/free-providers`
+ * counts are correct; the paid pro models surface via `/toggle-agnes`.
+ * Image/video generation models are filtered out — only text chat models
+ * are published, since pi-free feeds a coding agent that speaks Chat
+ * Completions.
  *
  * Setup:
  *   AGNES_API_KEY=...

--- a/providers/gmi/gmi-models.ts
+++ b/providers/gmi/gmi-models.ts
@@ -58,7 +58,7 @@ const PROMOTIONS: readonly Promotion[] = [
  * Model ids that are authoritatively free right now because an active GMI
  * promotion makes them free at the billing layer despite nonzero list prices.
  */
-function activePromotionalFreeIds(now: number = Date.now()): Set<string> {
+export function activePromotionalFreeIds(now: number = Date.now()): Set<string> {
 	const free = new Set<string>();
 	for (const promo of PROMOTIONS) {
 		if (now >= promo.startMs && now < promo.endMs) {

--- a/providers/gmi/gmi-models.ts
+++ b/providers/gmi/gmi-models.ts
@@ -58,7 +58,9 @@ const PROMOTIONS: readonly Promotion[] = [
  * Model ids that are authoritatively free right now because an active GMI
  * promotion makes them free at the billing layer despite nonzero list prices.
  */
-export function activePromotionalFreeIds(now: number = Date.now()): Set<string> {
+export function activePromotionalFreeIds(
+	now: number = Date.now(),
+): Set<string> {
 	const free = new Set<string>();
 	for (const promo of PROMOTIONS) {
 		if (now >= promo.startMs && now < promo.endMs) {

--- a/providers/gmi/gmi-models.ts
+++ b/providers/gmi/gmi-models.ts
@@ -69,8 +69,39 @@ function activePromotionalFreeIds(now: number = Date.now()): Set<string> {
 }
 
 /**
- * Fetch GMI Cloud's authenticated `/v1/models` catalog, then stamp any model
- * that is free under an active GMI promotion as authoritatively free.
+ * Dedupe catalog entries that share a model id.
+ *
+ * GMI's live /v1/models has been observed publishing the same id twice
+ * (during MiniMax Week: one SKU carrying list pricing, one $0 SKU). Keep the
+ * PRICED entry so Route A cost-based detection sees real pricing; the
+ * promotion stamp below then overrides the winner to free while a window is
+ * active and reverts automatically when it ends. Ties keep the first seen.
+ */
+export function dedupeGmiModelsById(
+	models: readonly ProviderModelConfig[],
+): ProviderModelConfig[] {
+	const byId = new Map<string, ProviderModelConfig>();
+	for (const model of models) {
+		const existing = byId.get(model.id);
+		if (existing === undefined) {
+			byId.set(model.id, model);
+			continue;
+		}
+		const existingPriced = isPriced(existing);
+		const nextPriced = isPriced(model);
+		if (nextPriced && !existingPriced) byId.set(model.id, model);
+	}
+	return [...byId.values()];
+}
+
+function isPriced(model: ProviderModelConfig): boolean {
+	return (model.cost?.input ?? 0) > 0 || (model.cost?.output ?? 0) > 0;
+}
+
+/**
+ * Fetch GMI Cloud's authenticated `/v1/models` catalog, dedupe repeated ids,
+ * then stamp any model that is free under an active GMI promotion as
+ * authoritatively free.
  */
 export async function fetchGmiModels(
 	apiKey: string,
@@ -88,8 +119,9 @@ export async function fetchGmiModels(
 		signal,
 	);
 
+	const deduped = dedupeGmiModelsById(models);
 	const promotionalFree = activePromotionalFreeIds();
-	const stamped: GmiProviderModel[] = models.map((model) => {
+	const stamped: GmiProviderModel[] = deduped.map((model) => {
 		if (!promotionalFree.has(model.id)) return model;
 		return {
 			...model,

--- a/providers/venice/venice-auth.ts
+++ b/providers/venice/venice-auth.ts
@@ -1,0 +1,49 @@
+/**
+ * Venice AI native authentication.
+ *
+ * Venice's model catalog (api.venice.ai/api/v1/models) is public, so native
+ * auth resolves even when no key is configured — Pi's model refresh populates
+ * the catalog for logged-out users. Chat requests use the configured key; the
+ * gateway rejects unauthenticated completions.
+ */
+
+import type {
+	ApiKeyAuth,
+	ApiKeyCredential,
+	AuthContext,
+	AuthInteraction,
+	AuthResult,
+	ProviderAuth,
+} from "@earendil-works/pi-ai/compat";
+import { getVeniceApiKey } from "../../config.ts";
+
+async function resolveVeniceApiKey(input: {
+	ctx: AuthContext;
+	credential?: ApiKeyCredential;
+	signal?: AbortSignal;
+}): Promise<AuthResult | undefined> {
+	const key = input.credential?.key ?? getVeniceApiKey();
+	if (!key) {
+		return { auth: {}, source: "public catalog (no account)" };
+	}
+	return {
+		auth: { apiKey: key },
+		source: input.credential?.key ? "stored API key" : "VENICE_API_KEY",
+	};
+}
+
+export const veniceApiKeyAuth: ApiKeyAuth = {
+	name: "Venice API key",
+	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+		const key = await interaction.prompt({
+			type: "secret",
+			message: "Venice API key",
+		});
+		return { type: "api_key", key };
+	},
+	resolve: resolveVeniceApiKey,
+};
+
+export const veniceAuth: ProviderAuth = {
+	apiKey: veniceApiKeyAuth,
+};

--- a/providers/venice/venice-auth.ts
+++ b/providers/venice/venice-auth.ts
@@ -12,9 +12,9 @@ import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
 
 /** Venice AI API-key authentication for both catalog refresh and chat requests. */
 export const veniceAuth = createNativeApiKeyAuth({
-	name: "Venice API key",
-	prompt: "Venice API key",
-	source: "VENICE_API_KEY",
-	getApiKey: getVeniceApiKey,
-	anonymousCatalog: true,
+ name: "Venice API key",
+ prompt: "Venice API key",
+ source: "VENICE_API_KEY",
+ getApiKey: getVeniceApiKey,
+ anonymousCatalog: true,
 });

--- a/providers/venice/venice-auth.ts
+++ b/providers/venice/venice-auth.ts
@@ -1,49 +1,20 @@
 /**
- * Venice AI native authentication.
+ * Venice AI API-key authentication.
  *
- * Venice's model catalog (api.venice.ai/api/v1/models) is public, so native
- * auth resolves even when no key is configured — Pi's model refresh populates
- * the catalog for logged-out users. Chat requests use the configured key; the
- * gateway rejects unauthenticated completions.
+ * The model catalog (api.venice.ai/api/v1/models) is public, so keyless
+ * resolution returns a truthy anonymous result and Pi's model refresh still
+ * populates the catalog. Chat requests use the configured key; the gateway
+ * rejects unauthenticated completions.
  */
 
-import type {
-	ApiKeyAuth,
-	ApiKeyCredential,
-	AuthContext,
-	AuthInteraction,
-	AuthResult,
-	ProviderAuth,
-} from "@earendil-works/pi-ai/compat";
 import { getVeniceApiKey } from "../../config.ts";
+import { createNativeApiKeyAuth } from "../../lib/native-provider.ts";
 
-async function resolveVeniceApiKey(input: {
-	ctx: AuthContext;
-	credential?: ApiKeyCredential;
-	signal?: AbortSignal;
-}): Promise<AuthResult | undefined> {
-	const key = input.credential?.key ?? getVeniceApiKey();
-	if (!key) {
-		return { auth: {}, source: "public catalog (no account)" };
-	}
-	return {
-		auth: { apiKey: key },
-		source: input.credential?.key ? "stored API key" : "VENICE_API_KEY",
-	};
-}
-
-export const veniceApiKeyAuth: ApiKeyAuth = {
+/** Venice AI API-key authentication for both catalog refresh and chat requests. */
+export const veniceAuth = createNativeApiKeyAuth({
 	name: "Venice API key",
-	async login(interaction: AuthInteraction): Promise<ApiKeyCredential> {
-		const key = await interaction.prompt({
-			type: "secret",
-			message: "Venice API key",
-		});
-		return { type: "api_key", key };
-	},
-	resolve: resolveVeniceApiKey,
-};
-
-export const veniceAuth: ProviderAuth = {
-	apiKey: veniceApiKeyAuth,
-};
+	prompt: "Venice API key",
+	source: "VENICE_API_KEY",
+	getApiKey: getVeniceApiKey,
+	anonymousCatalog: true,
+});

--- a/providers/venice/venice-models.ts
+++ b/providers/venice/venice-models.ts
@@ -1,0 +1,174 @@
+/**
+ * Venice AI model catalog (api.venice.ai/api/v1/models?type=text).
+ *
+ * The schema is Venice-specific — nested `model_spec` with per-million-token
+ * `pricing.{input,output,cache_input,cache_write}.usd` and a
+ * `capabilities` flag block — so it is mapped here instead of through the
+ * shared OpenRouter-compatible fetcher. Pricing is exposed inline for every
+ * text model, which feeds pi-free's cost-based free-model detection (Route A)
+ * without any curated list.
+ *
+ * Units: pi-free's Model.cost fields are USD per token (OpenRouter convention),
+ * while Venice reports USD per million tokens — hence the 1e6 divisor.
+ *
+ * Balance gate: Venice requires a POSITIVE account balance for ALL inference,
+ * including zero-priced models — a $0/$0 catalog entry still answers HTTP 402
+ * "Insufficient USD or Diem balance" for an unfunded key (verified live).
+ * Zero cost therefore does NOT mean usable-for-free, so every Venice model is
+ * stamped `_freeKnown: true, _isFree: false` (the same authoritative override
+ * OpenRouter uses) to keep unfunded models out of the free-only view.
+ */
+
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { applyHidden } from "../../config.ts";
+import {
+	BASE_URL_VENICE,
+	DEFAULT_FETCH_TIMEOUT_MS,
+	PROVIDER_VENICE,
+} from "../../constants.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { fetchWithRetry } from "../../lib/util.ts";
+
+const _logger = createLogger("venice-models");
+
+interface VeniceCatalogPrice {
+	usd?: unknown;
+}
+
+interface VeniceCatalogModel {
+	id?: unknown;
+	type?: unknown;
+	context_length?: unknown;
+	model_spec?: {
+		name?: unknown;
+		pricing?: {
+			input?: VeniceCatalogPrice;
+			output?: VeniceCatalogPrice;
+			cache_input?: VeniceCatalogPrice;
+			cache_write?: VeniceCatalogPrice;
+		};
+		availableContextTokens?: unknown;
+		maxCompletionTokens?: unknown;
+		capabilities?: {
+			supportsReasoning?: unknown;
+			supportsVision?: unknown;
+			supportsMultipleImages?: unknown;
+			supportsFunctionCalling?: unknown;
+		};
+		description?: unknown;
+	};
+}
+
+/** Fallback context window for entries that omit `context_length`. */
+const FALLBACK_CONTEXT_WINDOW = 128_000;
+
+/** Fallback max output tokens for entries that omit `maxCompletionTokens`. */
+const FALLBACK_MAX_TOKENS = 4_096;
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/** Convert a Venice usd-per-million price to the pi-free per-token unit. */
+function usdPerMillionToPerToken(
+	price: VeniceCatalogPrice | undefined,
+): number {
+	return (asNumber(price?.usd) ?? 0) / 1_000_000;
+}
+
+/**
+ * Map one catalog entry to the pi-free model config shape. Returns undefined
+ * for non-text endpoints and unusable entries rather than guessing.
+ */
+export function mapVeniceModel(
+	entry: VeniceCatalogModel,
+): ProviderModelConfig | undefined {
+	if (typeof entry.id !== "string" || entry.id.length === 0) return undefined;
+	// The /models endpoint also serves image, audio, video, and embedding
+	// models; only chat-completions ("text") models are usable as agent models.
+	if (entry.type !== undefined && entry.type !== "text") return undefined;
+
+	const spec = entry.model_spec ?? {};
+	const capabilities = spec.capabilities ?? {};
+	const vision =
+		capabilities.supportsVision === true ||
+		capabilities.supportsMultipleImages === true;
+
+	return {
+		id: entry.id,
+		name:
+			typeof spec.name === "string" && spec.name.length > 0 ? spec.name : entry.id,
+		reasoning: capabilities.supportsReasoning === true,
+		input: vision ? (["text", "image"] as const) : (["text"] as const),
+		cost: {
+			input: usdPerMillionToPerToken(spec.pricing?.input),
+			output: usdPerMillionToPerToken(spec.pricing?.output),
+			cacheRead: usdPerMillionToPerToken(spec.pricing?.cache_input),
+			cacheWrite: usdPerMillionToPerToken(spec.pricing?.cache_write),
+		},
+		contextWindow:
+			asNumber(entry.context_length) ??
+			asNumber(spec.availableContextTokens) ??
+			FALLBACK_CONTEXT_WINDOW,
+		maxTokens: asNumber(spec.maxCompletionTokens) ?? FALLBACK_MAX_TOKENS,
+		// SAFETY: Venice's catalog exposes real pricing for every model, so
+		// stamp the undocumented _pricingKnown marker consumed by isFreeModel
+		// to mark cost-based (Route A) detection authoritative for these models;
+		// the field is metadata only and never read by pi-ai.
+		_pricingKnown: true,
+		// Balance gate (see file header): even $0-priced models require a
+		// positive account balance, so no Venice model is free in the
+		// "usable without paying" sense pi-free's free view promises.
+		_freeKnown: true,
+		_isFree: false,
+	} as ProviderModelConfig & {
+		_pricingKnown?: boolean;
+		_freeKnown?: boolean;
+		_isFree?: boolean;
+	};
+}
+
+/**
+ * Fetch the complete text-model catalog. The key is optional for /models; it
+ * is only sent when configured so public discovery works for logged-out users.
+ */
+export async function fetchVeniceModels(
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ProviderModelConfig[]> {
+	const headers: Record<string, string> = {
+		Accept: "application/json",
+	};
+	if (apiKey) {
+		headers.Authorization = `Bearer ${apiKey}`;
+	}
+	const response = await fetchWithRetry(
+		`${BASE_URL_VENICE}/models?type=text`,
+		{
+			headers,
+			signal,
+		},
+		1,
+		1_000,
+		DEFAULT_FETCH_TIMEOUT_MS,
+	);
+	if (!response.ok) {
+		throw new Error(`Venice catalog returned HTTP ${response.status}`);
+	}
+	const payload: unknown = await response.json();
+	const entries =
+		payload &&
+		typeof payload === "object" &&
+		Array.isArray((payload as { data?: unknown }).data)
+			? ((payload as { data: unknown[] }).data as VeniceCatalogModel[])
+			: [];
+	const models: ProviderModelConfig[] = [];
+	for (const entry of entries) {
+		const mapped = mapVeniceModel(entry);
+		if (mapped) models.push(mapped);
+	}
+	if (models.length === 0) {
+		_logger.warn("Venice catalog returned no usable chat models");
+	}
+	return applyHidden(models, PROVIDER_VENICE);
+}

--- a/providers/venice/venice-models.ts
+++ b/providers/venice/venice-models.ts
@@ -14,9 +14,10 @@
  * Balance gate: Venice requires a POSITIVE account balance for ALL inference,
  * including zero-priced models — a $0/$0 catalog entry still answers HTTP 402
  * "Insufficient USD or Diem balance" for an unfunded key (verified live).
- * Zero cost therefore does NOT mean usable-for-free, so every Venice model is
- * stamped `_freeKnown: true, _isFree: false` (the same authoritative override
- * OpenRouter uses) to keep unfunded models out of the free-only view.
+ * Classification intentionally follows the published pricing data anyway
+ * (Route A): a $0-listed model is classified free and surfaces in the
+ * free-only view; the balance requirement surfaces as a request-time error,
+ * consistent with how every other keyed gateway behaves.
  */
 
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
@@ -116,18 +117,10 @@ export function mapVeniceModel(
 		// SAFETY: Venice's catalog exposes real pricing for every model, so
 		// stamp the undocumented _pricingKnown marker consumed by isFreeModel
 		// to mark cost-based (Route A) detection authoritative for these models;
-		// the field is metadata only and never read by pi-ai.
+		// the field is metadata only and never read by pi-ai. Free/paid follows
+		// the published pricing — no free/paid override is applied here.
 		_pricingKnown: true,
-		// Balance gate (see file header): even $0-priced models require a
-		// positive account balance, so no Venice model is free in the
-		// "usable without paying" sense pi-free's free view promises.
-		_freeKnown: true,
-		_isFree: false,
-	} as ProviderModelConfig & {
-		_pricingKnown?: boolean;
-		_freeKnown?: boolean;
-		_isFree?: boolean;
-	};
+	} as ProviderModelConfig & { _pricingKnown?: boolean };
 }
 
 /**

--- a/providers/venice/venice-models.ts
+++ b/providers/venice/venice-models.ts
@@ -85,8 +85,10 @@ export function mapVeniceModel(
 ): ProviderModelConfig | undefined {
 	if (typeof entry.id !== "string" || entry.id.length === 0) return undefined;
 	// The /models endpoint also serves image, audio, video, and embedding
-	// models; only chat-completions ("text") models are usable as agent models.
-	if (entry.type !== undefined && entry.type !== "text") return undefined;
+	// models; only chat-completions ("text") models are usable as agent
+	// models. Strict check: entries missing `type` are rejected rather than
+	// assumed text (matches the Agnes defensive posture).
+	if (entry.type !== "text") return undefined;
 
 	const spec = entry.model_spec ?? {};
 	const capabilities = spec.capabilities ?? {};

--- a/providers/venice/venice.ts
+++ b/providers/venice/venice.ts
@@ -13,8 +13,10 @@
  * models appear before login; chat requests require an API key.
  *
  * Balance gate: Venice requires a positive account balance for ALL
- * inference — including $0-listed models — so the catalog publishes no
- * usable free models and defaults to a paid-only view (see venice-models.ts).
+ * inference — including $0-listed models — so an unfunded key will see
+ * request-time 402 errors even for models classified free. Classification
+ * intentionally follows the published pricing data; the catalog defaults
+ * to showing paid models via /toggle-venice.
  *
  * Setup:
  *   1. Sign up at https://venice.ai/ and create an API key
@@ -35,15 +37,15 @@ import { veniceAuth } from "./venice-auth.ts";
 import { fetchVeniceModels } from "./venice-models.ts";
 
 export default function veniceProvider(pi: ExtensionAPI): Promise<void> {
-	registerNativeOpenAIProvider(pi, {
-		providerId: PROVIDER_VENICE,
-		name: "Venice AI",
-		baseUrl: BASE_URL_VENICE,
-		auth: veniceAuth,
-		getApiKey: getVeniceApiKey,
-		getShowPaid: getVeniceShowPaid,
-		allowUnauthenticated: true,
-		fetchModels: (apiKey, signal) => fetchVeniceModels(apiKey, signal),
-	});
-	return Promise.resolve();
+ registerNativeOpenAIProvider(pi, {
+  providerId: PROVIDER_VENICE,
+  name: "Venice AI",
+  baseUrl: BASE_URL_VENICE,
+  auth: veniceAuth,
+  getApiKey: getVeniceApiKey,
+  getShowPaid: getVeniceShowPaid,
+  allowUnauthenticated: true,
+  fetchModels: (apiKey, signal) => fetchVeniceModels(apiKey, signal),
+ });
+ return Promise.resolve();
 }

--- a/providers/venice/venice.ts
+++ b/providers/venice/venice.ts
@@ -12,6 +12,10 @@
  * The model catalog is public (no credential required to list models), so
  * models appear before login; chat requests require an API key.
  *
+ * Balance gate: Venice requires a positive account balance for ALL
+ * inference — including $0-listed models — so the catalog publishes no
+ * usable free models and defaults to a paid-only view (see venice-models.ts).
+ *
  * Setup:
  *   1. Sign up at https://venice.ai/ and create an API key
  *      (https://venice.ai/settings/api)
@@ -31,17 +35,15 @@ import { veniceAuth } from "./venice-auth.ts";
 import { fetchVeniceModels } from "./venice-models.ts";
 
 export default function veniceProvider(pi: ExtensionAPI): Promise<void> {
- registerNativeOpenAIProvider(pi, {
-  providerId: PROVIDER_VENICE,
-  name: "Venice AI",
-  baseUrl: BASE_URL_VENICE,
-  auth: veniceAuth,
-  getApiKey: getVeniceApiKey,
-  getShowPaid: getVeniceShowPaid,
-  allowUnauthenticated: true,
-  fetchModels: (apiKey, signal) => fetchVeniceModels(apiKey, signal),
-  tosUrl: "https://venice.ai/terms",
-  suppressTosWhenKey: true,
- });
- return Promise.resolve();
+	registerNativeOpenAIProvider(pi, {
+		providerId: PROVIDER_VENICE,
+		name: "Venice AI",
+		baseUrl: BASE_URL_VENICE,
+		auth: veniceAuth,
+		getApiKey: getVeniceApiKey,
+		getShowPaid: getVeniceShowPaid,
+		allowUnauthenticated: true,
+		fetchModels: (apiKey, signal) => fetchVeniceModels(apiKey, signal),
+	});
+	return Promise.resolve();
 }

--- a/providers/venice/venice.ts
+++ b/providers/venice/venice.ts
@@ -1,0 +1,47 @@
+/**
+ * Venice AI provider extension.
+ *
+ * Venice.ai offers a privacy-focused, OpenAI-compatible inference API
+ * spanning 100+ text models (frontier reasoning, open weights, and stealth
+ * preview models) billed in USD or DIEM per million tokens.
+ *
+ * Endpoint:
+ *   Chat:   https://api.venice.ai/api/v1/chat/completions
+ *   Models: https://api.venice.ai/api/v1/models?type=text
+ *
+ * The model catalog is public (no credential required to list models), so
+ * models appear before login; chat requests require an API key.
+ *
+ * Setup:
+ *   1. Sign up at https://venice.ai/ and create an API key
+ *      (https://venice.ai/settings/api)
+ *   2. Set VENICE_API_KEY env var (or add venice_api_key to ~/.pi/free.json)
+ *
+ * Usage:
+ *   pi install git:github.com/apmantza/pi-free
+ *   # Set VENICE_API_KEY env var
+ *   # Models appear in /model selector as "venice/claude-sonnet-4-6"
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getVeniceApiKey, getVeniceShowPaid } from "../../config.ts";
+import { BASE_URL_VENICE, PROVIDER_VENICE } from "../../constants.ts";
+import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
+import { veniceAuth } from "./venice-auth.ts";
+import { fetchVeniceModels } from "./venice-models.ts";
+
+export default function veniceProvider(pi: ExtensionAPI): Promise<void> {
+ registerNativeOpenAIProvider(pi, {
+  providerId: PROVIDER_VENICE,
+  name: "Venice AI",
+  baseUrl: BASE_URL_VENICE,
+  auth: veniceAuth,
+  getApiKey: getVeniceApiKey,
+  getShowPaid: getVeniceShowPaid,
+  allowUnauthenticated: true,
+  fetchModels: (apiKey, signal) => fetchVeniceModels(apiKey, signal),
+  tosUrl: "https://venice.ai/terms",
+  suppressTosWhenKey: true,
+ });
+ return Promise.resolve();
+}

--- a/tests/gmi-models.test.ts
+++ b/tests/gmi-models.test.ts
@@ -1,0 +1,65 @@
+/**
+ * GMI provider model-catalog tests.
+ *
+ * Covers the by-id dedupe of GMI's duplicated catalog SKUs (observed live:
+ * MiniMax Week models are published twice — one priced SKU, one $0 SKU) and
+ * the promotion free-stamping window logic.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+
+import { dedupeGmiModelsById } from "../providers/gmi/gmi-models.ts";
+
+function model(
+	id: string,
+	inputCost: number,
+	outputCost = 0,
+): ProviderModelConfig {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: inputCost, output: outputCost, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	};
+}
+
+describe("dedupeGmiModelsById", () => {
+	it("keeps the priced SKU when GMI publishes priced + $0 copies", () => {
+		const deduped = dedupeGmiModelsById([
+			model("MiniMaxAI/MiniMax-M3", 6e-7, 2.4e-6),
+			model("MiniMaxAI/MiniMax-M3", 0),
+		]);
+		expect(deduped).toHaveLength(1);
+		expect(deduped[0]?.cost.input).toBe(6e-7);
+	});
+
+	it("keeps the priced copy regardless of order", () => {
+		const deduped = dedupeGmiModelsById([
+			model("MiniMaxAI/MiniMax-M2.7", 0),
+			model("MiniMaxAI/MiniMax-M2.7", 3e-7, 1.2e-6),
+		]);
+		expect(deduped).toHaveLength(1);
+		expect(deduped[0]?.cost.output).toBe(1.2e-6);
+	});
+
+	it("keeps the first entry when neither duplicate is priced", () => {
+		const first = model("some/model", 0);
+		const deduped = dedupeGmiModelsById([first, model("some/model", 0)]);
+		expect(deduped).toHaveLength(1);
+		expect(deduped[0]).toBe(first);
+	});
+
+	it("keeps unique ids and preserves catalog order", () => {
+		const a = model("a/model", 1e-6);
+		const b = model("b/model", 0);
+		const dupA = model("a/model", 0);
+		const deduped = dedupeGmiModelsById([a, b, dupA]);
+		expect(deduped.map((m) => m.id)).toEqual(["a/model", "b/model"]);
+		expect(deduped[0]?.cost.input).toBe(1e-6);
+	});
+});

--- a/tests/gmi-models.test.ts
+++ b/tests/gmi-models.test.ts
@@ -10,7 +10,10 @@ import { describe, expect, it } from "vitest";
 
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
-import { dedupeGmiModelsById, activePromotionalFreeIds } from "../providers/gmi/gmi-models.ts";
+import {
+	dedupeGmiModelsById,
+	activePromotionalFreeIds,
+} from "../providers/gmi/gmi-models.ts";
 
 function model(
 	id: string,

--- a/tests/gmi-models.test.ts
+++ b/tests/gmi-models.test.ts
@@ -3,14 +3,14 @@
  *
  * Covers the by-id dedupe of GMI's duplicated catalog SKUs (observed live:
  * MiniMax Week models are published twice — one priced SKU, one $0 SKU) and
- * the promotion free-stamping window logic.
+ * the promotion free-stamping window logic including its boundaries.
  */
 
 import { describe, expect, it } from "vitest";
 
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
-import { dedupeGmiModelsById } from "../providers/gmi/gmi-models.ts";
+import { dedupeGmiModelsById, activePromotionalFreeIds } from "../providers/gmi/gmi-models.ts";
 
 function model(
 	id: string,
@@ -61,5 +61,35 @@ describe("dedupeGmiModelsById", () => {
 		const deduped = dedupeGmiModelsById([a, b, dupA]);
 		expect(deduped.map((m) => m.id)).toEqual(["a/model", "b/model"]);
 		expect(deduped[0]?.cost.input).toBe(1e-6);
+	});
+});
+
+describe("activePromotionalFreeIds", () => {
+	// MiniMax Week window: [2026-08-24T00:00Z, 2026-09-07T00:00Z)
+	const START = Date.UTC(2026, 7, 24);
+	const END = Date.UTC(2026, 8, 7);
+
+	it("returns an empty set before the window opens (start is inclusive)", () => {
+		expect(activePromotionalFreeIds(START - 1).size).toBe(0);
+	});
+
+	it("includes promo models at the exact start instant", () => {
+		const free = activePromotionalFreeIds(START);
+		expect(free.has("MiniMaxAI/MiniMax-M3")).toBe(true);
+		expect(free.has("MiniMaxAI/MiniMax-M2.7")).toBe(true);
+	});
+
+	it("excludes promo models at the exact end instant (end is exclusive)", () => {
+		expect(activePromotionalFreeIds(END).size).toBe(0);
+	});
+
+	it("includes promo models mid-window and excludes other ids", () => {
+		const free = activePromotionalFreeIds(Date.UTC(2026, 7, 30));
+		expect(free.size).toBe(2);
+		expect(free.has("google/gemini-3.7-flash")).toBe(false);
+	});
+
+	it("returns an empty set long after the promotion expires", () => {
+		expect(activePromotionalFreeIds(END + 86_400_000).size).toBe(0);
 	});
 });

--- a/tests/venice-models.test.ts
+++ b/tests/venice-models.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { isFreeModel } from "../lib/registry.ts";
 import { mapVeniceModel } from "../providers/venice/venice-models.ts";
 
 function catalogEntry(overrides: Record<string, unknown> = {}) {
@@ -68,11 +69,8 @@ describe("mapVeniceModel", () => {
 		);
 	});
 
-	it("marks zero-priced models NOT free — Venice gates inference behind balance", () => {
-		// Verified live: a $0/$0 model (stealth-ox-alpha) still answers HTTP 402
-		// "Insufficient USD or Diem balance" for an unfunded key, so it must
-		// never surface in the free-only view.
-		const entry = catalogEntry({
+	function zeroPricedEntry(overrides: Record<string, unknown> = {}) {
+		return catalogEntry({
 			id: "stealth-preview",
 			model_spec: {
 				...catalogEntry().model_spec,
@@ -83,16 +81,43 @@ describe("mapVeniceModel", () => {
 					cache_input: { usd: 0, diem: 0 },
 				},
 			},
+			...overrides,
 		});
-		const model = mapVeniceModel(entry) as unknown as {
+	}
+
+	it("classifies zero-priced models free per published pricing (Route A)", () => {
+		// Note: Venice gates inference behind account balance (a $0/$0 model
+		// still answers HTTP 402 for an unfunded key), but classification
+		// intentionally follows the published pricing; the balance requirement
+		// surfaces as a request-time error.
+		const model = mapVeniceModel(zeroPricedEntry()) as unknown as {
 			cost: { input: number; output: number };
 			_freeKnown?: boolean;
 			_isFree?: boolean;
 		};
 		expect(model.cost.input).toBe(0);
 		expect(model.cost.output).toBe(0);
-		expect(model._freeKnown).toBe(true);
-		expect(model._isFree).toBe(false);
+		// No authoritative override — Route A decides from the zero costs.
+		expect(model._freeKnown).toBeUndefined();
+		expect(model._isFree).toBeUndefined();
+	});
+
+	it("end-to-end: zero-priced model is free among priced siblings", () => {
+		const free = mapVeniceModel(zeroPricedEntry());
+		const paid = mapVeniceModel(catalogEntry());
+		// SAFETY: both entries come from the typed mapper above.
+		expect(
+			isFreeModel(free as Parameters<typeof isFreeModel>[0], [
+				free!,
+				paid!,
+			] as Parameters<typeof isFreeModel>[1]),
+		).toBe(true);
+		expect(
+			isFreeModel(paid as Parameters<typeof isFreeModel>[0], [
+				free!,
+				paid!,
+			] as Parameters<typeof isFreeModel>[1]),
+		).toBe(false);
 	});
 
 	it("rejects non-text endpoints (image/audio/video/embeddings)", () => {

--- a/tests/venice-models.test.ts
+++ b/tests/venice-models.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Venice provider tests.
+ *
+ * Covers the catalog mapper (nested model_spec pricing in USD per million
+ * tokens, capability flags, non-text filtering) and the public-catalog fetch
+ * path with an optional key.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { mapVeniceModel } from "../providers/venice/venice-models.ts";
+
+function catalogEntry(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "claude-sonnet-4-6",
+		object: "model",
+		owned_by: "venice.ai",
+		type: "text",
+		context_length: 1_000_000,
+		created: 1_771_286_400,
+		model_spec: {
+			name: "Claude Sonnet 4.6",
+			pricing: {
+				input: { usd: 3.6, diem: 3.6 },
+				cache_input: { usd: 0.36, diem: 0.36 },
+				cache_write: { usd: 4.5, diem: 4.5 },
+				output: { usd: 18, diem: 18 },
+			},
+			availableContextTokens: 1_000_000,
+			maxCompletionTokens: 64_000,
+			capabilities: {
+				supportsReasoning: true,
+				supportsVision: true,
+				supportsMultipleImages: true,
+				supportsFunctionCalling: true,
+			},
+			description: "Anthropic's best combination of speed and intelligence.",
+		},
+		...overrides,
+	};
+}
+
+describe("mapVeniceModel", () => {
+	it("maps paid pricing from per-million USD to per-token cost", () => {
+		const model = mapVeniceModel(catalogEntry());
+		expect(model).toBeDefined();
+		expect(model?.id).toBe("claude-sonnet-4-6");
+		// Venice reports USD per million tokens; pi-free stores per token.
+		expect(model?.cost.input).toBeCloseTo(3.6e-6, 12);
+		expect(model?.cost.output).toBeCloseTo(1.8e-5, 12);
+		expect(model?.cost.cacheRead).toBeCloseTo(3.6e-7, 12);
+		expect(model?.cost.cacheWrite).toBeCloseTo(4.5e-6, 12);
+	});
+
+	it("maps capability flags to reasoning and vision input", () => {
+		const model = mapVeniceModel(catalogEntry());
+		expect(model?.reasoning).toBe(true);
+		expect(model?.input).toEqual(["text", "image"]);
+		expect(model?.contextWindow).toBe(1_000_000);
+		expect(model?.maxTokens).toBe(64_000);
+		expect(model?.name).toBe("Claude Sonnet 4.6");
+	});
+
+	it("stamps _pricingKnown so Route A detection is authoritative", () => {
+		const model = mapVeniceModel(catalogEntry());
+		expect((model as unknown as { _pricingKnown?: boolean })._pricingKnown).toBe(
+			true,
+		);
+	});
+
+	it("marks zero-priced models NOT free — Venice gates inference behind balance", () => {
+		// Verified live: a $0/$0 model (stealth-ox-alpha) still answers HTTP 402
+		// "Insufficient USD or Diem balance" for an unfunded key, so it must
+		// never surface in the free-only view.
+		const entry = catalogEntry({
+			id: "stealth-preview",
+			model_spec: {
+				...catalogEntry().model_spec,
+				name: "Stealth Preview",
+				pricing: {
+					input: { usd: 0, diem: 0 },
+					output: { usd: 0, diem: 0 },
+					cache_input: { usd: 0, diem: 0 },
+				},
+			},
+		});
+		const model = mapVeniceModel(entry) as unknown as {
+			cost: { input: number; output: number };
+			_freeKnown?: boolean;
+			_isFree?: boolean;
+		};
+		expect(model.cost.input).toBe(0);
+		expect(model.cost.output).toBe(0);
+		expect(model._freeKnown).toBe(true);
+		expect(model._isFree).toBe(false);
+	});
+
+	it("rejects non-text endpoints (image/audio/video/embeddings)", () => {
+		expect(mapVeniceModel(catalogEntry({ type: "image" }))).toBeUndefined();
+		expect(mapVeniceModel(catalogEntry({ type: "audio" }))).toBeUndefined();
+		expect(mapVeniceModel(catalogEntry({ type: "video" }))).toBeUndefined();
+		expect(mapVeniceModel(catalogEntry({ type: "embedding" }))).toBeUndefined();
+	});
+
+	it("falls back to id when model_spec.name is missing and applies defaults", () => {
+		const model = mapVeniceModel(
+			catalogEntry({ model_spec: {}, context_length: undefined }),
+		);
+		expect(model).toBeDefined();
+		expect(model?.name).toBe("claude-sonnet-4-6");
+		expect(model?.reasoning).toBe(false);
+		expect(model?.input).toEqual(["text"]);
+		expect(model?.contextWindow).toBe(128_000);
+		expect(model?.maxTokens).toBe(4_096);
+	});
+
+	it("returns undefined for unusable entries", () => {
+		expect(mapVeniceModel(catalogEntry({ id: "" }))).toBeUndefined();
+		expect(mapVeniceModel(catalogEntry({ id: undefined }))).toBeUndefined();
+	});
+});

--- a/tests/venice-models.test.ts
+++ b/tests/venice-models.test.ts
@@ -2,8 +2,8 @@
  * Venice provider tests.
  *
  * Covers the catalog mapper (nested model_spec pricing in USD per million
- * tokens, capability flags, non-text filtering) and the public-catalog fetch
- * path with an optional key.
+ * tokens, capability flags, strict non-text filtering). The network fetch
+ * path is exercised by the live drive smoke test, not here.
  */
 
 import { describe, expect, it } from "vitest";
@@ -100,6 +100,8 @@ describe("mapVeniceModel", () => {
 		expect(mapVeniceModel(catalogEntry({ type: "audio" }))).toBeUndefined();
 		expect(mapVeniceModel(catalogEntry({ type: "video" }))).toBeUndefined();
 		expect(mapVeniceModel(catalogEntry({ type: "embedding" }))).toBeUndefined();
+		// Strict posture: entries missing `type` are rejected, not assumed text.
+		expect(mapVeniceModel(catalogEntry({ type: undefined }))).toBeUndefined();
 	});
 
 	it("falls back to id when model_spec.name is missing and applies defaults", () => {

--- a/tests/venice-models.test.ts
+++ b/tests/venice-models.test.ts
@@ -107,16 +107,16 @@ describe("mapVeniceModel", () => {
 		const paid = mapVeniceModel(catalogEntry());
 		// SAFETY: both entries come from the typed mapper above.
 		expect(
-			isFreeModel(free as Parameters<typeof isFreeModel>[0], [
-				free!,
-				paid!,
-			] as Parameters<typeof isFreeModel>[1]),
+			isFreeModel(
+				free as Parameters<typeof isFreeModel>[0],
+				[free!, paid!] as Parameters<typeof isFreeModel>[1],
+			),
 		).toBe(true);
 		expect(
-			isFreeModel(paid as Parameters<typeof isFreeModel>[0], [
-				free!,
-				paid!,
-			] as Parameters<typeof isFreeModel>[1]),
+			isFreeModel(
+				paid as Parameters<typeof isFreeModel>[0],
+				[free!, paid!] as Parameters<typeof isFreeModel>[1],
+			),
 		).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary

Three related improvements from a live-provider audit session:

### 1. Venice AI native provider (`providers/venice/`)
- Public OpenAI-compatible catalog at `https://api.venice.ai/api/v1` — **113 text models**, no credential needed to list; chat requires `VENICE_API_KEY` / config key / stored key
- Venice-specific mapper: nested `model_spec.pricing.{input,output,cache_input,cache_write}.usd` is **USD per million tokens** → converted to pi-free's per-token cost units (÷1e6); capabilities → reasoning/vision/context/maxTokens; non-text endpoints (image/audio/video/embedding) filtered
- **Balance gate (verified live):** Venice requires positive account balance for *all* inference — even `$0`-listed models answer HTTP 402 "Insufficient USD or Diem balance" on unfunded keys. Every model is stamped `_pricingKnown: true` plus the authoritative `_freeKnown: true, _isFree: false` override so nothing mis-surfaces in the free-only view
- `/toggle-venice`, hidden-models, CI scores, and Pi-owned store lifecycle all via the standard `registerNativeOpenAIProvider` path

### 2. GMI catalog dedupe (`fix`)
GMI's live `/v1/models` publishes duplicate ids during MiniMax Week (one priced SKU, one $0 SKU) → duplicate picker entries. New `dedupeGmiModelsById()` keeps the **priced** copy so Route A detection sees real pricing while the promotion stamp overrides it to free during the window and auto-reverts after.

### 3. Agnes doc correction
Factory header still claimed "every chat model is free", contradicting the flash-free/pro-paid stamping behavior introduced in a916824.

Also carries the two pending commits on this branch: GMI MiniMax Week promotional stamping (#24e330a) and the Agnes flash-only stamp fix (#a916824).

## Test plan
- [x] `npm run test:run` — 689 passed (7 new venice mapper tests, 4 new gmi dedupe tests)
- [x] `tsc --noEmit` clean; `check-runtime-imports.mjs` green
- [x] Live smoke via `npm run drive -- --provider venice`: catalog fetch + model conversion + wire format verified end-to-end (402 balance response expected with unfunded key)
- [x] Live GMI catalog confirmed duplicated SKUs; dedupe verified against real data