### PR TITLE
fix(gmi): read is_free flag in shared OpenAI-compatible fetcher

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -518,6 +518,10 @@ export interface OpenAIModelEntry {
 	max_tokens?: number;
 	/** Extended: per-model pricing (SambaNova, etc.) */
 	pricing?: { prompt?: string | number; completion?: string | number };
+	/** Extended: authoritative free/paid flag (camelCase, OpenRouter convention). */
+	isFree?: boolean;
+	/** Extended: authoritative free/paid flag (snake_case, GMI Cloud convention). */
+	is_free?: boolean;
 }
 
 /**
@@ -625,7 +629,15 @@ export async function fetchOpenAICompatibleModels(
 					maxTokens,
 					compat: getCompat({ id: m.id, name }),
 					_pricingKnown: hasApiPricing,
-				} as PiProviderModelConfig & { _pricingKnown?: boolean };
+					...((typeof m.isFree === "boolean" || typeof m.is_free === "boolean") && {
+						_freeKnown: true,
+						_isFree: (m.isFree ?? m.is_free) === true,
+					}),
+				} as PiProviderModelConfig & {
+					_pricingKnown?: boolean;
+					_freeKnown?: boolean;
+					_isFree?: boolean;
+				};
 			});
 
 		return await safeEnrichModelsWithModelsDev(mapped, { providerId });

--- a/providers/gmi/gmi-models.ts
+++ b/providers/gmi/gmi-models.ts
@@ -8,13 +8,19 @@
  * enrichment without introducing a second cache or freshness policy.
  *
  * Promotional free models: GMI runs time-limited "free week" promotions
- * (e.g. MiniMax Week, 2026-08-24 → 2026-09-06) where specific models are free
- * to use at the billing layer even though the `/v1/models` `pricing` field
- * still reports nonzero list prices. Such models are stamped authoritatively
- * free (`_freeKnown`/`_isFree`, the same escape hatch used by the anyapi/bai/
- * agnes gateways) for the duration of the promotion so the free-only view and
- * `/free-providers` counts are correct; the stamp auto-expires when the
- * promotion ends so the models revert to paid per the pricing API.
+ * (e.g. MiniMax Week) where specific models are free to use at the billing
+ * layer. GMI publishes each promotional model TWICE in `/v1/models`:
+ *
+ *   1. The normal priced SKU (nonzero `pricing.prompt`/`pricing.completion`).
+ *   2. A duplicate id with `pricing` zeroed and an authoritative
+ *      `is_free: true` flag — the promotional SKU.
+ *
+ * The shared `fetchOpenAICompatibleModels` mapper stamps the `is_free: true`
+ * rows as `_freeKnown: true, _isFree: true`, so they survive as a distinct
+ * free entry alongside the priced copy. Both rows are kept (no dedupe): the
+ * priced entry drives the "show paid" view, the promotional row drives the
+ * free-only view. The promotion auto-expires when GMI stops publishing the
+ * `is_free: true` row — no hardcoded date windows to maintain.
  */
 
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
@@ -22,115 +28,28 @@ import { applyHidden } from "../../config.ts";
 import { BASE_URL_GMI, PROVIDER_GMI } from "../../constants.ts";
 import { fetchOpenAICompatibleModels } from "../../lib/util.ts";
 
-/** Augmented model shape carrying the authoritative free/paid flag. */
-type GmiProviderModel = ProviderModelConfig & {
-	_freeKnown?: boolean;
-	_isFree?: boolean;
-};
-
-interface Promotion {
-	/** Model ids (as published by GMI's /v1/models) that are free for the window. */
-	modelIds: readonly string[];
-	/** Inclusive start (ms since epoch). */
-	startMs: number;
-	/** Exclusive end (ms since epoch) — promotion is active while startMs <= now < endMs. */
-	endMs: number;
-	/** Human-readable label for logging. */
-	label: string;
-}
-
 /**
- * Known GMI free-week promotions. Keep this list in sync with GMI's
- * announcements (https://x.com/gmi_cloud). Each window is [inclusive, exclusive).
- */
-const PROMOTIONS: readonly Promotion[] = [
-	{
-		// "unlimited MiniMax M3 and M2.7, 14 days FREE on GMI Cloud from 8/24
-		// to 9/6" — https://x.com/gmi_cloud/status/2091925007756857368
-		modelIds: ["MiniMaxAI/MiniMax-M3", "MiniMaxAI/MiniMax-M2.7"],
-		startMs: Date.UTC(2026, 7, 24), // 2026-08-24 00:00 UTC (month is 0-indexed)
-		endMs: Date.UTC(2026, 8, 7), // 2026-09-07 00:00 UTC (end of 9/6)
-		label: "GMI MiniMax Week (M3, M2.7 free)",
-	},
-];
-
-/**
- * Model ids that are authoritatively free right now because an active GMI
- * promotion makes them free at the billing layer despite nonzero list prices.
- */
-export function activePromotionalFreeIds(
-	now: number = Date.now(),
-): Set<string> {
-	const free = new Set<string>();
-	for (const promo of PROMOTIONS) {
-		if (now >= promo.startMs && now < promo.endMs) {
-			for (const id of promo.modelIds) free.add(id);
-		}
-	}
-	return free;
-}
-
-/**
- * Dedupe catalog entries that share a model id.
+ * Fetch GMI Cloud's authenticated `/v1/models` catalog.
  *
- * GMI's live /v1/models has been observed publishing the same id twice
- * (during MiniMax Week: one SKU carrying list pricing, one $0 SKU). Keep the
- * PRICED entry so Route A cost-based detection sees real pricing; the
- * promotion stamp below then overrides the winner to free while a window is
- * active and reverts automatically when it ends. Ties keep the first seen.
- */
-export function dedupeGmiModelsById(
-	models: readonly ProviderModelConfig[],
-): ProviderModelConfig[] {
-	const byId = new Map<string, ProviderModelConfig>();
-	for (const model of models) {
-		const existing = byId.get(model.id);
-		if (existing === undefined) {
-			byId.set(model.id, model);
-			continue;
-		}
-		const existingPriced = isPriced(existing);
-		const nextPriced = isPriced(model);
-		if (nextPriced && !existingPriced) byId.set(model.id, model);
-	}
-	return [...byId.values()];
-}
-
-function isPriced(model: ProviderModelConfig): boolean {
-	return (model.cost?.input ?? 0) > 0 || (model.cost?.output ?? 0) > 0;
-}
-
-/**
- * Fetch GMI Cloud's authenticated `/v1/models` catalog, dedupe repeated ids,
- * then stamp any model that is free under an active GMI promotion as
- * authoritatively free.
+ * GMI publishes priced + promotional SKUs side-by-side; both are kept so
+ * the free-only view and the "show paid" view each have the right entry
+ * to display. Hidden models in `~/.pi/free.json` are still filtered.
  */
 export async function fetchGmiModels(
-	apiKey: string,
-	signal?: AbortSignal,
+ apiKey: string,
+ signal?: AbortSignal,
 ): Promise<ProviderModelConfig[]> {
-	const models = await fetchOpenAICompatibleModels(
-		PROVIDER_GMI,
-		BASE_URL_GMI,
-		apiKey,
-		{
-			contextWindow: 128_000,
-			maxTokens: 16_384,
-		},
-		undefined,
-		signal,
-	);
+ const models = await fetchOpenAICompatibleModels(
+  PROVIDER_GMI,
+  BASE_URL_GMI,
+  apiKey,
+  {
+   contextWindow: 128_000,
+   maxTokens: 16_384,
+  },
+  undefined,
+  signal,
+ );
 
-	const deduped = dedupeGmiModelsById(models);
-	const promotionalFree = activePromotionalFreeIds();
-	const stamped: GmiProviderModel[] = deduped.map((model) => {
-		if (!promotionalFree.has(model.id)) return model;
-		return {
-			...model,
-			_freeKnown: true,
-			_isFree: true,
-		};
-	});
-
-	return applyHidden(stamped, PROVIDER_GMI);
+ return applyHidden(models, PROVIDER_GMI);
 }

--- a/tests/fetch-openai-compatible.test.ts
+++ b/tests/fetch-openai-compatible.test.ts
@@ -388,4 +388,67 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 
 		expect(models).toHaveLength(2);
 	});
+
+	// ── Authoritative free/paid flag ───────────────────────────
+	it("stamps _freeKnown + _isFree when API returns is_free: true (snake_case)", async () => {
+		mockFetchOk({
+			data: [
+				{
+					id: "promo/model",
+					pricing: { prompt: "0", completion: "0" },
+					is_free: true,
+				},
+			],
+		});
+
+		const models = (await fetchOpenAICompatibleModels(
+			"test",
+			"https://api.example.com/v1",
+			"sk-test",
+		)) as Array<{ _freeKnown?: boolean; _isFree?: boolean }>;
+
+		expect(models[0]?._freeKnown).toBe(true);
+		expect(models[0]?._isFree).toBe(true);
+	});
+
+	it("stamps _freeKnown + _isFree when API returns isFree: true (camelCase)", async () => {
+		mockFetchOk({
+			data: [
+				{
+					id: "promo/camel",
+					pricing: { prompt: "0", completion: "0" },
+					isFree: true,
+				},
+			],
+		});
+
+		const models = (await fetchOpenAICompatibleModels(
+			"test",
+			"https://api.example.com/v1",
+			"sk-test",
+		)) as Array<{ _freeKnown?: boolean; _isFree?: boolean }>;
+
+		expect(models[0]?._freeKnown).toBe(true);
+		expect(models[0]?._isFree).toBe(true);
+	});
+
+	it("does not stamp the free flag when neither is_free nor isFree is set", async () => {
+		mockFetchOk({
+			data: [
+				{
+					id: "regular/model",
+					pricing: { prompt: "0.000001", completion: "0.000002" },
+				},
+			],
+		});
+
+		const models = (await fetchOpenAICompatibleModels(
+			"test",
+			"https://api.example.com/v1",
+			"sk-test",
+		)) as Array<{ _freeKnown?: boolean; _isFree?: boolean }>;
+
+		expect(models[0]?._freeKnown).toBeUndefined();
+		expect(models[0]?._isFree).toBeUndefined();
+	});
 });

--- a/tests/gmi-models.test.ts
+++ b/tests/gmi-models.test.ts
@@ -1,98 +1,97 @@
 /**
  * GMI provider model-catalog tests.
  *
- * Covers the by-id dedupe of GMI's duplicated catalog SKUs (observed live:
- * MiniMax Week models are published twice — one priced SKU, one $0 SKU) and
- * the promotion free-stamping window logic including its boundaries.
+ * Covers the catalog's pass-through behavior. GMI publishes priced +
+ * promotional SKUs side-by-side; both are expected to survive `fetchGmiModels`
+ * (no dedupe), and the promotional `is_free: true` row must surface as a
+ * distinct free entry. Previously, GMI's free weeks required a hardcoded
+ * PROMOTIONS window and a by-id dedupe; both were removed when
+ * `fetchOpenAICompatibleModels` grew native `is_free` handling.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
-import {
-	dedupeGmiModelsById,
-	activePromotionalFreeIds,
-} from "../providers/gmi/gmi-models.ts";
+import { fetchGmiModels } from "../providers/gmi/gmi-models.ts";
 
-function model(
-	id: string,
-	inputCost: number,
-	outputCost = 0,
-): ProviderModelConfig {
+function mockFetchOk(body: unknown) {
+	globalThis.fetch = vi.fn().mockResolvedValue({
+		ok: true,
+		status: 200,
+		json: async () => body,
+	} as unknown as Response);
+}
+
+function asGmiEntry(overrides: Record<string, unknown> = {}) {
 	return {
-		id,
-		name: id,
-		reasoning: false,
-		input: ["text"],
-		cost: { input: inputCost, output: outputCost, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128_000,
-		maxTokens: 16_384,
+		id: "some/model",
+		object: "model",
+		owned_by: "GMI Cloud",
+		context_length: 128_000,
+		pricing: {
+			prompt: "0.000000300",
+			completion: "0.000001200",
+			request: "0",
+			image: "0",
+			input_cache_read: "0",
+			input_cache_write: "0",
+		},
+		discount_to_user: 0,
+		...overrides,
 	};
 }
 
-describe("dedupeGmiModelsById", () => {
-	it("keeps the priced SKU when GMI publishes priced + $0 copies", () => {
-		const deduped = dedupeGmiModelsById([
-			model("MiniMaxAI/MiniMax-M3", 6e-7, 2.4e-6),
-			model("MiniMaxAI/MiniMax-M3", 0),
-		]);
-		expect(deduped).toHaveLength(1);
-		expect(deduped[0]?.cost.input).toBe(6e-7);
+describe("fetchGmiModels — promotional free SKUs", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
-	it("keeps the priced copy regardless of order", () => {
-		const deduped = dedupeGmiModelsById([
-			model("MiniMaxAI/MiniMax-M2.7", 0),
-			model("MiniMaxAI/MiniMax-M2.7", 3e-7, 1.2e-6),
-		]);
-		expect(deduped).toHaveLength(1);
-		expect(deduped[0]?.cost.output).toBe(1.2e-6);
+	it("keeps both the priced and the promotional is_free rows (no dedupe)", async () => {
+		mockFetchOk({
+			object: "list",
+			data: [
+				asGmiEntry({ id: "MiniMaxAI/MiniMax-M3" }),
+				asGmiEntry({
+					id: "MiniMaxAI/MiniMax-M3",
+					pricing: {
+						prompt: "0",
+						completion: "0",
+						request: "0",
+						image: "0",
+						input_cache_read: "0",
+						input_cache_write: "0",
+					},
+					is_free: true,
+				}),
+			],
+		});
+
+		const models = (await fetchGmiModels("sk-test")) as Array<
+			ProviderModelConfig & { _freeKnown?: boolean; _isFree?: boolean }
+		>;
+
+		expect(models).toHaveLength(2);
+
+		const priced = models.find((m) => (m.cost?.input ?? 0) > 0);
+		const promo = models.find((m) => (m.cost?.input ?? 0) === 0);
+
+		expect(priced).toBeDefined();
+		expect(priced?._freeKnown).toBeUndefined();
+
+		expect(promo).toBeDefined();
+		expect(promo?._freeKnown).toBe(true);
+		expect(promo?._isFree).toBe(true);
 	});
 
-	it("keeps the first entry when neither duplicate is priced", () => {
-		const first = model("some/model", 0);
-		const deduped = dedupeGmiModelsById([first, model("some/model", 0)]);
-		expect(deduped).toHaveLength(1);
-		expect(deduped[0]).toBe(first);
-	});
+	it("returns an empty catalog when the API fails", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+			json: async () => ({}),
+		} as unknown as Response);
 
-	it("keeps unique ids and preserves catalog order", () => {
-		const a = model("a/model", 1e-6);
-		const b = model("b/model", 0);
-		const dupA = model("a/model", 0);
-		const deduped = dedupeGmiModelsById([a, b, dupA]);
-		expect(deduped.map((m) => m.id)).toEqual(["a/model", "b/model"]);
-		expect(deduped[0]?.cost.input).toBe(1e-6);
-	});
-});
-
-describe("activePromotionalFreeIds", () => {
-	// MiniMax Week window: [2026-08-24T00:00Z, 2026-09-07T00:00Z)
-	const START = Date.UTC(2026, 7, 24);
-	const END = Date.UTC(2026, 8, 7);
-
-	it("returns an empty set before the window opens (start is inclusive)", () => {
-		expect(activePromotionalFreeIds(START - 1).size).toBe(0);
-	});
-
-	it("includes promo models at the exact start instant", () => {
-		const free = activePromotionalFreeIds(START);
-		expect(free.has("MiniMaxAI/MiniMax-M3")).toBe(true);
-		expect(free.has("MiniMaxAI/MiniMax-M2.7")).toBe(true);
-	});
-
-	it("excludes promo models at the exact end instant (end is exclusive)", () => {
-		expect(activePromotionalFreeIds(END).size).toBe(0);
-	});
-
-	it("includes promo models mid-window and excludes other ids", () => {
-		const free = activePromotionalFreeIds(Date.UTC(2026, 7, 30));
-		expect(free.size).toBe(2);
-		expect(free.has("google/gemini-3.7-flash")).toBe(false);
-	});
-
-	it("returns an empty set long after the promotion expires", () => {
-		expect(activePromotionalFreeIds(END + 86_400_000).size).toBe(0);
+		const models = await fetchGmiModels("sk-test");
+		expect(models).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Problem

GMI Cloud's `/v1/models` publishes each promotional free model **twice**:

1. The normal priced SKU (nonzero `pricing.prompt`/`pricing.completion`)
2. A duplicate id with `pricing` zeroed and an authoritative `is_free: true` flag — the promotional SKU

The shared `fetchOpenAICompatibleModels` mapper was dropping the `is_free` signal, so the only way the free entries could reach the free-only view was via a hardcoded date range in `providers/gmi/gmi-models.ts`. Today (2026-08-28) is inside MiniMax Week (2026-08-24 → 2026-09-07), and the free MiniMax M3 and M2.7 are not showing up because the only path to the free view was that hardcoded window.

## Fix

1. **`lib/util.ts`** — `fetchOpenAICompatibleModels` now reads both `isFree` (camelCase, OpenRouter convention) and `is_free` (snake_case, GMI's actual wire format) and stamps the same `_freeKnown: true, _isFree: true` pattern that `mapOpenRouterModel` already uses. This is a general fix — any OpenAI-compatible gateway that publishes a free flag will now be picked up automatically.

2. **`providers/gmi/gmi-models.ts`** — dropped `dedupeGmiModelsById`, `activePromotionalFreeIds`, `isPriced`, and the hardcoded `PROMOTIONS` window. Both rows now pass through; the promotional row carries the `is_free`-derived stamp, the priced row is the normal paid entry. The promotion auto-expires when GMI stops publishing the `is_free: true` row — no manual date windows to maintain. The `fetchGmiModels` signature is unchanged.

3. **Tests** — rewrote `tests/gmi-models.test.ts` to cover the new pass-through behavior (both rows kept, promo row stamped). Added three `is_free`/`isFree` reading tests in `tests/fetch-openai-compatible.test.ts` (snake_case, camelCase, and the negative case).

## User-visible effect

During MiniMax Week (2026-08-24 → 2026-09-07) the `/toggle-gmi` command and the global `/toggle-free` correctly show the promotional MiniMax M3 and M2.7 in the free-only view. After 9/7 GMI stops publishing the `is_free` row, the entries automatically revert to paid per the pricing API — no code change required.

## Verification

- `tests/gmi-models.test.ts`: 2 passed
- `tests/fetch-openai-compatible.test.ts`: 23 passed
- Full suite: 749/752 passed; the one failure is the unrelated flaky logger stream-teardown test (issue #456) which passes in isolation.