### PR TITLE
chore: update benchmark data from Artificial Analysis

### DIFF
--- a/provider-failover/benchmarks.json
+++ b/provider-failover/benchmarks.json
@@ -1,690 +1,688 @@
 {
-	"gpt-oss-120b-low": {
+	"glm-5.3-flash": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "gpt-oss-120b (low)",
-		"codingIndex": 21.2,
-		"mathIndex": 66.7,
-		"mmluPro": 0.775,
-		"gpqa": 0.672,
-		"hle": 0.052
-	},
-	"gpt-5.6-terra-max": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Terra (max)",
-		"codingIndex": 76.7,
-		"gpqa": 0.925,
-		"hle": 0.418
-	},
-	"gpt-oss-120b-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "gpt-oss-120b (high)",
-		"codingIndex": 30.4,
-		"mathIndex": 93.4,
-		"mmluPro": 0.808,
-		"gpqa": 0.782,
-		"hle": 0.185
-	},
-	"o3": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "o3",
-		"mathIndex": 88.3,
-		"mmluPro": 0.853,
-		"gpqa": 0.827,
-		"hle": 0.2
-	},
-	"gpt-5.6-terra-low": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Terra (low)",
-		"codingIndex": 58.1,
-		"gpqa": 0.843,
-		"hle": 0.274
-	},
-	"gpt-5.6-sol-low": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Sol (low)",
-		"codingIndex": 69.7,
-		"gpqa": 0.898,
-		"hle": 0.366
-	},
-	"gpt-5.6-sol-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Sol (medium)",
-		"codingIndex": 76.3,
-		"gpqa": 0.926,
-		"hle": 0.397
-	},
-	"gpt-5.6-terra-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Terra (Non-reasoning)",
-		"codingIndex": 52.3,
-		"gpqa": 0.746,
-		"hle": 0.11
-	},
-	"gpt-5.6-terra-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Terra (medium)",
-		"codingIndex": 64.7,
-		"gpqa": 0.872,
-		"hle": 0.316
-	},
-	"gpt-5.3-codex-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.3 Codex (xhigh)",
-		"gpqa": 0.915,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5.3-Flash",
+		"codingIndex": 71.5,
+		"gpqa": 0.912,
 		"hle": 0.399
 	},
-	"gpt-5.6-luna-max": {
+	"qwen3.8-flash-next": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Luna (max)",
-		"codingIndex": 71.4,
-		"gpqa": 0.911,
-		"hle": 0.372
-	},
-	"gpt-oss-20b-low": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "gpt-oss-20b (low)",
-		"mathIndex": 62.3,
-		"mmluPro": 0.718,
-		"gpqa": 0.611,
-		"hle": 0.051
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8-Flash-Next",
+		"codingIndex": 73.1,
+		"gpqa": 0.923,
+		"hle": 0.38
 	},
 	"gpt-oss-20b-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "gpt-oss-20b (high)",
 		"codingIndex": 20.7,
 		"mathIndex": 89.3,
+		"mmluPro": 0.748,
 		"gpqa": 0.688,
-		"hle": 0.098
+		"hle": 0.11
 	},
-	"grok-1": {
+	"gpt-oss-20b-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok-1"
+		"lastUpdated": "2026-09-01",
+		"originalModel": "gpt-oss-20b (low)",
+		"mathIndex": 62.3,
+		"mmluPro": 0.718,
+		"gpqa": 0.611,
+		"hle": 0.053
 	},
-	"gpt-5.5-instant-june-2026": {
+	"gpt-5.6-terra-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 Instant (June 2026)",
-		"codingIndex": 39.4,
-		"gpqa": 0.823,
-		"hle": 0.186
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Terra (medium)",
+		"codingIndex": 64.7,
+		"gpqa": 0.872,
+		"hle": 0.333
 	},
-	"gpt-5.6-sol-high": {
+	"gpt-oss-120b-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Sol (high)",
-		"codingIndex": 77.2,
-		"gpqa": 0.928,
-		"hle": 0.441
+		"lastUpdated": "2026-09-01",
+		"originalModel": "gpt-oss-120b (high)",
+		"codingIndex": 30.4,
+		"mathIndex": 93.4,
+		"mmluPro": 0.808,
+		"gpqa": 0.782,
+		"hle": 0.196
 	},
-	"gpt-5.6-sol-max": {
+	"o3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Sol (max)",
-		"codingIndex": 77.4,
-		"gpqa": 0.941,
-		"hle": 0.472
+		"lastUpdated": "2026-09-01",
+		"originalModel": "o3",
+		"mathIndex": 88.3,
+		"mmluPro": 0.853,
+		"gpqa": 0.827,
+		"hle": 0.201
 	},
-	"gpt-5.6-sol-xhigh": {
+	"gpt-5.6-sol-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Sol (xhigh)",
-		"codingIndex": 78.3,
-		"gpqa": 0.931,
-		"hle": 0.447
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Sol (low)",
+		"codingIndex": 69.7,
+		"gpqa": 0.898,
+		"hle": 0.394
 	},
 	"gpt-5.6-luna-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-5.6 Luna (low)",
 		"codingIndex": 44.2,
 		"gpqa": 0.835,
-		"hle": 0.188
+		"hle": 0.198
 	},
-	"gpt-5.6-luna-medium": {
+	"gpt-oss-120b-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Luna (medium)",
-		"codingIndex": 50.7,
-		"gpqa": 0.859,
-		"hle": 0.245
+		"lastUpdated": "2026-09-01",
+		"originalModel": "gpt-oss-120b (low)",
+		"codingIndex": 21.2,
+		"mathIndex": 66.7,
+		"mmluPro": 0.775,
+		"gpqa": 0.672,
+		"hle": 0.059
 	},
-	"gpt-5.6-luna-high": {
+	"gpt-5.6-terra-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Luna (high)",
-		"codingIndex": 63.3,
-		"gpqa": 0.892,
-		"hle": 0.316
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Terra (max)",
+		"codingIndex": 76.7,
+		"gpqa": 0.925,
+		"hle": 0.429
+	},
+	"grok-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok-1"
+	},
+	"gpt-5.6-sol-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Sol (max)",
+		"codingIndex": 77.4,
+		"gpqa": 0.941,
+		"hle": 0.495
+	},
+	"gpt-5.6-luna-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Luna (max)",
+		"codingIndex": 71.4,
+		"gpqa": 0.911,
+		"hle": 0.395
 	},
 	"gpt-5.6-sol-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-5.6 Sol (Non-reasoning)",
 		"codingIndex": 65.1,
 		"gpqa": 0.79,
-		"hle": 0.158
+		"hle": 0.167
 	},
-	"gpt-5.6-luna-xhigh": {
+	"gpt-5.6-terra-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.6 Luna (xhigh)",
-		"codingIndex": 68.6,
-		"gpqa": 0.895,
-		"hle": 0.356
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Terra (Non-reasoning)",
+		"codingIndex": 52.3,
+		"gpqa": 0.746,
+		"hle": 0.114
 	},
 	"gpt-5.6-luna-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-5.6 Luna (Non-reasoning)",
 		"codingIndex": 39.3,
 		"gpqa": 0.645,
-		"hle": 0.067
+		"hle": 0.072
+	},
+	"gpt-5.6-sol-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Sol (medium)",
+		"codingIndex": 76.3,
+		"gpqa": 0.926,
+		"hle": 0.422
+	},
+	"gpt-5.6-sol-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Sol (xhigh)",
+		"codingIndex": 78.3,
+		"gpqa": 0.931,
+		"hle": 0.473
+	},
+	"gpt-5.6-terra-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Terra (low)",
+		"codingIndex": 58.1,
+		"gpqa": 0.843,
+		"hle": 0.292
+	},
+	"gpt-5.5-instant-june-2026": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 Instant (June 2026)",
+		"codingIndex": 39.4,
+		"gpqa": 0.823,
+		"hle": 0.199
+	},
+	"gpt-5.6-luna-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Luna (high)",
+		"codingIndex": 63.3,
+		"gpqa": 0.892,
+		"hle": 0.334
 	},
 	"gpt-5.6-terra-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-5.6 Terra (xhigh)",
 		"codingIndex": 70.6,
 		"gpqa": 0.908,
-		"hle": 0.4
+		"hle": 0.419
+	},
+	"gpt-5.6-sol-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Sol (high)",
+		"codingIndex": 77.2,
+		"gpqa": 0.928,
+		"hle": 0.46
+	},
+	"gpt-5.6-luna-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Luna (xhigh)",
+		"codingIndex": 68.6,
+		"gpqa": 0.895,
+		"hle": 0.37
 	},
 	"gpt-5.6-terra-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-5.6 Terra (high)",
 		"codingIndex": 67.1,
 		"gpqa": 0.896,
-		"hle": 0.367
+		"hle": 0.385
+	},
+	"gpt-5.3-codex-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.3 Codex (xhigh)",
+		"gpqa": 0.915,
+		"hle": 0.425
+	},
+	"gpt-5.6-luna-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.6 Luna (medium)",
+		"codingIndex": 50.7,
+		"gpqa": 0.859,
+		"hle": 0.258
 	},
 	"llama-3.3-instruct-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.3 Instruct 70B",
 		"codingIndex": 11.9,
 		"mathIndex": 7.7,
 		"mmluPro": 0.713,
 		"gpqa": 0.498,
-		"hle": 0.04
+		"hle": 0.036
 	},
 	"llama-3.1-instruct-405b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.1 Instruct 405B",
 		"mathIndex": 3,
 		"mmluPro": 0.732,
 		"gpqa": 0.515,
-		"hle": 0.042
+		"hle": 0.04
 	},
 	"llama-3.2-instruct-90b-vision": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.2 Instruct 90B (Vision)",
 		"mmluPro": 0.671,
 		"gpqa": 0.432,
-		"hle": 0.049
+		"hle": 0.045
 	},
 	"llama-3.2-instruct-11b-vision": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.2 Instruct 11B (Vision)",
 		"mathIndex": 1.7,
 		"mmluPro": 0.464,
 		"gpqa": 0.221,
-		"hle": 0.052
+		"hle": 0.055
+	},
+	"muse-spark-1.2-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Muse Spark 1.2 (xhigh)",
+		"codingIndex": 72.2,
+		"gpqa": 0.904,
+		"hle": 0.455
 	},
 	"llama-4-scout": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 4 Scout",
 		"codingIndex": 8.2,
 		"mathIndex": 14,
 		"mmluPro": 0.752,
 		"gpqa": 0.587,
-		"hle": 0.043
+		"hle": 0.038
 	},
 	"llama-4-maverick": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 4 Maverick",
 		"codingIndex": 16.3,
 		"mathIndex": 19.3,
+		"mmluPro": 0.809,
 		"gpqa": 0.671,
-		"hle": 0.048
+		"hle": 0.049
 	},
-	"muse-spark": {
+	"muse-glimmer-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Muse Spark",
-		"codingIndex": 58.6,
-		"gpqa": 0.884,
-		"hle": 0.399
-	},
-	"muse-spark-1.1-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Muse Spark 1.1 (xhigh)",
-		"codingIndex": 71.3,
-		"gpqa": 0.898,
-		"hle": 0.451
-	},
-	"gemma-4-31b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 31B (Non-reasoning)",
-		"codingIndex": 33.2,
-		"gpqa": 0.763,
-		"hle": 0.115
-	},
-	"gemini-3.5-flash-lite": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3.5 Flash-Lite",
-		"codingIndex": 49.3,
-		"gpqa": 0.838,
-		"hle": 0.175
-	},
-	"gemma-4-e4b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 E4B (Reasoning)",
-		"codingIndex": 9.4,
-		"gpqa": 0.576,
-		"hle": 0.037
-	},
-	"gemma-4-26b-a4b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 26B A4B (Non-reasoning)",
-		"gpqa": 0.714,
-		"hle": 0.107
-	},
-	"gemma-4-31b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 31B (Reasoning)",
-		"codingIndex": 43.4,
-		"gpqa": 0.857,
-		"hle": 0.227
-	},
-	"gemma-4-e2b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 E2B (Reasoning)",
-		"codingIndex": 7.2,
-		"gpqa": 0.433,
-		"hle": 0.048
-	},
-	"gemma-4-12b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 12B (Non-reasoning)",
-		"gpqa": 0.661,
-		"hle": 0.062
-	},
-	"gemma-4-12b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 12B (Reasoning)",
-		"codingIndex": 31,
-		"gpqa": 0.753,
-		"hle": 0.148
-	},
-	"gemma-4-e4b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 E4B (Non-reasoning)",
-		"gpqa": 0.549,
-		"hle": 0.047
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Muse Glimmer (high)",
+		"codingIndex": 49,
+		"gpqa": 0.835,
+		"hle": 0.22
 	},
 	"gemma-4-26b-a4b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemma 4 26B A4B (Reasoning)",
 		"codingIndex": 39.3,
 		"gpqa": 0.792,
-		"hle": 0.183
+		"hle": 0.193
 	},
-	"gemma-4-e2b-non-reasoning": {
+	"gemma-4-12b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 4 E2B (Non-reasoning)",
-		"gpqa": 0.405,
-		"hle": 0.045
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 12B (Reasoning)",
+		"codingIndex": 31,
+		"gpqa": 0.753,
+		"hle": 0.157
 	},
-	"gemini-3.1-pro-preview": {
+	"gemma-4-31b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3.1 Pro Preview",
-		"codingIndex": 68.8,
-		"gpqa": 0.941,
-		"hle": 0.447
-	},
-	"gemini-3.5-flash-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3.5 Flash (high)",
-		"codingIndex": 70.1,
-		"gpqa": 0.922,
-		"hle": 0.41
-	},
-	"diffusiongemma-26b-a4b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DiffusionGemma 26B A4B",
-		"codingIndex": 19.7,
-		"gpqa": 0.669,
-		"hle": 0.102
-	},
-	"gemini-3.6-flash-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3.6 Flash (high)",
-		"codingIndex": 69.2,
-		"gpqa": 0.928,
-		"hle": 0.383
-	},
-	"gemma-3-270m": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3 270M",
-		"mathIndex": 2.3,
-		"mmluPro": 0.055,
-		"gpqa": 0.224,
-		"hle": 0.042
-	},
-	"gemini-3.1-flash-lite": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3.1 Flash-Lite",
-		"codingIndex": 34.7,
-		"gpqa": 0.822,
-		"hle": 0.162
-	},
-	"gemini-2.5-pro": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Pro",
-		"codingIndex": 33.3,
-		"mathIndex": 87.7,
-		"gpqa": 0.844,
-		"hle": 0.211
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 31B (Reasoning)",
+		"codingIndex": 43.4,
+		"gpqa": 0.857,
+		"hle": 0.236
 	},
 	"gemini-3.5-flash-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 3.5 Flash (medium)",
 		"gpqa": 0.921,
-		"hle": 0.399
+		"hle": 0.413
+	},
+	"gemma-4-26b-a4b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 26B A4B (Non-reasoning)",
+		"gpqa": 0.714,
+		"hle": 0.115
+	},
+	"gemma-4-e2b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 E2B (Reasoning)",
+		"codingIndex": 7.2,
+		"gpqa": 0.433,
+		"hle": 0.048
+	},
+	"gemma-4-31b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 31B (Non-reasoning)",
+		"codingIndex": 33.2,
+		"gpqa": 0.763,
+		"hle": 0.118
+	},
+	"gemini-3.6-flash-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.6 Flash (high)",
+		"codingIndex": 69.2,
+		"gpqa": 0.928,
+		"hle": 0.408
+	},
+	"gemma-4-e4b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 E4B (Non-reasoning)",
+		"gpqa": 0.549,
+		"hle": 0.048
+	},
+	"gemma-4-e4b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 E4B (Reasoning)",
+		"codingIndex": 9.4,
+		"gpqa": 0.576,
+		"hle": 0.038
+	},
+	"gemini-3.5-flash-lite": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.5 Flash-Lite",
+		"codingIndex": 49.3,
+		"gpqa": 0.838,
+		"hle": 0.188
+	},
+	"diffusiongemma-26b-a4b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DiffusionGemma 26B A4B",
+		"codingIndex": 19.7,
+		"gpqa": 0.669,
+		"hle": 0.108
+	},
+	"gemma-4-12b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 12B (Non-reasoning)",
+		"gpqa": 0.661,
+		"hle": 0.063
+	},
+	"gemma-3-270m": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3 270M",
+		"mathIndex": 2.3,
+		"mmluPro": 0.055,
+		"gpqa": 0.224,
+		"hle": 0.036
+	},
+	"gemini-3.7-flash-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.7 Flash (high)",
+		"codingIndex": 76.1,
+		"gpqa": 0.945,
+		"hle": 0.479
+	},
+	"gemini-3.1-pro-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.1 Pro Preview",
+		"codingIndex": 68.8,
+		"gpqa": 0.941,
+		"hle": 0.47
+	},
+	"gemini-3.7-flash-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.7 Flash (low)",
+		"codingIndex": 71,
+		"gpqa": 0.901,
+		"hle": 0.351
+	},
+	"gemini-3.7-flash-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.7 Flash (medium)",
+		"codingIndex": 71.5,
+		"gpqa": 0.921,
+		"hle": 0.39
+	},
+	"gemma-4-e2b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 4 E2B (Non-reasoning)",
+		"gpqa": 0.405,
+		"hle": 0.047
 	},
 	"gemini-3.5-flash-minimal": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 3.5 Flash (minimal)",
 		"gpqa": 0.828,
-		"hle": 0.231
+		"hle": 0.241
 	},
-	"claude-opus-5-adaptive-reasoning-low-effort": {
+	"claude-sonnet-5-adaptive-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Low Effort)",
-		"codingIndex": 66.9,
-		"gpqa": 0.889,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Sonnet 5 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 71.5,
+		"gpqa": 0.911,
 		"hle": 0.413
 	},
 	"claude-4.5-haiku-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 4.5 Haiku (Reasoning)",
 		"codingIndex": 43.9,
 		"mathIndex": 83.7,
+		"mmluPro": 0.76,
 		"gpqa": 0.672,
-		"hle": 0.097
-	},
-	"claude-fable-5-adaptive-reasoning-max-effort-opus-4.8-fallback": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Fable 5 (Adaptive Reasoning, Max Effort, Opus 4.8 Fallback)",
-		"codingIndex": 76.5,
-		"gpqa": 0.926,
-		"hle": 0.533
-	},
-	"claude-sonnet-5-adaptive-reasoning-max-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Sonnet 5 (Adaptive Reasoning, Max Effort)",
-		"codingIndex": 71.5,
-		"gpqa": 0.911,
-		"hle": 0.396
-	},
-	"claude-sonnet-5-non-reasoning-high-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Sonnet 5 (Non-reasoning, High Effort)",
-		"codingIndex": 66.4,
-		"gpqa": 0.8,
-		"hle": 0.178
+		"hle": 0.104
 	},
 	"claude-opus-5-adaptive-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Max Effort)",
 		"codingIndex": 78,
 		"gpqa": 0.932,
-		"hle": 0.526
+		"hle": 0.549
 	},
-	"claude-opus-5-adaptive-reasoning-medium-effort": {
+	"claude-fable-5-adaptive-reasoning-max-effort-opus-4.8-fallback": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Medium Effort)",
-		"codingIndex": 74.3,
-		"gpqa": 0.919,
-		"hle": 0.492
-	},
-	"claude-4.5-haiku-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4.5 Haiku (Non-reasoning)",
-		"mathIndex": 39,
-		"mmluPro": 0.8,
-		"gpqa": 0.646,
-		"hle": 0.043
-	},
-	"claude-sonnet-4.6-non-reasoning-low-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, Low Effort)",
-		"gpqa": 0.797,
-		"hle": 0.108
-	},
-	"claude-opus-5-adaptive-reasoning-high-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 5 (Adaptive Reasoning, High Effort)",
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Fable 5 (Adaptive Reasoning, Max Effort, Opus 4.8 Fallback)",
 		"codingIndex": 76.5,
-		"gpqa": 0.937,
-		"hle": 0.507
+		"gpqa": 0.926,
+		"hle": 0.555
 	},
 	"claude-opus-5-adaptive-reasoning-xhigh-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Xhigh Effort)",
 		"codingIndex": 77,
 		"gpqa": 0.937,
-		"hle": 0.525
+		"hle": 0.544
 	},
-	"mistral-large-3": {
+	"claude-opus-5-adaptive-reasoning-low-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Large 3",
-		"codingIndex": 20.1,
-		"mathIndex": 38,
-		"mmluPro": 0.807,
-		"gpqa": 0.68,
-		"hle": 0.041
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Low Effort)",
+		"codingIndex": 66.9,
+		"gpqa": 0.889,
+		"hle": 0.434
 	},
-	"magistral-small-1.2": {
+	"claude-opus-5-adaptive-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Magistral Small 1.2",
-		"codingIndex": 14.7,
-		"mathIndex": 80.3,
-		"mmluPro": 0.768,
-		"gpqa": 0.663,
-		"hle": 0.061
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, High Effort)",
+		"codingIndex": 76.5,
+		"gpqa": 0.937,
+		"hle": 0.528
+	},
+	"claude-4.5-haiku-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4.5 Haiku (Non-reasoning)",
+		"mathIndex": 39,
+		"mmluPro": 0.8,
+		"gpqa": 0.646,
+		"hle": 0.042
+	},
+	"claude-sonnet-5-non-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Sonnet 5 (Non-reasoning, High Effort)",
+		"codingIndex": 66.4,
+		"gpqa": 0.8,
+		"hle": 0.19
+	},
+	"claude-opus-5-adaptive-reasoning-medium-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 5 (Adaptive Reasoning, Medium Effort)",
+		"codingIndex": 74.3,
+		"gpqa": 0.919,
+		"hle": 0.513
+	},
+	"claude-sonnet-4.6-non-reasoning-low-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, Low Effort)",
+		"gpqa": 0.797,
+		"hle": 0.112
 	},
 	"ministral-3-14b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Ministral 3 14B",
 		"codingIndex": 14.4,
 		"mathIndex": 30,
@@ -692,11 +690,23 @@
 		"gpqa": 0.572,
 		"hle": 0.046
 	},
+	"magistral-medium-1.2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Magistral Medium 1.2",
+		"codingIndex": 21.3,
+		"mathIndex": 82,
+		"mmluPro": 0.815,
+		"gpqa": 0.739,
+		"hle": 0.103
+	},
 	"ministral-3-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Ministral 3 8B",
 		"codingIndex": 9.7,
 		"mathIndex": 31.7,
@@ -708,28 +718,75 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Ministral 3 3B",
 		"codingIndex": 4.8,
 		"mathIndex": 22,
+		"mmluPro": 0.524,
 		"gpqa": 0.358,
-		"hle": 0.053
+		"hle": 0.054
+	},
+	"mistral-large-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Large 3",
+		"codingIndex": 20.1,
+		"mathIndex": 38,
+		"mmluPro": 0.807,
+		"gpqa": 0.68,
+		"hle": 0.042
+	},
+	"magistral-small-1.2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Magistral Small 1.2",
+		"codingIndex": 14.7,
+		"mathIndex": 80.3,
+		"mmluPro": 0.768,
+		"gpqa": 0.663,
+		"hle": 0.064
+	},
+	"devstral-small-2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Devstral Small 2",
+		"codingIndex": 29.3,
+		"mathIndex": 34.3,
+		"mmluPro": 0.678,
+		"gpqa": 0.532,
+		"hle": 0.035
+	},
+	"mistral-medium-3.5": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Medium 3.5",
+		"codingIndex": 46.9,
+		"gpqa": 0.748,
+		"hle": 0.138
 	},
 	"mistral-small-4-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Small 4 (Reasoning)",
 		"codingIndex": 26.6,
 		"gpqa": 0.769,
-		"hle": 0.095
+		"hle": 0.099
 	},
 	"devstral-2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Devstral 2",
 		"codingIndex": 31.3,
 		"mathIndex": 36.7,
@@ -737,248 +794,310 @@
 		"gpqa": 0.594,
 		"hle": 0.036
 	},
-	"magistral-medium-1.2": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Magistral Medium 1.2",
-		"codingIndex": 21.3,
-		"mathIndex": 82,
-		"mmluPro": 0.815,
-		"gpqa": 0.739,
-		"hle": 0.096
-	},
-	"mistral-medium-3.5": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Medium 3.5",
-		"codingIndex": 46.9,
-		"gpqa": 0.748,
-		"hle": 0.128
-	},
 	"mistral-small-4-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Small 4 (Non-reasoning)",
 		"gpqa": 0.571,
-		"hle": 0.037
+		"hle": 0.038
 	},
-	"devstral-small-2": {
+	"deepseek-v4-pro-0813-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Devstral Small 2",
-		"codingIndex": 29.3,
-		"mathIndex": 34.3,
-		"mmluPro": 0.678,
-		"gpqa": 0.532,
-		"hle": 0.034
-	},
-	"deepseek-v4-pro-reasoning-max-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V4 Pro (Reasoning, Max Effort)",
-		"codingIndex": 59.4,
-		"gpqa": 0.888,
-		"hle": 0.359
-	},
-	"deepseek-v4-pro-reasoning-high-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V4 Pro (Reasoning, High Effort)",
-		"codingIndex": 58.7,
-		"gpqa": 0.905,
-		"hle": 0.335
-	},
-	"deepseek-v4-pro-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V4 Pro (Non-reasoning)",
-		"gpqa": 0.717,
-		"hle": 0.077
-	},
-	"deepseek-v4-flash-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V4 Flash (Non-reasoning)",
-		"gpqa": 0.716,
-		"hle": 0.07
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V4 Pro 0813 (Reasoning, Max Effort)",
+		"codingIndex": 68.8,
+		"gpqa": 0.928,
+		"hle": 0.41
 	},
 	"deepseek-v4-flash-0731-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek V4 Flash 0731 (Reasoning, Max Effort)",
 		"codingIndex": 69.1,
 		"gpqa": 0.908,
-		"hle": 0.368
+		"hle": 0.386
+	},
+	"deepseek-v4-pro-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V4 Pro (Reasoning, Max Effort)",
+		"codingIndex": 59.4,
+		"gpqa": 0.888,
+		"hle": 0.375
+	},
+	"deepseek-v4-flash-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V4 Flash (Non-reasoning)",
+		"gpqa": 0.716,
+		"hle": 0.078
+	},
+	"deepseek-v4-pro-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V4 Pro (Non-reasoning)",
+		"gpqa": 0.717,
+		"hle": 0.082
+	},
+	"deepseek-v4-pro-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V4 Pro (Reasoning, High Effort)",
+		"codingIndex": 58.7,
+		"gpqa": 0.905,
+		"hle": 0.352
+	},
+	"llama-65b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Llama 65B"
+	},
+	"deepseek-v4-flash-vision-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V4 Flash Vision (Reasoning, Max Effort)",
+		"codingIndex": 65,
+		"gpqa": 0.913,
+		"hle": 0.345
 	},
 	"r1-1776": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "R1 1776"
 	},
 	"falcon-h1r-7b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Falcon-H1R-7B",
 		"mathIndex": 80,
 		"mmluPro": 0.725,
 		"gpqa": 0.661,
-		"hle": 0.108
-	},
-	"grok-4.3-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.3 (Non-reasoning)",
-		"codingIndex": 35.2,
-		"gpqa": 0.658,
-		"hle": 0.065
-	},
-	"grok-4.5-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.5 (high)",
-		"codingIndex": 72.4,
-		"gpqa": 0.931,
-		"hle": 0.403
+		"hle": 0.11
 	},
 	"grok-4.3-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok 4.3 (medium)",
 		"gpqa": 0.89,
-		"hle": 0.281
+		"hle": 0.3
+	},
+	"grok-4.3-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.3 (Non-reasoning)",
+		"codingIndex": 35.2,
+		"gpqa": 0.658,
+		"hle": 0.068
 	},
 	"grok-4.3-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok 4.3 (low)",
 		"gpqa": 0.843,
-		"hle": 0.173
+		"hle": 0.184
+	},
+	"grok-4.6-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.6 (xhigh)",
+		"codingIndex": 75.9,
+		"gpqa": 0.935,
+		"hle": 0.441
+	},
+	"grok-4.6-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.6 (high)",
+		"codingIndex": 76.8,
+		"gpqa": 0.949,
+		"hle": 0.429
+	},
+	"grok-4.6-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.6 (low)",
+		"codingIndex": 66.3,
+		"gpqa": 0.879,
+		"hle": 0.276
+	},
+	"grok-4.5-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.5 (high)",
+		"codingIndex": 72.4,
+		"gpqa": 0.931,
+		"hle": 0.427
+	},
+	"grok-4.6-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.6 (medium)",
+		"codingIndex": 74.4,
+		"gpqa": 0.935,
+		"hle": 0.421
 	},
 	"nova-micro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova Micro",
 		"mathIndex": 6,
 		"mmluPro": 0.531,
 		"gpqa": 0.358,
-		"hle": 0.047
-	},
-	"nova-2.0-lite-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova 2.0 Lite (high)",
-		"codingIndex": 23,
-		"mathIndex": 94.3,
-		"mmluPro": 0.818,
-		"gpqa": 0.811,
-		"hle": 0.109
-	},
-	"nova-2.0-lite-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova 2.0 Lite (Non-reasoning)",
-		"mathIndex": 33.7,
-		"mmluPro": 0.743,
-		"gpqa": 0.603,
-		"hle": 0.03
+		"hle": 0.046
 	},
 	"nova-2.0-omni-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova 2.0 Omni (medium)",
 		"mathIndex": 89.7,
 		"mmluPro": 0.809,
 		"gpqa": 0.76,
-		"hle": 0.068
+		"hle": 0.07
+	},
+	"nova-2.0-pro-preview-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova 2.0 Pro Preview (medium)",
+		"codingIndex": 34,
+		"mathIndex": 89,
+		"mmluPro": 0.83,
+		"gpqa": 0.785,
+		"hle": 0.094
+	},
+	"qwen-chat-14b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen Chat 14B"
 	},
 	"nova-2.0-omni-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova 2.0 Omni (Non-reasoning)",
 		"mathIndex": 37,
 		"mmluPro": 0.719,
 		"gpqa": 0.555,
+		"hle": 0.038
+	},
+	"nova-2.0-lite-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova 2.0 Lite (high)",
+		"codingIndex": 23,
+		"mathIndex": 94.3,
+		"mmluPro": 0.818,
+		"gpqa": 0.811,
+		"hle": 0.116
+	},
+	"nova-2.0-lite-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova 2.0 Lite (low)",
+		"mathIndex": 46.7,
+		"mmluPro": 0.788,
+		"gpqa": 0.698,
+		"hle": 0.04
+	},
+	"nova-2.0-lite-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova 2.0 Lite (Non-reasoning)",
+		"mathIndex": 33.7,
+		"mmluPro": 0.743,
+		"gpqa": 0.603,
+		"hle": 0.029
+	},
+	"nova-2.0-pro-preview-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova 2.0 Pro Preview (Non-reasoning)",
+		"codingIndex": 20.9,
+		"mathIndex": 30.7,
+		"mmluPro": 0.772,
+		"gpqa": 0.636,
 		"hle": 0.039
 	},
 	"nova-2.0-omni-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova 2.0 Omni (low)",
 		"mathIndex": 56,
 		"mmluPro": 0.798,
-		"gpqa": 0.699,
-		"hle": 0.04
+		"gpqa": 0.699
 	},
-	"nova-2.0-pro-preview-medium": {
+	"nova-premier": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova 2.0 Pro Preview (medium)",
-		"codingIndex": 34,
-		"mathIndex": 89,
-		"mmluPro": 0.83,
-		"gpqa": 0.785,
-		"hle": 0.089
-	},
-	"nova-2.0-lite-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova 2.0 Lite (medium)",
-		"mathIndex": 88.7,
-		"mmluPro": 0.813,
-		"gpqa": 0.768,
-		"hle": 0.086
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova Premier",
+		"mathIndex": 17.3,
+		"mmluPro": 0.733,
+		"gpqa": 0.569,
+		"hle": 0.042
 	},
 	"nova-2.0-pro-preview-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova 2.0 Pro Preview (low)",
 		"codingIndex": 25.9,
 		"mathIndex": 63.3,
@@ -986,121 +1105,83 @@
 		"gpqa": 0.751,
 		"hle": 0.052
 	},
-	"nova-2.0-lite-low": {
+	"nova-2.0-lite-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova 2.0 Lite (low)",
-		"mathIndex": 46.7,
-		"mmluPro": 0.788,
-		"gpqa": 0.698,
-		"hle": 0.042
-	},
-	"nova-premier": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova Premier",
-		"mathIndex": 17.3,
-		"mmluPro": 0.733,
-		"gpqa": 0.569,
-		"hle": 0.047
-	},
-	"nova-2.0-pro-preview-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nova 2.0 Pro Preview (Non-reasoning)",
-		"codingIndex": 20.9,
-		"mathIndex": 30.7,
-		"mmluPro": 0.772,
-		"gpqa": 0.636,
-		"hle": 0.04
-	},
-	"llama-65b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Llama 65B"
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nova 2.0 Lite (medium)",
+		"mathIndex": 88.7,
+		"mmluPro": 0.813,
+		"gpqa": 0.768,
+		"hle": 0.09
 	},
 	"phi-4": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Phi-4",
 		"mathIndex": 18,
 		"mmluPro": 0.714,
 		"gpqa": 0.575,
-		"hle": 0.041
-	},
-	"phi-4-mini-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Phi-4 Mini Instruct",
-		"codingIndex": 3.8,
-		"mathIndex": 6.7,
-		"mmluPro": 0.465,
-		"gpqa": 0.331,
-		"hle": 0.042
+		"hle": 0.038
 	},
 	"phi-4-multimodal-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Phi-4 Multimodal Instruct",
 		"mmluPro": 0.485,
 		"gpqa": 0.315,
+		"hle": 0.05
+	},
+	"phi-4-mini-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Phi-4 Mini Instruct",
+		"codingIndex": 3.8,
+		"mathIndex": 6.7,
+		"mmluPro": 0.465,
+		"gpqa": 0.331,
 		"hle": 0.044
 	},
-	"lfm2.5-1.2b-instruct": {
+	"lfm2.5-2.6b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "LFM2.5-1.2B-Instruct",
-		"gpqa": 0.326,
-		"hle": 0.068
-	},
-	"lfm2.5-1.2b-thinking": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "LFM2.5-1.2B-Thinking",
-		"gpqa": 0.339,
-		"hle": 0.061
+		"lastUpdated": "2026-09-01",
+		"originalModel": "LFM2.5-2.6B",
+		"codingIndex": 7.7,
+		"gpqa": 0.558,
+		"hle": 0.062
 	},
 	"lfm2.5-8b-a1b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LFM2.5-8B-A1B",
 		"gpqa": 0.513,
 		"hle": 0.069
 	},
-	"lfm2.5-vl-1.6b": {
+	"lfm2.5-1.2b-thinking": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "LFM2.5-VL-1.6B",
-		"gpqa": 0.289,
-		"hle": 0.051
+		"lastUpdated": "2026-09-01",
+		"originalModel": "LFM2.5-1.2B-Thinking",
+		"gpqa": 0.339,
+		"hle": 0.062
 	},
 	"lfm2-8b-a1b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LFM2 8B A1B",
 		"mathIndex": 25.3,
 		"mmluPro": 0.505,
@@ -1111,920 +1192,996 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LFM2 2.6B",
 		"mathIndex": 8.3,
+		"mmluPro": 0.298,
 		"gpqa": 0.306,
-		"hle": 0.052
+		"hle": 0.055
+	},
+	"lfm2.5-vl-1.6b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "LFM2.5-VL-1.6B",
+		"gpqa": 0.289,
+		"hle": 0.051
+	},
+	"lfm2.5-1.2b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "LFM2.5-1.2B-Instruct",
+		"gpqa": 0.326,
+		"hle": 0.067
 	},
 	"lfm2-24b-a2b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LFM2 24B A2B",
 		"gpqa": 0.474,
-		"hle": 0.044
+		"hle": 0.042
 	},
-	"solar-pro-3": {
+	"solar-pro-4": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Solar Pro 3",
-		"codingIndex": 16.2,
-		"gpqa": 0.724,
-		"hle": 0.101
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Solar Pro 4",
+		"codingIndex": 52.7,
+		"gpqa": 0.891,
+		"hle": 0.292
 	},
 	"solar-open-100b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Solar Open 100B (Reasoning)",
 		"gpqa": 0.657,
-		"hle": 0.092
+		"hle": 0.104
+	},
+	"solar-pro-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Solar Pro 3",
+		"codingIndex": 16.2,
+		"gpqa": 0.724,
+		"hle": 0.103
+	},
+	"solar-open2-250b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Solar Open2 250B",
+		"codingIndex": 44.7,
+		"gpqa": 0.857,
+		"hle": 0.285
 	},
 	"minimax-m3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiniMax-M3",
 		"codingIndex": 58.6,
 		"gpqa": 0.929,
-		"hle": 0.371
+		"hle": 0.39
 	},
 	"llama-3.1-nemotron-instruct-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.1 Nemotron Instruct 70B",
 		"mathIndex": 11,
 		"mmluPro": 0.69,
 		"gpqa": 0.465,
-		"hle": 0.046
-	},
-	"nvidia-nemotron-nano-12b-v2-vl-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Non-reasoning)",
-		"mathIndex": 26.7,
-		"mmluPro": 0.649,
-		"gpqa": 0.439,
-		"hle": 0.045
-	},
-	"nvidia-nemotron-nano-9b-v2-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Reasoning)",
-		"mathIndex": 69.7,
-		"mmluPro": 0.742,
-		"gpqa": 0.57,
-		"hle": 0.046
+		"hle": 0.042
 	},
 	"nvidia-nemotron-nano-9b-v2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Non-reasoning)",
 		"mathIndex": 62.3,
 		"mmluPro": 0.739,
 		"gpqa": 0.557,
-		"hle": 0.04
+		"hle": 0.046
 	},
-	"llama-3.1-nemotron-ultra-253b-v1-reasoning": {
+	"nemotron-3-ultra-550b-a55b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Llama 3.1 Nemotron Ultra 253B v1 (Reasoning)",
-		"mathIndex": 63.7,
-		"mmluPro": 0.825,
-		"gpqa": 0.728,
-		"hle": 0.081
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nemotron 3 Ultra 550B A55B (Reasoning)",
+		"codingIndex": 49.3,
+		"gpqa": 0.867,
+		"hle": 0.284
 	},
-	"nemotron-cascade-2-30b-a3b": {
+	"nvidia-nemotron-3-nano-30b-a3b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nemotron Cascade 2 30B A3B",
-		"codingIndex": 25.3,
-		"gpqa": 0.758,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Reasoning)",
+		"codingIndex": 14.4,
+		"mathIndex": 91,
+		"mmluPro": 0.794,
+		"gpqa": 0.757,
 		"hle": 0.114
 	},
 	"nemotron-3-nano-omni-30b-a3b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nemotron 3 Nano Omni 30B A3B Reasoning",
 		"codingIndex": 13.8,
 		"gpqa": 0.469,
-		"hle": 0.053
+		"hle": 0.048
 	},
-	"nvidia-nemotron-3-super-120b-a12b-reasoning": {
+	"nvidia-nemotron-nano-12b-v2-vl-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "NVIDIA Nemotron 3 Super 120B A12B (Reasoning)",
+		"lastUpdated": "2026-09-01",
+		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Non-reasoning)",
+		"mathIndex": 26.7,
+		"mmluPro": 0.649,
+		"gpqa": 0.439,
+		"hle": 0.043
+	},
+	"llama-3.1-nemotron-ultra-253b-v1-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Llama 3.1 Nemotron Ultra 253B v1 (Reasoning)",
+		"mathIndex": 63.7,
+		"mmluPro": 0.825,
+		"gpqa": 0.728,
+		"hle": 0.074
+	},
+	"nemotron-3.5-lightning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nemotron 3.5 Lightning",
+		"codingIndex": 26.8,
+		"gpqa": 0.743,
+		"hle": 0.106
+	},
+	"nvidia-nemotron-nano-9b-v2-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "NVIDIA Nemotron Nano 9B V2 (Reasoning)",
+		"mathIndex": 69.7,
+		"mmluPro": 0.742,
+		"gpqa": 0.57,
+		"hle": 0.049
+	},
+	"nvidia-nemotron-nano-12b-v2-vl-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Reasoning)",
+		"mathIndex": 75,
+		"mmluPro": 0.759,
+		"gpqa": 0.572,
+		"hle": 0.055
+	},
+	"nemotron-3-super-120b-a12b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nemotron 3 Super 120B A12B (Reasoning)",
 		"codingIndex": 37.7,
 		"gpqa": 0.8,
-		"hle": 0.192
-	},
-	"nvidia-nemotron-3-nano-30b-a3b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Reasoning)",
-		"codingIndex": 14.4,
-		"mathIndex": 91,
-		"mmluPro": 0.794,
-		"gpqa": 0.757,
-		"hle": 0.102
+		"hle": 0.208
 	},
 	"llama-nemotron-super-49b-v1.5-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama Nemotron Super 49B v1.5 (Non-reasoning)",
 		"mathIndex": 8,
+		"mmluPro": 0.692,
 		"gpqa": 0.481,
 		"hle": 0.043
 	},
-	"nemotron-3-ultra-550b-a55b-reasoning": {
+	"llama-nemotron-super-49b-v1.5-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Nemotron 3 Ultra 550B A55B (Reasoning)",
-		"codingIndex": 49.3,
-		"gpqa": 0.867,
-		"hle": 0.266
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Llama Nemotron Super 49B v1.5 (Reasoning)",
+		"mathIndex": 76.7,
+		"mmluPro": 0.814,
+		"gpqa": 0.748,
+		"hle": 0.073
 	},
 	"nvidia-nemotron-3-nano-30b-a3b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "NVIDIA Nemotron 3 Nano 30B A3B (Non-reasoning)",
 		"mathIndex": 13.3,
 		"mmluPro": 0.579,
 		"gpqa": 0.399,
 		"hle": 0.046
 	},
-	"qwen-chat-14b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen Chat 14B"
-	},
 	"nvidia-nemotron-3-nano-4b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "NVIDIA Nemotron 3 Nano 4B",
 		"codingIndex": 8,
 		"gpqa": 0.513,
-		"hle": 0.048
+		"hle": 0.049
 	},
-	"nvidia-nemotron-nano-12b-v2-vl-reasoning": {
+	"nemotron-cascade-2-30b-a3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "NVIDIA Nemotron Nano 12B v2 VL (Reasoning)",
-		"mathIndex": 75,
-		"mmluPro": 0.759,
-		"gpqa": 0.572,
-		"hle": 0.053
-	},
-	"llama-nemotron-super-49b-v1.5-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Llama Nemotron Super 49B v1.5 (Reasoning)",
-		"mathIndex": 76.7,
-		"gpqa": 0.748,
-		"hle": 0.068
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Nemotron Cascade 2 30B A3B",
+		"codingIndex": 25.3,
+		"gpqa": 0.758,
+		"hle": 0.12
 	},
 	"kimi-k2.7-code": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Kimi K2.7 Code",
 		"codingIndex": 60.8,
 		"gpqa": 0.896,
-		"hle": 0.328
-	},
-	"kimi-k2.6-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Kimi K2.6 (Non-reasoning)",
-		"gpqa": 0.788,
-		"hle": 0.182
+		"hle": 0.35
 	},
 	"kimi-k3-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Kimi K3 (max)",
 		"codingIndex": 76.2,
 		"gpqa": 0.935,
-		"hle": 0.443
-	},
-	"kimi-k3-low": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Kimi K3 (low)",
-		"codingIndex": 72,
-		"gpqa": 0.842,
-		"hle": 0.24
+		"hle": 0.469
 	},
 	"kimi-linear-48b-a3b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Kimi Linear 48B A3B Instruct",
 		"mathIndex": 36.3,
 		"mmluPro": 0.585,
 		"gpqa": 0.412,
-		"hle": 0.027
+		"hle": 0.025
+	},
+	"kimi-k3-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Kimi K3 (low)",
+		"codingIndex": 72,
+		"gpqa": 0.842,
+		"hle": 0.25
 	},
 	"step-3.7-flash": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Step 3.7 Flash",
 		"codingIndex": 39.6,
 		"gpqa": 0.809,
-		"hle": 0.199
+		"hle": 0.214
 	},
 	"step3-vl-10b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Step3 VL 10B",
 		"gpqa": 0.69,
-		"hle": 0.102
+		"hle": 0.108
+	},
+	"olmo-3.1-32b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Olmo 3.1 32B Instruct",
+		"gpqa": 0.539,
+		"hle": 0.05
+	},
+	"olmo-3-7b-think": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Olmo 3 7B Think",
+		"mathIndex": 70.7,
+		"mmluPro": 0.655,
+		"gpqa": 0.516,
+		"hle": 0.06
+	},
+	"olmo-3.1-32b-think": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Olmo 3.1 32B Think",
+		"mathIndex": 77.3,
+		"mmluPro": 0.763,
+		"gpqa": 0.591,
+		"hle": 0.063
+	},
+	"molmo2-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Molmo2-8B",
+		"gpqa": 0.425,
+		"hle": 0.043
 	},
 	"olmo-3-7b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Olmo 3 7B Instruct",
 		"mathIndex": 41.3,
 		"mmluPro": 0.522,
 		"gpqa": 0.4,
 		"hle": 0.058
 	},
-	"olmo-3.1-32b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Olmo 3.1 32B Instruct",
-		"gpqa": 0.539,
-		"hle": 0.049
-	},
-	"olmo-3-7b-think": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Olmo 3 7B Think",
-		"mathIndex": 70.7,
-		"mmluPro": 0.655,
-		"gpqa": 0.516,
-		"hle": 0.057
-	},
-	"molmo2-8b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Molmo2-8B",
-		"gpqa": 0.425,
-		"hle": 0.044
-	},
-	"olmo-3.1-32b-think": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Olmo 3.1 32B Think",
-		"mathIndex": 77.3,
-		"mmluPro": 0.763,
-		"gpqa": 0.591,
-		"hle": 0.06
-	},
 	"molmo-7b-d": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Molmo 7B-D",
 		"mathIndex": 0,
 		"mmluPro": 0.371,
 		"gpqa": 0.24,
 		"hle": 0.051
 	},
-	"granite-4.0-1b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.0 1B",
-		"mathIndex": 6.3,
-		"mmluPro": 0.325,
-		"gpqa": 0.281,
-		"hle": 0.051
-	},
-	"granite-4.0-h-1b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.0 H 1B",
-		"mathIndex": 6.3,
-		"gpqa": 0.263,
-		"hle": 0.05
-	},
-	"granite-4.1-8b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.1 8B",
-		"codingIndex": 9.5,
-		"gpqa": 0.433,
-		"hle": 0.038
-	},
-	"granite-4.0-h-small": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.0 H Small",
-		"mathIndex": 13.7,
-		"mmluPro": 0.624,
-		"gpqa": 0.416,
-		"hle": 0.037
-	},
-	"granite-4.0-h-350m": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.0 H 350M",
-		"mathIndex": 1.3,
-		"gpqa": 0.257,
-		"hle": 0.064
-	},
 	"granite-4.1-3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Granite 4.1 3B",
 		"codingIndex": 4.7,
 		"gpqa": 0.314,
 		"hle": 0.034
 	},
-	"granite-4.0-micro": {
+	"granite-4.0-350m": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.0 Micro",
-		"mathIndex": 6,
-		"gpqa": 0.336,
-		"hle": 0.051
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.0 350M",
+		"mathIndex": 0,
+		"mmluPro": 0.124,
+		"gpqa": 0.261,
+		"hle": 0.055
+	},
+	"granite-4.2-3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.2 3B",
+		"codingIndex": 17.5,
+		"gpqa": 0.559,
+		"hle": 0.066
+	},
+	"granite-4.2-30b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.2 30B",
+		"codingIndex": 29.9,
+		"gpqa": 0.644,
+		"hle": 0.112
+	},
+	"granite-4.0-h-small": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.0 H Small",
+		"mathIndex": 13.7,
+		"mmluPro": 0.624,
+		"gpqa": 0.416,
+		"hle": 0.038
+	},
+	"granite-4.1-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.1 8B",
+		"codingIndex": 9.5,
+		"gpqa": 0.433,
+		"hle": 0.038
+	},
+	"granite-4.0-h-1b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.0 H 1B",
+		"mathIndex": 6.3,
+		"mmluPro": 0.277,
+		"gpqa": 0.263,
+		"hle": 0.05
 	},
 	"granite-4.1-30b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Granite 4.1 30B",
 		"codingIndex": 10.4,
 		"gpqa": 0.481,
-		"hle": 0.042
+		"hle": 0.041
 	},
-	"granite-4.0-350m": {
+	"granite-4.2-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Granite 4.0 350M",
-		"mathIndex": 0,
-		"gpqa": 0.261,
-		"hle": 0.057
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.2 8B",
+		"codingIndex": 22.4,
+		"gpqa": 0.631,
+		"hle": 0.097
+	},
+	"granite-4.0-h-350m": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.0 H 350M",
+		"mathIndex": 1.3,
+		"mmluPro": 0.127,
+		"gpqa": 0.257,
+		"hle": 0.064
+	},
+	"granite-4.0-1b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.0 1B",
+		"mathIndex": 6.3,
+		"mmluPro": 0.325,
+		"gpqa": 0.281,
+		"hle": 0.048
+	},
+	"granite-4.0-micro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Granite 4.0 Micro",
+		"mathIndex": 6,
+		"mmluPro": 0.447,
+		"gpqa": 0.336,
+		"hle": 0.05
 	},
 	"mercury-2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mercury 2",
 		"codingIndex": 31.1,
 		"gpqa": 0.77,
-		"hle": 0.155
+		"hle": 0.171
 	},
 	"reka-flash-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Reka Flash 3",
 		"mathIndex": 33.7,
 		"mmluPro": 0.669,
 		"gpqa": 0.529,
-		"hle": 0.051
-	},
-	"hermes-4---llama-3.1-70b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Hermes 4 - Llama-3.1 70B (Reasoning)",
-		"mathIndex": 68.7,
-		"mmluPro": 0.811,
-		"gpqa": 0.699,
-		"hle": 0.079
+		"hle": 0.044
 	},
 	"hermes-4---llama-3.1-70b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Hermes 4 - Llama-3.1 70B (Non-reasoning)",
 		"mathIndex": 11.3,
+		"mmluPro": 0.664,
 		"gpqa": 0.491,
 		"hle": 0.036
-	},
-	"hermes-4---llama-3.1-405b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Hermes 4 - Llama-3.1 405B (Non-reasoning)",
-		"mathIndex": 15.3,
-		"gpqa": 0.536,
-		"hle": 0.042
 	},
 	"deephermes-3---mistral-24b-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepHermes 3 - Mistral 24B Preview (Non-reasoning)",
 		"mmluPro": 0.58,
 		"gpqa": 0.382,
-		"hle": 0.039
+		"hle": 0.038
 	},
 	"deephermes-3---llama-3.1-8b-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepHermes 3 - Llama-3.1 8B Preview (Non-reasoning)",
 		"mmluPro": 0.365,
 		"gpqa": 0.27,
 		"hle": 0.043
 	},
+	"hermes-4---llama-3.1-405b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Hermes 4 - Llama-3.1 405B (Non-reasoning)",
+		"mathIndex": 15.3,
+		"mmluPro": 0.729,
+		"gpqa": 0.536,
+		"hle": 0.042
+	},
+	"hermes-4---llama-3.1-70b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Hermes 4 - Llama-3.1 70B (Reasoning)",
+		"mathIndex": 68.7,
+		"mmluPro": 0.811,
+		"gpqa": 0.699,
+		"hle": 0.088
+	},
 	"hermes-4---llama-3.1-405b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Hermes 4 - Llama-3.1 405B (Reasoning)",
 		"mathIndex": 69.7,
 		"mmluPro": 0.829,
 		"gpqa": 0.727,
-		"hle": 0.103
-	},
-	"exaone-4.0-1.2b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Exaone 4.0 1.2B (Reasoning)",
-		"mathIndex": 50.3,
-		"gpqa": 0.515,
-		"hle": 0.058
+		"hle": 0.109
 	},
 	"k-exaone-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "K-EXAONE (Reasoning)",
 		"codingIndex": 32.1,
 		"mathIndex": 90.3,
 		"mmluPro": 0.838,
 		"gpqa": 0.783,
-		"hle": 0.131
-	},
-	"exaone-4.0-1.2b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Exaone 4.0 1.2B (Non-reasoning)",
-		"mathIndex": 24,
-		"gpqa": 0.424,
-		"hle": 0.058
+		"hle": 0.139
 	},
 	"exaone-4.0-32b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "EXAONE 4.0 32B (Reasoning)",
 		"mathIndex": 80,
+		"mmluPro": 0.818,
 		"gpqa": 0.739,
-		"hle": 0.105
+		"hle": 0.114
 	},
-	"exaone-4.0-32b-non-reasoning": {
+	"exaone-4.0-1.2b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "EXAONE 4.0 32B (Non-reasoning)",
-		"mathIndex": 39.3,
-		"gpqa": 0.628,
-		"hle": 0.049
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Exaone 4.0 1.2B (Reasoning)",
+		"mathIndex": 50.3,
+		"mmluPro": 0.588,
+		"gpqa": 0.515,
+		"hle": 0.06
 	},
 	"exaone-4.5-33b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "EXAONE 4.5 33B",
 		"codingIndex": 23.6,
 		"gpqa": 0.794,
-		"hle": 0.116
+		"hle": 0.129
+	},
+	"exaone-4.0-1.2b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Exaone 4.0 1.2B (Non-reasoning)",
+		"mathIndex": 24,
+		"mmluPro": 0.5,
+		"gpqa": 0.424,
+		"hle": 0.057
+	},
+	"exaone-4.0-32b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "EXAONE 4.0 32B (Non-reasoning)",
+		"mathIndex": 39.3,
+		"mmluPro": 0.768,
+		"gpqa": 0.628,
+		"hle": 0.05
+	},
+	"k-exaone-2.0": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "K-EXAONE 2.0",
+		"codingIndex": 40.6,
+		"gpqa": 0.829,
+		"hle": 0.186
 	},
 	"k-exaone-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "K-EXAONE (Non-reasoning)",
 		"mathIndex": 44,
 		"mmluPro": 0.81,
 		"gpqa": 0.695,
-		"hle": 0.054
-	},
-	"mimo-v2.5-pro": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiMo-V2.5-Pro",
-		"codingIndex": 60.2,
-		"gpqa": 0.866,
-		"hle": 0.338
-	},
-	"mimo-v2.5": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiMo-V2.5",
-		"codingIndex": 56.8,
-		"gpqa": 0.849,
-		"hle": 0.252
+		"hle": 0.057
 	},
 	"mimo-v2.5-pro-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiMo-V2.5-Pro (Non-reasoning)",
 		"gpqa": 0.762,
-		"hle": 0.133
-	},
-	"mimo-v2-flash-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiMo-V2-Flash (Non-reasoning)",
-		"codingIndex": 49.8,
-		"mathIndex": 67.7,
-		"mmluPro": 0.744,
-		"gpqa": 0.656,
-		"hle": 0.08
-	},
-	"mimo-v2-omni-0327": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiMo-V2-Omni-0327",
-		"gpqa": 0.855,
-		"hle": 0.204
-	},
-	"mimo-v2-omni": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiMo-V2-Omni",
-		"gpqa": 0.828,
-		"hle": 0.199
+		"hle": 0.148
 	},
 	"mimo-v2-flash-feb-2026": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiMo-V2-Flash (Feb 2026)",
 		"gpqa": 0.835,
-		"hle": 0.2
+		"hle": 0.221
+	},
+	"mimo-v2.5": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiMo-V2.5",
+		"codingIndex": 56.8,
+		"gpqa": 0.849,
+		"hle": 0.272
+	},
+	"mimo-v2.5-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiMo-V2.5-Pro",
+		"codingIndex": 60.2,
+		"gpqa": 0.866,
+		"hle": 0.357
+	},
+	"mimo-v2-omni": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiMo-V2-Omni",
+		"gpqa": 0.828,
+		"hle": 0.221
+	},
+	"mimo-v2-flash-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiMo-V2-Flash (Non-reasoning)",
+		"codingIndex": 49.8,
+		"mathIndex": 67.7,
+		"mmluPro": 0.744,
+		"gpqa": 0.656,
+		"hle": 0.086
+	},
+	"mimo-v2-omni-0327": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiMo-V2-Omni-0327",
+		"gpqa": 0.855,
+		"hle": 0.226
 	},
 	"ernie-4.5-300b-a47b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "ERNIE 4.5 300B A47B",
 		"mathIndex": 41.3,
 		"mmluPro": 0.776,
 		"gpqa": 0.811,
-		"hle": 0.035
+		"hle": 0.033
 	},
 	"ernie-5.0-thinking-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "ERNIE 5.0 Thinking Preview",
 		"mathIndex": 85,
 		"mmluPro": 0.83,
 		"gpqa": 0.777,
-		"hle": 0.127
-	},
-	"sarvam-30b-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Sarvam 30B (high)",
-		"gpqa": 0.633,
-		"hle": 0.07
+		"hle": 0.133
 	},
 	"sarvam-105b-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Sarvam 105B (high)",
 		"gpqa": 0.738,
-		"hle": 0.101
+		"hle": 0.11
+	},
+	"sarvam-30b-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Sarvam 30B (high)",
+		"gpqa": 0.633,
+		"hle": 0.075
 	},
 	"hypernova-60b-2605": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "HyperNova 60B 2605",
 		"codingIndex": 23.2,
 		"gpqa": 0.733,
-		"hle": 0.151
+		"hle": 0.166
 	},
 	"hy3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Hy3",
 		"codingIndex": 58.8,
 		"gpqa": 0.897,
-		"hle": 0.316
-	},
-	"hy3-preview-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Hy3-preview (Non-reasoning)",
-		"gpqa": 0.732,
-		"hle": 0.063
-	},
-	"hy3-preview-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Hy3-preview (Reasoning)",
-		"gpqa": 0.867,
-		"hle": 0.255
-	},
-	"kat-coder-pro-v1": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "KAT-Coder-Pro V1",
-		"mathIndex": 94.7,
-		"mmluPro": 0.813,
-		"gpqa": 0.764,
-		"hle": 0.334
+		"hle": 0.335
 	},
 	"kat-coder-pro-v2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "KAT Coder Pro V2",
 		"codingIndex": 59.5,
 		"gpqa": 0.855,
-		"hle": 0.16
+		"hle": 0.161
 	},
 	"intellect-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "INTELLECT-3",
 		"mathIndex": 88,
 		"mmluPro": 0.822,
 		"gpqa": 0.761,
-		"hle": 0.121
-	},
-	"motif-2-12.7b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Motif-2-12.7B-Reasoning",
-		"mathIndex": 80.3,
-		"mmluPro": 0.796,
-		"gpqa": 0.695,
-		"hle": 0.082
+		"hle": 0.131
 	},
 	"motif-3-beta": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Motif 3 (Beta)",
 		"codingIndex": 62,
 		"gpqa": 0.869,
-		"hle": 0.382
+		"hle": 0.404
 	},
-	"k2-v2-high": {
+	"motif-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "K2-V2 (high)",
-		"mathIndex": 78.3,
-		"mmluPro": 0.786,
-		"gpqa": 0.681,
-		"hle": 0.098
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Motif 3",
+		"codingIndex": 63.5,
+		"gpqa": 0.834,
+		"hle": 0.37
+	},
+	"motif-2-12.7b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Motif-2-12.7B-Reasoning",
+		"mathIndex": 80.3,
+		"mmluPro": 0.796,
+		"gpqa": 0.695,
+		"hle": 0.088
 	},
 	"k2-v2-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "K2-V2 (low)",
 		"mathIndex": 35.3,
 		"mmluPro": 0.713,
 		"gpqa": 0.541,
-		"hle": 0.039
+		"hle": 0.036
+	},
+	"k2-think-v2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "K2 Think V2",
+		"codingIndex": 21,
+		"gpqa": 0.713,
+		"hle": 0.101
 	},
 	"k2-v2-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "K2-V2 (medium)",
 		"mathIndex": 64.7,
 		"mmluPro": 0.761,
 		"gpqa": 0.598,
 		"hle": 0.044
 	},
-	"k2-think-v2": {
+	"k2-v2-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "K2 Think V2",
-		"codingIndex": 21,
-		"gpqa": 0.713,
-		"hle": 0.095
+		"lastUpdated": "2026-09-01",
+		"originalModel": "K2-V2 (high)",
+		"mathIndex": 78.3,
+		"mmluPro": 0.786,
+		"gpqa": 0.681,
+		"hle": 0.105
 	},
 	"mi-dm-k-2.5-pro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mi:dm K 2.5 Pro",
 		"mathIndex": 76.7,
 		"mmluPro": 0.809,
 		"gpqa": 0.701,
-		"hle": 0.077
+		"hle": 0.081
 	},
 	"hyperclova-x-seed-think-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "HyperCLOVA X SEED Think (32B)",
 		"mathIndex": 59,
 		"mmluPro": 0.785,
 		"gpqa": 0.615,
 		"hle": 0.055
 	},
-	"longcat-flash-lite": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "LongCat Flash Lite",
-		"gpqa": 0.636,
-		"hle": 0.06
-	},
 	"longcat-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LongCat 2.0",
 		"codingIndex": 45.3,
 		"gpqa": 0.78,
-		"hle": 0.321
+		"hle": 0.337
+	},
+	"longcat-flash-lite": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "LongCat Flash Lite",
+		"gpqa": 0.636,
+		"hle": 0.058
 	},
 	"tri-21b-think": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Tri-21B-Think",
 		"gpqa": 0.601,
-		"hle": 0.061
+		"hle": 0.059
 	},
 	"nanbeige4.1-3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nanbeige4.1-3B",
 		"codingIndex": 9.6,
 		"gpqa": 0.849,
-		"hle": 0.1
-	},
-	"apertus-8b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Apertus 8B Instruct",
-		"gpqa": 0.256,
-		"hle": 0.05
+		"hle": 0.109
 	},
 	"apertus-70b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Apertus 70B Instruct",
 		"gpqa": 0.272,
 		"hle": 0.055
+	},
+	"apertus-8b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Apertus 8B Instruct",
+		"gpqa": 0.256,
+		"hle": 0.05
+	},
+	"minicpm-v-4.6-1.3b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiniCPM-V 4.6 1.3B",
+		"codingIndex": 0.7,
+		"gpqa": 0.305,
+		"hle": 0.051
 	},
 	"minicpm5-1b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiniCPM5-1B (Reasoning)",
 		"gpqa": 0.278,
 		"hle": 0.065
@@ -2033,155 +2190,175 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiniCPM5-1B (Non-reasoning)",
 		"gpqa": 0.269,
-		"hle": 0.046
-	},
-	"minicpm-v-4.6-1.3b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiniCPM-V 4.6 1.3B",
-		"codingIndex": 0.7,
-		"gpqa": 0.305,
-		"hle": 0.049
+		"hle": 0.045
 	},
 	"trinity-large-thinking": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Trinity Large Thinking",
 		"codingIndex": 25.8,
 		"gpqa": 0.752,
-		"hle": 0.147
-	},
-	"jt-mini": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "JT-MINI",
-		"gpqa": 0.676,
-		"hle": 0.066
+		"hle": 0.158
 	},
 	"jt-35b-flash": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "JT-35B-Flash",
 		"gpqa": 0.829,
-		"hle": 0.061
+		"hle": 0.064
 	},
 	"jt-4.1-flash-236b-a21b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "JT-4.1 Flash 236B A21B",
 		"codingIndex": 52.4,
 		"gpqa": 0.845,
-		"hle": 0.161
+		"hle": 0.178
+	},
+	"jt-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "JT-MINI",
+		"gpqa": 0.676,
+		"hle": 0.064
+	},
+	"a.x-k2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "A.X-K2",
+		"codingIndex": 38.8,
+		"gpqa": 0.857,
+		"hle": 0.296
 	},
 	"nex-n2-pro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nex-N2-Pro",
 		"codingIndex": 59.1,
 		"gpqa": 0.892,
-		"hle": 0.324
+		"hle": 0.337
 	},
 	"inkling-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Inkling (xhigh)",
 		"codingIndex": 52.1,
 		"gpqa": 0.872,
-		"hle": 0.297
+		"hle": 0.319
 	},
 	"inkling-small": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Inkling Small",
 		"codingIndex": 52.9,
 		"gpqa": 0.895,
-		"hle": 0.316
+		"hle": 0.333
 	},
 	"g9v3-3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "G9v3-3B",
 		"codingIndex": 9.9,
 		"gpqa": 0.438,
-		"hle": 0.04
+		"hle": 0.045
+	},
+	"g9v3-39a5b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "G9v3-39A5B",
+		"codingIndex": 33.1,
+		"gpqa": 0.805,
+		"hle": 0.175
 	},
 	"glm-5.2-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-5.2 (max)",
 		"codingIndex": 68.8,
 		"gpqa": 0.895,
-		"hle": 0.401
+		"hle": 0.411
 	},
 	"glm-5.2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-5.2 (Non-reasoning)",
 		"codingIndex": 46.5,
 		"gpqa": 0.686,
-		"hle": 0.084
+		"hle": 0.098
 	},
-	"command-a+": {
+	"glm-5.3-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Command A+",
-		"codingIndex": 27.8,
-		"gpqa": 0.761,
-		"hle": 0.114
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5.3 (max)",
+		"codingIndex": 74.8,
+		"gpqa": 0.917,
+		"hle": 0.423
 	},
 	"north-mini-code": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "North Mini Code",
 		"codingIndex": 36.5,
 		"gpqa": 0.757,
-		"hle": 0.1
+		"hle": 0.111
 	},
 	"command-a": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Command A",
 		"mathIndex": 13,
 		"mmluPro": 0.712,
 		"gpqa": 0.527,
-		"hle": 0.046
+		"hle": 0.04
+	},
+	"command-a+": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Command A+",
+		"codingIndex": 27.8,
+		"gpqa": 0.761,
+		"hle": 0.12
 	},
 	"tiny-aya-global": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Tiny Aya Global",
 		"gpqa": 0.305,
 		"hle": 0.052
@@ -2190,1009 +2367,1069 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Apriel-v1.6-15B-Thinker",
 		"mathIndex": 88,
 		"mmluPro": 0.79,
 		"gpqa": 0.733,
-		"hle": 0.098
-	},
-	"jamba-1.7-large": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Jamba 1.7 Large",
-		"mathIndex": 2.3,
-		"gpqa": 0.39,
-		"hle": 0.038
+		"hle": 0.108
 	},
 	"jamba-1.7-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Jamba 1.7 Mini",
 		"mathIndex": 0.3,
+		"mmluPro": 0.388,
 		"gpqa": 0.322,
-		"hle": 0.045
+		"hle": 0.044
 	},
 	"jamba-reasoning-3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Jamba Reasoning 3B",
 		"mathIndex": 10.7,
 		"mmluPro": 0.577,
 		"gpqa": 0.333,
-		"hle": 0.046
+		"hle": 0.038
 	},
-	"qwen3.5-397b-a17b-non-reasoning": {
+	"jamba-1.7-large": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 397B A17B (Non-reasoning)",
-		"gpqa": 0.861,
-		"hle": 0.188
-	},
-	"qwen3-next-80b-a3b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Next 80B A3B (Reasoning)",
-		"codingIndex": 17.4,
-		"mathIndex": 84.3,
-		"mmluPro": 0.824,
-		"gpqa": 0.759,
-		"hle": 0.117
-	},
-	"qwen3.5-397b-a17b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 397B A17B (Reasoning)",
-		"codingIndex": 48.2,
-		"gpqa": 0.893,
-		"hle": 0.273
-	},
-	"qwen3.6-35b-a3b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.6 35B A3B (Non-reasoning)",
-		"codingIndex": 28.1,
-		"gpqa": 0.817,
-		"hle": 0.125
-	},
-	"qwen3.5-4b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 4B (Non-reasoning)",
-		"codingIndex": 20.3,
-		"gpqa": 0.712,
-		"hle": 0.075
-	},
-	"qwen3.5-122b-a10b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 122B A10B (Reasoning)",
-		"codingIndex": 45.7,
-		"gpqa": 0.857,
-		"hle": 0.234
-	},
-	"qwen3.7-max": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.7 Max",
-		"codingIndex": 66,
-		"gpqa": 0.923,
-		"hle": 0.381
-	},
-	"qwen3-next-80b-a3b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Next 80B A3B Instruct",
-		"mathIndex": 66.3,
-		"mmluPro": 0.819,
-		"gpqa": 0.738,
-		"hle": 0.073
-	},
-	"qwen3.5-9b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 9B (Reasoning)",
-		"codingIndex": 28.7,
-		"gpqa": 0.806,
-		"hle": 0.133
-	},
-	"qwen3.5-122b-a10b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 122B A10B (Non-reasoning)",
-		"codingIndex": 43.3,
-		"gpqa": 0.827,
-		"hle": 0.148
-	},
-	"qwen3.6-35b-a3b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.6 35B A3B (Reasoning)",
-		"codingIndex": 41.9,
-		"gpqa": 0.841,
-		"hle": 0.202
-	},
-	"qwen3.5-2b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 2B (Reasoning)",
-		"codingIndex": 2.9,
-		"gpqa": 0.456,
-		"hle": 0.021
-	},
-	"qwen3.6-27b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.6 27B (Reasoning)",
-		"codingIndex": 53.7,
-		"gpqa": 0.842,
-		"hle": 0.216
-	},
-	"qwen3.5-4b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 4B (Reasoning)",
-		"codingIndex": 22.6,
-		"gpqa": 0.771,
-		"hle": 0.078
-	},
-	"qwen3-omni-30b-a3b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Omni 30B A3B (Reasoning)",
-		"mathIndex": 74,
-		"mmluPro": 0.792,
-		"gpqa": 0.726,
-		"hle": 0.073
-	},
-	"qwen3-omni-30b-a3b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Omni 30B A3B Instruct",
-		"mathIndex": 52.3,
-		"mmluPro": 0.725,
-		"gpqa": 0.62,
-		"hle": 0.051
-	},
-	"qwen3.5-2b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 2B (Non-reasoning)",
-		"codingIndex": 2.4,
-		"gpqa": 0.438,
-		"hle": 0.049
-	},
-	"qwen3.5-9b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 9B (Non-reasoning)",
-		"codingIndex": 23.5,
-		"gpqa": 0.786,
-		"hle": 0.086
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Jamba 1.7 Large",
+		"mathIndex": 2.3,
+		"mmluPro": 0.577,
+		"gpqa": 0.39,
+		"hle": 0.037
 	},
 	"qwen3.5-omni-plus": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3.5 Omni Plus",
 		"gpqa": 0.826,
-		"hle": 0.139
-	},
-	"qwen3.6-plus": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.6 Plus",
-		"codingIndex": 54.5,
-		"gpqa": 0.882,
-		"hle": 0.257
-	},
-	"qwen3.5-35b-a3b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 35B A3B (Non-reasoning)",
-		"codingIndex": 37,
-		"gpqa": 0.819,
-		"hle": 0.128
-	},
-	"qwen3-coder-next": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Coder Next",
-		"codingIndex": 36.2,
-		"gpqa": 0.737,
-		"hle": 0.093
-	},
-	"qwen3.5-omni-flash": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 Omni Flash",
-		"gpqa": 0.742,
-		"hle": 0.071
+		"hle": 0.149
 	},
 	"qwen3.6-27b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3.6 27B (Non-reasoning)",
 		"codingIndex": 46.6,
 		"gpqa": 0.829,
-		"hle": 0.136
+		"hle": 0.151
 	},
-	"qwen3.7-plus": {
+	"qwen3.6-35b-a3b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.7 Plus",
-		"codingIndex": 55.9,
-		"gpqa": 0.9,
-		"hle": 0.334
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.6 35B A3B (Non-reasoning)",
+		"codingIndex": 28.1,
+		"gpqa": 0.817,
+		"hle": 0.139
+	},
+	"qwen3.8-27b-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8 27B (low)",
+		"codingIndex": 58.2,
+		"gpqa": 0.845,
+		"hle": 0.14
+	},
+	"qwen3.6-35b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.6 35B A3B (Reasoning)",
+		"codingIndex": 41.9,
+		"gpqa": 0.841,
+		"hle": 0.222
+	},
+	"qwen3.6-27b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.6 27B (Reasoning)",
+		"codingIndex": 53.7,
+		"gpqa": 0.842,
+		"hle": 0.231
+	},
+	"qwen3-next-80b-a3b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Next 80B A3B Instruct",
+		"mathIndex": 66.3,
+		"mmluPro": 0.819,
+		"gpqa": 0.738,
+		"hle": 0.076
+	},
+	"qwen3.5-122b-a10b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 122B A10B (Reasoning)",
+		"codingIndex": 45.7,
+		"gpqa": 0.857,
+		"hle": 0.252
+	},
+	"qwen3.5-397b-a17b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 397B A17B (Reasoning)",
+		"codingIndex": 48.2,
+		"gpqa": 0.893,
+		"hle": 0.29
 	},
 	"qwen3.5-0.8b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3.5 0.8B (Reasoning)",
 		"codingIndex": 0,
 		"gpqa": 0.111,
-		"hle": 0.012
+		"hle": 0.011
+	},
+	"qwen3-coder-next": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Coder Next",
+		"codingIndex": 36.2,
+		"gpqa": 0.737,
+		"hle": 0.101
+	},
+	"qwen3-next-80b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Next 80B A3B (Reasoning)",
+		"codingIndex": 17.4,
+		"mathIndex": 84.3,
+		"mmluPro": 0.824,
+		"gpqa": 0.759,
+		"hle": 0.126
+	},
+	"qwen3.5-9b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 9B (Reasoning)",
+		"codingIndex": 28.7,
+		"gpqa": 0.806,
+		"hle": 0.149
+	},
+	"qwen3.8-2.4t-a95b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8 2.4T A95B",
+		"codingIndex": 71.9,
+		"gpqa": 0.935,
+		"hle": 0.424
+	},
+	"qwen3.5-397b-a17b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 397B A17B (Non-reasoning)",
+		"gpqa": 0.861,
+		"hle": 0.198
+	},
+	"qwen3.7-plus": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.7 Plus",
+		"codingIndex": 55.9,
+		"gpqa": 0.9,
+		"hle": 0.356
+	},
+	"qwen3.8-27b-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8 27B (xhigh)",
+		"codingIndex": 68.1,
+		"gpqa": 0.905,
+		"hle": 0.339
+	},
+	"qwen3-omni-30b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Omni 30B A3B (Reasoning)",
+		"mathIndex": 74,
+		"mmluPro": 0.792,
+		"gpqa": 0.726,
+		"hle": 0.075
+	},
+	"qwen3.5-35b-a3b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 35B A3B (Non-reasoning)",
+		"codingIndex": 37,
+		"gpqa": 0.819,
+		"hle": 0.134
+	},
+	"qwen3.5-122b-a10b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 122B A10B (Non-reasoning)",
+		"codingIndex": 43.3,
+		"gpqa": 0.827,
+		"hle": 0.159
+	},
+	"qwen3-omni-30b-a3b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Omni 30B A3B Instruct",
+		"mathIndex": 52.3,
+		"mmluPro": 0.725,
+		"gpqa": 0.62,
+		"hle": 0.046
+	},
+	"qwen3.5-4b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 4B (Reasoning)",
+		"codingIndex": 22.6,
+		"gpqa": 0.771,
+		"hle": 0.099
+	},
+	"qwen3.8-27b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8 27B (Non-reasoning)",
+		"codingIndex": 44.6,
+		"gpqa": 0.818,
+		"hle": 0.121
+	},
+	"qwen3.5-9b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 9B (Non-reasoning)",
+		"codingIndex": 23.5,
+		"gpqa": 0.786,
+		"hle": 0.094
+	},
+	"qwen3.5-2b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 2B (Reasoning)",
+		"codingIndex": 2.9,
+		"gpqa": 0.456,
+		"hle": 0.026
 	},
 	"qwen3.5-0.8b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3.5 0.8B (Non-reasoning)",
 		"codingIndex": 1.2,
 		"gpqa": 0.236,
-		"hle": 0.049
+		"hle": 0.051
 	},
-	"ling-2.6-1t": {
+	"qwen3.5-4b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Ling-2.6-1T",
-		"gpqa": 0.752,
-		"hle": 0.082
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 4B (Non-reasoning)",
+		"codingIndex": 20.3,
+		"gpqa": 0.712,
+		"hle": 0.08
+	},
+	"qwen3.8-max": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8 Max",
+		"codingIndex": 71.8,
+		"gpqa": 0.927,
+		"hle": 0.43
+	},
+	"qwen3.8-27b-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.8 27B (medium)",
+		"codingIndex": 56.1,
+		"gpqa": 0.845,
+		"hle": 0.141
+	},
+	"qwen3.5-2b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 2B (Non-reasoning)",
+		"codingIndex": 2.4,
+		"gpqa": 0.438,
+		"hle": 0.05
+	},
+	"qwen3.5-omni-flash": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 Omni Flash",
+		"gpqa": 0.742,
+		"hle": 0.076
 	},
 	"ring-flash-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Ring-flash-2.0",
 		"mathIndex": 83.7,
 		"mmluPro": 0.793,
 		"gpqa": 0.725,
-		"hle": 0.089
+		"hle": 0.096
 	},
-	"ling-mini-2.0": {
+	"ling-3.0-flash": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Ling-mini-2.0",
-		"mathIndex": 49.3,
-		"mmluPro": 0.671,
-		"gpqa": 0.562,
-		"hle": 0.05
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ling 3.0 Flash",
+		"codingIndex": 50.6,
+		"gpqa": 0.855,
+		"hle": 0.237
 	},
-	"ling-2.6-flash": {
+	"ling-3.0-tiny": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Ling 2.6 Flash",
-		"codingIndex": 25.3,
-		"gpqa": 0.593,
-		"hle": 0.062
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ling 3.0 Tiny",
+		"codingIndex": 26.5,
+		"gpqa": 0.734,
+		"hle": 0.093
 	},
 	"ring-2.6-1t": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Ring-2.6-1T",
 		"codingIndex": 42.8,
 		"gpqa": 0.857,
-		"hle": 0.183
+		"hle": 0.216
 	},
 	"doubao-seed-code": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Doubao Seed Code",
 		"mathIndex": 79.3,
 		"mmluPro": 0.854,
 		"gpqa": 0.764,
-		"hle": 0.133
+		"hle": 0.141
 	},
 	"agnes-2.5-pro-alpha": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Agnes 2.5 Pro Alpha",
 		"codingIndex": 58.8,
 		"gpqa": 0.876,
-		"hle": 0.319
+		"hle": 0.336
+	},
+	"agnes-2.5-pro-beta": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Agnes 2.5 Pro Beta",
+		"codingIndex": 62.3,
+		"gpqa": 0.905,
+		"hle": 0.375
 	},
 	"celeris-1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Celeris-1",
 		"codingIndex": 14.4,
+		"mmluPro": 0.78,
 		"gpqa": 0.631,
-		"hle": 0.066
+		"hle": 0.068
 	},
 	"o1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "o1",
 		"codingIndex": 39.7,
 		"mmluPro": 0.841,
 		"gpqa": 0.747,
-		"hle": 0.077
+		"hle": 0.07
 	},
 	"o1-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "o1-preview",
-		"codingIndex": 34
+		"codingIndex": 34,
+		"mathIndex": 79.7,
+		"mmluPro": 0.848,
+		"gpqa": 0.765
 	},
 	"o1-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "o1-mini",
 		"mmluPro": 0.742,
 		"gpqa": 0.603,
-		"hle": 0.049
+		"hle": 0.036
 	},
 	"gpt-4o-aug-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4o (Aug '24)",
 		"gpqa": 0.521,
-		"hle": 0.029
+		"hle": 0.023
 	},
 	"gpt-4o-may-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4o (May '24)",
 		"codingIndex": 24.2,
 		"mmluPro": 0.74,
 		"gpqa": 0.526,
-		"hle": 0.028
+		"hle": 0.018
 	},
 	"gpt-4-turbo": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4 Turbo",
 		"codingIndex": 21.5,
 		"mmluPro": 0.694,
-		"hle": 0.033
+		"hle": 0.031
 	},
 	"gpt-4o-nov-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4o (Nov '24)",
 		"mathIndex": 6,
 		"mmluPro": 0.748,
 		"gpqa": 0.543,
-		"hle": 0.033
+		"hle": 0.024
 	},
 	"gpt-4o-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4o mini",
 		"codingIndex": 11.4,
 		"mathIndex": 14.7,
 		"mmluPro": 0.648,
 		"gpqa": 0.426,
-		"hle": 0.04
+		"hle": 0.042
 	},
 	"gpt-3.5-turbo": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-3.5 Turbo",
 		"codingIndex": 10.7,
 		"mmluPro": 0.462,
 		"gpqa": 0.297
 	},
-	"gpt-5-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 (high)",
-		"codingIndex": 37.8,
-		"mathIndex": 94.3,
-		"gpqa": 0.854,
-		"hle": 0.265
-	},
-	"gpt-5-minimal": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 (minimal)",
-		"mathIndex": 31.7,
-		"gpqa": 0.673,
-		"hle": 0.054
-	},
-	"gpt-5.5-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 (Non-reasoning)",
-		"codingIndex": 56.5,
-		"gpqa": 0.768,
-		"hle": 0.126
-	},
-	"gpt-5.5-low": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 (low)",
-		"codingIndex": 60.9,
-		"gpqa": 0.91,
-		"hle": 0.31
-	},
-	"gpt-5.5-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 (medium)",
-		"codingIndex": 71.5,
-		"gpqa": 0.926,
-		"hle": 0.406
-	},
-	"gpt-5.1-codex-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.1 Codex (high)",
-		"mathIndex": 95.7,
-		"mmluPro": 0.86,
-		"gpqa": 0.86,
-		"hle": 0.234
-	},
-	"gpt-5-mini-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 mini (medium)",
-		"mathIndex": 85,
-		"gpqa": 0.803,
-		"hle": 0.146
-	},
-	"gpt-5.1-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.1 (Non-reasoning)",
-		"mathIndex": 38,
-		"mmluPro": 0.801,
-		"gpqa": 0.643,
-		"hle": 0.052
-	},
-	"gpt-5.2-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.2 (Non-reasoning)",
-		"mathIndex": 51,
-		"mmluPro": 0.814,
-		"gpqa": 0.712,
-		"hle": 0.073
-	},
-	"gpt-5.1-codex-mini-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.1 Codex mini (high)",
-		"mathIndex": 91.7,
-		"mmluPro": 0.82,
-		"gpqa": 0.813,
-		"hle": 0.169
-	},
-	"gpt-5.5-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 (xhigh)",
-		"codingIndex": 74.9,
-		"gpqa": 0.935,
-		"hle": 0.443
-	},
-	"gpt-5-nano-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 nano (high)",
-		"mathIndex": 83.7,
-		"mmluPro": 0.78,
-		"gpqa": 0.676,
-		"hle": 0.082
-	},
-	"gpt-5.4-mini-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 mini (medium)",
-		"gpqa": 0.823,
-		"hle": 0.171
-	},
-	"gpt-5.4-mini-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 mini (Non-Reasoning)",
-		"gpqa": 0.606,
-		"hle": 0.057
-	},
-	"gpt-5.4-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 (xhigh)",
-		"codingIndex": 71.1,
-		"gpqa": 0.92,
-		"hle": 0.416
-	},
-	"gpt-5-nano-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 nano (medium)",
-		"mathIndex": 78.3,
-		"gpqa": 0.67,
-		"hle": 0.076
-	},
-	"gpt-5.4-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 (Non-reasoning)",
-		"gpqa": 0.748,
-		"hle": 0.106
-	},
-	"gpt-5.4-low": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 (low)",
-		"gpqa": 0.871,
-		"hle": 0.289
-	},
-	"gpt-5-nano-minimal": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 nano (minimal)",
-		"mathIndex": 27.3,
-		"gpqa": 0.428,
-		"hle": 0.041
-	},
 	"gpt-4.1-nano": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4.1 nano",
 		"codingIndex": 11.1,
 		"mathIndex": 24,
 		"mmluPro": 0.657,
 		"gpqa": 0.512,
-		"hle": 0.039
+		"hle": 0.038
 	},
-	"gpt-5.5-high": {
+	"gpt-5.5-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 (high)",
-		"codingIndex": 71.6,
-		"gpqa": 0.932,
-		"hle": 0.43
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 (Non-reasoning)",
+		"codingIndex": 56.5,
+		"gpqa": 0.768,
+		"hle": 0.137
 	},
-	"gpt-4.1": {
+	"gpt-5.2-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-4.1",
-		"mathIndex": 34.7,
-		"mmluPro": 0.806,
-		"gpqa": 0.666,
-		"hle": 0.046
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.2 (Non-reasoning)",
+		"mathIndex": 51,
+		"mmluPro": 0.814,
+		"gpqa": 0.712,
+		"hle": 0.08
 	},
-	"gpt-5-low": {
+	"gpt-5.5-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 (low)",
-		"mathIndex": 83,
-		"gpqa": 0.808,
-		"hle": 0.184
-	},
-	"gpt-5.2-codex-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.2 Codex (xhigh)",
-		"gpqa": 0.899,
-		"hle": 0.335
-	},
-	"o4-mini-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "o4-mini (high)",
-		"mathIndex": 90.7,
-		"mmluPro": 0.832,
-		"gpqa": 0.784,
-		"hle": 0.175
-	},
-	"gpt-5-medium": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 (medium)",
-		"mathIndex": 91.7,
-		"gpqa": 0.842,
-		"hle": 0.235
-	},
-	"gpt-5.5-instant-may-2026": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.5 Instant (May 2026)",
-		"gpqa": 0.846,
-		"hle": 0.203
-	},
-	"gpt-5-mini-minimal": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 mini (minimal)",
-		"mathIndex": 46.7,
-		"gpqa": 0.687,
-		"hle": 0.05
-	},
-	"gpt-4.1-mini": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-4.1 mini",
-		"codingIndex": 20.2,
-		"mathIndex": 46.3,
-		"mmluPro": 0.781,
-		"gpqa": 0.664,
-		"hle": 0.046
-	},
-	"gpt-5.2-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.2 (xhigh)",
-		"mathIndex": 99,
-		"mmluPro": 0.874,
-		"gpqa": 0.903,
-		"hle": 0.354
-	},
-	"gpt-5.4-nano-xhigh": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 nano (xhigh)",
-		"codingIndex": 56.1,
-		"gpqa": 0.817,
-		"hle": 0.265
-	},
-	"o1-pro": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "o1-pro"
-	},
-	"gpt-4.5-preview": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-4.5 (Preview)"
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 (medium)",
+		"codingIndex": 71.5,
+		"gpqa": 0.926,
+		"hle": 0.424
 	},
 	"gpt-4": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4",
-		"codingIndex": 13.1
+		"codingIndex": 13.1,
+		"mmluPro": 0.562,
+		"gpqa": 0.349
 	},
-	"gpt-5.2-medium": {
+	"gpt-5-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.2 (medium)",
-		"mathIndex": 96.7,
-		"mmluPro": 0.859,
-		"gpqa": 0.864,
-		"hle": 0.249
-	},
-	"o3-pro": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "o3-pro",
-		"gpqa": 0.845
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 (medium)",
+		"mathIndex": 91.7,
+		"mmluPro": 0.867,
+		"gpqa": 0.842,
+		"hle": 0.254
 	},
 	"gpt-5-codex-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-5 Codex (high)",
 		"mathIndex": 98.7,
 		"mmluPro": 0.865,
 		"gpqa": 0.837,
-		"hle": 0.256
+		"hle": 0.278
 	},
-	"gpt-5.1-high": {
+	"gpt-4.5-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.1 (high)",
-		"codingIndex": 49.4,
-		"mathIndex": 94,
-		"gpqa": 0.873,
-		"hle": 0.265
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-4.5 (Preview)"
 	},
-	"gpt-5-mini-high": {
+	"gpt-5.4-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 mini (high)",
-		"codingIndex": 15.6,
-		"mathIndex": 90.7,
-		"gpqa": 0.828,
-		"hle": 0.197
-	},
-	"gpt-5-chatgpt": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5 (ChatGPT)",
-		"mathIndex": 48.3,
-		"gpqa": 0.686,
-		"hle": 0.058
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 (xhigh)",
+		"codingIndex": 71.1,
+		"gpqa": 0.92,
+		"hle": 0.437
 	},
 	"gpt-4o-march-2025-chatgpt-4o-latest": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GPT-4o (March 2025, chatgpt-4o-latest)",
 		"mathIndex": 25.7,
 		"mmluPro": 0.803,
 		"gpqa": 0.655,
-		"hle": 0.05
+		"hle": 0.04
 	},
-	"gpt-4o-chatgpt": {
+	"gpt-5.4-low": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-4o (ChatGPT)",
-		"mmluPro": 0.773,
-		"gpqa": 0.511,
-		"hle": 0.037
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 (low)",
+		"gpqa": 0.871,
+		"hle": 0.308
 	},
-	"gpt-5.4-mini-xhigh": {
+	"gpt-5.1-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 mini (xhigh)",
-		"codingIndex": 56.1,
-		"gpqa": 0.875,
-		"hle": 0.266
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.1 (high)",
+		"codingIndex": 49.4,
+		"mathIndex": 94,
+		"mmluPro": 0.87,
+		"gpqa": 0.873,
+		"hle": 0.285
+	},
+	"gpt-5.2-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.2 (xhigh)",
+		"mathIndex": 99,
+		"mmluPro": 0.874,
+		"gpqa": 0.903,
+		"hle": 0.377
+	},
+	"gpt-5.4-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 (Non-reasoning)",
+		"gpqa": 0.748,
+		"hle": 0.113
+	},
+	"gpt-5-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 (high)",
+		"codingIndex": 37.8,
+		"mathIndex": 94.3,
+		"mmluPro": 0.871,
+		"gpqa": 0.854,
+		"hle": 0.285
+	},
+	"gpt-4.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-4.1",
+		"mathIndex": 34.7,
+		"mmluPro": 0.806,
+		"gpqa": 0.666,
+		"hle": 0.042
+	},
+	"gpt-5.4-mini-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 mini (medium)",
+		"gpqa": 0.823,
+		"hle": 0.186
 	},
 	"o3-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "o3-mini",
 		"mmluPro": 0.791,
 		"gpqa": 0.748,
-		"hle": 0.087
+		"hle": 0.079
 	},
-	"gpt-5.4-nano-medium": {
+	"gpt-5-mini-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 nano (medium)",
-		"gpqa": 0.761,
-		"hle": 0.147
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 mini (high)",
+		"codingIndex": 15.6,
+		"mathIndex": 90.7,
+		"mmluPro": 0.837,
+		"gpqa": 0.828,
+		"hle": 0.215
 	},
-	"gpt-5.4-nano-non-reasoning": {
+	"gpt-5.5-xhigh": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GPT-5.4 nano (Non-Reasoning)",
-		"gpqa": 0.558,
-		"hle": 0.042
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 (xhigh)",
+		"codingIndex": 74.9,
+		"gpqa": 0.935,
+		"hle": 0.458
+	},
+	"gpt-5.2-codex-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.2 Codex (xhigh)",
+		"gpqa": 0.899,
+		"hle": 0.357
 	},
 	"o3-mini-high": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "o3-mini (high)",
 		"codingIndex": 16.3,
 		"mmluPro": 0.802,
 		"gpqa": 0.773,
-		"hle": 0.123
+		"hle": 0.12
+	},
+	"gpt-5-nano-minimal": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 nano (minimal)",
+		"mathIndex": 27.3,
+		"mmluPro": 0.556,
+		"gpqa": 0.428,
+		"hle": 0.04
+	},
+	"gpt-5.1-codex-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.1 Codex (high)",
+		"mathIndex": 95.7,
+		"mmluPro": 0.86,
+		"gpqa": 0.86,
+		"hle": 0.257
+	},
+	"o3-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "o3-pro",
+		"gpqa": 0.845
+	},
+	"gpt-5.1-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.1 (Non-reasoning)",
+		"mathIndex": 38,
+		"mmluPro": 0.801,
+		"gpqa": 0.643,
+		"hle": 0.053
+	},
+	"gpt-5-nano-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 nano (high)",
+		"mathIndex": 83.7,
+		"mmluPro": 0.78,
+		"gpqa": 0.676,
+		"hle": 0.095
+	},
+	"gpt-5.1-codex-mini-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.1 Codex mini (high)",
+		"mathIndex": 91.7,
+		"mmluPro": 0.82,
+		"gpqa": 0.813,
+		"hle": 0.185
+	},
+	"gpt-5.2-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.2 (medium)",
+		"mathIndex": 96.7,
+		"mmluPro": 0.859,
+		"gpqa": 0.864,
+		"hle": 0.267
+	},
+	"o4-mini-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "o4-mini (high)",
+		"mathIndex": 90.7,
+		"mmluPro": 0.832,
+		"gpqa": 0.784,
+		"hle": 0.165
+	},
+	"gpt-4.1-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-4.1 mini",
+		"codingIndex": 20.2,
+		"mathIndex": 46.3,
+		"mmluPro": 0.781,
+		"gpqa": 0.664,
+		"hle": 0.05
+	},
+	"gpt-5.4-nano-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 nano (xhigh)",
+		"codingIndex": 56.1,
+		"gpqa": 0.817,
+		"hle": 0.283
+	},
+	"gpt-5.4-mini-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 mini (xhigh)",
+		"codingIndex": 56.1,
+		"gpqa": 0.875,
+		"hle": 0.281
+	},
+	"gpt-5-nano-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 nano (medium)",
+		"mathIndex": 78.3,
+		"mmluPro": 0.772,
+		"gpqa": 0.67,
+		"hle": 0.087
+	},
+	"gpt-5-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 (low)",
+		"mathIndex": 83,
+		"mmluPro": 0.86,
+		"gpqa": 0.808,
+		"hle": 0.196
+	},
+	"gpt-5-mini-minimal": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 mini (minimal)",
+		"mathIndex": 46.7,
+		"mmluPro": 0.775,
+		"gpqa": 0.687,
+		"hle": 0.051
+	},
+	"gpt-5.4-mini-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 mini (Non-Reasoning)",
+		"gpqa": 0.606,
+		"hle": 0.059
+	},
+	"gpt-5-chatgpt": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 (ChatGPT)",
+		"mathIndex": 48.3,
+		"mmluPro": 0.82,
+		"gpqa": 0.686,
+		"hle": 0.066
+	},
+	"gpt-5-minimal": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 (minimal)",
+		"mathIndex": 31.7,
+		"mmluPro": 0.806,
+		"gpqa": 0.673,
+		"hle": 0.06
+	},
+	"o1-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "o1-pro"
+	},
+	"gpt-5.5-instant-may-2026": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 Instant (May 2026)",
+		"gpqa": 0.846,
+		"hle": 0.216
+	},
+	"gpt-5.5-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 (low)",
+		"codingIndex": 60.9,
+		"gpqa": 0.91,
+		"hle": 0.327
+	},
+	"gpt-5-mini-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5 mini (medium)",
+		"mathIndex": 85,
+		"mmluPro": 0.828,
+		"gpqa": 0.803,
+		"hle": 0.159
+	},
+	"gpt-5.4-nano-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 nano (Non-Reasoning)",
+		"gpqa": 0.558,
+		"hle": 0.041
+	},
+	"gpt-5.5-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.5 (high)",
+		"codingIndex": 71.6,
+		"gpqa": 0.932,
+		"hle": 0.45
+	},
+	"gpt-4o-chatgpt": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-4o (ChatGPT)",
+		"mmluPro": 0.773,
+		"gpqa": 0.511,
+		"hle": 0.027
+	},
+	"gpt-5.4-nano-medium": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GPT-5.4 nano (medium)",
+		"gpqa": 0.761,
+		"hle": 0.159
 	},
 	"llama-3.1-instruct-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.1 Instruct 70B",
 		"mathIndex": 4,
 		"mmluPro": 0.676,
 		"gpqa": 0.409,
-		"hle": 0.046
+		"hle": 0.045
 	},
 	"llama-3.1-instruct-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.1 Instruct 8B",
 		"codingIndex": 5.4,
 		"mathIndex": 4.3,
 		"mmluPro": 0.476,
 		"gpqa": 0.259,
-		"hle": 0.051
+		"hle": 0.053
 	},
 	"llama-3.2-instruct-3b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.2 Instruct 3B",
 		"mathIndex": 3.3,
+		"mmluPro": 0.347,
 		"gpqa": 0.255,
-		"hle": 0.052
+		"hle": 0.053
 	},
 	"llama-3-instruct-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3 Instruct 70B",
 		"mmluPro": 0.574,
 		"gpqa": 0.379,
-		"hle": 0.044
+		"hle": 0.045
 	},
 	"llama-3-instruct-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3 Instruct 8B",
 		"mmluPro": 0.405,
 		"gpqa": 0.296,
@@ -3202,772 +3439,836 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.2 Instruct 1B",
 		"mathIndex": 0,
+		"mmluPro": 0.2,
 		"gpqa": 0.196,
-		"hle": 0.053
-	},
-	"llama-2-chat-7b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Llama 2 Chat 7B",
-		"mmluPro": 0.164,
-		"gpqa": 0.227,
-		"hle": 0.058
+		"hle": 0.055
 	},
 	"llama-2-chat-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 2 Chat 70B",
 		"mmluPro": 0.406,
 		"gpqa": 0.327,
-		"hle": 0.05
+		"hle": 0.052
+	},
+	"muse-spark-1.1-xhigh": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Muse Spark 1.1 (xhigh)",
+		"codingIndex": 71.3,
+		"gpqa": 0.898,
+		"hle": 0.462
 	},
 	"llama-2-chat-13b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 2 Chat 13B",
 		"mmluPro": 0.406,
 		"gpqa": 0.321,
-		"hle": 0.047
+		"hle": 0.048
+	},
+	"llama-2-chat-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Llama 2 Chat 7B",
+		"mmluPro": 0.164,
+		"gpqa": 0.227,
+		"hle": 0.053
+	},
+	"muse-spark": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Muse Spark",
+		"codingIndex": 58.6,
+		"gpqa": 0.884,
+		"hle": 0.407
 	},
 	"gemini-2.0-pro-experimental-feb-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.0 Pro Experimental (Feb '25)",
 		"codingIndex": 25.5,
 		"mmluPro": 0.805,
 		"gpqa": 0.622,
-		"hle": 0.068
+		"hle": 0.062
 	},
 	"gemini-2.0-flash-experimental": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.0 Flash (experimental)",
 		"mmluPro": 0.782,
 		"gpqa": 0.636,
-		"hle": 0.047
+		"hle": 0.041
 	},
 	"gemini-1.5-pro-sep-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 1.5 Pro (Sep '24)",
 		"codingIndex": 23.6,
 		"mmluPro": 0.75,
 		"gpqa": 0.589,
-		"hle": 0.049
+		"hle": 0.046
 	},
 	"gemini-2.0-flash-lite-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.0 Flash-Lite (Preview)",
 		"gpqa": 0.542,
-		"hle": 0.044
+		"hle": 0.041
 	},
 	"gemini-2.0-flash-feb-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.0 Flash (Feb '25)",
 		"mathIndex": 21.7,
 		"mmluPro": 0.779,
 		"gpqa": 0.623,
-		"hle": 0.053
+		"hle": 0.043
 	},
 	"gemini-1.5-flash-sep-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 1.5 Flash (Sep '24)",
 		"mmluPro": 0.68,
 		"gpqa": 0.463,
-		"hle": 0.035
+		"hle": 0.032
 	},
 	"gemini-1.5-flash-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 1.5 Flash-8B",
 		"mmluPro": 0.569,
 		"gpqa": 0.359,
-		"hle": 0.045
-	},
-	"gemini-1.5-pro-may-24": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 1.5 Pro (May '24)",
-		"codingIndex": 19.8,
-		"mmluPro": 0.657,
-		"gpqa": 0.371,
-		"hle": 0.039
-	},
-	"gemma-3-27b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3 27B Instruct",
-		"codingIndex": 10.1,
-		"mathIndex": 20.7,
-		"gpqa": 0.428,
 		"hle": 0.047
-	},
-	"gemma-3n-e4b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3n E4B Instruct",
-		"codingIndex": 3.2,
-		"mathIndex": 14.3,
-		"gpqa": 0.296,
-		"hle": 0.044
-	},
-	"gemini-2.0-flash-thinking-experimental-jan-25": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.0 Flash Thinking Experimental (Jan '25)",
-		"codingIndex": 24.1,
-		"mmluPro": 0.798,
-		"gpqa": 0.701,
-		"hle": 0.071
-	},
-	"gemma-3-1b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3 1B Instruct",
-		"mathIndex": 3.3,
-		"gpqa": 0.237,
-		"hle": 0.052
-	},
-	"gemma-3n-e2b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3n E2B Instruct",
-		"mathIndex": 10.3,
-		"gpqa": 0.229,
-		"hle": 0.04
-	},
-	"gemini-3-pro-preview-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3 Pro Preview (high)",
-		"mathIndex": 95.7,
-		"mmluPro": 0.898,
-		"gpqa": 0.908,
-		"hle": 0.372
-	},
-	"gemma-3n-e4b-instruct-preview-may-25": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3n E4B Instruct Preview (May '25)",
-		"mmluPro": 0.483,
-		"gpqa": 0.278,
-		"hle": 0.049
-	},
-	"gemini-2.0-flash-lite-feb-25": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.0 Flash-Lite (Feb '25)",
-		"mmluPro": 0.724,
-		"gpqa": 0.535,
-		"hle": 0.036
-	},
-	"gemma-3-12b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3 12B Instruct",
-		"codingIndex": 5.8,
-		"mathIndex": 18.3,
-		"gpqa": 0.349,
-		"hle": 0.048
-	},
-	"gemini-3-flash-preview-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3 Flash Preview (Reasoning)",
-		"mathIndex": 97,
-		"mmluPro": 0.89,
-		"gpqa": 0.898,
-		"hle": 0.347
-	},
-	"gemini-2.5-flash-preview-sep-25-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Reasoning)",
-		"mathIndex": 78.3,
-		"mmluPro": 0.842,
-		"gpqa": 0.793,
-		"hle": 0.127
-	},
-	"gemini-1.5-flash-may-24": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 1.5 Flash (May '24)",
-		"mmluPro": 0.574,
-		"gpqa": 0.324,
-		"hle": 0.042
-	},
-	"palm-2": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "PALM-2",
-		"codingIndex": 4.6
-	},
-	"gemini-2.5-flash-preview-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Reasoning)",
-		"mmluPro": 0.8,
-		"gpqa": 0.698,
-		"hle": 0.116
-	},
-	"gemma-3-4b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemma 3 4B Instruct",
-		"codingIndex": 2.7,
-		"mathIndex": 12.7,
-		"gpqa": 0.291,
-		"hle": 0.052
 	},
 	"gemini-2.5-flash-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.5 Flash (Non-reasoning)",
 		"mathIndex": 60.3,
 		"mmluPro": 0.809,
 		"gpqa": 0.683,
-		"hle": 0.051
+		"hle": 0.047
 	},
-	"gemini-2.5-flash-preview-sep-25-non-reasoning": {
+	"gemma-3-27b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Non-reasoning)",
-		"mathIndex": 56.7,
-		"mmluPro": 0.836,
-		"gpqa": 0.766,
-		"hle": 0.078
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3 27B Instruct",
+		"codingIndex": 10.1,
+		"mathIndex": 20.7,
+		"mmluPro": 0.669,
+		"gpqa": 0.428,
+		"hle": 0.044
 	},
-	"gemini-2.5-flash-preview-non-reasoning": {
+	"gemini-2.5-flash-preview-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash Preview (Non-reasoning)",
-		"mmluPro": 0.783,
-		"gpqa": 0.594,
-		"hle": 0.05
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Reasoning)",
+		"mmluPro": 0.8,
+		"gpqa": 0.698,
+		"hle": 0.121
 	},
-	"gemini-1.0-pro": {
+	"gemini-2.0-flash-thinking-experimental-jan-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 1.0 Pro",
-		"mmluPro": 0.431,
-		"gpqa": 0.277,
-		"hle": 0.046
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.0 Flash Thinking Experimental (Jan '25)",
+		"codingIndex": 24.1,
+		"mmluPro": 0.798,
+		"gpqa": 0.701,
+		"hle": 0.064
 	},
 	"gemini-2.5-pro-preview-mar-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.5 Pro Preview (Mar' 25)",
 		"codingIndex": 46.7,
 		"mmluPro": 0.858,
 		"gpqa": 0.836,
-		"hle": 0.171
+		"hle": 0.18
 	},
-	"gemini-2.5-flash-lite-non-reasoning": {
+	"gemini-3.1-flash-lite": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash-Lite (Non-reasoning)",
-		"mathIndex": 35.3,
-		"gpqa": 0.474,
-		"hle": 0.037
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.1 Flash-Lite",
+		"codingIndex": 34.7,
+		"gpqa": 0.822,
+		"hle": 0.172
 	},
-	"gemini-2.5-flash-lite-preview-sep-25-non-reasoning": {
+	"gemini-2.5-flash-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Non-reasoning)",
-		"mathIndex": 46.7,
-		"mmluPro": 0.796,
-		"gpqa": 0.651,
-		"hle": 0.046
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Non-reasoning)",
+		"mmluPro": 0.783,
+		"gpqa": 0.594,
+		"hle": 0.038
+	},
+	"palm-2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "PALM-2",
+		"codingIndex": 4.6
+	},
+	"gemma-3-1b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3 1B Instruct",
+		"mathIndex": 3.3,
+		"mmluPro": 0.135,
+		"gpqa": 0.237,
+		"hle": 0.053
+	},
+	"gemma-3-12b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3 12B Instruct",
+		"codingIndex": 5.8,
+		"mathIndex": 18.3,
+		"mmluPro": 0.595,
+		"gpqa": 0.349,
+		"hle": 0.042
+	},
+	"gemini-3-pro-preview-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3 Pro Preview (high)",
+		"mathIndex": 95.7,
+		"mmluPro": 0.898,
+		"gpqa": 0.908,
+		"hle": 0.397
+	},
+	"gemini-1.0-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 1.0 Pro",
+		"mmluPro": 0.431,
+		"gpqa": 0.277,
+		"hle": 0.042
+	},
+	"gemini-2.5-flash-preview-sep-25-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Reasoning)",
+		"mathIndex": 78.3,
+		"mmluPro": 0.842,
+		"gpqa": 0.793,
+		"hle": 0.138
+	},
+	"gemma-3-4b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3 4B Instruct",
+		"codingIndex": 2.7,
+		"mathIndex": 12.7,
+		"mmluPro": 0.417,
+		"gpqa": 0.291,
+		"hle": 0.053
+	},
+	"gemini-2.5-flash-preview-sep-25-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash Preview (Sep '25) (Non-reasoning)",
+		"mathIndex": 56.7,
+		"mmluPro": 0.836,
+		"gpqa": 0.766,
+		"hle": 0.087
 	},
 	"gemini-2.5-flash-lite-preview-sep-25-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Reasoning)",
 		"mathIndex": 68.7,
 		"mmluPro": 0.808,
 		"gpqa": 0.709,
-		"hle": 0.066
+		"hle": 0.07
 	},
-	"gemini-3-pro-preview-low": {
+	"gemini-3-flash-preview-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 3 Pro Preview (low)",
-		"mathIndex": 86.7,
-		"mmluPro": 0.895,
-		"gpqa": 0.887,
-		"hle": 0.276
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3 Flash Preview (Reasoning)",
+		"mathIndex": 97,
+		"mmluPro": 0.89,
+		"gpqa": 0.898,
+		"hle": 0.366
 	},
 	"gemini-2.0-flash-thinking-experimental-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.0 Flash Thinking Experimental (Dec '24)"
 	},
-	"gemini-1.0-ultra": {
+	"gemini-2.0-flash-lite-feb-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 1.0 Ultra",
-		"codingIndex": 17.6
-	},
-	"gemini-2.5-flash-lite-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash-Lite (Reasoning)",
-		"mathIndex": 53.3,
-		"gpqa": 0.625,
-		"hle": 0.064
-	},
-	"gemini-2.5-flash-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Gemini 2.5 Flash (Reasoning)",
-		"mathIndex": 73.3,
-		"mmluPro": 0.832,
-		"gpqa": 0.79,
-		"hle": 0.111
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.0 Flash-Lite (Feb '25)",
+		"mmluPro": 0.724,
+		"gpqa": 0.535,
+		"hle": 0.034
 	},
 	"gemini-3-flash-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 3 Flash Preview (Non-reasoning)",
 		"mathIndex": 55.7,
 		"mmluPro": 0.882,
 		"gpqa": 0.812,
-		"hle": 0.141
+		"hle": 0.15
+	},
+	"gemini-2.5-flash-lite-preview-sep-25-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash-Lite Preview (Sep '25) (Non-reasoning)",
+		"mathIndex": 46.7,
+		"mmluPro": 0.796,
+		"gpqa": 0.651,
+		"hle": 0.051
+	},
+	"gemini-2.5-flash-lite-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash-Lite (Reasoning)",
+		"mathIndex": 53.3,
+		"mmluPro": 0.759,
+		"gpqa": 0.625,
+		"hle": 0.068
 	},
 	"gemini-2.5-pro-preview-may-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Gemini 2.5 Pro Preview (May' 25)",
 		"mmluPro": 0.837,
 		"gpqa": 0.822,
-		"hle": 0.154
+		"hle": 0.199
+	},
+	"gemma-3n-e2b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3n E2B Instruct",
+		"mathIndex": 10.3,
+		"mmluPro": 0.378,
+		"gpqa": 0.229,
+		"hle": 0.042
+	},
+	"gemini-2.5-flash-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash (Reasoning)",
+		"mathIndex": 73.3,
+		"mmluPro": 0.832,
+		"gpqa": 0.79,
+		"hle": 0.121
+	},
+	"gemini-2.5-flash-lite-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Flash-Lite (Non-reasoning)",
+		"mathIndex": 35.3,
+		"mmluPro": 0.724,
+		"gpqa": 0.474,
+		"hle": 0.037
+	},
+	"gemini-1.5-pro-may-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 1.5 Pro (May '24)",
+		"codingIndex": 19.8,
+		"mmluPro": 0.657,
+		"gpqa": 0.371,
+		"hle": 0.035
+	},
+	"gemini-3.5-flash-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3.5 Flash (high)",
+		"codingIndex": 70.1,
+		"gpqa": 0.922,
+		"hle": 0.427
+	},
+	"gemini-3-pro-preview-low": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 3 Pro Preview (low)",
+		"mathIndex": 86.7,
+		"mmluPro": 0.895,
+		"gpqa": 0.887,
+		"hle": 0.295
+	},
+	"gemini-1.5-flash-may-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 1.5 Flash (May '24)",
+		"mmluPro": 0.574,
+		"gpqa": 0.324,
+		"hle": 0.044
+	},
+	"gemma-3n-e4b-instruct-preview-may-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3n E4B Instruct Preview (May '25)",
+		"mmluPro": 0.483,
+		"gpqa": 0.278,
+		"hle": 0.048
+	},
+	"gemini-1.0-ultra": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 1.0 Ultra",
+		"codingIndex": 17.6
+	},
+	"gemini-2.5-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemini 2.5 Pro",
+		"codingIndex": 33.3,
+		"mathIndex": 87.7,
+		"mmluPro": 0.862,
+		"gpqa": 0.844,
+		"hle": 0.225
+	},
+	"gemma-3n-e4b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Gemma 3n E4B Instruct",
+		"codingIndex": 3.2,
+		"mathIndex": 14.3,
+		"mmluPro": 0.488,
+		"gpqa": 0.296,
+		"hle": 0.045
 	},
 	"claude-3.5-sonnet-oct-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 3.5 Sonnet (Oct '24)",
 		"codingIndex": 30.2,
 		"mmluPro": 0.772,
 		"gpqa": 0.599,
-		"hle": 0.039
+		"hle": 0.037
 	},
 	"claude-3.5-sonnet-june-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 3.5 Sonnet (June '24)",
 		"codingIndex": 26,
 		"mmluPro": 0.751,
 		"gpqa": 0.56,
-		"hle": 0.037
+		"hle": 0.032
 	},
 	"claude-3-opus": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 3 Opus",
 		"codingIndex": 19.5,
 		"mmluPro": 0.696,
 		"gpqa": 0.489,
-		"hle": 0.031
+		"hle": 0.028
 	},
 	"claude-3.5-haiku": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 3.5 Haiku",
 		"codingIndex": 15.9,
 		"mmluPro": 0.634,
 		"gpqa": 0.408,
-		"hle": 0.035
+		"hle": 0.036
 	},
 	"claude-3-sonnet": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 3 Sonnet",
 		"mmluPro": 0.579,
 		"gpqa": 0.4,
-		"hle": 0.038
+		"hle": 0.036
 	},
 	"claude-3-haiku": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 3 Haiku",
 		"gpqa": 0.374,
-		"hle": 0.039
+		"hle": 0.041
 	},
 	"claude-instant": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude Instant",
 		"codingIndex": 7.8,
 		"mmluPro": 0.434,
 		"gpqa": 0.33,
-		"hle": 0.038
-	},
-	"claude-2.1": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 2.1",
-		"codingIndex": 14,
-		"mmluPro": 0.495,
-		"gpqa": 0.319,
-		"hle": 0.042
-	},
-	"claude-opus-4.7-non-reasoning-high-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 4.7 (Non-reasoning, High Effort)",
-		"gpqa": 0.885,
-		"hle": 0.312
-	},
-	"claude-3.7-sonnet-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 3.7 Sonnet (Non-reasoning)",
-		"mathIndex": 21,
-		"mmluPro": 0.803,
-		"gpqa": 0.656,
-		"hle": 0.048
-	},
-	"claude-opus-4.7-adaptive-reasoning-max-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 4.7 (Adaptive Reasoning, Max Effort)",
-		"codingIndex": 73.6,
-		"gpqa": 0.914,
-		"hle": 0.396
-	},
-	"claude-opus-4.6-adaptive-reasoning-max-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 4.6 (Adaptive Reasoning, Max Effort)",
-		"gpqa": 0.896,
-		"hle": 0.367
-	},
-	"claude-4.5-sonnet-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4.5 Sonnet (Non-reasoning)",
-		"mathIndex": 37,
-		"mmluPro": 0.86,
-		"gpqa": 0.727,
-		"hle": 0.071
-	},
-	"claude-4.1-opus-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4.1 Opus (Reasoning)",
-		"mathIndex": 80.3,
-		"mmluPro": 0.88,
-		"gpqa": 0.809,
-		"hle": 0.119
+		"hle": 0.035
 	},
 	"claude-opus-4.5-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude Opus 4.5 (Reasoning)",
 		"mathIndex": 91.3,
 		"mmluPro": 0.895,
 		"gpqa": 0.866,
-		"hle": 0.284
-	},
-	"claude-opus-4.5-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 4.5 (Non-reasoning)",
-		"mathIndex": 62.7,
-		"mmluPro": 0.889,
-		"gpqa": 0.81,
-		"hle": 0.129
-	},
-	"claude-2.0": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 2.0",
-		"codingIndex": 12.9,
-		"mmluPro": 0.486,
-		"gpqa": 0.344
-	},
-	"claude-4-sonnet-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4 Sonnet (Reasoning)",
-		"codingIndex": 37.6,
-		"mathIndex": 74.3,
-		"gpqa": 0.777,
-		"hle": 0.096
-	},
-	"claude-4-opus-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4 Opus (Reasoning)",
-		"mathIndex": 73.3,
-		"mmluPro": 0.873,
-		"gpqa": 0.796,
-		"hle": 0.117
-	},
-	"claude-4.1-opus-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4.1 Opus (Non-reasoning)"
-	},
-	"claude-4.5-sonnet-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4.5 Sonnet (Reasoning)",
-		"codingIndex": 52.1,
-		"mathIndex": 88,
-		"gpqa": 0.834,
-		"hle": 0.173
-	},
-	"claude-sonnet-4.6-adaptive-reasoning-max-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Sonnet 4.6 (Adaptive Reasoning, Max Effort)",
-		"codingIndex": 63,
-		"gpqa": 0.875,
-		"hle": 0.3
-	},
-	"claude-sonnet-4.6-non-reasoning-high-effort": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, High Effort)",
-		"gpqa": 0.799,
-		"hle": 0.132
-	},
-	"claude-3.7-sonnet-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 3.7 Sonnet (Reasoning)",
-		"codingIndex": 36.4,
-		"mathIndex": 56.3,
-		"mmluPro": 0.837,
-		"gpqa": 0.772,
-		"hle": 0.103
-	},
-	"claude-4-opus-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude 4 Opus (Non-reasoning)",
-		"mathIndex": 36.3,
-		"mmluPro": 0.86,
-		"gpqa": 0.701,
-		"hle": 0.059
+		"hle": 0.301
 	},
 	"claude-4-sonnet-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude 4 Sonnet (Non-reasoning)",
 		"mathIndex": 38,
+		"mmluPro": 0.837,
 		"gpqa": 0.683,
-		"hle": 0.04
+		"hle": 0.043
 	},
-	"claude-opus-4.6-non-reasoning-high-effort": {
+	"claude-4.1-opus-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Claude Opus 4.6 (Non-reasoning, High Effort)",
-		"gpqa": 0.84,
-		"hle": 0.186
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4.1 Opus (Reasoning)",
+		"mathIndex": 80.3,
+		"mmluPro": 0.88,
+		"gpqa": 0.809,
+		"hle": 0.125
+	},
+	"claude-4-sonnet-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4 Sonnet (Reasoning)",
+		"codingIndex": 37.6,
+		"mathIndex": 74.3,
+		"mmluPro": 0.842,
+		"gpqa": 0.777,
+		"hle": 0.107
+	},
+	"claude-2.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 2.1",
+		"codingIndex": 14,
+		"mmluPro": 0.495,
+		"gpqa": 0.319,
+		"hle": 0.039
 	},
 	"claude-opus-4.8-adaptive-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Claude Opus 4.8 (Adaptive Reasoning, Max Effort)",
 		"codingIndex": 74.3,
 		"gpqa": 0.92,
-		"hle": 0.457
+		"hle": 0.487
+	},
+	"claude-4.5-sonnet-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4.5 Sonnet (Non-reasoning)",
+		"mathIndex": 37,
+		"mmluPro": 0.86,
+		"gpqa": 0.727,
+		"hle": 0.072
+	},
+	"claude-4.5-sonnet-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4.5 Sonnet (Reasoning)",
+		"codingIndex": 52.1,
+		"mathIndex": 88,
+		"mmluPro": 0.875,
+		"gpqa": 0.834,
+		"hle": 0.178
+	},
+	"claude-4-opus-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4 Opus (Reasoning)",
+		"mathIndex": 73.3,
+		"mmluPro": 0.873,
+		"gpqa": 0.796,
+		"hle": 0.123
+	},
+	"claude-sonnet-4.6-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Sonnet 4.6 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 63,
+		"gpqa": 0.875,
+		"hle": 0.336
+	},
+	"claude-opus-4.7-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 4.7 (Adaptive Reasoning, Max Effort)",
+		"codingIndex": 73.6,
+		"gpqa": 0.914,
+		"hle": 0.423
+	},
+	"claude-4.1-opus-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4.1 Opus (Non-reasoning)"
+	},
+	"claude-opus-4.6-adaptive-reasoning-max-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 4.6 (Adaptive Reasoning, Max Effort)",
+		"gpqa": 0.896,
+		"hle": 0.399
+	},
+	"claude-opus-4.6-non-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 4.6 (Non-reasoning, High Effort)",
+		"gpqa": 0.84,
+		"hle": 0.191
+	},
+	"claude-opus-4.5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 4.5 (Non-reasoning)",
+		"mathIndex": 62.7,
+		"mmluPro": 0.889,
+		"gpqa": 0.81,
+		"hle": 0.132
+	},
+	"claude-sonnet-4.6-non-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Sonnet 4.6 (Non-reasoning, High Effort)",
+		"gpqa": 0.799,
+		"hle": 0.133
+	},
+	"claude-3.7-sonnet-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 3.7 Sonnet (Reasoning)",
+		"codingIndex": 36.4,
+		"mathIndex": 56.3,
+		"mmluPro": 0.837,
+		"gpqa": 0.772,
+		"hle": 0.097
+	},
+	"claude-opus-4.7-non-reasoning-high-effort": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude Opus 4.7 (Non-reasoning, High Effort)",
+		"gpqa": 0.885,
+		"hle": 0.333
+	},
+	"claude-4-opus-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 4 Opus (Non-reasoning)",
+		"mathIndex": 36.3,
+		"mmluPro": 0.86,
+		"gpqa": 0.701,
+		"hle": 0.062
+	},
+	"claude-3.7-sonnet-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 3.7 Sonnet (Non-reasoning)",
+		"mathIndex": 21,
+		"mmluPro": 0.803,
+		"gpqa": 0.656,
+		"hle": 0.042
+	},
+	"claude-2.0": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Claude 2.0",
+		"codingIndex": 12.9,
+		"mmluPro": 0.486,
+		"gpqa": 0.344
 	},
 	"mistral-large-2-nov-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Large 2 (Nov '24)",
 		"mathIndex": 14,
 		"mmluPro": 0.697,
 		"gpqa": 0.486,
-		"hle": 0.04
+		"hle": 0.033
 	},
 	"mistral-large-2-jul-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Large 2 (Jul '24)",
 		"mathIndex": 0,
 		"mmluPro": 0.683,
 		"gpqa": 0.472,
-		"hle": 0.032
+		"hle": 0.029
 	},
 	"pixtral-large": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Pixtral Large",
 		"mathIndex": 2.3,
 		"mmluPro": 0.701,
 		"gpqa": 0.505,
-		"hle": 0.036
+		"hle": 0.028
 	},
 	"mistral-small-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Small 3",
 		"mathIndex": 4.3,
 		"mmluPro": 0.652,
 		"gpqa": 0.462,
-		"hle": 0.041
+		"hle": 0.038
 	},
 	"mistral-small-sep-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Small (Sep '24)",
 		"mmluPro": 0.529,
 		"gpqa": 0.381,
@@ -3977,132 +4278,114 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mixtral 8x22B Instruct",
 		"mmluPro": 0.537,
 		"gpqa": 0.332,
-		"hle": 0.041
+		"hle": 0.04
 	},
 	"mistral-small-feb-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Small (Feb '24)",
 		"mmluPro": 0.419,
 		"gpqa": 0.302,
-		"hle": 0.044
+		"hle": 0.041
 	},
 	"mistral-large-feb-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Large (Feb '24)",
 		"mmluPro": 0.515,
 		"gpqa": 0.351,
-		"hle": 0.034
+		"hle": 0.035
 	},
 	"mixtral-8x7b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mixtral 8x7B Instruct",
 		"mmluPro": 0.387,
 		"gpqa": 0.292,
-		"hle": 0.045
+		"hle": 0.047
 	},
 	"mistral-7b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral 7B Instruct",
 		"mmluPro": 0.245,
 		"gpqa": 0.177,
-		"hle": 0.043
-	},
-	"mistral-medium-3": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Medium 3",
-		"mathIndex": 30.3,
-		"mmluPro": 0.76,
-		"gpqa": 0.578,
-		"hle": 0.043
-	},
-	"devstral-small-jul-25": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Devstral Small (Jul '25)",
-		"mathIndex": 29.3,
-		"gpqa": 0.414,
-		"hle": 0.037
-	},
-	"mistral-small-3.1": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Small 3.1",
-		"codingIndex": 26.3,
-		"mathIndex": 3.7,
-		"mmluPro": 0.659,
-		"gpqa": 0.454,
-		"hle": 0.048
-	},
-	"mistral-saba": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Saba",
-		"mmluPro": 0.611,
-		"gpqa": 0.424,
-		"hle": 0.041
-	},
-	"magistral-medium-1": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Magistral Medium 1",
-		"mathIndex": 40.3,
-		"mmluPro": 0.753,
-		"gpqa": 0.679,
-		"hle": 0.095
-	},
-	"mistral-small-3.2": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Small 3.2",
-		"codingIndex": 12.5,
-		"mathIndex": 27,
-		"gpqa": 0.505,
-		"hle": 0.043
+		"hle": 0.045
 	},
 	"magistral-small-1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Magistral Small 1",
 		"mathIndex": 41.3,
+		"mmluPro": 0.746,
 		"gpqa": 0.641,
-		"hle": 0.072
+		"hle": 0.076
+	},
+	"mistral-medium-3.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Medium 3.1",
+		"codingIndex": 20.5,
+		"mathIndex": 38.3,
+		"mmluPro": 0.683,
+		"gpqa": 0.588,
+		"hle": 0.047
+	},
+	"mistral-saba": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Saba",
+		"mmluPro": 0.611,
+		"gpqa": 0.424,
+		"hle": 0.043
+	},
+	"mistral-small-3.2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Small 3.2",
+		"codingIndex": 12.5,
+		"mathIndex": 27,
+		"mmluPro": 0.681,
+		"gpqa": 0.505,
+		"hle": 0.043
+	},
+	"mistral-small-3.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Small 3.1",
+		"codingIndex": 26.3,
+		"mathIndex": 3.7,
+		"mmluPro": 0.659,
+		"gpqa": 0.454,
+		"hle": 0.043
 	},
 	"devstral-small-may-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Devstral Small (May '25)",
 		"mmluPro": 0.632,
 		"gpqa": 0.434,
@@ -4112,518 +4395,547 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Devstral Medium",
 		"mathIndex": 4.7,
+		"mmluPro": 0.708,
 		"gpqa": 0.492,
 		"hle": 0.038
 	},
-	"mistral-medium-3.1": {
+	"devstral-small-jul-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Mistral Medium 3.1",
-		"codingIndex": 20.5,
-		"mathIndex": 38.3,
-		"gpqa": 0.588,
-		"hle": 0.044
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Devstral Small (Jul '25)",
+		"mathIndex": 29.3,
+		"mmluPro": 0.622,
+		"gpqa": 0.414,
+		"hle": 0.038
+	},
+	"mistral-medium-3": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Mistral Medium 3",
+		"mathIndex": 30.3,
+		"mmluPro": 0.76,
+		"gpqa": 0.578,
+		"hle": 0.041
+	},
+	"magistral-medium-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Magistral Medium 1",
+		"mathIndex": 40.3,
+		"mmluPro": 0.753,
+		"gpqa": 0.679,
+		"hle": 0.098
 	},
 	"mistral-medium": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Mistral Medium",
 		"mmluPro": 0.491,
 		"gpqa": 0.349,
-		"hle": 0.034
+		"hle": 0.035
 	},
 	"deepseek-r1-distill-llama-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek R1 Distill Llama 70B",
 		"mathIndex": 53.7,
 		"mmluPro": 0.795,
 		"gpqa": 0.402,
-		"hle": 0.061
+		"hle": 0.051
 	},
 	"deepseek-r1-distill-qwen-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek R1 Distill Qwen 32B",
 		"mathIndex": 63,
 		"mmluPro": 0.739,
 		"gpqa": 0.615,
-		"hle": 0.055
+		"hle": 0.046
 	},
 	"deepseek-v3-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek V3 (Dec '24)",
 		"codingIndex": 23,
 		"mathIndex": 26,
 		"mmluPro": 0.752,
 		"gpqa": 0.557,
-		"hle": 0.036
+		"hle": 0.029
 	},
 	"deepseek-r1-distill-qwen-14b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek R1 Distill Qwen 14B",
 		"mathIndex": 55.7,
 		"mmluPro": 0.74,
 		"gpqa": 0.484,
-		"hle": 0.044
+		"hle": 0.041
 	},
 	"deepseek-v2.5-dec-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek-V2.5 (Dec '24)"
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek-V2.5 (Dec '24)",
+		"mmluPro": 0.666,
+		"gpqa": 0.423
 	},
 	"deepseek-coder-v2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek-Coder-V2"
 	},
 	"deepseek-r1-distill-llama-8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek R1 Distill Llama 8B",
 		"mathIndex": 41.3,
 		"mmluPro": 0.543,
-		"gpqa": 0.302,
-		"hle": 0.042
+		"gpqa": 0.302
 	},
 	"deepseek-llm-67b-chat-v1": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek LLM 67B Chat (V1)"
 	},
 	"deepseek-r1-distill-qwen-1.5b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek R1 Distill Qwen 1.5B",
 		"mathIndex": 22,
 		"mmluPro": 0.269,
 		"gpqa": 0.098,
-		"hle": 0.033
+		"hle": 0.031
 	},
 	"deepseek-v4-flash-reasoning-high-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek V4 Flash (Reasoning, High Effort)",
 		"codingIndex": 52,
 		"gpqa": 0.867,
-		"hle": 0.278
-	},
-	"deepseek-v3.1-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.1 (Reasoning)",
-		"mathIndex": 89.7,
-		"gpqa": 0.779,
-		"hle": 0.13
-	},
-	"deepseek-r1-0528-may-25": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek R1 0528 (May '25)",
-		"mathIndex": 76,
-		"gpqa": 0.813,
-		"hle": 0.149
-	},
-	"deepseek-v3-0324": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3 0324",
-		"codingIndex": 21.2,
-		"mathIndex": 41,
-		"gpqa": 0.655,
-		"hle": 0.052
-	},
-	"deepseek-r1-0528-qwen3-8b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek R1 0528 Qwen3 8B",
-		"mathIndex": 63.7,
-		"gpqa": 0.612,
-		"hle": 0.056
+		"hle": 0.303
 	},
 	"deepseek-v4-flash-reasoning-max-effort": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek V4 Flash (Reasoning, Max Effort)",
 		"codingIndex": 56.2,
 		"gpqa": 0.894,
-		"hle": 0.321
-	},
-	"deepseek-r1-jan-25": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek R1 (Jan '25)",
-		"codingIndex": 24.6,
-		"mathIndex": 68,
-		"mmluPro": 0.844,
-		"gpqa": 0.708,
-		"hle": 0.093
-	},
-	"deepseek-v3.1-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.1 (Non-reasoning)",
-		"mathIndex": 49.7,
-		"gpqa": 0.735,
-		"hle": 0.063
-	},
-	"deepseek-coder-v2-lite-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek Coder V2 Lite Instruct",
-		"mmluPro": 0.429,
-		"gpqa": 0.319,
-		"hle": 0.053
-	},
-	"deepseek-v3.2-exp-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.2 Exp (Non-reasoning)",
-		"mathIndex": 57.7,
-		"mmluPro": 0.836,
-		"gpqa": 0.738,
-		"hle": 0.086
+		"hle": 0.348
 	},
 	"deepseek-v3.2-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek V3.2 (Reasoning)",
 		"codingIndex": 44.2,
 		"mathIndex": 92,
 		"mmluPro": 0.862,
 		"gpqa": 0.84,
-		"hle": 0.222
+		"hle": 0.246
 	},
-	"deepseek-v3.1-terminus-non-reasoning": {
+	"deepseek-v3.1-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.1 Terminus (Non-reasoning)",
-		"mathIndex": 53.7,
-		"mmluPro": 0.836,
-		"gpqa": 0.751,
-		"hle": 0.084
-	},
-	"deepseek-v3.2-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.2 (Non-reasoning)",
-		"mathIndex": 59,
-		"mmluPro": 0.837,
-		"gpqa": 0.751,
-		"hle": 0.105
-	},
-	"deepseek-v2.5": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek-V2.5"
-	},
-	"deepseek-v2-chat": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek-V2-Chat"
-	},
-	"deepseek-v3.2-speciale": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.2 Speciale",
-		"mathIndex": 96.7,
-		"mmluPro": 0.863,
-		"gpqa": 0.871,
-		"hle": 0.261
-	},
-	"deepseek-v3.1-terminus-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "DeepSeek V3.1 Terminus (Reasoning)",
-		"codingIndex": 43.5,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.1 (Reasoning)",
 		"mathIndex": 89.7,
 		"mmluPro": 0.851,
-		"gpqa": 0.792,
-		"hle": 0.152
+		"gpqa": 0.779,
+		"hle": 0.143
+	},
+	"deepseek-v3.2-exp-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.2 Exp (Non-reasoning)",
+		"mathIndex": 57.7,
+		"mmluPro": 0.836,
+		"gpqa": 0.738,
+		"hle": 0.09
+	},
+	"deepseek-coder-v2-lite-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek Coder V2 Lite Instruct",
+		"mmluPro": 0.429,
+		"gpqa": 0.319,
+		"hle": 0.054
 	},
 	"deepseek-v3.2-exp-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DeepSeek V3.2 Exp (Reasoning)",
 		"mathIndex": 87.7,
 		"mmluPro": 0.85,
 		"gpqa": 0.797,
-		"hle": 0.138
+		"hle": 0.149
 	},
-	"sonar-reasoning-pro": {
+	"deepseek-r1-0528-may-25": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Sonar Reasoning Pro"
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek R1 0528 (May '25)",
+		"mathIndex": 76,
+		"mmluPro": 0.849,
+		"gpqa": 0.813,
+		"hle": 0.158
+	},
+	"deepseek-r1-jan-25": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek R1 (Jan '25)",
+		"codingIndex": 24.6,
+		"mathIndex": 68,
+		"mmluPro": 0.844,
+		"gpqa": 0.708,
+		"hle": 0.085
+	},
+	"deepseek-v2.5": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek-V2.5"
+	},
+	"deepseek-v3.1-terminus-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.1 Terminus (Non-reasoning)",
+		"mathIndex": 53.7,
+		"mmluPro": 0.836,
+		"gpqa": 0.751,
+		"hle": 0.087
+	},
+	"deepseek-v3.1-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.1 (Non-reasoning)",
+		"mathIndex": 49.7,
+		"mmluPro": 0.833,
+		"gpqa": 0.735,
+		"hle": 0.067
+	},
+	"deepseek-v3.2-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.2 (Non-reasoning)",
+		"mathIndex": 59,
+		"mmluPro": 0.837,
+		"gpqa": 0.751,
+		"hle": 0.112
+	},
+	"deepseek-v3-0324": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3 0324",
+		"codingIndex": 21.2,
+		"mathIndex": 41,
+		"mmluPro": 0.819,
+		"gpqa": 0.655,
+		"hle": 0.047
+	},
+	"deepseek-v3.2-speciale": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.2 Speciale",
+		"mathIndex": 96.7,
+		"mmluPro": 0.863,
+		"gpqa": 0.871,
+		"hle": 0.287
+	},
+	"deepseek-v2-chat": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek-V2-Chat"
+	},
+	"deepseek-v3.1-terminus-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek V3.1 Terminus (Reasoning)",
+		"codingIndex": 43.5,
+		"mathIndex": 89.7,
+		"mmluPro": 0.851,
+		"gpqa": 0.792,
+		"hle": 0.164
+	},
+	"deepseek-r1-0528-qwen3-8b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "DeepSeek R1 0528 Qwen3 8B",
+		"mathIndex": 63.7,
+		"mmluPro": 0.739,
+		"gpqa": 0.612,
+		"hle": 0.059
 	},
 	"sonar": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Sonar",
 		"mmluPro": 0.689,
 		"gpqa": 0.471,
-		"hle": 0.073
-	},
-	"sonar-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Sonar Reasoning",
-		"gpqa": 0.623
+		"hle": 0.049
 	},
 	"sonar-pro": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Sonar Pro",
 		"mmluPro": 0.755,
 		"gpqa": 0.578,
-		"hle": 0.079
+		"hle": 0.066
+	},
+	"sonar-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Sonar Reasoning",
+		"gpqa": 0.623
+	},
+	"sonar-reasoning-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Sonar Reasoning Pro"
 	},
 	"grok-beta": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok Beta",
 		"mmluPro": 0.703,
 		"gpqa": 0.471,
-		"hle": 0.047
-	},
-	"grok-build-0.1-0616": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok Build 0.1 0616",
-		"codingIndex": 51.5,
-		"gpqa": 0.895,
-		"hle": 0.36
-	},
-	"grok-2-dec-24": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 2 (Dec '24)",
-		"mmluPro": 0.709,
-		"gpqa": 0.51,
-		"hle": 0.038
+		"hle": 0.044
 	},
 	"grok-4.20-0309-v2-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok 4.20 0309 v2 (Reasoning)",
 		"gpqa": 0.911,
-		"hle": 0.322
-	},
-	"grok-4-fast-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4 Fast (Non-reasoning)",
-		"mathIndex": 41.3,
-		"mmluPro": 0.73,
-		"gpqa": 0.606,
-		"hle": 0.05
-	},
-	"grok-3-mini-reasoning-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 3 mini Reasoning (high)",
-		"mathIndex": 84.7,
-		"mmluPro": 0.828,
-		"gpqa": 0.791,
-		"hle": 0.111
-	},
-	"grok-4.20-0309-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.20 0309 (Non-reasoning)",
-		"gpqa": 0.785,
-		"hle": 0.225
-	},
-	"grok-4.20-0309-v2-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.20 0309 v2 (Non-reasoning)",
-		"gpqa": 0.776,
-		"hle": 0.242
+		"hle": 0.345
 	},
 	"grok-4.1-fast-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok 4.1 Fast (Reasoning)",
 		"mathIndex": 89.3,
 		"mmluPro": 0.854,
 		"gpqa": 0.853,
-		"hle": 0.176
-	},
-	"grok-4-fast-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4 Fast (Reasoning)",
-		"mathIndex": 89.7,
-		"mmluPro": 0.85,
-		"gpqa": 0.847,
-		"hle": 0.17
-	},
-	"grok-code-fast-1": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok Code Fast 1",
-		"mathIndex": 43.3,
-		"mmluPro": 0.793,
-		"gpqa": 0.727,
-		"hle": 0.075
-	},
-	"grok-4.20-0309-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.20 0309 (Reasoning)",
-		"gpqa": 0.885,
-		"hle": 0.3
-	},
-	"grok-4": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4",
-		"mathIndex": 92.7,
-		"mmluPro": 0.866,
-		"gpqa": 0.877,
-		"hle": 0.239
-	},
-	"grok-4.3-high": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.3 (high)",
-		"codingIndex": 42.2,
-		"gpqa": 0.901,
-		"hle": 0.35
-	},
-	"grok-4.1-fast-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Grok 4.1 Fast (Non-reasoning)",
-		"mathIndex": 34.3,
-		"mmluPro": 0.743,
-		"gpqa": 0.637,
-		"hle": 0.05
+		"hle": 0.193
 	},
 	"grok-3": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok 3",
 		"mathIndex": 58,
 		"mmluPro": 0.799,
 		"gpqa": 0.693,
+		"hle": 0.041
+	},
+	"grok-2-dec-24": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 2 (Dec '24)",
+		"mmluPro": 0.709,
+		"gpqa": 0.51,
+		"hle": 0.031
+	},
+	"grok-4-fast-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4 Fast (Non-reasoning)",
+		"mathIndex": 41.3,
+		"mmluPro": 0.73,
+		"gpqa": 0.606,
+		"hle": 0.045
+	},
+	"grok-3-mini-reasoning-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 3 mini Reasoning (high)",
+		"mathIndex": 84.7,
+		"mmluPro": 0.828,
+		"gpqa": 0.791,
+		"hle": 0.11
+	},
+	"grok-4.3-high": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.3 (high)",
+		"codingIndex": 42.2,
+		"gpqa": 0.901,
+		"hle": 0.372
+	},
+	"grok-build-0.1-0616": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok Build 0.1 0616",
+		"codingIndex": 51.5,
+		"gpqa": 0.895,
+		"hle": 0.383
+	},
+	"grok-4.1-fast-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.1 Fast (Non-reasoning)",
+		"mathIndex": 34.3,
+		"mmluPro": 0.743,
+		"gpqa": 0.637,
 		"hle": 0.051
+	},
+	"grok-4.20-0309-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.20 0309 (Non-reasoning)",
+		"gpqa": 0.785,
+		"hle": 0.245
+	},
+	"grok-4-fast-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4 Fast (Reasoning)",
+		"mathIndex": 89.7,
+		"mmluPro": 0.85,
+		"gpqa": 0.847,
+		"hle": 0.191
+	},
+	"grok-4": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4",
+		"mathIndex": 92.7,
+		"mmluPro": 0.866,
+		"gpqa": 0.877,
+		"hle": 0.267
+	},
+	"grok-4.20-0309-v2-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.20 0309 v2 (Non-reasoning)",
+		"gpqa": 0.776,
+		"hle": 0.279
+	},
+	"grok-4.20-0309-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok 4.20 0309 (Reasoning)",
+		"gpqa": 0.885,
+		"hle": 0.324
+	},
+	"grok-code-fast-1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Grok Code Fast 1",
+		"mathIndex": 43.3,
+		"mmluPro": 0.793,
+		"gpqa": 0.727,
+		"hle": 0.08
 	},
 	"grok-3-reasoning-beta": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Grok 3 Reasoning Beta"
 	},
 	"openchat-3.5-1210": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "OpenChat 3.5 (1210)",
 		"mmluPro": 0.31,
 		"gpqa": 0.23,
@@ -4633,40 +4945,40 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova Pro",
 		"mathIndex": 7,
 		"mmluPro": 0.691,
 		"gpqa": 0.499,
-		"hle": 0.034
+		"hle": 0.032
 	},
 	"nova-lite": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Nova Lite",
 		"mathIndex": 7,
 		"mmluPro": 0.59,
 		"gpqa": 0.433,
-		"hle": 0.046
+		"hle": 0.043
 	},
 	"phi-3-mini-instruct-3.8b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Phi-3 Mini Instruct 3.8B",
 		"mathIndex": 0.3,
 		"mmluPro": 0.435,
 		"gpqa": 0.319,
-		"hle": 0.044
+		"hle": 0.05
 	},
 	"lfm-40b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LFM 40B",
 		"mmluPro": 0.425,
 		"gpqa": 0.327,
@@ -4676,292 +4988,308 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "LFM2 1.2B",
 		"mathIndex": 3.3,
 		"mmluPro": 0.257,
 		"gpqa": 0.228,
-		"hle": 0.057
+		"hle": 0.056
 	},
 	"solar-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Solar Mini"
-	},
-	"solar-pro-2-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Solar Pro 2 (Reasoning)",
-		"mathIndex": 61.3,
-		"gpqa": 0.687,
-		"hle": 0.07
-	},
-	"solar-pro-2-preview-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Solar Pro 2 (Preview) (Reasoning)",
-		"mmluPro": 0.768,
-		"gpqa": 0.578,
-		"hle": 0.057
-	},
-	"solar-pro-2-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Solar Pro 2 (Non-reasoning)",
-		"mathIndex": 30,
-		"gpqa": 0.561,
-		"hle": 0.038
 	},
 	"solar-pro-2-preview-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Solar Pro 2 (Preview) (Non-reasoning)",
+		"mmluPro": 0.725,
 		"gpqa": 0.544,
-		"hle": 0.038
+		"hle": 0.037
+	},
+	"solar-pro-2-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Solar Pro 2 (Reasoning)",
+		"mathIndex": 61.3,
+		"mmluPro": 0.805,
+		"gpqa": 0.687,
+		"hle": 0.074
+	},
+	"solar-pro-2-preview-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Solar Pro 2 (Preview) (Reasoning)",
+		"mmluPro": 0.768,
+		"gpqa": 0.578,
+		"hle": 0.061
+	},
+	"solar-pro-2-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Solar Pro 2 (Non-reasoning)",
+		"mathIndex": 30,
+		"mmluPro": 0.75,
+		"gpqa": 0.561,
+		"hle": 0.037
 	},
 	"dbrx-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "DBRX Instruct",
 		"mmluPro": 0.397,
 		"gpqa": 0.331,
-		"hle": 0.066
-	},
-	"minimax-m2.5": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiniMax-M2.5",
-		"gpqa": 0.848,
-		"hle": 0.191
-	},
-	"minimax-m2.7": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiniMax-M2.7",
-		"codingIndex": 52.6,
-		"gpqa": 0.874,
-		"hle": 0.281
+		"hle": 0.029
 	},
 	"minimax-m2": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiniMax-M2",
 		"mathIndex": 78.3,
 		"mmluPro": 0.82,
 		"gpqa": 0.777,
-		"hle": 0.125
-	},
-	"minimax-m2.1": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiniMax-M2.1",
-		"mathIndex": 82.7,
-		"mmluPro": 0.875,
-		"gpqa": 0.83,
-		"hle": 0.222
+		"hle": 0.137
 	},
 	"minimax-m1-40k": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiniMax M1 40k",
 		"mathIndex": 13.7,
+		"mmluPro": 0.808,
 		"gpqa": 0.682,
-		"hle": 0.075
+		"hle": 0.078
+	},
+	"minimax-m2.1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiniMax-M2.1",
+		"mathIndex": 82.7,
+		"mmluPro": 0.875,
+		"gpqa": 0.83,
+		"hle": 0.232
+	},
+	"minimax-m2.5": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiniMax-M2.5",
+		"gpqa": 0.848,
+		"hle": 0.205
+	},
+	"minimax-m2.7": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiniMax-M2.7",
+		"codingIndex": 52.6,
+		"gpqa": 0.874,
+		"hle": 0.296
 	},
 	"minimax-m1-80k": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiniMax M1 80k",
 		"mathIndex": 61,
 		"mmluPro": 0.816,
 		"gpqa": 0.697,
-		"hle": 0.082
-	},
-	"llama-3.3-nemotron-super-49b-v1-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Non-reasoning)",
-		"mathIndex": 7.7,
-		"mmluPro": 0.698,
-		"gpqa": 0.517,
-		"hle": 0.035
+		"hle": 0.089
 	},
 	"llama-3.3-nemotron-super-49b-v1-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Reasoning)",
 		"mathIndex": 54.7,
 		"mmluPro": 0.785,
 		"gpqa": 0.643,
-		"hle": 0.065
+		"hle": 0.056
+	},
+	"llama-3.3-nemotron-super-49b-v1-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Llama 3.3 Nemotron Super 49B v1 (Non-reasoning)",
+		"mathIndex": 7.7,
+		"mmluPro": 0.698,
+		"gpqa": 0.517,
+		"hle": 0.038
 	},
 	"llama-3.1-nemotron-nano-4b-v1.1-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.1 Nemotron Nano 4B v1.1 (Reasoning)",
 		"mathIndex": 50,
+		"mmluPro": 0.556,
 		"gpqa": 0.408,
-		"hle": 0.051
-	},
-	"kimi-k2-0905": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Kimi K2 0905",
-		"mathIndex": 57.3,
-		"mmluPro": 0.819,
-		"gpqa": 0.767,
-		"hle": 0.063
-	},
-	"kimi-k2": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Kimi K2",
-		"mathIndex": 57,
-		"gpqa": 0.766,
-		"hle": 0.07
+		"hle": 0.052
 	},
 	"kimi-k2.6": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Kimi K2.6",
 		"codingIndex": 61.8,
 		"gpqa": 0.911,
-		"hle": 0.359
-	},
-	"kimi-k2-thinking": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Kimi K2 Thinking",
-		"mathIndex": 94.7,
-		"mmluPro": 0.848,
-		"gpqa": 0.838,
-		"hle": 0.223
-	},
-	"kimi-k2.5-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Kimi K2.5 (Non-reasoning)",
-		"gpqa": 0.789,
-		"hle": 0.123
+		"hle": 0.375
 	},
 	"kimi-k2.5-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Kimi K2.5 (Reasoning)",
 		"codingIndex": 46.8,
 		"gpqa": 0.879,
-		"hle": 0.294
+		"hle": 0.307
+	},
+	"kimi-k2.5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Kimi K2.5 (Non-reasoning)",
+		"gpqa": 0.789,
+		"hle": 0.132
+	},
+	"kimi-k2-thinking": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Kimi K2 Thinking",
+		"mathIndex": 94.7,
+		"mmluPro": 0.848,
+		"gpqa": 0.838,
+		"hle": 0.238
+	},
+	"kimi-k2.6-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Kimi K2.6 (Non-reasoning)",
+		"gpqa": 0.788,
+		"hle": 0.196
+	},
+	"kimi-k2": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Kimi K2",
+		"mathIndex": 57,
+		"mmluPro": 0.824,
+		"gpqa": 0.766,
+		"hle": 0.074
+	},
+	"kimi-k2-0905": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Kimi K2 0905",
+		"mathIndex": 57.3,
+		"mmluPro": 0.819,
+		"gpqa": 0.767,
+		"hle": 0.064
 	},
 	"step-3.5-flash": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Step 3.5 Flash",
 		"gpqa": 0.831,
-		"hle": 0.191
+		"hle": 0.211
 	},
 	"step-3.5-flash-2603": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Step 3.5 Flash 2603",
 		"gpqa": 0.826,
-		"hle": 0.226
+		"hle": 0.245
 	},
 	"llama-3.1-tulu3-405b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Llama 3.1 Tulu3 405B",
 		"mmluPro": 0.716,
 		"gpqa": 0.516,
-		"hle": 0.035
-	},
-	"olmo-2-7b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "OLMo 2 7B",
-		"mathIndex": 0.7,
-		"mmluPro": 0.282,
-		"gpqa": 0.288,
-		"hle": 0.055
+		"hle": 0.033
 	},
 	"olmo-3-32b-think": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Olmo 3 32B Think",
 		"mathIndex": 73.7,
 		"mmluPro": 0.759,
 		"gpqa": 0.61,
-		"hle": 0.059
+		"hle": 0.064
+	},
+	"olmo-2-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "OLMo 2 7B",
+		"mathIndex": 0.7,
+		"mmluPro": 0.282,
+		"gpqa": 0.288,
+		"hle": 0.054
 	},
 	"olmo-2-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "OLMo 2 32B",
 		"mathIndex": 3.3,
 		"mmluPro": 0.511,
 		"gpqa": 0.328,
-		"hle": 0.037
+		"hle": 0.036
 	},
 	"granite-3.3-8b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Granite 3.3 8B (Non-reasoning)",
 		"mathIndex": 6.7,
+		"mmluPro": 0.468,
 		"gpqa": 0.338,
 		"hle": 0.042
 	},
@@ -4969,256 +5297,287 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Reka Flash (Sep '24)"
 	},
 	"hermes-3---llama-3.1-70b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Hermes 3 - Llama-3.1 70B",
 		"mmluPro": 0.571,
 		"gpqa": 0.401,
-		"hle": 0.041
-	},
-	"mimo-v2-pro": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "MiMo-V2-Pro",
-		"gpqa": 0.87,
-		"hle": 0.283
+		"hle": 0.04
 	},
 	"mimo-v2-flash-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "MiMo-V2-Flash (Reasoning)",
 		"mathIndex": 96.3,
 		"mmluPro": 0.843,
 		"gpqa": 0.846,
-		"hle": 0.211
+		"hle": 0.228
+	},
+	"mimo-v2-pro": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "MiMo-V2-Pro",
+		"gpqa": 0.87,
+		"hle": 0.304
 	},
 	"sarvam-m-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Sarvam M (Reasoning)",
 		"mmluPro": 0.696,
 		"gpqa": 0.416,
-		"hle": 0.033
+		"hle": 0.031
+	},
+	"hy3-preview-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Hy3-preview (Reasoning)",
+		"gpqa": 0.867,
+		"hle": 0.278
+	},
+	"hy3-preview-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Hy3-preview (Non-reasoning)",
+		"gpqa": 0.732,
+		"hle": 0.07
+	},
+	"kat-coder-pro-v1": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "KAT-Coder-Pro V1",
+		"mathIndex": 94.7,
+		"mmluPro": 0.813,
+		"gpqa": 0.764,
+		"hle": 0.336
 	},
 	"tri-21b-think-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Tri-21B-think Preview",
 		"gpqa": 0.538,
-		"hle": 0.057
+		"hle": 0.058
 	},
-	"glm-5.1-non-reasoning": {
+	"glm-4.5-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-5.1 (Non-reasoning)",
-		"gpqa": 0.839,
-		"hle": 0.256
-	},
-	"glm-4.7-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.7 (Non-reasoning)",
-		"mathIndex": 48,
-		"mmluPro": 0.794,
-		"gpqa": 0.664,
-		"hle": 0.061
-	},
-	"glm-4.7-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.7 (Reasoning)",
-		"codingIndex": 45.3,
-		"mathIndex": 95,
-		"gpqa": 0.859,
-		"hle": 0.251
-	},
-	"glm-5.1-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-5.1 (Reasoning)",
-		"codingIndex": 55.8,
-		"gpqa": 0.868,
-		"hle": 0.28
-	},
-	"glm-5-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-5 (Reasoning)",
-		"gpqa": 0.82,
-		"hle": 0.272
-	},
-	"glm-5-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-5 (Non-reasoning)",
-		"gpqa": 0.666,
-		"hle": 0.072
-	},
-	"glm-4.5-air": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.5-Air",
-		"mathIndex": 80.7,
-		"gpqa": 0.733,
-		"hle": 0.068
-	},
-	"glm-4.6-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.6 (Reasoning)",
-		"codingIndex": 45.8,
-		"mathIndex": 86,
-		"mmluPro": 0.829,
-		"gpqa": 0.78,
-		"hle": 0.133
-	},
-	"glm-4.6-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.6 (Non-reasoning)",
-		"mathIndex": 44.3,
-		"mmluPro": 0.784,
-		"gpqa": 0.632,
-		"hle": 0.052
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.5 (Reasoning)",
+		"mathIndex": 73.7,
+		"mmluPro": 0.835,
+		"gpqa": 0.782,
+		"hle": 0.13
 	},
 	"glm-4.7-flash-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-4.7-Flash (Reasoning)",
 		"gpqa": 0.581,
-		"hle": 0.071
+		"hle": 0.076
+	},
+	"glm-5.1-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5.1 (Reasoning)",
+		"codingIndex": 55.8,
+		"gpqa": 0.868,
+		"hle": 0.301
+	},
+	"glm-4.7-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.7 (Reasoning)",
+		"codingIndex": 45.3,
+		"mathIndex": 95,
+		"mmluPro": 0.856,
+		"gpqa": 0.859,
+		"hle": 0.274
+	},
+	"glm-5-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5 (Reasoning)",
+		"gpqa": 0.82,
+		"hle": 0.293
 	},
 	"glm-4.6v-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-4.6V (Reasoning)",
 		"mathIndex": 85.3,
 		"mmluPro": 0.799,
 		"gpqa": 0.719,
-		"hle": 0.089
+		"hle": 0.096
+	},
+	"glm-5.1-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5.1 (Non-reasoning)",
+		"gpqa": 0.839,
+		"hle": 0.279
+	},
+	"glm-4.6-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.6 (Reasoning)",
+		"codingIndex": 45.8,
+		"mathIndex": 86,
+		"mmluPro": 0.829,
+		"gpqa": 0.78,
+		"hle": 0.145
+	},
+	"glm-4.7-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.7 (Non-reasoning)",
+		"mathIndex": 48,
+		"mmluPro": 0.794,
+		"gpqa": 0.664,
+		"hle": 0.064
+	},
+	"glm-4.5v-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.5V (Non-reasoning)",
+		"mathIndex": 15.3,
+		"mmluPro": 0.751,
+		"gpqa": 0.573,
+		"hle": 0.035
+	},
+	"glm-4.6-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.6 (Non-reasoning)",
+		"mathIndex": 44.3,
+		"mmluPro": 0.784,
+		"gpqa": 0.632,
+		"hle": 0.055
 	},
 	"glm-5v-turbo-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM 5V Turbo (Reasoning)",
 		"gpqa": 0.809,
-		"hle": 0.158
+		"hle": 0.171
 	},
 	"glm-4.6v-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-4.6V (Non-reasoning)",
 		"mathIndex": 26.3,
 		"mmluPro": 0.752,
 		"gpqa": 0.566,
 		"hle": 0.037
 	},
+	"glm-5-turbo": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5-Turbo",
+		"gpqa": 0.847,
+		"hle": 0.278
+	},
+	"glm-5-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-5 (Non-reasoning)",
+		"gpqa": 0.666,
+		"hle": 0.076
+	},
 	"glm-4.7-flash-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-4.7-Flash (Non-reasoning)",
 		"gpqa": 0.452,
-		"hle": 0.049
+		"hle": 0.05
 	},
-	"glm-4.5-reasoning": {
+	"glm-4.5-air": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.5 (Reasoning)",
-		"mathIndex": 73.7,
-		"mmluPro": 0.835,
-		"gpqa": 0.782,
-		"hle": 0.122
+		"lastUpdated": "2026-09-01",
+		"originalModel": "GLM-4.5-Air",
+		"mathIndex": 80.7,
+		"mmluPro": 0.815,
+		"gpqa": 0.733,
+		"hle": 0.07
 	},
 	"glm-4.5v-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "GLM-4.5V (Reasoning)",
 		"mathIndex": 73,
 		"mmluPro": 0.788,
 		"gpqa": 0.684,
-		"hle": 0.059
-	},
-	"glm-4.5v-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-4.5V (Non-reasoning)",
-		"mathIndex": 15.3,
-		"mmluPro": 0.751,
-		"gpqa": 0.573,
-		"hle": 0.036
-	},
-	"glm-5-turbo": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "GLM-5-Turbo",
-		"gpqa": 0.847,
-		"hle": 0.254
+		"hle": 0.063
 	},
 	"command-r+-apr-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Command-R+ (Apr '24)",
 		"mmluPro": 0.432,
 		"gpqa": 0.323,
-		"hle": 0.045
+		"hle": 0.046
 	},
 	"command-r-mar-24": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Command-R (Mar '24)",
 		"mmluPro": 0.338,
 		"gpqa": 0.284,
@@ -5228,663 +5587,715 @@
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Apriel-v1.5-15B-Thinker",
 		"mathIndex": 87.5,
 		"mmluPro": 0.773,
 		"gpqa": 0.713,
-		"hle": 0.12
-	},
-	"jamba-1.6-large": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Jamba 1.6 Large",
-		"mmluPro": 0.565,
-		"gpqa": 0.387,
-		"hle": 0.04
+		"hle": 0.121
 	},
 	"jamba-1.5-large": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Jamba 1.5 Large",
 		"mmluPro": 0.572,
 		"gpqa": 0.427,
-		"hle": 0.04
-	},
-	"jamba-1.5-mini": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Jamba 1.5 Mini",
-		"mmluPro": 0.371,
-		"gpqa": 0.302,
-		"hle": 0.051
+		"hle": 0.041
 	},
 	"jamba-1.6-mini": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Jamba 1.6 Mini",
 		"mmluPro": 0.367,
 		"gpqa": 0.3,
-		"hle": 0.046
+		"hle": 0.043
+	},
+	"jamba-1.5-mini": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Jamba 1.5 Mini",
+		"mmluPro": 0.371,
+		"gpqa": 0.302,
+		"hle": 0.051
+	},
+	"jamba-1.6-large": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Jamba 1.6 Large",
+		"mmluPro": 0.565,
+		"gpqa": 0.387,
+		"hle": 0.036
 	},
 	"arctic-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Arctic Instruct"
 	},
 	"qwen2.5-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen2.5 Max",
 		"mmluPro": 0.762,
 		"gpqa": 0.587,
-		"hle": 0.045
+		"hle": 0.038
 	},
 	"qwen2.5-instruct-72b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen2.5 Instruct 72B",
 		"mathIndex": 14,
 		"mmluPro": 0.72,
 		"gpqa": 0.491,
-		"hle": 0.042
+		"hle": 0.036
 	},
 	"qwen2.5-coder-instruct-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen2.5 Coder Instruct 32B",
 		"mmluPro": 0.635,
 		"gpqa": 0.417,
-		"hle": 0.038
+		"hle": 0.035
 	},
 	"qwen2.5-turbo": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen2.5 Turbo",
 		"mmluPro": 0.633,
 		"gpqa": 0.41,
-		"hle": 0.042
+		"hle": 0.041
 	},
 	"qwen2-instruct-72b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen2 Instruct 72B",
 		"mmluPro": 0.622,
 		"gpqa": 0.371,
 		"hle": 0.037
 	},
-	"qwen3-235b-a22b-reasoning": {
+	"qwen3.6-max-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 235B A22B (Reasoning)",
-		"mathIndex": 82,
-		"mmluPro": 0.828,
-		"gpqa": 0.7,
-		"hle": 0.117
-	},
-	"qwen3-vl-30b-a3b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 30B A3B (Reasoning)",
-		"mathIndex": 82.3,
-		"mmluPro": 0.807,
-		"gpqa": 0.72,
-		"hle": 0.087
-	},
-	"qwen3-30b-a3b-2507-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 30B A3B 2507 (Reasoning)",
-		"codingIndex": 12.1,
-		"mathIndex": 56.3,
-		"mmluPro": 0.805,
-		"gpqa": 0.707,
-		"hle": 0.098
-	},
-	"qwen3-235b-a22b-2507-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 235B A22B 2507 Instruct",
-		"mathIndex": 71.7,
-		"gpqa": 0.753,
-		"hle": 0.106
-	},
-	"qwen3-1.7b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 1.7B (Non-reasoning)",
-		"mathIndex": 7.3,
-		"mmluPro": 0.411,
-		"gpqa": 0.283,
-		"hle": 0.052
-	},
-	"qwen3-coder-480b-a35b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Coder 480B A35B Instruct",
-		"mathIndex": 39.3,
-		"mmluPro": 0.788,
-		"gpqa": 0.618,
-		"hle": 0.044
-	},
-	"qwen3-32b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 32B (Non-reasoning)",
-		"mathIndex": 19.7,
-		"mmluPro": 0.727,
-		"gpqa": 0.535,
-		"hle": 0.043
-	},
-	"qwq-32b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "QwQ 32B",
-		"mathIndex": 29,
-		"mmluPro": 0.764,
-		"gpqa": 0.593,
-		"hle": 0.082
-	},
-	"qwen1.5-chat-110b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen1.5 Chat 110B",
-		"gpqa": 0.289
-	},
-	"qwen3-30b-a3b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 30B A3B (Reasoning)",
-		"mathIndex": 72.3,
-		"mmluPro": 0.777,
-		"gpqa": 0.616,
-		"hle": 0.066
-	},
-	"qwen3-vl-30b-a3b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 30B A3B Instruct",
-		"mathIndex": 72.3,
-		"mmluPro": 0.764,
-		"gpqa": 0.695,
-		"hle": 0.064
-	},
-	"qwen3.5-27b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 27B (Non-reasoning)",
-		"gpqa": 0.842,
-		"hle": 0.132
-	},
-	"qwen3-max-preview": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 Max (Preview)",
-		"mathIndex": 75,
-		"mmluPro": 0.838,
-		"gpqa": 0.764,
-		"hle": 0.093
-	},
-	"qwen3-vl-32b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 32B Instruct",
-		"mathIndex": 68.3,
-		"mmluPro": 0.791,
-		"gpqa": 0.671,
-		"hle": 0.063
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.6 Max Preview",
+		"gpqa": 0.888,
+		"hle": 0.308
 	},
 	"qwen3-coder-30b-a3b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 Coder 30B A3B Instruct",
 		"mathIndex": 29,
 		"mmluPro": 0.706,
 		"gpqa": 0.516,
-		"hle": 0.04
-	},
-	"qwen3-8b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 8B (Non-reasoning)",
-		"mathIndex": 24.3,
-		"mmluPro": 0.643,
-		"gpqa": 0.452,
-		"hle": 0.028
-	},
-	"qwen3-235b-a22b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 235B A22B (Non-reasoning)",
-		"mathIndex": 23.7,
-		"mmluPro": 0.762,
-		"gpqa": 0.613,
-		"hle": 0.047
-	},
-	"qwen3.6-max-preview": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.6 Max Preview",
-		"gpqa": 0.888,
-		"hle": 0.289
-	},
-	"qwen2.5-coder-instruct-7b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen2.5 Coder Instruct 7B ",
-		"mmluPro": 0.473,
-		"gpqa": 0.339,
-		"hle": 0.048
-	},
-	"qwen3-vl-4b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 4B (Reasoning)",
-		"mathIndex": 25.7,
-		"mmluPro": 0.7,
-		"gpqa": 0.494,
-		"hle": 0.044
-	},
-	"qwen2.5-instruct-32b": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen2.5 Instruct 32B",
-		"mmluPro": 0.697,
-		"gpqa": 0.466,
 		"hle": 0.038
-	},
-	"qwen3-235b-a22b-2507-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 235B A22B 2507 (Reasoning)",
-		"codingIndex": 22.1,
-		"mathIndex": 91,
-		"mmluPro": 0.843,
-		"gpqa": 0.79,
-		"hle": 0.15
-	},
-	"qwen3-30b-a3b-2507-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 30B A3B 2507 Instruct",
-		"mathIndex": 66.3,
-		"mmluPro": 0.777,
-		"gpqa": 0.659,
-		"hle": 0.068
-	},
-	"qwen3-32b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 32B (Reasoning)",
-		"codingIndex": 15.3,
-		"mathIndex": 73,
-		"mmluPro": 0.798,
-		"gpqa": 0.668,
-		"hle": 0.083
-	},
-	"qwen3.5-27b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 27B (Reasoning)",
-		"gpqa": 0.858,
-		"hle": 0.222
-	},
-	"qwq-32b-preview": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "QwQ 32B-Preview",
-		"mmluPro": 0.648,
-		"gpqa": 0.557,
-		"hle": 0.048
-	},
-	"qwen3-0.6b-non-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 0.6B (Non-reasoning)",
-		"mathIndex": 10.3,
-		"mmluPro": 0.231,
-		"gpqa": 0.231,
-		"hle": 0.052
-	},
-	"qwen3-vl-8b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 8B (Reasoning)",
-		"mathIndex": 30.7,
-		"mmluPro": 0.749,
-		"gpqa": 0.579,
-		"hle": 0.033
 	},
 	"qwen3-vl-235b-a22b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 VL 235B A22B Instruct",
 		"mathIndex": 70.7,
 		"mmluPro": 0.823,
 		"gpqa": 0.712,
-		"hle": 0.063
+		"hle": 0.066
 	},
-	"qwen3.5-35b-a3b-reasoning": {
+	"qwq-32b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3.5 35B A3B (Reasoning)",
-		"gpqa": 0.845,
-		"hle": 0.197
+		"lastUpdated": "2026-09-01",
+		"originalModel": "QwQ 32B",
+		"mathIndex": 29,
+		"mmluPro": 0.764,
+		"gpqa": 0.593,
+		"hle": 0.073
 	},
-	"qwen3-vl-4b-instruct": {
+	"qwen3-vl-30b-a3b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 4B Instruct",
-		"mathIndex": 37,
-		"mmluPro": 0.634,
-		"gpqa": 0.371,
-		"hle": 0.037
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 30B A3B (Reasoning)",
+		"mathIndex": 82.3,
+		"mmluPro": 0.807,
+		"gpqa": 0.72,
+		"hle": 0.089
 	},
-	"qwen3-vl-235b-a22b-reasoning": {
+	"qwen3.7-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 235B A22B (Reasoning)",
-		"mathIndex": 88.3,
-		"mmluPro": 0.836,
-		"gpqa": 0.772,
-		"hle": 0.101
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.7 Max",
+		"codingIndex": 66,
+		"gpqa": 0.923,
+		"hle": 0.405
+	},
+	"qwen3-vl-32b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 32B Instruct",
+		"mathIndex": 68.3,
+		"mmluPro": 0.791,
+		"gpqa": 0.671,
+		"hle": 0.068
+	},
+	"qwq-32b-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "QwQ 32B-Preview",
+		"mmluPro": 0.648,
+		"gpqa": 0.557,
+		"hle": 0.039
+	},
+	"qwen3-235b-a22b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 235B A22B (Reasoning)",
+		"mathIndex": 82,
+		"mmluPro": 0.828,
+		"gpqa": 0.7,
+		"hle": 0.11
+	},
+	"qwen3-235b-a22b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 235B A22B (Non-reasoning)",
+		"mathIndex": 23.7,
+		"mmluPro": 0.762,
+		"gpqa": 0.613,
+		"hle": 0.042
+	},
+	"qwen2.5-instruct-32b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen2.5 Instruct 32B",
+		"mmluPro": 0.697,
+		"gpqa": 0.466,
+		"hle": 0.04
+	},
+	"qwen3-235b-a22b-2507-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 235B A22B 2507 Instruct",
+		"mathIndex": 71.7,
+		"mmluPro": 0.828,
+		"gpqa": 0.753,
+		"hle": 0.111
+	},
+	"qwen3-30b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 30B A3B (Reasoning)",
+		"mathIndex": 72.3,
+		"mmluPro": 0.777,
+		"gpqa": 0.616,
+		"hle": 0.062
+	},
+	"qwen3-32b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 32B (Non-reasoning)",
+		"mathIndex": 19.7,
+		"mmluPro": 0.727,
+		"gpqa": 0.535,
+		"hle": 0.041
+	},
+	"qwen3-32b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 32B (Reasoning)",
+		"codingIndex": 15.3,
+		"mathIndex": 73,
+		"mmluPro": 0.798,
+		"gpqa": 0.668,
+		"hle": 0.074
 	},
 	"qwen3-14b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 14B (Reasoning)",
 		"codingIndex": 13.8,
 		"mathIndex": 55.7,
 		"mmluPro": 0.774,
 		"gpqa": 0.604,
-		"hle": 0.043
+		"hle": 0.045
 	},
-	"qwen3-8b-reasoning": {
+	"qwen3-vl-8b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 8B (Reasoning)",
-		"codingIndex": 9,
-		"mathIndex": 19,
-		"mmluPro": 0.743,
-		"gpqa": 0.589,
-		"hle": 0.042
-	},
-	"qwen3-vl-8b-instruct": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 VL 8B Instruct",
-		"mathIndex": 27.3,
-		"mmluPro": 0.686,
-		"gpqa": 0.427,
-		"hle": 0.029
-	},
-	"qwen3-4b-reasoning": {
-		"contextWindow": 8192,
-		"supportsReasoning": false,
-		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 4B (Reasoning)",
-		"mathIndex": 22.3,
-		"mmluPro": 0.696,
-		"gpqa": 0.522,
-		"hle": 0.051
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 8B (Reasoning)",
+		"mathIndex": 30.7,
+		"mmluPro": 0.749,
+		"gpqa": 0.579,
+		"hle": 0.038
 	},
 	"qwen3-max": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 Max",
 		"mathIndex": 80.7,
 		"mmluPro": 0.841,
 		"gpqa": 0.764,
-		"hle": 0.111
+		"hle": 0.119
 	},
-	"qwen3-1.7b-reasoning": {
+	"qwen3-8b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 1.7B (Reasoning)",
-		"mathIndex": 38.7,
-		"mmluPro": 0.57,
-		"gpqa": 0.356,
-		"hle": 0.048
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 8B (Non-reasoning)",
+		"mathIndex": 24.3,
+		"mmluPro": 0.643,
+		"gpqa": 0.452,
+		"hle": 0.019
+	},
+	"qwen3-30b-a3b-2507-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 30B A3B 2507 (Reasoning)",
+		"codingIndex": 12.1,
+		"mathIndex": 56.3,
+		"mmluPro": 0.805,
+		"gpqa": 0.707,
+		"hle": 0.103
+	},
+	"qwen3-30b-a3b-2507-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 30B A3B 2507 Instruct",
+		"mathIndex": 66.3,
+		"mmluPro": 0.777,
+		"gpqa": 0.659,
+		"hle": 0.069
+	},
+	"qwen3-coder-480b-a35b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Coder 480B A35B Instruct",
+		"mathIndex": 39.3,
+		"mmluPro": 0.788,
+		"gpqa": 0.618,
+		"hle": 0.045
+	},
+	"qwen2.5-coder-instruct-7b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen2.5 Coder Instruct 7B ",
+		"mmluPro": 0.473,
+		"gpqa": 0.339,
+		"hle": 0.049
 	},
 	"qwen3-4b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 4B (Non-reasoning)",
 		"mmluPro": 0.586,
 		"gpqa": 0.398,
-		"hle": 0.037
+		"hle": 0.033
 	},
 	"qwen3-max-thinking": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 Max Thinking",
 		"gpqa": 0.861,
-		"hle": 0.262
+		"hle": 0.28
 	},
-	"qwen3-0.6b-reasoning": {
+	"qwen3-8b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 0.6B (Reasoning)",
-		"mathIndex": 18,
-		"mmluPro": 0.347,
-		"gpqa": 0.239,
-		"hle": 0.057
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 8B (Reasoning)",
+		"codingIndex": 9,
+		"mathIndex": 19,
+		"mmluPro": 0.743,
+		"gpqa": 0.589,
+		"hle": 0.039
 	},
-	"qwen-chat-72b": {
+	"qwen3-235b-a22b-2507-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen Chat 72B"
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 235B A22B 2507 (Reasoning)",
+		"codingIndex": 22.1,
+		"mathIndex": 91,
+		"mmluPro": 0.843,
+		"gpqa": 0.79,
+		"hle": 0.159
 	},
-	"qwen3-4b-2507-reasoning": {
+	"qwen3-vl-235b-a22b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 4B 2507 (Reasoning)",
-		"mathIndex": 82.7,
-		"gpqa": 0.667,
-		"hle": 0.059
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 235B A22B (Reasoning)",
+		"mathIndex": 88.3,
+		"mmluPro": 0.836,
+		"gpqa": 0.772,
+		"hle": 0.119
+	},
+	"qwen3-14b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 14B (Non-reasoning)",
+		"mathIndex": 58,
+		"mmluPro": 0.675,
+		"gpqa": 0.47,
+		"hle": 0.041
 	},
 	"qwen3-30b-a3b-non-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 30B A3B (Non-reasoning)",
 		"mathIndex": 21.7,
 		"mmluPro": 0.71,
 		"gpqa": 0.515,
 		"hle": 0.046
 	},
-	"qwen3-14b-non-reasoning": {
+	"qwen3.6-plus": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Qwen3 14B (Non-reasoning)",
-		"mathIndex": 58,
-		"mmluPro": 0.675,
-		"gpqa": 0.47,
-		"hle": 0.042
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.6 Plus",
+		"codingIndex": 54.5,
+		"gpqa": 0.882,
+		"hle": 0.278
+	},
+	"qwen3.5-35b-a3b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 35B A3B (Reasoning)",
+		"gpqa": 0.845,
+		"hle": 0.21
+	},
+	"qwen3.5-27b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 27B (Reasoning)",
+		"gpqa": 0.858,
+		"hle": 0.239
+	},
+	"qwen3-0.6b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 0.6B (Non-reasoning)",
+		"mathIndex": 10.3,
+		"mmluPro": 0.231,
+		"gpqa": 0.231,
+		"hle": 0.049
+	},
+	"qwen3-4b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 4B (Reasoning)",
+		"mathIndex": 22.3,
+		"mmluPro": 0.696,
+		"gpqa": 0.522,
+		"hle": 0.044
+	},
+	"qwen3-4b-2507-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 4B 2507 (Reasoning)",
+		"mathIndex": 82.7,
+		"mmluPro": 0.743,
+		"gpqa": 0.667,
+		"hle": 0.062
+	},
+	"qwen3-1.7b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 1.7B (Non-reasoning)",
+		"mathIndex": 7.3,
+		"mmluPro": 0.411,
+		"gpqa": 0.283,
+		"hle": 0.053
+	},
+	"qwen3.5-27b-non-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3.5 27B (Non-reasoning)",
+		"gpqa": 0.842,
+		"hle": 0.139
 	},
 	"qwen3-vl-32b-reasoning": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 VL 32B (Reasoning)",
 		"mathIndex": 84.7,
 		"mmluPro": 0.818,
 		"gpqa": 0.733,
-		"hle": 0.096
+		"hle": 0.101
+	},
+	"qwen3-0.6b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 0.6B (Reasoning)",
+		"mathIndex": 18,
+		"mmluPro": 0.347,
+		"gpqa": 0.239,
+		"hle": 0.056
+	},
+	"qwen3-1.7b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 1.7B (Reasoning)",
+		"mathIndex": 38.7,
+		"mmluPro": 0.57,
+		"gpqa": 0.356,
+		"hle": 0.046
+	},
+	"qwen3-vl-30b-a3b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 30B A3B Instruct",
+		"mathIndex": 72.3,
+		"mmluPro": 0.764,
+		"gpqa": 0.695,
+		"hle": 0.063
 	},
 	"qwen3-max-thinking-preview": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 Max Thinking (Preview)",
 		"mathIndex": 82.3,
 		"mmluPro": 0.824,
 		"gpqa": 0.776,
-		"hle": 0.12
+		"hle": 0.127
+	},
+	"qwen3-vl-4b-reasoning": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 4B (Reasoning)",
+		"mathIndex": 25.7,
+		"mmluPro": 0.7,
+		"gpqa": 0.494,
+		"hle": 0.046
+	},
+	"qwen3-vl-4b-instruct": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 4B Instruct",
+		"mathIndex": 37,
+		"mmluPro": 0.634,
+		"gpqa": 0.371,
+		"hle": 0.036
+	},
+	"qwen1.5-chat-110b": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen1.5 Chat 110B",
+		"gpqa": 0.289
 	},
 	"qwen3-4b-2507-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Qwen3 4B 2507 Instruct",
 		"mathIndex": 52.3,
 		"mmluPro": 0.672,
 		"gpqa": 0.517,
-		"hle": 0.047
+		"hle": 0.045
 	},
-	"ring-1t": {
+	"qwen3-vl-8b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Ring-1T",
-		"mathIndex": 89.3,
-		"mmluPro": 0.806,
-		"gpqa": 0.774,
-		"hle": 0.102
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 VL 8B Instruct",
+		"mathIndex": 27.3,
+		"mmluPro": 0.686,
+		"gpqa": 0.427,
+		"hle": 0.027
 	},
-	"ling-1t": {
+	"qwen-chat-72b": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
-		"originalModel": "Ling-1T",
-		"mathIndex": 71.3,
-		"mmluPro": 0.822,
-		"gpqa": 0.719,
-		"hle": 0.072
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen Chat 72B"
+	},
+	"qwen3-max-preview": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Qwen3 Max (Preview)",
+		"mathIndex": 75,
+		"mmluPro": 0.838,
+		"gpqa": 0.764,
+		"hle": 0.101
 	},
 	"ling-flash-2.0": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Ling-flash-2.0",
 		"mathIndex": 65.3,
 		"mmluPro": 0.777,
 		"gpqa": 0.657,
+		"hle": 0.062
+	},
+	"ling-2.6-flash": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ling 2.6 Flash",
+		"codingIndex": 25.3,
+		"gpqa": 0.593,
 		"hle": 0.063
+	},
+	"ring-1t": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ring-1T",
+		"mathIndex": 89.3,
+		"mmluPro": 0.806,
+		"gpqa": 0.774,
+		"hle": 0.111
+	},
+	"ling-mini-2.0": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ling-mini-2.0",
+		"mathIndex": 49.3,
+		"mmluPro": 0.671,
+		"gpqa": 0.562,
+		"hle": 0.051
+	},
+	"ling-2.6-1t": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ling-2.6-1T",
+		"gpqa": 0.752,
+		"hle": 0.087
+	},
+	"ling-1t": {
+		"contextWindow": 8192,
+		"supportsReasoning": false,
+		"supportsVision": false,
+		"lastUpdated": "2026-09-01",
+		"originalModel": "Ling-1T",
+		"mathIndex": 71.3,
+		"mmluPro": 0.822,
+		"gpqa": 0.719,
+		"hle": 0.073
 	},
 	"seed-oss-36b-instruct": {
 		"contextWindow": 8192,
 		"supportsReasoning": false,
 		"supportsVision": false,
-		"lastUpdated": "2026-08-01",
+		"lastUpdated": "2026-09-01",
 		"originalModel": "Seed-OSS-36B-Instruct",
 		"mathIndex": 84.7,
 		"mmluPro": 0.815,
 		"gpqa": 0.726,
-		"hle": 0.091
+		"hle": 0.099
 	}
 }


### PR DESCRIPTION
## Automated Benchmark Update

This PR updates the hardcoded benchmark data with fresh scores from
[Artificial Analysis](https://artificialanalysis.ai).

### Changes
- Updated `provider-failover/hardcoded-benchmarks.ts`
- New data as of 2026-08-31T10:20:27Z

### Verification
- [ ] Review score changes for major models
- [ ] Run tests: `npm run test:run`
- [ ] Check no unexpected tier downgrades

Auto-generated by GitHub Actions.