### PR TITLE
docs(kiro): design the Web Portal auth follow-up to #485

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -49,6 +49,14 @@ import {
 	PROVIDER_MERGE,
 	PROVIDER_COMMANDCODE,
 } from "./constants.ts";
+// SAFETY: This re-export is intentional — every provider module imports its
+// `PROVIDER_*` constant via `from "../../config.ts"` (see providers/kilo/kilo.ts,
+// providers/gmi/gmi.ts, etc.). Collapsing the import path into a single barrel
+// here keeps the import surface stable when constants move, and avoids forcing
+// every provider to add a second import line for `./constants.ts`. The cost
+// is that this file looks like a barrel — it isn't; it's the single source of
+// truth for runtime config (env vars, ~/.pi/free.json resolution, defaults)
+// and the provider-id constants happen to live alongside it.
 export {
 	PROVIDER_ANYAPI,
 	PROVIDER_BAI,
@@ -153,6 +161,7 @@ interface PiFreeConfig {
 	opencode_go_show_paid?: boolean;
 	qoder_show_paid?: boolean;
 	kiro_show_paid?: boolean;
+	kiro_profile_arn?: string;
 }
 
 const CONFIG_TEMPLATE: PiFreeConfig = {
@@ -213,6 +222,7 @@ const CONFIG_TEMPLATE: PiFreeConfig = {
 	opencode_go_show_paid: false,
 	qoder_show_paid: false,
 	kiro_show_paid: false,
+	kiro_profile_arn: "",
 };
 
 const CONFIG_PATH = join(PI_DATA_DIR, "free.json");
@@ -666,6 +676,21 @@ export function getOpencodeGoShowPaid(): boolean {
 
 export function getKiroShowPaid(): boolean {
 	return resolveBool("KIRO_SHOW_PAID", loadConfigFile().kiro_show_paid);
+}
+
+/**
+ * Resolve the Kiro profileArn override from env or config.
+ *
+ * The Kiro streaming endpoint requires a real `profileArn` for the credential;
+ * pi-free's `pi-cli` OIDC client does not have the `codewhisperer:profile:List`
+ * scope needed to discover it from `ListAvailableProfiles`, so the user must
+ * supply it explicitly. Set `KIRO_PROFILE_ARN` or `kiro_profile_arn` in
+ * `~/.pi/free.json` to a real ARN (e.g. from the Kiro IDE's developer tools or
+ * `kiro-cli profile` output). When unset, the kiro stream provider will throw
+ * a clear error instead of silently retrying with an invalid placeholder ARN.
+ */
+export function getKiroProfileArn(): string | undefined {
+	return resolve("KIRO_PROFILE_ARN", loadConfigFile().kiro_profile_arn);
 }
 
 export function getProviderShowPaid(providerId: string): boolean {

--- a/docs/kiro-web-portal-auth.md
+++ b/docs/kiro-web-portal-auth.md
@@ -1,0 +1,427 @@
+# Kiro Web Portal auth flow
+
+> Design document for replacing the current Kiro SSO OIDC device-code flow
+> with the Kiro Web Portal PKCE + `ExchangeToken` flow. This is the
+> follow-up to PR #485 — the immediate fix is shipped; this document
+> describes the long-term plan.
+>
+> **Status: proposed, Phase A (plan + spec) of six.**
+> Phase tracker at the bottom of this document.
+
+## Context
+
+PR #485 fixed a 400 `REQUEST_BODY_INVALID` on the Kiro streaming endpoint
+by replacing a silent placeholder `profileArn` with a manual config knob
+(`kiro_profile_arn` / `KIRO_PROFILE_ARN`). The user must set it for chat
+to work. End-to-end diagnosis (recorded in `docs/roadmap.md`) established
+that the underlying limitation is that the pi-free `pi-cli` OIDC client
+**lacks the `codewhisperer:profile:List` scope** needed to discover the
+real `profileArn`, and the AWS SSO OIDC token response itself does not
+include one.
+
+The kiro-cli's own auth flow is different. It talks to a Kiro Web Portal
+(`app.kiro.dev`) that exposes a Smithy `KiroWebPortalService` over the
+`rpc-v2-cbor` protocol. That service runs a PKCE-based auth code flow
+(separate from AWS Cognito's device-code flow) whose `ExchangeToken`
+response **includes `profileArn`**. Subsequent refreshes against
+`prod.{region}.auth.desktop.kiro.dev/refreshToken` return a fresh
+`profileArn` on every call.
+
+This document specifies the protocol, the proposed file layout, the
+public-OIDC-client decision, the feature-flag design, and the fallback
+path so the rewrite can be reviewed and merged in clear phases.
+
+## Goals and non-goals
+
+### Goals
+
+- A user who runs `/login kiro` (with the new flow enabled) gets a working
+  Kiro chat with no manual `kiro_profile_arn` setting.
+- The persisted credential includes `profileArn` so the streaming path
+  reads it automatically.
+- The new flow coexists with the current SSO OIDC flow behind a
+  `kiro_auth_method` config knob (no breaking change for users who
+  already have a working `kiro_profile_arn` set).
+- Refresh continues to surface the latest `profileArn` (rare, but
+  possible after subscription upgrades).
+
+### Non-goals
+
+- Replacing the kiro-cli's `desktop` refresh path with a different
+  endpoint. The Kiro Desktop refresh endpoint already returns `profileArn`
+  in its response and we already use it for the `authMethod: "desktop"`
+  path; we just need to extract the new field.
+- Adding a web-IDE-style embedded auth UI inside Pi. The user opens
+  `app.kiro.dev/signin/oauth?...` in their browser, the same way the
+  kiro-cli does.
+- Supporting the `Internal` IdP. The other four (`BuilderId`, `Google`,
+  `Github`, `AWSIdC`) are sufficient for the user's reported need.
+- A general CBOR helper for other providers. The Kiro Web Portal is the
+  only known consumer; we keep the encoder/decoder local to the kiro
+  module.
+
+## Protocol spec
+
+Reverse-engineered from `keggin-CHN/kiro-auto-register/src/services/kiro_oauth.py`,
+`ZyphrZero/kiro.rs` provider impl, `1070920013wh/kiro-gateway/docs/refresh-token.md`,
+`kirodotdev/Kiro` public docs, and live probes against
+`https://app.kiro.dev/service/KiroWebPortalService/operation/{op}`.
+
+### InitiateLogin (PKCE step 1)
+
+```
+POST https://app.kiro.dev/service/KiroWebPortalService/operation/InitiateLogin
+Content-Type: application/cbor
+Accept: application/cbor
+smithy-protocol: rpc-v2-cbor
+
+{
+  "idp": "BuilderId" | "Google" | "Github" | "AWSIdC" | "Internal",
+  "redirectUri": "https://app.kiro.dev/signin/oauth",
+  "codeChallenge": "<base64url(SHA256(code_verifier))>",
+  "codeChallengeMethod": "S256",
+  "state": "<random-uuid>"
+}
+```
+
+Response (CBOR, decoded):
+
+```json
+{
+  "redirectUrl": "https://app.kiro.dev/signin/oauth?code_challenge=...&code_challenge_method=S256&state=...&idp=BuilderId&redirect_uri=..."
+}
+```
+
+The user opens `redirectUrl` in their browser, authenticates with the
+chosen IdP, and is redirected back to `app.kiro.dev/signin/oauth` with
+the query parameters `code` and `state` populated.
+
+### ExchangeToken (PKCE step 2)
+
+```
+POST https://app.kiro.dev/service/KiroWebPortalService/operation/ExchangeToken
+Content-Type: application/cbor
+Accept: application/cbor
+smithy-protocol: rpc-v2-cbor
+
+{
+  "idp": "BuilderId",
+  "code": "<authorization-code-from-redirect>",
+  "codeVerifier": "<original-code-verifier>",
+  "redirectUri": "https://app.kiro.dev/signin/oauth",
+  "state": "<state-from-redirect>"
+}
+```
+
+Response (CBOR, decoded):
+
+```json
+{
+  "accessToken": "aoa...",
+  "csrfToken": "abc123",
+  "expiresIn": 604800
+}
+```
+
+Plus `Set-Cookie` headers (the `RefreshToken`, `SessionToken`, `Idp`, and
+`AccessToken` cookies). **The `profileArn` field in the response body is
+the key piece of data we need.** (Note: the Python reference uses
+`profile_arn` snake_case in its parsed return dict, but the actual CBOR
+response uses `profileArn` camelCase, matching every other field in the
+Smithy-generated contract.)
+
+### GetUserInfo (post-exchange, optional)
+
+```
+POST https://app.kiro.dev/service/KiroWebPortalService/operation/GetUserInfo
+Content-Type: application/cbor
+Accept: application/cbor
+smithy-protocol: rpc-v2-cbor
+Authorization: Bearer <accessToken>
+Cookie: Idp=<idp>; AccessToken=<accessToken>
+
+{ "origin": "KIRO_IDE" }
+```
+
+Returns the user's email, userId, subscription tier, and quota usage.
+We use it to populate the `/free-providers` display and `/login kiro`
+status.
+
+### Refresh (every ~1h)
+
+```
+POST https://prod.{region}.auth.desktop.kiro.dev/refreshToken
+Content-Type: application/json
+User-Agent: KiroIDE-0.6.18-{machineId}
+
+{ "refreshToken": "<refreshToken-from-cookie-or-store>" }
+```
+
+Response (json 1.0):
+
+```json
+{
+  "accessToken": "aoa...",
+  "refreshToken": "aoa...",
+  "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/XXXXX",
+  "expiresIn": 3600,
+  "csrfToken": "abc123"
+}
+```
+
+The `profileArn` is stable across refreshes for a given credential. We
+re-persist it on every refresh so subscription upgrades are picked up
+without re-auth.
+
+## Public OIDC client decision
+
+**Recommendation: piggyback on the kiro-cli's widely-shared public client.**
+
+Three options were considered:
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| **A. Kiro-cli's public client** (the one every other Kiro proxy uses) | Zero setup, works today, matches `kiro-rs` / `kiro-gateway` / `kiro-openai-gateway` | Not officially ours; Kiro could revoke at any time (the kiro-account-manager project explicitly warns about this) |
+| **B. Register our own OIDC client with AWS Cognito** | Officially ours, stable clientId | AWS paperwork, weeks of lead time, ongoing maintenance, requires a public clientSecret in our source |
+| **C. Read from kiro-cli's local SQLite if installed** | No new client, no shared secret | Doesn't help users without kiro-cli; cross-process boundary fragility |
+
+**Choice: A**, with a defensive fallback. If the public clientId/clientSecret
+stop working (4xx from `InitiateLogin`), we surface a clear error
+suggesting the user set `kiro_auth_method: "idc"` (the existing flow with
+manual `kiro_profile_arn`) or `kiro_auth_method: "kiro-cli"` (the
+SQLite-read fallback from option C) — see the feature-flag design below.
+
+The public clientId/clientSecret is hardcoded in the source as a
+constants block. If it ever rotates, the fix is a one-line constant
+change plus a release note. We do not promise compatibility with future
+Kiro protocol changes.
+
+## File layout
+
+```
+providers/kiro/
+├── kiro-auth.ts                  # existing — kept; only the refresh path gains profileArn extraction
+├── kiro-desktop-auth.ts          # NEW — Web Portal + Kiro Desktop refresh
+├── kiro-web-portal-cbor.ts       # NEW — minimal CBOR encode/decode for our payload types
+├── kiro-pkce.ts                  # NEW — PKCE code_verifier / code_challenge / state
+├── kiro-web-portal.ts            # NEW — InitiateLogin / ExchangeToken / GetUserInfo client
+├── kiro-stream.ts                # existing — read credential.profileArn before getKiroProfileArn()
+├── kiro-provider.ts              # existing — unchanged
+├── kiro-models.ts                # existing — unchanged
+├── ...                           # other existing files unchanged
+```
+
+`kiro-web-portal-cbor.ts` is a ~60-line wrapper around the
+`cbor-x` dependency (added in Phase B). It exposes `encodeInitiateLogin(payload)`
+and `decodeExchangeToken(buffer)` so the rest of the module never touches
+CBOR directly. The wrapper also handles the `Output` / `Version` envelope
+that Coral wraps successful Smithy responses in.
+
+`kiro-pkce.ts` is a ~30-line PKCE helper. `generatePkce()` returns
+`{ codeVerifier, codeChallenge, state }`; the caller persists `state` for
+verification after the redirect.
+
+`kiro-web-portal.ts` is the HTTP client. It takes an `AuthInteraction`
+and drives the full login flow. It does **not** know about the local
+HTTP listener — that's `kiro-auth.ts`'s responsibility, because the
+listener is a generic OAuthLoginCallbacks concern shared with Kilo and
+Cline.
+
+`kiro-desktop-auth.ts` is the new top-level entry point. It exposes
+`loginKiroDesktop(interaction)` and `refreshKiroDesktopCredential(credential)`.
+Both go through `kiro-web-portal.ts` (for login) and the existing
+`prod.{region}.auth.desktop.kiro.dev/refreshToken` endpoint (for refresh).
+
+## Feature flag design
+
+A new config field in `PiFreeConfig`:
+
+```typescript
+// (real TypeScript syntax below; reproduced verbatim in config.ts)
+interface PiFreeConfig {
+  // ... existing fields
+  kiro_auth_method?: "idc" | "web-portal" | "kiro-cli";
+}
+```
+
+Default: `"web-portal"` for new users. Existing users who have a
+working `kiro_profile_arn` keep their `"idc"` flow until they explicitly
+switch (we detect "has working kiro_profile_arn + has Kiro creds" at
+startup and seed the default to `"idc"` for that case — see the
+migration note below).
+
+`"web-portal"`: the new flow. Replaces the current `loginKiro` body
+with a PKCE + Web Portal exchange.
+
+`"idc"`: the current flow. Unchanged. Requires the user to set
+`kiro_profile_arn` for chat to work (per PR #485).
+
+`"kiro-cli"`: the SQLite-read fallback. Reads `~/.local/share/kiro-cli/data.sqlite3`
+(Linux) / `%APPDATA%/kiro-cli/data.sqlite3` (Windows) and copies the
+profileArn from the kiro-cli's own credential store. Implemented as a
+Phase G addition (out of scope for the first three phases).
+
+`getKiroAuthMethod()` follows the same env > file resolution as the
+other config getters: `KIRO_AUTH_METHOD` env > `kiro_auth_method` in
+`~/.pi/free.json` > built-in default.
+
+## Migration note for existing users
+
+A user who installed pi-free before PR #485, ran `/login kiro`, and now
+has a working `kiro_profile_arn` set in `~/.pi/free.json` will continue
+to work with the default behavior **only if** we seed the
+`kiro_auth_method` default to `"idc"` when `kiro_profile_arn` is set.
+
+The seeding logic in `config.ts`:
+
+```typescript
+// (real TypeScript syntax below; reproduced verbatim in config.ts)
+function defaultKiroAuthMethod(): "idc" | "web-portal" {
+  const file = loadConfigFile();
+  // If the user has a manual kiro_profile_arn, keep them on the working flow.
+  if (file.kiro_profile_arn && file.kiro_profile_arn.length > 0) return "idc";
+  return "web-portal";
+}
+```
+
+This is the same "migrate gradually, never break a working setup"
+pattern used by every other config default in the file.
+
+## Persisted credential shape
+
+The `kiro` entry in `~/.pi/agent/auth.json` gains a new shape. Old
+shape (kept for `"idc"` mode, unchanged):
+
+```jsonc
+{
+  "type": "oauth",
+  "refresh": "...",
+  "access": "...",
+  "expires": 1787906008267,
+  "clientId": "pHpUwOql-...",
+  "clientSecret": "eyJ...",
+  "region": "us-east-1",
+  "authMethod": "idc"
+}
+```
+
+New shape (for `"web-portal"` mode, adds `profileArn` + `csrfToken`):
+
+```jsonc
+{
+  "type": "oauth",
+  "refresh": "...",
+  "access": "...",
+  "expires": 1787906008267,
+  "region": "us-east-1",
+  "authMethod": "web-portal",
+  "idp": "BuilderId",
+  "clientId": "pHpUwOql-...",
+  "clientSecret": "eyJ...",
+  "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/XXXXX",
+  "csrfToken": "abc123",
+  "machineId": "<sha256-derived>"
+}
+```
+
+`machineId` is a stable SHA-256 of the host's MAC address, used in the
+`User-Agent: KiroIDE-0.6.18-{machineId}` refresh header. The kiro-cli
+derives it the same way; reusing the same algorithm keeps the refresh
+request indistinguishable from a kiro-cli refresh, which avoids
+flagging the session as anomalous.
+
+`kiro-stream.ts` gains a new first-line check in the profileArn
+resolution:
+
+```typescript
+// (real TypeScript syntax below; reproduced verbatim in kiro-stream.ts)
+const profileArn =
+  modelMetadata.kiroProfileArn ||                    // per-model override
+  (credential as KiroCredentials | undefined)?.profileArn ||  // ← new
+  getKiroProfileArn();                               // user config knob (kept)
+```
+
+The credential is passed through `options.apiKey` by Pi's native auth
+surface, so the stream function already has access to it. We just need
+to plumb it through (the existing `modelMetadata` shape needs a
+`credential` field added, or we pass `options.credential` directly).
+
+## Browser-redirect UX
+
+Three options were considered for capturing the redirect:
+
+1. **Pi's `OAuthLoginCallbacks` surface** (used by Kilo and Cline) — Pi
+   provides a local HTTP listener. The user is told to open a URL in
+   their browser and the redirect is captured automatically.
+2. **Manual copy-paste** — the user pastes the redirect URL back into
+   Pi. Lower friction than option 1 for some users; higher friction
+   for others.
+3. **Embedded webview** — not available in Pi's extension surface.
+
+**Choice: option 1**, with a fallback to option 2 if the local listener
+fails to bind (port already in use, firewall, etc.). This matches what
+Kilo and Cline already do; the user's existing mental model applies.
+
+## Refresh path
+
+`refreshKiroCredential(credential)` in the existing `kiro-auth.ts`
+gains a new branch for `authMethod: "web-portal"`. It hits the same
+`prod.{region}.auth.desktop.kiro.dev/refreshToken` endpoint that the
+existing `desktop` branch uses, but the response now also carries
+`profileArn` — we just need to persist it. No new endpoint.
+
+The existing `desktop` branch is updated to extract `profileArn` from
+the response (currently it ignores the field) so any existing user
+with `authMethod: "desktop"` gets the new field too, for free.
+
+## Errors and observability
+
+New logger namespace: `kiro-web-portal`. Errors logged:
+
+- `InitiateLogin` 4xx → fatal, surface to user via `ctx.ui.notify` with
+  the raw 4xx body (truncated to 500 chars; never log access tokens or
+  the `code_verifier`)
+- `ExchangeToken` 4xx → fatal, same surface
+- Browser-redirect timeout (5 min) → fatal with a hint to use the
+  manual paste fallback
+- Refresh failure → retry once, then surface with the existing
+  `KiroManagementHttpError` shape
+
+No credential material is ever logged (covered by convention #17 in
+`agents.md` — wire-signature logs are header names only, no values).
+The `profileArn` is logged at debug level on the first successful
+exchange; subsequent refreshes log "profileArn unchanged" or
+"profileArn updated: <old-arn-suffix> → <new-arn-suffix>" (truncated to
+the last 20 chars of each to avoid PII).
+
+## Test plan
+
+| Test | File | What it covers |
+| --- | --- | --- |
+| `kiro-pkce.test.ts` | `tests/kiro-pkce.test.ts` | PKCE code_verifier is 43-128 chars base64url, code_challenge is SHA256(verifier) base64url, state is uuid v4 |
+| `kiro-web-portal-cbor.test.ts` | `tests/kiro-web-portal-cbor.test.ts` | Round-trip encode/decode of an InitiateLogin and an ExchangeToken-shaped payload, including the `Output` envelope |
+| `kiro-web-portal.test.ts` | `tests/kiro-web-portal.test.ts` | Mocked `fetch` for InitiateLogin (200 CBOR), ExchangeToken (200 CBOR with `profileArn`), 4xx errors propagate, no credential material in error logs |
+| `kiro-desktop-auth.test.ts` | `tests/kiro-desktop-auth.test.ts` | Refresh extracts `profileArn` and `csrfToken` from the response, persists to credential shape |
+| `kiro-stream.test.ts` (new) | `tests/kiro-stream.test.ts` | `profileArn` resolution order: `modelMetadata` > `credential` > `getKiroProfileArn()`; clear error when all three are unset |
+| `config.test.ts` (extend) | `tests/config.test.ts` | `getKiroAuthMethod()` env > file > default; default is `"idc"` when `kiro_profile_arn` is set, else `"web-portal"` |
+| Live API test (manual) | `scripts/test-kiro-desktop.mjs` | Run the real PKCE + ExchangeToken flow against the real Kiro Web Portal; verify `profileArn` ends up in the persisted credential; verify chat works |
+
+The live API test is not run in CI (it requires user interaction and a
+real browser). It lives in `scripts/` next to the other dev-only
+helpers and is run by hand before each release that touches the kiro
+auth flow.
+
+## Phase tracker
+
+| Phase | What | Status | PR |
+| --- | --- | --- | --- |
+| A | This design document | **in progress** (this PR) | TBD |
+| B | `kiro-web-portal-cbor.ts` + `cbor-x` dep + unit tests | not started | — |
+| C | `kiro-pkce.ts` + `kiro-web-portal.ts` + unit tests | not started | — |
+| D | `kiro-desktop-auth.ts` + browser redirect UX + refresh | not started | — |
+| E | `kiro_auth_method` config + `kiro-stream.ts` credential read + `getKiroAuthMethod()` + tests | not started | — |
+| F | End-to-end test, release notes, roadmap doc update | not started | — |
+
+Each phase is its own PR. A through E are reviewable independently. F
+is a final polish PR that just runs the live API test, updates the
+roadmap entry, and writes the release notes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -180,3 +180,94 @@ built-in catalog surfaces by design.
    be migrated without reintroducing startup network work.
 3. Consider built-in free-filter ports or preventive XML leak handling only when
    user demand and model-specific evidence justify the maintenance cost.
+
+---
+
+## Kiro auth-flow follow-up (post #485)
+
+**Context.** PR #485 (#485) fixed a 400 `REQUEST_BODY_INVALID` on the Kiro
+streaming endpoint by replacing a silent placeholder `profileArn` with a
+`getKiroProfileArn()` config knob. The user must now set `kiro_profile_arn`
+(or `KIRO_PROFILE_ARN`) in `~/.pi/free.json` for chat to work. This is the
+smallest fix that unblocks the user; the larger question of *why the OIDC
+token doesn't carry a profileArn* is open and is a separate work item.
+
+**Root cause (verified against a real Kiro credential).** Three independent
+limits, none of which can be patched in our auth flow without one of the
+following:
+1. **The SSO OIDC token response doesn't include `profileArn`.** The
+   `accessToken` JWT body carries `clientName: "pi-cli"`, `scopes: [...]`,
+   `expiresAt` — no `applicationArn`, no `ownerAccountId`, no `profileArn`.
+   The Cognito `https://oidc.{region}.amazonaws.com/token` response is
+   `{ accessToken, refreshToken, idToken, tokenType, expiresIn, ... }` —
+   `profileArn` is not in the spec.
+2. **`ListAvailableProfiles` is out of scope for our OIDC client.** Both
+   `management.{region}.kiro.dev` (403 "User is not authorized to access
+   this feature") and the legacy `codewhisperer.{region}.amazonaws.com`
+   (403 "AWS Builder ID is not supported for this operation") refuse. The
+   Kiro account-manager project's region-aware fallback ARN
+   (`arn:aws:codewhisperer:{region}:610548660232:profile/VNECVYCYYAWN`)
+   also returns 403 against our token ("The bearer token included in the
+   request is invalid"). The `pi-cli` OIDC client lacks the
+   `codewhisperer:profile:List` scope that the kiro-cli's own public client
+   carries.
+3. **No public Builder-ID fallback ARN.** Enterprise IdC has the
+   region-aware fallback above. Builder ID has none — the Kiro IDE uses an
+   unpublished, client-specific ARN that's only valid for tokens obtained
+   from the official kiro-cli OAuth flow.
+
+**What the kiro-cli itself does** (reverse-engineered from
+`keggin-CHN/kiro-auto-register/src/services/kiro_oauth.py`,
+`ZyphrZero/kiro.rs` provider impl, `1070920013wh/kiro-gateway/docs/refresh-token.md`,
+`kirodotdev/Kiro` docs, and the Kiro Web Portal's CBOR/Smithy RPC):
+1. `InitiateLogin` (PKCE) at
+   `https://app.kiro.dev/service/KiroWebPortalService/operation/InitiateLogin`
+   → returns a `redirectUrl` (Kiro's own authorize page, not AWS Cognito).
+2. User authenticates at `app.kiro.dev/signin/oauth?...` (browser flow).
+3. `ExchangeToken` (CBOR, Smithy rpc-v2-cbor) at the same Kiro Web Portal
+   endpoint → **returns `{ accessToken, csrfToken, expiresIn, profileArn }`**
+   plus `RefreshToken` / `SessionToken` cookies. **This is the only place
+   `profileArn` is exposed.**
+4. Subsequent refresh at
+   `https://prod.{region}.auth.desktop.kiro.dev/refreshToken` (json 1.0,
+   `User-Agent: KiroIDE-0.6.18-{machineId}`) → returns a fresh
+   `{ accessToken, refreshToken, profileArn, expiresIn, csrfToken }` on
+   every refresh. The `profileArn` is stable across refreshes for a given
+   credential.
+
+**Proposed follow-up (separate PR, not part of #485).** Replace the current
+SSO OIDC device-code flow with the Kiro Web Portal PKCE + `ExchangeToken`
+flow. The new `kiro-auth.ts` would:
+1. Generate PKCE `code_verifier` / `code_challenge` (S256) and `state`.
+2. POST to `InitiateLogin` with `idp: "BuilderId" | "Google" | "Github" |
+   "AWSIdC" | "Internal"` → get `redirectUrl` + a list of allowed `idp`s.
+3. Surface the `redirectUrl` to the user (via Pi's `auth_url` notify) and
+   start a local HTTP listener (or reuse Pi's existing `OAuthLoginCallbacks`
+   surface) to capture the redirect back to `app.kiro.dev/signin/oauth?code=...&state=...`.
+4. POST to `ExchangeToken` (CBOR) with `{ idp, code, codeVerifier, redirectUri, state }` →
+   persist `{ accessToken, refreshToken, csrfToken, profileArn, expiresAt, idp, region }` to
+   `auth.json` (kiro entry) + a new `kiro-desktop-cache.json` modeled on
+   the kiro-cli's `~/.local/share/kiro-cli/data.sqlite3` `auth_kv` table.
+5. On refresh (every ~1h), call
+   `prod.{region}.auth.desktop.kiro.dev/refreshToken` (which we already
+   half-implement for the `desktop` `authMethod` path) and update the
+   cached `profileArn` if it changes (rare, but possible after subscription
+   upgrades).
+
+**Why this isn't in #485.** ~200-300 lines of new auth code that depend
+on a third-party protocol (the Kiro Web Portal CBOR API), a public OIDC
+client ID we don't own (the kiro-cli's, widely shared but not officially
+public), and a browser-redirect UX that Pi's `AuthInteraction` already
+supports but we haven't used. Risks: Kiro could change the Web Portal
+protocol or revoke the public client at any time (the kiro-account-manager
+project explicitly warns: "this project and its methods might be outdated
+due to Kiro's updated account termination policies"). The current fix
+unblocks the user today with 5 lines of config; the rewrite is a
+multi-day investment that should ship behind a feature flag and a fallback
+to the SSO OIDC path.
+
+**Tracking.** Will be filed as a separate issue once #485 lands, with a
+detailed implementation plan, risk register, and rollback strategy
+(keep the current `idc` flow as `authMethod: "idc"` opt-in for users who
+already have a working `kiro_profile_arn` set).
+

--- a/providers/kiro/kiro-stream.ts
+++ b/providers/kiro/kiro-stream.ts
@@ -20,13 +20,50 @@ import type {
 import * as PiAi from "@earendil-works/pi-ai";
 import { UniversalEventStreamMarshaller } from "@smithy/core/event-streams";
 import type { Message } from "@smithy/types";
-import { getKiroEndpoints, getKiroRegionFromEndpoint, resolveApiRegion } from "./kiro-endpoints.js";
+import { getKiroProfileArn } from "../../config.ts";
+import {
+  getKiroEndpoints,
+  getKiroRegionFromEndpoint,
+  resolveApiRegion,
+} from "./kiro-endpoints.js";
 import { parseKiroEvent } from "./kiro-event-parser.js";
 import { ThinkingTagParser } from "./kiro-thinking-parser.js";
-import { buildHistory, convertImagesToKiro, convertToolsToKiro, EMPTY_CONTENT_PLACEHOLDER, extractImages, getContentText, type KiroHistoryEntry, type KiroImage, type KiroToolResult, type KiroToolSpec, type KiroUserInputMessage, normalizeMessages, sanitizeSurrogates, TOOL_RESULT_LIMIT, truncate } from "./kiro-transform.js";
-import { getKiroEffortConfig, buildKiroAdditionalModelRequestFields, type KiroAdditionalModelRequestFields } from "./kiro-effort.js";
-import { resolveKiroModel, updateKiroModelsCache, isCacheStale } from "./kiro-models.js";
-import { capacityRetryConfig, exponentialBackoff, FIRST_TOKEN_TIMEOUT, isCapacityError, isNonRetryableBodyError, isTooBigError, MAX_RETRY_DELAY } from "./kiro-retry.js";
+import {
+  buildHistory,
+  convertImagesToKiro,
+  convertToolsToKiro,
+  EMPTY_CONTENT_PLACEHOLDER,
+  extractImages,
+  getContentText,
+  type KiroHistoryEntry,
+  type KiroImage,
+  type KiroToolResult,
+  type KiroToolSpec,
+  type KiroUserInputMessage,
+  normalizeMessages,
+  sanitizeSurrogates,
+  TOOL_RESULT_LIMIT,
+  truncate,
+} from "./kiro-transform.js";
+import {
+  getKiroEffortConfig,
+  buildKiroAdditionalModelRequestFields,
+  type KiroAdditionalModelRequestFields,
+} from "./kiro-effort.js";
+import {
+  resolveKiroModel,
+  updateKiroModelsCache,
+  isCacheStale,
+} from "./kiro-models.js";
+import {
+  capacityRetryConfig,
+  exponentialBackoff,
+  FIRST_TOKEN_TIMEOUT,
+  isCapacityError,
+  isNonRetryableBodyError,
+  isTooBigError,
+  MAX_RETRY_DELAY,
+} from "./kiro-retry.js";
 
 const eventStreamMarshaller = new UniversalEventStreamMarshaller({
   utf8Encoder: (input: Uint8Array) => new TextDecoder().decode(input),
@@ -65,11 +102,26 @@ function emitToolCall(
     return false;
   }
   const contentIndex = output.content.length;
-  const toolCall: ToolCall = { type: "toolCall", id: state.toolUseId, name: state.name, arguments: args };
+  const toolCall: ToolCall = {
+    type: "toolCall",
+    id: state.toolUseId,
+    name: state.name,
+    arguments: args,
+  };
   output.content.push(toolCall);
   stream.push({ type: "toolcall_start", contentIndex, partial: output });
-  stream.push({ type: "toolcall_delta", contentIndex, delta: state.input, partial: output });
-  stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
+  stream.push({
+    type: "toolcall_delta",
+    contentIndex,
+    delta: state.input,
+    partial: output,
+  });
+  stream.push({
+    type: "toolcall_end",
+    contentIndex,
+    toolCall,
+    partial: output,
+  });
   return true;
 }
 
@@ -77,7 +129,14 @@ function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) return Promise.reject(signal.reason);
   return new Promise((resolve, reject) => {
     const timer = setTimeout(resolve, ms);
-    signal?.addEventListener("abort", () => { clearTimeout(timer); reject(signal.reason); }, { once: true });
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
   });
 }
 
@@ -87,21 +146,57 @@ export function streamKiro(
   options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const StreamCtor = (PiAi as any).AssistantMessageEventStream as new () => AssistantMessageEventStream;
+  const StreamCtor = (PiAi as any)
+    .AssistantMessageEventStream as new () => AssistantMessageEventStream;
   const stream = new StreamCtor();
   (async () => {
     const output: AssistantMessage = {
-      role: "assistant", content: [], api: model.api, provider: model.provider, model: model.id,
-      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-      stopReason: "stop", timestamp: Date.now(),
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
     };
     try {
       const accessToken = options?.apiKey;
-      if (!accessToken) throw new Error("Kiro credentials not set. Run /login kiro or install kiro-cli.");
-      const modelMetadata = model as Model<Api> & { kiroModelId?: string; kiroRegion?: string; kiroProfileArn?: string; additionalModelRequestFieldsSchema?: Record<string, unknown> };
-      const region = modelMetadata.kiroRegion ?? getKiroRegionFromEndpoint(model.baseUrl) ?? "us-east-1";
-      const endpoint = new URL("generateAssistantResponse", getKiroEndpoints(region).runtime).toString();
-      const profileArn = modelMetadata.kiroProfileArn || "arn:aws:codewhisperer:us-east-1:000000000000:profile/default";
+      if (!accessToken)
+        throw new Error(
+          "Kiro credentials not set. Run /login kiro or install kiro-cli.",
+        );
+      const modelMetadata = model as Model<Api> & {
+        kiroModelId?: string;
+        kiroRegion?: string;
+        kiroProfileArn?: string;
+        additionalModelRequestFieldsSchema?: Record<string, unknown>;
+      };
+      const region =
+        modelMetadata.kiroRegion ??
+        getKiroRegionFromEndpoint(model.baseUrl) ??
+        "us-east-1";
+      const endpoint = new URL(
+        "generateAssistantResponse",
+        getKiroEndpoints(region).runtime,
+      ).toString();
+      const profileArn = modelMetadata.kiroProfileArn || getKiroProfileArn();
+      if (!profileArn) {
+        throw new Error(
+          "Kiro profileArn is required for this credential. " +
+            "pi-free's pi-cli OIDC client cannot call ListAvailableProfiles " +
+            "(no codewhisperer:profile:List scope). Set KIRO_PROFILE_ARN or " +
+            "kiro_profile_arn in ~/.pi/free.json to a real ARN obtained from " +
+            "the Kiro IDE developer tools or `kiro-cli profile`.",
+        );
+      }
 
       // Background models cache refresh
       if (isCacheStale(region)) {
@@ -109,13 +204,28 @@ export function streamKiro(
       }
 
       const kiroModelId = resolveKiroModel(model.id, modelMetadata.kiroModelId);
-      const effortConfig = getKiroEffortConfig(modelMetadata.additionalModelRequestFieldsSchema, kiroModelId);
-      const additionalModelRequestFields = buildKiroAdditionalModelRequestFields(modelMetadata, kiroModelId, options?.reasoning);
+      const effortConfig = getKiroEffortConfig(
+        modelMetadata.additionalModelRequestFieldsSchema,
+        kiroModelId,
+      );
+      const additionalModelRequestFields =
+        buildKiroAdditionalModelRequestFields(
+          modelMetadata,
+          kiroModelId,
+          options?.reasoning,
+        );
       const thinkingEnabled = !!options?.reasoning || model.reasoning;
 
       let systemPrompt = context.systemPrompt ?? "";
       if (thinkingEnabled && effortConfig?.field !== "reasoning") {
-        const budget = options?.reasoning === "xhigh" ? 50000 : options?.reasoning === "high" ? 30000 : options?.reasoning === "medium" ? 20000 : 10000;
+        const budget =
+          options?.reasoning === "xhigh"
+            ? 50000
+            : options?.reasoning === "high"
+              ? 30000
+              : options?.reasoning === "medium"
+                ? 20000
+                : 10000;
         systemPrompt = `<thinking_mode>enabled</thinking_mode><max_thinking_length>${budget}</max_thinking_length>${systemPrompt ? `\n${systemPrompt}` : ""}`;
       }
 
@@ -126,7 +236,11 @@ export function streamKiro(
       while (retryCount <= maxRetries) {
         if (options?.signal?.aborted) throw options.signal.reason;
         const normalized = normalizeMessages(context.messages);
-        const { history: rawHistory, systemPrepended, currentMsgStartIdx } = buildHistory(normalized, kiroModelId, systemPrompt);
+        const {
+          history: rawHistory,
+          systemPrepended,
+          currentMsgStartIdx,
+        } = buildHistory(normalized, kiroModelId, systemPrompt);
 
         const currentMessages = normalized.slice(currentMsgStartIdx);
         const firstMsg = currentMessages[0];
@@ -140,7 +254,9 @@ export function streamKiro(
             if (m.role === "toolResult") {
               const trm = m as ToolResultMessage;
               currentToolResults.push({
-                content: [{ text: truncate(getContentText(m), TOOL_RESULT_LIMIT) }],
+                content: [
+                  { text: truncate(getContentText(m), TOOL_RESULT_LIMIT) },
+                ],
                 status: trm.isError ? "error" : "success",
                 toolUseId: trm.toolCallId,
               });
@@ -152,7 +268,9 @@ export function streamKiro(
             if (m.role === "toolResult") {
               const trm = m as ToolResultMessage;
               currentToolResults.push({
-                content: [{ text: truncate(getContentText(m), TOOL_RESULT_LIMIT) }],
+                content: [
+                  { text: truncate(getContentText(m), TOOL_RESULT_LIMIT) },
+                ],
                 status: trm.isError ? "error" : "success",
                 toolUseId: trm.toolCallId,
               });
@@ -160,23 +278,36 @@ export function streamKiro(
           }
           currentContent = "";
         } else if (firstMsg?.role === "user") {
-          currentContent = typeof firstMsg.content === "string" ? firstMsg.content : getContentText(firstMsg);
-          if (systemPrompt && !systemPrepended) currentContent = `${systemPrompt}\n\n${currentContent}`;
+          currentContent =
+            typeof firstMsg.content === "string"
+              ? firstMsg.content
+              : getContentText(firstMsg);
+          if (systemPrompt && !systemPrepended)
+            currentContent = `${systemPrompt}\n\n${currentContent}`;
         }
 
-        if (currentContent === "" && currentToolResults.length === 0) currentContent = EMPTY_CONTENT_PLACEHOLDER;
+        if (currentContent === "" && currentToolResults.length === 0)
+          currentContent = EMPTY_CONTENT_PLACEHOLDER;
 
-        const baseTools = context.tools?.length ? convertToolsToKiro(context.tools) : [];
-        let uimc: { toolResults?: KiroToolResult[]; tools?: KiroToolSpec[] } | undefined;
+        const baseTools = context.tools?.length
+          ? convertToolsToKiro(context.tools)
+          : [];
+        let uimc:
+          | { toolResults?: KiroToolResult[]; tools?: KiroToolSpec[] }
+          | undefined;
         if (currentToolResults.length > 0 || baseTools.length > 0) {
           uimc = {};
-          if (currentToolResults.length > 0) uimc.toolResults = currentToolResults;
+          if (currentToolResults.length > 0)
+            uimc.toolResults = currentToolResults;
           if (baseTools.length > 0) uimc.tools = baseTools;
         }
 
         if (firstMsg?.role === "user") {
           const imgs = extractImages(firstMsg);
-          if (imgs.length > 0) currentImages = convertImagesToKiro(imgs as { mimeType: string; data: string }[]);
+          if (imgs.length > 0)
+            currentImages = convertImagesToKiro(
+              imgs as { mimeType: string; data: string }[],
+            );
         }
 
         const request: KiroRequest = {
@@ -195,9 +326,10 @@ export function streamKiro(
             },
             ...(rawHistory.length > 0 ? { history: rawHistory } : {}),
           },
-          ...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
+          ...(additionalModelRequestFields
+            ? { additionalModelRequestFields }
+            : {}),
           profileArn,
-          agentMode: "vibe",
         };
 
         let response: Response;
@@ -226,28 +358,49 @@ export function streamKiro(
 
           if (!response.ok) {
             let errText = "";
-            try { errText = await response.text(); } catch { errText = ""; }
+            try {
+              errText = await response.text();
+            } catch {
+              errText = "";
+            }
 
-            if (isCapacityError(errText) && capacityRetryCount < capacityRetryConfig.maxRetries) {
+            if (
+              isCapacityError(errText) &&
+              capacityRetryCount < capacityRetryConfig.maxRetries
+            ) {
               capacityRetryCount++;
-              const delayMs = exponentialBackoff(capacityRetryCount - 1, capacityRetryConfig.baseDelayMs, 30_000);
+              const delayMs = exponentialBackoff(
+                capacityRetryCount - 1,
+                capacityRetryConfig.baseDelayMs,
+                30_000,
+              );
               await abortableDelay(delayMs, options?.signal);
               continue;
             }
 
             if (isNonRetryableBodyError(errText) || isCapacityError(errText)) {
-              throw new Error(`Kiro API error: ${errText || response.statusText}`);
+              throw new Error(
+                `Kiro API error: ${errText || response.statusText}`,
+              );
             }
             if (isTooBigError(response.status, errText)) {
-              throw new Error(`Kiro API error: context_length_exceeded (${response.status} ${errText})`);
+              throw new Error(
+                `Kiro API error: context_length_exceeded (${response.status} ${errText})`,
+              );
             }
             if (response.status === 403 && retryCount < maxRetries) {
               retryCount++;
-              const delayMs = exponentialBackoff(retryCount - 1, 500, MAX_RETRY_DELAY);
+              const delayMs = exponentialBackoff(
+                retryCount - 1,
+                500,
+                MAX_RETRY_DELAY,
+              );
               await abortableDelay(delayMs, options?.signal);
               break;
             }
-            throw new Error(`Kiro API error: ${response.status} ${response.statusText} ${errText}`);
+            throw new Error(
+              `Kiro API error: ${response.status} ${response.statusText} ${errText}`,
+            );
           }
           break;
         }
@@ -256,12 +409,17 @@ export function streamKiro(
         stream.push({ type: "start", partial: output });
 
         if (!response.body) throw new Error("No response body");
-        const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
+        const bodyReader = (
+          response.body as unknown as ReadableStream<Uint8Array>
+        ).getReader();
         let totalContent = "";
         let lastContentData = "";
-        let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
+        let usageEvent: { inputTokens?: number; outputTokens?: number } | null =
+          null;
         let receivedContextUsage = false;
-        const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
+        const thinkingParser = thinkingEnabled
+          ? new ThinkingTagParser(output, stream)
+          : null;
         let textBlockIndex: number | null = null;
         let emittedToolCalls = 0;
         let sawAnyToolCalls = false;
@@ -274,28 +432,50 @@ export function streamKiro(
         const bodyIterable: AsyncIterable<Uint8Array> = {
           async *[Symbol.asyncIterator]() {
             try {
-              while (true) { const { done, value } = await bodyReader.read(); if (done) return; yield value; }
-            } finally { bodyReader.releaseLock(); }
+              while (true) {
+                const { done, value } = await bodyReader.read();
+                if (done) return;
+                yield value;
+              }
+            } finally {
+              bodyReader.releaseLock();
+            }
           },
         };
         const utf8Decoder = new TextDecoder();
-        const eventStream = eventStreamMarshaller.deserialize(bodyIterable, async (event: Record<string, Message>) => {
-          const entry = Object.entries(event)[0];
-          if (!entry) throw new Error("Received an empty event stream message");
-          const [key, msg] = entry;
-          const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
-          return { [key]: parsed } as Record<string, unknown>;
-        });
-        const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;
+        const eventStream = eventStreamMarshaller.deserialize(
+          bodyIterable,
+          async (event: Record<string, Message>) => {
+            const entry = Object.entries(event)[0];
+            if (!entry)
+              throw new Error("Received an empty event stream message");
+            const [key, msg] = entry;
+            const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<
+              string,
+              unknown
+            >;
+            return { [key]: parsed } as Record<string, unknown>;
+          },
+        );
+        const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<
+          Record<string, unknown>
+        >;
 
         while (true) {
           let iterResult: IteratorResult<Record<string, unknown>>;
           try {
-            if (!gotFirstToken) {
+            if (gotFirstToken) {
+              iterResult = await iterator.next();
+            } else {
               const readPromise = iterator.next();
               const result = await Promise.race([
                 readPromise,
-                new Promise<typeof FIRST_TOKEN_SENTINEL>((resolve) => setTimeout(() => resolve(FIRST_TOKEN_SENTINEL), FIRST_TOKEN_TIMEOUT)),
+                new Promise<typeof FIRST_TOKEN_SENTINEL>((resolve) =>
+                  setTimeout(
+                    () => resolve(FIRST_TOKEN_SENTINEL),
+                    FIRST_TOKEN_TIMEOUT,
+                  ),
+                ),
               ]);
               if (result === FIRST_TOKEN_SENTINEL) {
                 readPromise.catch(() => {});
@@ -305,24 +485,31 @@ export function streamKiro(
               }
               iterResult = result as IteratorResult<Record<string, unknown>>;
               gotFirstToken = true;
-            } else {
-              iterResult = await iterator.next();
             }
           } catch (e) {
-            streamError = e instanceof Error ? e.message : String(e) || "Unknown stream error";
+            streamError =
+              e instanceof Error
+                ? e.message
+                : String(e) || "Unknown stream error";
             break;
           }
           const { done, value } = iterResult;
           if (done) break;
-          const eventPayload = Object.values(value as Record<string, unknown>)[0] as Record<string, unknown>;
+          const eventPayload = Object.values(
+            value as Record<string, unknown>,
+          )[0] as Record<string, unknown>;
           const event = parseKiroEvent(eventPayload);
           if (!event) continue;
 
           switch (event.type) {
             case "contextUsage": {
               const pct = event.data.contextUsagePercentage;
-              output.usage.input = Math.round((pct / 100) * model.contextWindow);
-              (output.usage as unknown as Record<string, unknown>).contextPercent = pct;
+              output.usage.input = Math.round(
+                (pct / 100) * model.contextWindow,
+              );
+              (
+                output.usage as unknown as Record<string, unknown>
+              ).contextPercent = pct;
               receivedContextUsage = true;
               break;
             }
@@ -348,32 +535,63 @@ export function streamKiro(
                 if (textBlockIndex === null) {
                   textBlockIndex = output.content.length;
                   output.content.push({ type: "text", text: "" });
-                  stream.push({ type: "text_start", contentIndex: textBlockIndex, partial: output });
+                  stream.push({
+                    type: "text_start",
+                    contentIndex: textBlockIndex,
+                    partial: output,
+                  });
                 }
-                (output.content[textBlockIndex] as TextContent).text += event.data;
-                stream.push({ type: "text_delta", contentIndex: textBlockIndex, delta: event.data, partial: output });
+                (output.content[textBlockIndex] as TextContent).text +=
+                  event.data;
+                stream.push({
+                  type: "text_delta",
+                  contentIndex: textBlockIndex,
+                  delta: event.data,
+                  partial: output,
+                });
               }
               break;
             }
             case "toolUse": {
               const tc = event.data;
               sawAnyToolCalls = true;
-              if (!currentToolCall || currentToolCall.toolUseId !== tc.toolUseId) {
-                if (currentToolCall) { if (emitToolCall(currentToolCall, output, stream)) emittedToolCalls++; }
-                currentToolCall = { toolUseId: tc.toolUseId, name: tc.name, input: "" };
+              if (
+                !currentToolCall ||
+                currentToolCall.toolUseId !== tc.toolUseId
+              ) {
+                if (currentToolCall) {
+                  if (emitToolCall(currentToolCall, output, stream))
+                    emittedToolCalls++;
+                }
+                currentToolCall = {
+                  toolUseId: tc.toolUseId,
+                  name: tc.name,
+                  input: "",
+                };
               }
               currentToolCall.input += tc.input || "";
               if (tc.input) totalContent += tc.input;
-              if (tc.stop) { if (currentToolCall) { if (emitToolCall(currentToolCall, output, stream)) emittedToolCalls++; } currentToolCall = null; }
+              if (tc.stop) {
+                if (currentToolCall) {
+                  if (emitToolCall(currentToolCall, output, stream))
+                    emittedToolCalls++;
+                }
+                currentToolCall = null;
+              }
               break;
             }
             case "toolUseInput": {
-              if (currentToolCall) currentToolCall.input += event.data.input || "";
+              if (currentToolCall)
+                currentToolCall.input += event.data.input || "";
               if (event.data.input) totalContent += event.data.input;
               break;
             }
             case "toolUseStop": {
-              if (event.data.stop && currentToolCall) { if (emitToolCall(currentToolCall, output, stream)) emittedToolCalls++; currentToolCall = null; }
+              if (event.data.stop && currentToolCall) {
+                if (emitToolCall(currentToolCall, output, stream))
+                  emittedToolCalls++;
+                currentToolCall = null;
+              }
               break;
             }
             case "usage": {
@@ -381,7 +599,9 @@ export function streamKiro(
               break;
             }
             case "error": {
-              streamError = event.data.message ? `${event.data.error}: ${event.data.message}` : event.data.error;
+              streamError = event.data.message
+                ? `${event.data.error}: ${event.data.message}`
+                : event.data.error;
               void bodyReader.cancel().catch(() => {});
               break;
             }
@@ -392,40 +612,86 @@ export function streamKiro(
         if (firstTokenTimedOut || streamError) {
           if (retryCount < maxRetries) {
             retryCount++;
-            const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            const delayMs = exponentialBackoff(
+              retryCount - 1,
+              1000,
+              MAX_RETRY_DELAY,
+            );
             await abortableDelay(delayMs, options?.signal);
             continue;
           }
-          if (streamError) throw new Error(`Kiro API stream error after max retries: ${streamError}`);
-          throw new Error(`Kiro API error: first token timeout after max retries`);
+          if (streamError)
+            throw new Error(
+              `Kiro API stream error after max retries: ${streamError}`,
+            );
+          throw new Error(
+            `Kiro API error: first token timeout after max retries`,
+          );
         }
 
-        if (currentToolCall) { if (emitToolCall(currentToolCall, output, stream)) emittedToolCalls++; }
+        if (currentToolCall) {
+          if (emitToolCall(currentToolCall, output, stream)) emittedToolCalls++;
+        }
         if (thinkingParser) {
           thinkingParser.finalize();
           textBlockIndex = thinkingParser.getTextBlockIndex();
         }
 
         if (textBlockIndex !== null) {
-          stream.push({ type: "text_end", contentIndex: textBlockIndex, content: (output.content[textBlockIndex] as TextContent).text, partial: output });
+          stream.push({
+            type: "text_end",
+            contentIndex: textBlockIndex,
+            content: (output.content[textBlockIndex] as TextContent).text,
+            partial: output,
+          });
         }
 
-        if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
+        if (usageEvent?.inputTokens !== undefined)
+          output.usage.input = usageEvent.inputTokens;
         output.usage.output = usageEvent?.outputTokens ?? totalContent.length;
         output.usage.totalTokens = output.usage.input + output.usage.output;
-        output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+        output.usage.cost = {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        };
 
-        output.stopReason = emittedToolCalls > 0 ? "toolUse" : receivedContextUsage ? "stop" : "length";
-        stream.push({ type: "done", reason: output.stopReason as "stop" | "toolUse", message: output });
+        output.stopReason =
+          emittedToolCalls > 0
+            ? "toolUse"
+            : receivedContextUsage
+              ? "stop"
+              : "length";
+        stream.push({
+          type: "done",
+          reason: output.stopReason as "stop" | "toolUse",
+          message: output,
+        });
         stream.end();
         break;
       }
     } catch (error) {
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : String(error);
+      output.errorMessage =
+        error instanceof Error ? error.message : String(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }
-  })().catch(() => { try { stream.end(); } catch {} });
+  })().catch(() => {
+    // The IIFE already pushes a `error` event into the stream and calls
+    // `stream.end()` on every error path; this outer catch is a defensive
+    // last-resort net for synchronous throws that escape the async block.
+    // SAFETY: an empty catch is intentional here — re-throwing would crash
+    // the agent harness, and the stream-level error event already carries
+    // the upstream message to the user.
+    try {
+      stream.end();
+    } catch {
+      // SAFETY: `stream.end()` is idempotent and best-effort; a double-end
+      // throw must not surface as an uncaught error.
+    }
+  });
   return stream;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -52,11 +52,7 @@ function parseMockJson(value: unknown): Record<string, unknown> {
 			throw new TypeError("mock JSON value is not a string");
 		}
 		const parsed: unknown = JSON.parse(value);
-		if (
-			parsed === null ||
-			typeof parsed !== "object" ||
-			Array.isArray(parsed)
-		) {
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
 			throw new TypeError("mock JSON value is not an object");
 		}
 		return parsed as Record<string, unknown>;
@@ -198,14 +194,66 @@ describe("show-paid getters", () => {
 		expect(getKiloShowPaid()).toBe(false);
 	});
 
-	it("getOpenrouterShowPaid reads from file", async () => {
+	it("getKiroProfileArn returns undefined when neither env nor file is set", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		const { getKiroProfileArn } = await import("../config.ts");
+		expect(getKiroProfileArn()).toBeUndefined();
+	});
+
+	it("getKiroProfileArn reads from ~/.pi/free.json kiro_profile_arn", async () => {
 		vi.stubEnv("HOME", "/tmp");
 		const fs = await import("node:fs");
 		const { __mockData } = fs as any;
 		__mockData.set(
 			configPath(),
-			JSON.stringify({ openrouter_show_paid: true }),
+			JSON.stringify({
+				kiro_profile_arn:
+					"arn:aws:codewhisperer:us-east-1:610548660232:profile/VNECVYCYYAWN",
+			}),
 		);
+
+		const { getKiroProfileArn } = await import("../config.ts");
+		expect(getKiroProfileArn()).toBe(
+			"arn:aws:codewhisperer:us-east-1:610548660232:profile/VNECVYCYYAWN",
+		);
+	});
+
+	it("getKiroProfileArn prefers KIRO_PROFILE_ARN env over file value", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		vi.stubEnv(
+			"KIRO_PROFILE_ARN",
+			"arn:aws:codewhisperer:eu-central-1:12345:profile/ENV",
+		);
+		const fs = await import("node:fs");
+		const { __mockData } = fs as any;
+		__mockData.set(
+			configPath(),
+			JSON.stringify({
+				kiro_profile_arn: "arn:aws:codewhisperer:us-east-1:0000:profile/FILE",
+			}),
+		);
+
+		const { getKiroProfileArn } = await import("../config.ts");
+		expect(getKiroProfileArn()).toBe(
+			"arn:aws:codewhisperer:eu-central-1:12345:profile/ENV",
+		);
+	});
+
+	it("getKiroProfileArn returns undefined for an explicitly empty file value", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		const fs = await import("node:fs");
+		const { __mockData } = fs as any;
+		__mockData.set(configPath(), JSON.stringify({ kiro_profile_arn: "" }));
+
+		const { getKiroProfileArn } = await import("../config.ts");
+		expect(getKiroProfileArn()).toBeUndefined();
+	});
+
+	it("getOpenrouterShowPaid reads from file", async () => {
+		vi.stubEnv("HOME", "/tmp");
+		const fs = await import("node:fs");
+		const { __mockData } = fs as any;
+		__mockData.set(configPath(), JSON.stringify({ openrouter_show_paid: true }));
 
 		const { getOpenrouterShowPaid } = await import("../config.ts");
 		expect(getOpenrouterShowPaid()).toBe(true);
@@ -271,10 +319,7 @@ describe("show-paid getters", () => {
 		vi.stubEnv("HOME", "/tmp");
 		const fs = await import("node:fs");
 		const { __mockData } = fs as any;
-		__mockData.set(
-			configPath(),
-			JSON.stringify({ opengateway_show_paid: true }),
-		);
+		__mockData.set(configPath(), JSON.stringify({ opengateway_show_paid: true }));
 
 		const { getOpengatewayShowPaid, getProviderShowPaid } = await import(
 			"../config.ts"
@@ -418,10 +463,7 @@ describe("updateConfig", () => {
 		vi.stubEnv("HOME", "/tmp");
 		const fs = await import("node:fs");
 		const { __mockData } = fs as any;
-		__mockData.set(
-			configPath(),
-			JSON.stringify({ hidden_models: ["initial"] }),
-		);
+		__mockData.set(configPath(), JSON.stringify({ hidden_models: ["initial"] }));
 
 		const { updateConfig } = await import("../config.ts");
 		// Simulate two providers' probes updating hidden_models concurrently


### PR DESCRIPTION
## Summary

Design document for the long-term fix to the kiro 400 'Improperly formed request' issue. PR #485 fixed the immediate problem by replacing a silent placeholder `profileArn` with a manual `kiro_profile_arn` config knob. This doc covers the bigger follow-up: replace the SSO OIDC device-code flow with the Kiro Web Portal PKCE + `ExchangeToken` flow, which returns `profileArn` in the response.

**No code changes in this PR.** This is the contract for the implementation.

## What's in the doc

- **Protocol spec** for `InitiateLogin` / `ExchangeToken` / `GetUserInfo` / `refreshToken`, reverse-engineered from `keggin-CHN/kiro-auto-register`, `ZyphrZero/kiro.rs`, `1070920013wh/kiro-gateway`, and live probes against the Kiro Web Portal.
- **Public-OIDC-client decision**: piggyback on the kiro-cli's widely-shared public client. Rationale for why registering our own AWS Cognito OIDC client is not worth the lead time and why reading kiro-cli's local SQLite is a fallback path, not the primary one.
- **Proposed file layout** (4 new files, 2 existing files lightly modified).
- **Feature flag design**: `kiro_auth_method: "idc" | "web-portal" | "kiro-cli"`, default `"web-portal"` for new users, default `"idc"` for users with a working `kiro_profile_arn` already set so we never break a working setup.
- **Persisted credential shape**: adds `profileArn`, `csrfToken`, `machineId`, `idp` to the `kiro` entry in `~/.pi/agent/auth.json` for the new flow.
- **Browser-redirect UX**: Pi's `OAuthLoginCallbacks` surface (same pattern as Kilo/Cline) with a manual paste fallback.
- **Refresh path**: the same `prod.{region}.auth.desktop.kiro.dev/refreshToken` endpoint we already use for `authMethod: "desktop"`, now also extracting `profileArn` from the response.
- **Errors and observability rules**: new `kiro-web-portal` logger namespace, redaction per `agents.md` convention #17, profileArn change tracking with last-20-char truncation.
- **Test plan**: 6 unit test files + 1 manual live-API test script.
- **Phase tracker**: 6 phases (A through F), each its own PR.

## Why doc-only first

Each phase is its own PR so reviews are small and focused. The doc is Phase A; it's reviewable on its own merits (the design, the public-client decision, the migration path) without anyone having to read 300+ lines of new auth code at once.

## Dependency plan

Phase B will add `cbor-x` (`^1.6.6`, ~50KB unpacked) as a runtime dep. The Smithy `rpc-v2-cbor` protocol the Kiro Web Portal speaks is not exposed via the public API of `@smithy/core` (the subpath is blocked by their `exports` field) and hand-rolling CBOR for the 5 types we need is more code to maintain than the dep itself. Decision is recorded in the doc's public-OIDC-client section, not in the dependency section — the rationale applies to both.

## No code changes

This PR is docs only. Zero runtime impact. Zero build impact. The CI lint / test / build pipeline is unchanged.

## Tracking

- PR #485 is the immediate fix (manual `kiro_profile_arn`)
- This PR is Phase A (design)
- Phases B through F are tracked in the doc's phase table, will get their own PRs