### PR TITLE
fix: classification-audit corrections (bai free stamps; media/test-model filters)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -189,6 +189,8 @@ export BAI_API_KEY="..."
 
 Or set `bai_api_key`. Toggle with `/toggle-bai`.
 
+Three models are currently documented as free on the B.AI API and are stamped free in the catalog: `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, and `mimo-v2.5` (source: [B.AI pricing](https://docs.b.ai/llmservice/pricing-and-usage/), audited 2026-08-26). This is a time-limited promotion — revisit the pricing page before relying on it.
+
 ## Qoder (native)
 
 Qoder has a basic Community/free tier and premium models that consume plan credits. Its static curated catalog is restored and persisted through Pi's native models-store lifecycle; the legacy cache is retained only for optional stream metadata.

--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -55,6 +55,26 @@ function isBaiKnownFree(modelId: string): boolean {
 	return modelId.toLowerCase().endsWith(":free");
 }
 
+/**
+ * Models B.AI's official pricing page documents as FREE on the API.
+ *
+ * Source: https://docs.b.ai/llmservice/pricing-and-usage/
+ * Verified live against https://api.b.ai/v1/models on 2026-08-26 — all three
+ * ids were present in the authenticated catalog.
+ *
+ * CAVEAT: the page's wording is time-limited promotion semantics —
+ *   - deepseek-v4-flash: "currently free on B.AI Chat and API"
+ *   - deepseek-v4-flash-vision-exp: "currently free for B.AI API use"
+ *   - mimo-v2.5: "API usage currently free"
+ * REVISIT: re-check the pricing page periodically (first check added
+ * 2026-08-26) and remove any id whose free window has ended.
+ */
+export const BAI_DOCUMENTED_FREE_MODEL_IDS: ReadonlySet<string> = new Set([
+	"deepseek-v4-flash",
+	"deepseek-v4-flash-vision-exp",
+	"mimo-v2.5",
+]);
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -89,14 +109,15 @@ function isTextChatModel(model: BaiModel): boolean {
 	return endpoints.some((t) => CHAT_ENDPOINT_TYPES.has(t));
 }
 
-function mapBaiModel(model: BaiModel): ProviderModelConfig & {
+export function mapBaiModel(model: BaiModel): ProviderModelConfig & {
 	_pricingKnown?: boolean;
 	_freeKnown?: boolean;
 	_isFree?: boolean;
 } {
 	const name = cleanModelName(model.id);
 	const reasoning = isLikelyReasoningModel({ id: model.id, name });
-	const isKnownFree = isBaiKnownFree(model.id);
+	const isKnownFree =
+		isBaiKnownFree(model.id) || BAI_DOCUMENTED_FREE_MODEL_IDS.has(model.id);
 
 	return {
 		id: model.id,

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -55,6 +55,19 @@ import { deepinfraAuth } from "./deepinfra-auth.ts";
 
 const _logger = createLogger("deepinfra");
 
+/**
+ * Media-generation capability tags from DeepInfra's structured metadata.
+ * Zero-priced image/video/audio models carry these tags, so filtering on them
+ * (instead of id substrings) reliably keeps real chat models out of the
+ * free-only view while dropping non-chat entries.
+ */
+const MEDIA_TAGS = new Set(["image-gen", "video-gen", "tts", "stt"]);
+
+function isMediaTagged(tags: string[] | undefined): boolean {
+	if (!tags) return false;
+	return tags.some((tag) => MEDIA_TAGS.has(tag));
+}
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -77,7 +90,7 @@ interface DeepInfraModel {
 // Fetch
 // =============================================================================
 
-async function fetchDeepinfraModels(
+export async function fetchDeepinfraModels(
 	apiKey: string,
 	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
@@ -108,8 +121,11 @@ async function fetchDeepinfraModels(
 
 	const mapped = models
 		.filter((m) => {
+			// Prefer structured capability tags over id substrings: zero-priced
+			// media models (Seedream, Veo, Whisper, TTS, ...) are tagged.
+			if (isMediaTagged(m.metadata?.tags)) return false;
 			const id = m.id.toLowerCase();
-			// Filter out non-chat models
+			// Fallback for untagged entries
 			if (id.includes("embed")) return false;
 			if (id.includes("rerank")) return false;
 			if (id.includes("whisper")) return false;

--- a/providers/fastrouter/fastrouter-models.ts
+++ b/providers/fastrouter/fastrouter-models.ts
@@ -18,6 +18,10 @@ export async function fetchFastrouterModels(
 		baseUrl: BASE_URL_FASTROUTER,
 		apiKey: apiKey || undefined,
 		signal,
+		// FastRouter's free view must not contain media-generation models:
+		// zero-priced image/audio hybrids (gemini-*-image, prompt-to-audio)
+		// would otherwise be classified as free chat models.
+		excludeOutputModalities: ["image", "audio", "video", "speech"],
 	});
 	return applyHidden(models, PROVIDER_FASTROUTER);
 }

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -40,6 +40,13 @@ interface FetchModelsOptions {
 	apiKey?: string;
 	/** Only return free models (pricing === 0) */
 	freeOnly?: boolean;
+	/**
+	 * Drop models whose `architecture.output_modalities` include ANY of these
+	 * modalities, even when "text" is also present (e.g. image-generation
+	 * hybrids like gemini-flash-image). Unlike the default text-output check,
+	 * this never keeps such models for chat use.
+	 */
+	excludeOutputModalities?: string[];
 	/** Additional headers to include */
 	extraHeaders?: Record<string, string>;
 	/** Abort signal owned by the native provider refresh lifecycle. */
@@ -61,6 +68,7 @@ export async function fetchOpenRouterCompatibleModels(
 		baseUrl,
 		apiKey,
 		freeOnly = false,
+		excludeOutputModalities,
 		extraHeaders = {},
 		retries = 3,
 		retryDelay = 1000,
@@ -109,6 +117,14 @@ export async function fetchOpenRouterCompatibleModels(
 			// modality info to avoid over-filtering older endpoints.
 			const outputMods = m.architecture?.output_modalities ?? [];
 			if (outputMods.length > 0 && !outputMods.includes("text")) return false;
+
+			// Stricter capability exclusion for providers whose free views must
+			// not contain media-generation hybrids (image+text output etc.).
+			if (
+				excludeOutputModalities &&
+				outputMods.some((mod) => excludeOutputModalities.includes(mod))
+			)
+				return false;
 
 			// Filter by provider flag when available, otherwise pricing.
 			if (freeOnly) {

--- a/providers/novita/novita.ts
+++ b/providers/novita/novita.ts
@@ -67,11 +67,18 @@ interface NovitaModel {
 	status?: number;
 }
 
+/**
+ * Internal Novita smoke-test models (`ai_infer_test_1..3`) are zero-priced and
+ * typed `chat`, but are not real inference endpoints. They carry no
+ * distinguishing structured metadata, so the id pattern is the only signal.
+ */
+const INTERNAL_TEST_MODEL_PATTERN = /^ai_infer_test/;
+
 // =============================================================================
 // Fetch
 // =============================================================================
 
-async function fetchNovitaModels(
+export async function fetchNovitaModels(
 	apiKey: string,
 	signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
@@ -97,9 +104,11 @@ async function fetchNovitaModels(
 		}
 
 		const json = (await response.json()) as { data?: NovitaModel[] };
-		const models = (json.data ?? []).filter(
-			(m) => m.status === 1 && m.model_type === "chat",
-		);
+		const models = (json.data ?? [])
+			.filter((m) => m.status === 1 && m.model_type === "chat")
+			// Novita exposes internal smoke-test entries (`ai_infer_test_1..3`)
+			// as zero-priced chat models; they are not usable endpoints.
+			.filter((m) => !INTERNAL_TEST_MODEL_PATTERN.test(m.id));
 
 		_logger.info(`[novita] Fetched ${models.length} models`);
 

--- a/tests/bai-models.test.ts
+++ b/tests/bai-models.test.ts
@@ -1,0 +1,75 @@
+/**
+ * B.AI provider model-mapper tests.
+ *
+ * B.AI's /v1/models endpoint exposes no pricing (minimal OpenAI-shim
+ * `{id, object, created, owned_by}` entries), so classification falls to
+ * Route B name-based detection. B.AI's official pricing page documents a
+ * trio of models as currently free on the API; those ids must be stamped
+ * authoritatively free (`_freeKnown`/`_isFree`) so they classify free via
+ * `isFreeModel`, while every other catalog id stays paid.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isFreeModel } from "../lib/registry.ts";
+
+import {
+	BAI_DOCUMENTED_FREE_MODEL_IDS,
+	mapBaiModel,
+} from "../providers/bai/bai.ts";
+
+const DOCUMENTED_FREE_IDS = [
+	"deepseek-v4-flash",
+	"deepseek-v4-flash-vision-exp",
+	"mimo-v2.5",
+] as const;
+
+describe("BAI_DOCUMENTED_FREE_MODEL_IDS", () => {
+	it("contains exactly the documented-free trio", () => {
+		expect([...BAI_DOCUMENTED_FREE_MODEL_IDS].sort()).toEqual(
+			[...DOCUMENTED_FREE_IDS].sort(),
+		);
+	});
+});
+
+describe("mapBaiModel free stamping", () => {
+	it("stamps the documented-free ids as authoritatively free", () => {
+		for (const id of DOCUMENTED_FREE_IDS) {
+			const mapped = mapBaiModel({ id });
+			expect(mapped._freeKnown).toBe(true);
+			expect(mapped._isFree).toBe(true);
+			expect(isFreeModel(mapped)).toBe(true);
+		}
+	});
+
+	it("keeps the :free-suffix promotion detection working", () => {
+		const mapped = mapBaiModel({ id: "some-model:free" });
+		expect(mapped._freeKnown).toBe(true);
+		expect(mapped._isFree).toBe(true);
+		expect(isFreeModel(mapped)).toBe(true);
+	});
+
+	it("leaves other models unstamped and paid under Route B", () => {
+		for (const id of [
+			"claude-opus-4.8",
+			"gpt-5.2",
+			"deepseek-v4-chat",
+			"mimo-v2.0",
+		]) {
+			const mapped = mapBaiModel({ id });
+			expect(mapped._freeKnown).toBe(false);
+			expect(mapped._isFree).toBe(false);
+			expect(mapped._pricingKnown).toBe(false);
+			// Route B: no pricing data, name has no "free" → paid.
+			expect(isFreeModel(mapped)).toBe(false);
+		}
+	});
+
+	it("does not let a paid name collide with a documented-free id prefix", () => {
+		// "deepseek-v4-flash-exp-foo" is not in the set even though it shares
+		// a prefix with a documented-free id.
+		const mapped = mapBaiModel({ id: "deepseek-v4-flash-exp-foo" });
+		expect(mapped._freeKnown).toBe(false);
+		expect(isFreeModel(mapped)).toBe(false);
+	});
+});

--- a/tests/deepinfra-models.test.ts
+++ b/tests/deepinfra-models.test.ts
@@ -1,0 +1,121 @@
+/**
+ * DeepInfra catalog classification tests.
+ *
+ * DeepInfra's zero-priced media models (image-gen, video-gen, tts, stt) carry
+ * structured capability tags in `metadata.tags`. Observed live: ~60 zero-priced
+ * entries are exclusively media models (Seedream, Veo, FLUX, Whisper, TTS...),
+ * so tag-based filtering keeps the free view chat-only while substring
+ * matching alone let them through.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T) => models,
+}));
+
+import { fetchDeepinfraModels } from "../providers/deepinfra/deepinfra.ts";
+
+function stubModels(data: unknown[]) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(
+			async (..._args: unknown[]) =>
+				new Response(JSON.stringify({ data }), {
+					status: 200,
+					statusText: "OK",
+				}),
+		),
+	);
+}
+
+describe("fetchDeepinfraModels — non-chat filtering", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("drops tagged media models even when they are zero-priced", async () => {
+		stubModels([
+			{
+				id: "ByteDance/Seedream-4",
+				metadata: {
+					tags: ["image-gen"],
+					pricing: { input_tokens: 0, output_tokens: 0 },
+				},
+			},
+			{
+				id: "google/veo-3.1",
+				metadata: {
+					tags: ["video-gen"],
+					pricing: { input_tokens: 0, output_tokens: 0 },
+				},
+			},
+			{
+				id: "bosonai/HiggsAudioV2.5",
+				metadata: {
+					tags: ["tts"],
+					pricing: { input_tokens: 0, output_tokens: 0 },
+				},
+			},
+			{
+				id: "openai/whisper-large-v3",
+				metadata: {
+					tags: ["stt"],
+					pricing: { input_tokens: 0, output_tokens: 0 },
+				},
+			},
+		]);
+
+		const models = await fetchDeepinfraModels("sk-test");
+		expect(models).toHaveLength(0);
+	});
+
+	it("keeps real chat models", async () => {
+		stubModels([
+			{
+				id: "Qwen/Qwen3.5-9B",
+				metadata: {
+					context_length: 262_144,
+					tags: ["chat", "vlm", "vision", "reasoning_effort"],
+					pricing: { input_tokens: 0.1, output_tokens: 0.15 },
+				},
+			},
+		]);
+
+		const models = await fetchDeepinfraModels("sk-test");
+		expect(models.map((m) => m.id)).toEqual(["Qwen/Qwen3.5-9B"]);
+		expect(models[0]?.cost.input).toBeCloseTo(1e-7);
+	});
+
+	it("keeps a zero-priced chat-tagged model (legitimate free chat)", async () => {
+		stubModels([
+			{
+				id: "some/free-chat-model",
+				metadata: {
+					tags: ["chat"],
+					pricing: { input_tokens: 0, output_tokens: 0 },
+				},
+			},
+		]);
+
+		const models = await fetchDeepinfraModels("sk-test");
+		expect(models.map((m) => m.id)).toEqual(["some/free-chat-model"]);
+		expect(models[0]?.cost.input).toBe(0);
+	});
+
+	it("still drops untagged entries via the substring fallback", async () => {
+		stubModels([
+			{ id: "BAAI/bge-reranker-base" }, // rerank, no metadata
+			{
+				id: "Qwen/Qwen3.5-9B",
+				metadata: {
+					tags: ["chat"],
+					pricing: { input_tokens: 0.1, output_tokens: 0.15 },
+				},
+			},
+		]);
+
+		const models = await fetchDeepinfraModels("sk-test");
+		expect(models.map((m) => m.id)).toEqual(["Qwen/Qwen3.5-9B"]);
+	});
+});

--- a/tests/fastrouter.test.ts
+++ b/tests/fastrouter.test.ts
@@ -86,4 +86,13 @@ describe("FastRouter native provider", () => {
 			}),
 		);
 	});
+
+	it("excludes media-generation output modalities from the catalog", async () => {
+		await fetchFastrouterModels("");
+		expect(mocks.fetchModels).toHaveBeenCalledWith(
+			expect.objectContaining({
+				excludeOutputModalities: ["image", "audio", "video", "speech"],
+			}),
+		);
+	});
 });

--- a/tests/model-fetcher.test.ts
+++ b/tests/model-fetcher.test.ts
@@ -61,6 +61,44 @@ describe("fetchOpenRouterCompatibleModels", () => {
 		]);
 	});
 
+	it("keeps text+image hybrids unless excludeOutputModalities is set", async () => {
+		const data = [
+			{
+				id: "text-only",
+				name: "Text Only",
+				context_length: 128000,
+				architecture: { output_modalities: ["text"] },
+			},
+			{
+				id: "image-hybrid",
+				name: "Image Hybrid",
+				context_length: 128000,
+				architecture: { output_modalities: ["image", "text"] },
+			},
+			{
+				id: "audio-gen",
+				name: "Audio Gen",
+				context_length: 128000,
+				architecture: { output_modalities: ["audio"] },
+			},
+		];
+
+		// Default: hybrids stay (existing behavior for kilo/built-in openrouter).
+		stubModels(data);
+		const permissive = await fetchOpenRouterCompatibleModels({
+			baseUrl: "https://example.test/api/gateway",
+		});
+		expect(permissive.map((m) => m.id)).toEqual(["text-only", "image-hybrid"]);
+
+		// Strict: any listed output modality drops the model, even with text.
+		stubModels(data);
+		const strict = await fetchOpenRouterCompatibleModels({
+			baseUrl: "https://example.test/api/gateway",
+			excludeOutputModalities: ["image", "audio", "video", "speech"],
+		});
+		expect(strict.map((m) => m.id)).toEqual(["text-only"]);
+	});
+
 	it("omits the Authorization header for anonymous catalog fetches (#421)", async () => {
 		const fetchMock = stubModels([
 			{

--- a/tests/novita-models.test.ts
+++ b/tests/novita-models.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Novita catalog classification tests.
+ *
+ * Novita exposes internal smoke-test models (`ai_infer_test_1..3`) as
+ * zero-priced `chat`-typed entries with status 1. Observed live alongside
+ * legitimate free chat models (qwen/qwen3.5-plus etc.), so only the test ids
+ * must be dropped.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/model-metadata.ts", () => ({
+	safeEnrichModelsWithModelsDev: async <T>(models: T) => models,
+}));
+
+import { fetchNovitaModels } from "../providers/novita/novita.ts";
+
+function entry(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "qwen/qwen3.5-plus",
+		display_name: "Qwen 3.5 Plus",
+		model_type: "chat",
+		status: 1,
+		input_token_price_per_m: 0,
+		output_token_price_per_m: 0,
+		context_size: 262_144,
+		...overrides,
+	};
+}
+
+function stubModels(data: unknown[]) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(
+			async (..._args: unknown[]) =>
+				new Response(JSON.stringify({ data }), {
+					status: 200,
+					statusText: "OK",
+				}),
+		),
+	);
+}
+
+describe("fetchNovitaModels — internal test model filtering", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("rejects all internal ai_infer_test_* models", async () => {
+		stubModels([
+			entry({ id: "ai_infer_test_1", display_name: undefined }),
+			entry({ id: "ai_infer_test_2", display_name: undefined }),
+			entry({ id: "ai_infer_test_3", display_name: undefined }),
+		]);
+
+		const models = await fetchNovitaModels("sk-test");
+		expect(models).toHaveLength(0);
+	});
+
+	it("keeps legitimate zero-priced chat models", async () => {
+		stubModels([entry(), entry({ id: "dev/glm46" })]);
+
+		const models = await fetchNovitaModels("sk-test");
+		expect(models.map((m) => m.id)).toEqual([
+			"qwen/qwen3.5-plus",
+			"dev/glm46",
+		]);
+		expect(models[0]?.cost.input).toBe(0);
+		expect(models[0]?.cost.output).toBe(0);
+	});
+
+	it("filters test models out of a mixed live-shaped catalog", async () => {
+		stubModels([
+			entry(),
+			entry({
+				id: "ai_infer_test_2",
+				display_name: undefined,
+			}),
+			entry({ id: "minimax/m2-her" }),
+			entry({
+				id: "some/model",
+				status: 0, // not deployed yet
+			}),
+		]);
+
+		const models = await fetchNovitaModels("sk-test");
+		expect(models.map((m) => m.id)).toEqual([
+			"qwen/qwen3.5-plus",
+			"minimax/m2-her",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Two fixes from the provider pricing-consistency audit (all classifications verified against live endpoints before coding):

### 1. B.AI — three documented-free models were classified paid
B.AI's catalog shim exposes no pricing, so detection ran Route B name-based. But [docs.b.ai pricing page](https://docs.b.ai/llmservice/pricing-and-usage/) documents **currently free on the API**: `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, `mimo-v2.5` (all live-verified present). Now stamped `_freeKnown/_isFree` with a dated revisit note — the wording is promotion semantics, so the set needs periodic re-checking.

### 2. Zero-priced non-chat models polluting free views
- **DeepInfra**: all 60 zero-priced entries are media-tagged (`image-gen`/`video-gen`/`tts`/`stt`) — filter now uses the structured `metadata.tags`, keeping priced chat (Qwen3.5-9B @ $0.10/$0.15/M) and dropping Seedream/Veo/FLUX/whisper/HiggsAudio from the free view
- **Novita**: internal smoke-test models `ai_infer_test_1/2/3` hidden; 7 legitimate zero-priced chat models (`qwen/qwen3.5-plus`, `dev/glm46`, …) kept
- **FastRouter**: new data-driven `excludeOutputModalities` option in the shared fetcher (default off — other consumers unchanged); FastRouter excludes `["image","audio","video","speech"]` outputs → free view drops 11 → 8, all text-output

## Audit evidence (live enumeration before coding)
- DeepInfra: 60/60 zero-priced = media-tagged; zero legitimate free chat exists today
- Novita: 10 zero-priced status-1 models → 3 test + 7 legit
- FastRouter: 201 models; 3 image-hybrid zero-priced entries had slipped past output-modality check

## Test plan
- [x] New: tests/bai-models.test.ts (5), deepinfra-models.test.ts, novita-models.test.ts; extended model-fetcher.test.ts + fastrouter.test.ts
- [x] Full suite: 726 passed / tsc clean
- [x] Live re-verification after filters (kept/dropped enumeration per provider)