### PR TITLE
fix: add @smithy/core dependency for Kiro event-stream parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
 			"name": "pi-free",
 			"version": "2.6.0",
 			"license": "MIT",
+			"dependencies": {
+				"@smithy/core": "^3.24.5"
+			},
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "^0.84.2",
+				"@smithy/types": "^4.17.2",
 				"@vitest/coverage-v8": "^4.1.10",
 				"@vitest/ui": "^4.1.10",
 				"tsx": "^4.23.12",
@@ -3438,7 +3442,6 @@
 			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
 			"integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/types": "^4.17.0",
 				"tslib": "^2.6.2"
@@ -3521,11 +3524,10 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
-			"integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+			"version": "4.17.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+			"integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -5296,8 +5298,7 @@
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsx": {
 			"version": "4.23.12",

--- a/package.json
+++ b/package.json
@@ -85,11 +85,15 @@
 	},
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "^0.84.2",
+		"@smithy/types": "^4.17.2",
 		"@vitest/coverage-v8": "^4.1.10",
 		"@vitest/ui": "^4.1.10",
 		"tsx": "^4.23.12",
 		"typescript": "^7.0.2",
 		"vitest": "^4.1.10"
+	},
+	"dependencies": {
+		"@smithy/core": "^3.24.5"
 	},
 	"pi": {
 		"extensions": [


### PR DESCRIPTION
The Kiro provider's custom stream uses @smithy/core/event-streams for binary Smithy event-stream decoding. Without this dependency, the compiled extension fails to load at runtime: 'Cannot find module @smithy/core/event-streams'. This broke the CI install test on all three platforms. Adds @smithy/core ^3.24.5 to dependencies and @smithy/types ^4.17.2 to devDependencies.