### PR TITLE
chore: prepare 2.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-09-02
+
 ### Removed
 
 - **Kiro provider** — removed entirely. Login never recovered reliably: the Kiro Web Portal validates `redirect_uri` against a per-IdP allowlist that rejected every loopback callback URL on the BuilderId (AWS SSO) leg with `401 "Authentication required or access denied."`, and after the redirect-allowlist fix the flow still could not be made dependable end to end. The provider directory (`providers/kiro/`, 18 modules), its 7 test files, the `docs/kiro-web-portal-auth.md` design doc, and the `scripts/test-kiro-desktop.mjs` live driver are gone, along with the `kiro` constants, the `kiro_show_paid` / `kiro_profile_arn` / `kiro_auth_method` config keys and getters, and the kiro-only dependencies (`@smithy/core`, `@smithy/types`, `cbor-x`). Existing users: any `kiro*` keys left in `~/.pi/free.json` are ignored harmlessly; the `kiro` entry in `~/.pi/agent/auth.json` becomes inert and can be deleted; `/login kiro`, `/logout kiro`, and the provider itself no longer exist.

--- a/agents.md
+++ b/agents.md
@@ -6,7 +6,7 @@
 
 A **Pi extension** (`@earendil-works/pi-coding-agent`) that registers free and paid AI model providers with Pi's model picker. It shows free models by default and lets users toggle per-provider between free-only and all-models view via `/toggle-{provider}` commands.
 
-**Package:** `pi-free` v2.3.0
+**Package:** `pi-free` v2.7.0
 **Author:** Apostolos Mantzaris  
 **License:** MIT  
 **Repo:** `github.com/apmantza/pi-free`  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-free",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-free",
-			"version": "2.6.0",
+			"version": "2.7.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "^0.84.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-free",
-	"version": "2.6.0",
+	"version": "2.7.0",
 	"type": "module",
 	"description": "AI model providers for Pi with free model filtering and dynamic model fetching",
 	"keywords": [


### PR DESCRIPTION
Release prep for v2.7.0.

## Summary
- Remove Kiro provider
- Add auto-fallback, Agnes AI, GMI Cloud providers
- Fix opencode-free auth fallback

See CHANGELOG.md for full notes.