### PR TITLE
fix(lint): pass localeCompare comparator to string sorts (Sonar S2871)

### DIFF
--- a/scripts/drive-pi-ai.ts
+++ b/scripts/drive-pi-ai.ts
@@ -91,7 +91,7 @@ function parseArgs(argv: string[]): Record<string, string | boolean> {
 }
 
 function listProviders(store: Record<string, { models?: StoreModel[] }>): void {
-	const ids = Object.keys(store).sort();
+	const ids = Object.keys(store).sort((a, b) => a.localeCompare(b));
 	for (const id of ids) {
 		const models = store[id]?.models ?? [];
 		console.log(`${id}: ${models.length} models`);
@@ -153,7 +153,7 @@ async function main(): Promise<number> {
 	const providerModels = store[providerId]?.models ?? [];
 	if (providerModels.length === 0) {
 		console.error(`Provider '${providerId}' has no models in the store.`);
-		console.error(`Available: ${Object.keys(store).sort().join(", ")}`);
+		console.error(`Available: ${Object.keys(store).sort((a, b) => a.localeCompare(b)).join(", ")}`);
 		return 1;
 	}
 


### PR DESCRIPTION
Clears the two CRITICAL SonarCloud BUG findings (typescript:S2871) in `scripts/drive-pi-ai.ts`: `.sort()` on provider-id strings without a compare function. Passes `(a, b) => a.localeCompare(b)` — behavior is identical for the ASCII provider ids, but the sort no longer depends on implicit string conversion / locale-sensitive default ordering.

No functional change; no test changes needed (the file is a dev-only drive script covered by no unit tests).