### PR TITLE
fix(stale-ctx): drop dead-session work quietly in auto-fallback + built-in-toggle (#509)

### DIFF
--- a/lib/auto-fallback/index.ts
+++ b/lib/auto-fallback/index.ts
@@ -40,6 +40,7 @@ import type {
 import { getProviderRegistry } from "../registry.ts";
 import { fallbackState } from "../fallback-state.ts";
 import { createLogger } from "../logger.ts";
+import { isStaleContextError, safeNotify } from "../stale-ctx.ts";
 import { createBlacklist, type Blacklist } from "./blacklist.ts";
 import { getAutoFallbackConfig } from "./config.ts";
 import {
@@ -182,9 +183,11 @@ export function createAutoFallback(): AutoFallbackHandle {
 		const registry = getProviderRegistry();
 		const out: FallbackCandidate[] = [];
 		for (const [providerId, entry] of registry) {
-			if (!matchesScope(providerId, scope, failingProvider, cfg.whitelistProviders)) {
+			if (
+				!matchesScope(providerId, scope, failingProvider, cfg.whitelistProviders)
+			) {
 				continue;
-		}
+			}
 			for (const m of entry.stored.free) {
 				out.push({
 					provider: providerId,
@@ -243,7 +246,10 @@ export function createAutoFallback(): AutoFallbackHandle {
 
 		if (ranked.length === 0) {
 			const exhausted = noCandidatesAvailable();
-			ctx.ui.notify(
+			// Best-effort: the session may have been replaced while the
+			// candidate auth checks above were awaiting (#509).
+			safeNotify(
+				ctx,
 				exhausted
 					? `Auto-fallback: no other free model available (provider ${provider} exhausted) — staying on ${provider}/${modelId}.`
 					: `Auto-fallback: no alternative free model for ${provider}/${modelId}.`,
@@ -336,7 +342,10 @@ export function createAutoFallback(): AutoFallbackHandle {
 
 		// We had candidates but none were switchable (all lacked auth or
 		// rejected the switch).
-		ctx.ui.notify(
+		// Best-effort: the session may have been replaced during the switch
+		// attempts above (#509).
+		safeNotify(
+			ctx,
 			`Auto-fallback: no switchable free model available (tried ${tried} candidate${tried === 1 ? "" : "s"}; the rest need an API key or rejected the switch).`,
 			"warning",
 		);
@@ -411,6 +420,14 @@ export function createAutoFallback(): AutoFallbackHandle {
 		} catch (err) {
 			const name = err instanceof Error ? err.name : String(err);
 			if (name === "AbortError") return false;
+			// A stale pi/ctx just means the session moved on mid-switch
+			// (#509) — not a provider failure worth warning about.
+			if (isStaleContextError(err)) {
+				_logger.info("auto-fallback: setModel skipped, session changed", {
+					error: err instanceof Error ? err.message : String(err),
+				});
+				return false;
+			}
 			_logger.warn("auto-fallback: setModel threw", {
 				error: err instanceof Error ? err.message : String(err),
 			});
@@ -444,6 +461,14 @@ export function createAutoFallback(): AutoFallbackHandle {
 		try {
 			void sender(content, { expandPromptTemplates: false });
 		} catch (err) {
+			// A stale pi just means the session moved on before the replay
+			// could dispatch (#509) — not worth warning about.
+			if (isStaleContextError(err)) {
+				_logger.info("auto-fallback: auto-continue skipped, session changed", {
+					error: err instanceof Error ? err.message : String(err),
+				});
+				return;
+			}
 			_logger.warn("auto-fallback: sendUserMessage threw", {
 				error: err instanceof Error ? err.message : String(err),
 			});
@@ -532,6 +557,33 @@ export function createAutoFallback(): AutoFallbackHandle {
 			// switching, auto-continue) so each settled run is processed
 			// exactly once, in order.
 			extensionPi.on("agent_settled", async (_event, ctx) => {
+				try {
+					await handleAgentSettled(ctx);
+				} catch (error) {
+					// Pi surfaces handler throws as a user-visible Extension
+					// error for the current turn. A stale ctx just means the
+					// session was replaced/reloaded mid-settle (#509) — the
+					// fallback work belongs to the dead session, so drop it
+					// quietly instead of alarming the user.
+					if (isStaleContextError(error)) {
+						_logger.info(
+							"auto-fallback: session changed mid-settle; dropping fallback work",
+							{
+								error: error instanceof Error ? error.message : String(error),
+							},
+						);
+						return;
+					}
+					throw error;
+				}
+			});
+
+			/**
+			 * Settled-run orchestration: recovery, strike, switch, auto-continue.
+			 * Extracted so the `agent_settled` registration above can guard the
+			 * whole decision chain against Pi's stale-context throws (#509).
+			 */
+			async function handleAgentSettled(ctx: ExtensionContext): Promise<void> {
 				lastSeenCtx = ctx;
 				if (!isAutoFallbackLive()) return;
 				if (!ctx.model) return;
@@ -576,8 +628,7 @@ export function createAutoFallback(): AutoFallbackHandle {
 					lastAssistant,
 					ctx.model.provider,
 					ctx.model.id,
-					(provider, modelId) =>
-						fallbackState.getLastStatus(provider, modelId),
+					(provider, modelId) => fallbackState.getLastStatus(provider, modelId),
 				);
 				if (!failure) {
 					return; // clean run, user abort, or unrecoverable — nothing to do
@@ -621,7 +672,7 @@ export function createAutoFallback(): AutoFallbackHandle {
 						pendingAutoContinue = null;
 					}
 				}
-			});
+			}
 
 			extensionPi.on("model_select", (_event, ctx) => {
 				lastSeenCtx = ctx;

--- a/lib/auto-fallback/notify.ts
+++ b/lib/auto-fallback/notify.ts
@@ -17,6 +17,7 @@
  */
 
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { safeNotify, safeSetStatus } from "../stale-ctx.ts";
 
 type NotifyLevel = "silent" | "toast" | "status_bar" | "both";
 
@@ -78,7 +79,8 @@ export function createNotifier(
 				: `Auto-fallback: tried ${triedKeys.size} free models in last ${formatWindowMs(windowMs)}, currently on ${last?.toKey ?? "?"}`;
 
 		if (options.level === "toast" || options.level === "both") {
-			ctx.ui.notify(message, "info");
+			// Best-effort: ctx may belong to a replaced session (#509).
+			safeNotify(ctx, message, "info");
 		}
 		// The status bar is updated by recordSwitch below — emitSummary()
 		// never clears it (clearStatus is called explicitly on success).
@@ -93,7 +95,8 @@ export function createNotifier(
 		const label = activeSince
 			? `🛟 Fallback active (since ${formatClock(activeSince)})`
 			: "🛟 Fallback active";
-		ctx.ui.setStatus(statusKey, label);
+		// Best-effort: ctx may belong to a replaced session (#509).
+		safeSetStatus(ctx, statusKey, label);
 	}
 
 	return {
@@ -113,7 +116,9 @@ export function createNotifier(
 			// outages. If the window closes, the next switch is a new "first".
 			if (buffer.length === 1) {
 				if (options.level === "toast" || options.level === "both") {
-					ctx.ui.notify(
+					// Best-effort: ctx may belong to a replaced session (#509).
+					safeNotify(
+						ctx,
 						`Auto-fallback: ${record.fromKey} → ${record.toKey} (${record.reason})`,
 						"info",
 					);
@@ -124,7 +129,8 @@ export function createNotifier(
 			const ctx = getCtx();
 			if (!ctx) return;
 			if (options.level !== "silent") {
-				ctx.ui.setStatus(statusKey, undefined);
+				// Best-effort: ctx may belong to a replaced session (#509).
+				safeSetStatus(ctx, statusKey, undefined);
 			}
 			activeSince = null;
 			buffer.length = 0;

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -27,6 +27,7 @@ import {
 	getOpenrouterShowPaid,
 } from "../config.ts";
 import { createLogger } from "./logger.ts";
+import { isStaleContextError } from "./stale-ctx.ts";
 import {
 	getProviderRegistry,
 	isFreeModel,
@@ -333,6 +334,21 @@ export function setupBuiltInProviderToggles(pi: ExtensionAPI): void {
 						// restore's not-found retry waits for this refresh to land.
 						scheduleEndpointRefresh(config, state);
 						await maybeRestoreSavedModel(pi, config, entry.snapshot);
+					} catch (error) {
+						// The session may have been replaced/reloaded while the
+						// capture was awaiting credentials (#509). That work belongs
+						// to the dead session: drop it quietly (a live session's
+						// session_start starts a fresh capture) instead of rejecting,
+						// which trackDetachedSessionStart would report as
+						// "detached failed". Real errors still reject.
+						if (!isStaleContextError(error)) throw error;
+						_logger.info(
+							`[built-in-toggle] ${config.id}: session changed during capture; dropping detached capture`,
+							{
+								error: error instanceof Error ? error.message : String(error),
+							},
+						);
+						return;
 					} finally {
 						pendingCaptures.delete(config.id);
 					}
@@ -533,6 +549,17 @@ async function maybeRestoreSavedModel(
 			);
 		}
 	} catch (error) {
+		// A stale pi/ctx just means the session moved on before the restore
+		// could run (#509) — routine, not a warning.
+		if (isStaleContextError(error)) {
+			_logger.info(
+				`[built-in-toggle] ${config.id}: session changed before saved-model restore; skipping`,
+				{
+					error: error instanceof Error ? error.message : String(error),
+				},
+			);
+			return;
+		}
 		_logger.warn(
 			`[built-in-toggle] ${config.id}: saved-model restore failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
@@ -857,6 +884,17 @@ function scheduleEndpointRefresh(
 			// session-start-metrics "detached failed" warn per blip.
 			// Counters keep /free-health aware of the stale catalog.
 			recordNetworkFetch(config.id, undefined, false);
+			// A stale ctx just means the session moved on mid-refresh (#509)
+			// — routine, not a warning.
+			if (isStaleContextError(error)) {
+				_logger.info(
+					`[built-in-toggle] ${config.id}: session changed during endpoint refresh; keeping cached catalog`,
+					{
+						error: error instanceof Error ? error.message : String(error),
+					},
+				);
+				return;
+			}
 			_logger.warn(`[built-in-toggle] ${config.id}: endpoint refresh failed`, {
 				error: error instanceof Error ? error.message : String(error),
 				stack: error instanceof Error ? error.stack : undefined,
@@ -890,42 +928,69 @@ function registerToggleCommand(
 	pi.registerCommand(commandName, {
 		description: `Toggle free/paid ${config.id} models`,
 		handler: async (_args, ctx) => {
-			// A detached session-start capture may still be in flight; wait for
-			// it instead of racing a second capture (which would overwrite
-			// provider state and could clobber the view the user is toggling).
-			await pendingCaptures.get(config.id)?.task;
-			let state = providerStates.get(config.id);
-			if (!state) {
-				// Models may have loaded after session_start — try capture again.
-				state = await tryCaptureProvider(pi, config, ctx);
-			} else if (ctx.modelRegistry) {
-				// Commands run with the current session context; refresh the
-				// registry even when the catalog was captured in an older session.
-				state.setModelRegistry(ctx.modelRegistry);
-			}
-			if (!state) {
-				ctx.ui.notify(
-					`${config.id}: models not loaded yet. Start a session first, then try again.`,
-					"warning",
-				);
-				return;
-			}
-
-			const applied = state.toggleState.toggle(state.reRegister);
-
-			if (applied.mode === "all") {
-				ctx.ui.notify(
-					`${config.id}: showing all ${state.stored.all.length} models`,
-					"info",
-				);
-			} else {
-				ctx.ui.notify(
-					`${config.id}: showing ${state.stored.free.length} free models`,
-					"info",
+			try {
+				await runToggleCommand(ctx);
+			} catch (error) {
+				// The command ctx may belong to a replaced session (#509).
+				// There is no live UI left to explain that on — drop it
+				// quietly. Real errors still propagate as Extension errors.
+				if (!isStaleContextError(error)) throw error;
+				_logger.info(
+					`[built-in-toggle] ${config.id}: session changed during toggle; ignoring`,
+					{
+						error: error instanceof Error ? error.message : String(error),
+					},
 				);
 			}
 		},
 	});
+
+	/**
+	 * Toggle-command body, extracted so the registration can guard it
+	 * against Pi's stale-context throws (#509). The ctx type is structural:
+	 * both event and command contexts expose this surface.
+	 */
+	async function runToggleCommand(ctx: {
+		modelRegistry: CurrentModelRegistry;
+		ui: {
+			notify(message: string, type?: "info" | "warning" | "error"): void;
+		};
+	}): Promise<void> {
+		// A detached session-start capture may still be in flight; wait for
+		// it instead of racing a second capture (which would overwrite
+		// provider state and could clobber the view the user is toggling).
+		await pendingCaptures.get(config.id)?.task;
+		let state = providerStates.get(config.id);
+		if (!state) {
+			// Models may have loaded after session_start — try capture again.
+			state = await tryCaptureProvider(pi, config, ctx);
+		} else if (ctx.modelRegistry) {
+			// Commands run with the current session context; refresh the
+			// registry even when the catalog was captured in an older session.
+			state.setModelRegistry(ctx.modelRegistry);
+		}
+		if (!state) {
+			ctx.ui.notify(
+				`${config.id}: models not loaded yet. Start a session first, then try again.`,
+				"warning",
+			);
+			return;
+		}
+
+		const applied = state.toggleState.toggle(state.reRegister);
+
+		if (applied.mode === "all") {
+			ctx.ui.notify(
+				`${config.id}: showing all ${state.stored.all.length} models`,
+				"info",
+			);
+		} else {
+			ctx.ui.notify(
+				`${config.id}: showing ${state.stored.free.length} free models`,
+				"info",
+			);
+		}
+	}
 }
 
 // =============================================================================

--- a/lib/stale-ctx.ts
+++ b/lib/stale-ctx.ts
@@ -1,0 +1,96 @@
+/**
+ * Stale extension-context guard helpers (issue #509).
+ *
+ * Pi invalidates an extension runner's `ExtensionAPI` (`pi`) and every
+ * `ExtensionContext` (`ctx`) it handed out as soon as the session is
+ * replaced or reloaded (`ctx.newSession()`, `ctx.fork()`,
+ * `ctx.switchSession()`, `ctx.reload()`, resume with replacement). From
+ * that moment any `pi.*` call or lazy `ctx.*` getter access throws:
+ *
+ *   "This extension ctx is stale after session replacement or reload. ..."
+ *
+ * Extension event emission catches handler throws and surfaces them as a
+ * user-visible `Extension error (...)`, and detached `session_start` work
+ * that rejects is logged as `... detached failed`. Both are pure noise when
+ * the cause is simply "the session moved on while async work was in
+ * flight" — the follow-up to #393 (fixed for the toggle-opencode path by
+ * #394) for the auto-fallback auto-continue path and the detached
+ * built-in-toggle capture path.
+ *
+ * Rule: snapshot what you need from `ctx` synchronously at handler entry,
+ * and treat a stale-context throw after an `await` as "session moved on" —
+ * log at debug/info and stop work for the dead session instead of throwing.
+ */
+
+import { createLogger } from "./logger.ts";
+
+const _logger = createLogger("stale-ctx");
+
+/**
+ * Distinctive fragment of Pi's session-replacement guard message. Matched
+ * as a substring (not the full sentence) so minor upstream rewording does
+ * not silently disable the guard.
+ */
+const STALE_CTX_FRAGMENT = "is stale after session replacement or reload";
+
+/** True when `error` is Pi's stale extension-context guard (incl. causes). */
+export function isStaleContextError(error: unknown): boolean {
+ if (!(error instanceof Error)) return false;
+ if (error.message.includes(STALE_CTX_FRAGMENT)) return true;
+ const cause = (error as { cause?: unknown }).cause;
+ return cause instanceof Error && cause.message.includes(STALE_CTX_FRAGMENT);
+}
+
+/** Minimal UI surface the safe helpers need (structurally matches pi's ctx). */
+export interface NotifyUiLike {
+ notify(message: string, type?: "info" | "warning" | "error"): void;
+ setStatus(key: string, text: string | undefined): void;
+}
+
+export interface NotifyCtxLike {
+ ui: NotifyUiLike;
+}
+
+function reportStale(action: string, error: unknown): void {
+ _logger.debug(
+  `stale extension context during ${action}; session moved on, skipping`,
+  {
+   error: error instanceof Error ? error.message : String(error),
+  },
+ );
+}
+
+/**
+ * Best-effort `ctx.ui.notify` that never throws for a dead session — there
+ * is no UI left to update. Non-stale errors are rethrown unchanged so real
+ * bugs keep their existing visibility.
+ */
+export function safeNotify(
+ ctx: NotifyCtxLike,
+ message: string,
+ type?: "info" | "warning" | "error",
+): void {
+ try {
+  ctx.ui.notify(message, type);
+ } catch (error) {
+  if (!isStaleContextError(error)) throw error;
+  reportStale("notify", error);
+ }
+}
+
+/**
+ * Best-effort `ctx.ui.setStatus` with the same dead-session semantics as
+ * {@link safeNotify}.
+ */
+export function safeSetStatus(
+ ctx: NotifyCtxLike,
+ key: string,
+ text: string | undefined,
+): void {
+ try {
+  ctx.ui.setStatus(key, text);
+ } catch (error) {
+  if (!isStaleContextError(error)) throw error;
+  reportStale("setStatus", error);
+ }
+}

--- a/tests/auto-fallback.integration.test.ts
+++ b/tests/auto-fallback.integration.test.ts
@@ -878,4 +878,132 @@ describe("auto-fallback integration", () => {
 		);
 		expect(pi.sendUserMessage).toHaveBeenCalledTimes(2);
 	});
+
+	// #509: Pi invalidates ctx/pi on session replacement or reload, and
+	// surfaces handler throws as a user-visible Extension error. A stale ctx
+	// mid-settle must drop the fallback work quietly, not alarm the user.
+	const STALE_CTX_MESSAGE =
+		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession().";
+
+	/** Fresh ctx but with Pi-style lazy guarded `ui` that throws stale. */
+	function buildStaleUiCtx(
+		currentModel: { provider: string; id: string },
+		noAuthProviders: string[] = [],
+	) {
+		const ctx = buildMockCtx(currentModel, noAuthProviders);
+		return {
+			...ctx,
+			get ui(): { notify: () => void; setStatus: () => void } {
+				throw new Error(STALE_CTX_MESSAGE);
+			},
+		};
+	}
+
+	function emitFailureMessage(
+		pi: MockPi,
+		provider: string,
+		model: string,
+		ctx: unknown,
+	) {
+		return emit(
+			pi,
+			"message_end",
+			{
+				message: {
+					role: "assistant",
+					provider,
+					model,
+					stopReason: "error",
+					errorMessage: "rate limit exceeded",
+				},
+			},
+			ctx,
+		);
+	}
+
+	it("still switches without an Extension error when the settle ctx is stale (#509)", async () => {
+		mockGetAutoFallbackConfig.mockReturnValue({
+			enabled: true,
+			scope: "provider" as const,
+			whitelistProviders: [] as string[],
+			blacklistTtlMs: 60_000,
+			blacklistMaxStrikes: 3,
+			notifyLevel: "both" as const, // exercise the notifier's ctx.ui touches
+			restoreMode: "manual" as const,
+			autoContinue: true,
+			autoContinueMax: 3,
+		});
+		const pi = buildMockPi({ provider: "kilo", id: "gpt-4o" });
+		const handle = createAutoFallback();
+		handle.register(
+			pi as unknown as Parameters<
+				ReturnType<typeof createAutoFallback>["register"]
+			>[0],
+		);
+
+		await emit(
+			pi,
+			"after_provider_response",
+			{ status: 429, headers: {} },
+			buildMockCtx({ provider: "kilo", id: "gpt-4o" }),
+		);
+		await emitFailureMessage(
+			pi,
+			"kilo",
+			"gpt-4o",
+			buildMockCtx({ provider: "kilo", id: "gpt-4o" }),
+		);
+		// The session is replaced before agent_settled runs: every ctx.ui
+		// touch below throws stale. The handler must not propagate it (Pi
+		// would surface it as `Extension error (...)` for the current turn).
+		await emit(
+			pi,
+			"agent_settled",
+			{},
+			buildStaleUiCtx({ provider: "kilo", id: "gpt-4o" }),
+		);
+
+		expect(pi.setModel).toHaveBeenCalledTimes(1);
+		const status = handle.getStatus();
+		expect(status.switchCount).toBe(1);
+		expect(status.lastSwitchReason).toBe("error");
+	});
+
+	it("notifies best-effort on the no-candidate path with a stale ctx (#509)", async () => {
+		// A single free model: the failed model is the only candidate, so
+		// the settle lands on the no-candidate notify branch.
+		mockProviderRegistry.clear();
+		const solo = [{ id: "solo", name: "solo" }];
+		mockProviderRegistry.set("kilo", {
+			stored: { free: solo, all: solo },
+			reRegister: vi.fn(),
+		});
+		const pi = buildMockPi({ provider: "kilo", id: "solo" });
+		createAutoFallback().register(
+			pi as unknown as Parameters<
+				ReturnType<typeof createAutoFallback>["register"]
+			>[0],
+		);
+
+		await emit(
+			pi,
+			"after_provider_response",
+			{ status: 429, headers: {} },
+			buildMockCtx({ provider: "kilo", id: "solo" }),
+		);
+		await emitFailureMessage(
+			pi,
+			"kilo",
+			"solo",
+			buildMockCtx({ provider: "kilo", id: "solo" }),
+		);
+		await emit(
+			pi,
+			"agent_settled",
+			{},
+			buildStaleUiCtx({ provider: "kilo", id: "solo" }),
+		);
+
+		expect(pi.setModel).not.toHaveBeenCalled();
+	});
 });

--- a/tests/built-in-toggle-stale.test.ts
+++ b/tests/built-in-toggle-stale.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Stale-context tests for lib/built-in-toggle.ts (issue #509).
+ *
+ * Pi invalidates ctx/pi on session replacement or reload; async capture work
+ * that was already in flight then throws Pi's stale guard. The detached
+ * capture must drop that work quietly (resolve) instead of rejecting, which
+ * session-start-metrics would report as
+ * `built-in-toggle-capture-opencode-free detached failed`. Likewise the
+ * toggle command must not surface an Extension error for a dead session.
+ *
+ * session-start-metrics is mocked with a spy around the real contract so the
+ * test can observe each detached task's outcome directly.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STALE_MESSAGE =
+	"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
+
+interface DetachedOutcome {
+	label: string;
+	ok: boolean;
+	error?: unknown;
+}
+const detachedOutcomes: DetachedOutcome[] = [];
+
+const mockGetOpencodeFreeShowPaid = vi.fn();
+const mockGetOpencodeGoShowPaid = vi.fn();
+const mockGetOpenrouterShowPaid = vi.fn();
+const mockGetOpencodeApiKey = vi.fn();
+const mockSaveConfig = vi.fn();
+const mockRegisterWithGlobalToggle = vi.fn();
+const mockProviderRegistry = new Map<string, unknown>();
+
+/** Let detached session-start tasks settle (same window as the main suite). */
+async function settleDetachedCapture(): Promise<void> {
+	for (let i = 0; i < 10; i += 1) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
+vi.mock("../lib/session-start-metrics.ts", () => ({
+	wrapSessionStartHandler: (
+		_label: string,
+		handler: (...args: never[]) => unknown,
+	) => handler,
+	trackDetachedSessionStart: (
+		label: string,
+		work: PromiseLike<unknown>,
+		onError?: (error: unknown) => void,
+	) => {
+		void Promise.resolve(work).then(
+			() => {
+				detachedOutcomes.push({ label, ok: true });
+			},
+			(error: unknown) => {
+				detachedOutcomes.push({ label, ok: false, error });
+				try {
+					onError?.(error);
+				} catch {
+					// Observability callbacks must not create an unhandled rejection.
+				}
+			},
+		);
+	},
+}));
+
+vi.mock("../config.ts", () => ({
+	getOpencodeApiKey: () => mockGetOpencodeApiKey(),
+	getOpencodeFreeShowPaid: () => mockGetOpencodeFreeShowPaid(),
+	getOpencodeGoShowPaid: () => mockGetOpencodeGoShowPaid(),
+	getOpenrouterShowPaid: () => mockGetOpenrouterShowPaid(),
+	saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+}));
+
+vi.mock("../lib/registry.ts", () => ({
+	getProviderRegistry: () => mockProviderRegistry,
+	isFreeModel: () => true,
+	registerWithGlobalToggle: (...args: unknown[]) =>
+		mockRegisterWithGlobalToggle(...args),
+}));
+
+describe("built-in-toggle stale context (#509)", () => {
+	let mockPi: ExtensionAPI;
+	let handlers: Record<string, Function>;
+	let commands: Record<string, Function>;
+	let setupBuiltInProviderToggles: typeof import("../lib/built-in-toggle.ts")["setupBuiltInProviderToggles"];
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		detachedOutcomes.length = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("network disabled in built-in-toggle tests");
+			}),
+		);
+		handlers = {};
+		commands = {};
+		mockProviderRegistry.clear();
+		mockGetOpencodeFreeShowPaid.mockReturnValue(false);
+		mockGetOpencodeGoShowPaid.mockReturnValue(false);
+		mockGetOpenrouterShowPaid.mockReturnValue(false);
+		mockGetOpencodeApiKey.mockReturnValue(undefined);
+
+		mockPi = {
+			registerCommand: vi.fn((name: string, config: { handler: Function }) => {
+				commands[name] = config.handler;
+			}),
+			registerProvider: vi.fn(),
+			setModel: vi.fn(async () => true),
+			on: vi.fn((event: string, handler: Function) => {
+				handlers[event] = handler;
+			}),
+		} as unknown as ExtensionAPI;
+
+		({ setupBuiltInProviderToggles } = await import("../lib/built-in-toggle.ts"));
+	});
+
+	function staleRegistry() {
+		const stale = () => {
+			throw new Error(STALE_MESSAGE);
+		};
+		return { getAll: stale, getAvailable: stale };
+	}
+
+	function opencodeModels() {
+		return [
+			{
+				provider: "opencode",
+				id: "free-model",
+				name: "Free Model",
+				api: "openai-completions",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+				baseUrl: "https://example.com",
+			},
+		];
+	}
+
+	it("resolves (not rejects) detached captures when the session is replaced mid-capture", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		// The session is replaced while the detached capture awaits: every
+		// lazy ctx.modelRegistry access now throws Pi's stale guard.
+		await handlers.session_start({}, { modelRegistry: staleRegistry() });
+		await settleDetachedCapture();
+
+		const captures = detachedOutcomes.filter((o) =>
+			o.label.startsWith("built-in-toggle-capture-"),
+		);
+		expect(captures.length).toBeGreaterThan(0);
+		for (const capture of captures) {
+			expect(capture.ok).toBe(true);
+		}
+		expect(
+			detachedOutcomes.find(
+				(o) => o.label === "built-in-toggle-capture-opencode-free",
+			)?.ok,
+		).toBe(true);
+	});
+
+	it("captures cleanly on the next session_start after a stale capture", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		await handlers.session_start({}, { modelRegistry: staleRegistry() });
+		await settleDetachedCapture();
+
+		// The live session retries: pending state was cleared, so a fresh
+		// capture registers into the current session's registry.
+		const registerProvider = vi.fn();
+		await handlers.session_start(
+			{},
+			{
+				modelRegistry: {
+					getAvailable: () => opencodeModels(),
+					getApiKeyForProvider: async () => undefined,
+					registerProvider,
+				},
+			},
+		);
+		await settleDetachedCapture();
+
+		expect(registerProvider).toHaveBeenCalledWith(
+			"opencode-free",
+			expect.objectContaining({
+				models: [expect.objectContaining({ id: "free-model" })],
+			}),
+		);
+	});
+
+	it("toggle command ignores a stale command ctx instead of throwing", async () => {
+		setupBuiltInProviderToggles(mockPi);
+
+		// No capture has run, so the command goes straight to tryCaptureProvider
+		// with the dead session's registry — must resolve, not reject.
+		await commands["toggle-opencode-free"](
+			{},
+			{ modelRegistry: staleRegistry() },
+		);
+	});
+});

--- a/tests/stale-ctx.test.ts
+++ b/tests/stale-ctx.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for lib/stale-ctx.ts — Pi's session-replacement guard helpers.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+	isStaleContextError,
+	safeNotify,
+	safeSetStatus,
+} from "../lib/stale-ctx.ts";
+
+const STALE_MESSAGE =
+	"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
+
+describe("isStaleContextError", () => {
+	it("matches Pi's exact guard message", () => {
+		expect(isStaleContextError(new Error(STALE_MESSAGE))).toBe(true);
+	});
+
+	it("matches a message containing the distinctive fragment", () => {
+		expect(
+			isStaleContextError(
+				new Error(`Extension error (...): ${STALE_MESSAGE} (extra)`),
+			),
+		).toBe(true);
+	});
+
+	it("follows the cause chain", () => {
+		expect(
+			isStaleContextError(
+				new Error("wrapper", { cause: new Error(STALE_MESSAGE) }),
+			),
+		).toBe(true);
+	});
+
+	it("rejects unrelated errors", () => {
+		expect(isStaleContextError(new Error("No API key for kilo/x"))).toBe(false);
+		expect(isStaleContextError(new Error("stale cache entry"))).toBe(false);
+	});
+
+	it("rejects non-Error values", () => {
+		expect(isStaleContextError(undefined)).toBe(false);
+		expect(isStaleContextError(null)).toBe(false);
+		expect(isStaleContextError("stale after session replacement")).toBe(false);
+		expect(isStaleContextError({ message: STALE_MESSAGE })).toBe(false);
+	});
+});
+
+describe("safeNotify", () => {
+	it("passes through to ctx.ui.notify", () => {
+		const notify = vi.fn();
+		safeNotify({ ui: { notify, setStatus: vi.fn() } }, "hi", "info");
+		expect(notify).toHaveBeenCalledWith("hi", "info");
+	});
+
+	it("swallows a stale-context throw (lazy ctx getter, like Pi's)", () => {
+		const notify = vi.fn();
+		const staleCtx = {
+			get ui(): { notify: typeof notify; setStatus: () => void } {
+				throw new Error(STALE_MESSAGE);
+			},
+		};
+		expect(() => safeNotify(staleCtx, "hi", "warning")).not.toThrow();
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("rethrows non-stale errors", () => {
+		const boom = new Error("ui exploded");
+		const ctx = {
+			ui: {
+				notify: () => {
+					throw boom;
+				},
+				setStatus: vi.fn(),
+			},
+		};
+		expect(() => safeNotify(ctx, "hi")).toThrow(boom);
+	});
+});
+
+describe("safeSetStatus", () => {
+	it("passes through to ctx.ui.setStatus", () => {
+		const setStatus = vi.fn();
+		safeSetStatus({ ui: { notify: vi.fn(), setStatus } }, "fallback", "x");
+		expect(setStatus).toHaveBeenCalledWith("fallback", "x");
+	});
+
+	it("swallows a stale-context throw", () => {
+		const setStatus = vi.fn();
+		const staleCtx = {
+			get ui(): { notify: () => void; setStatus: typeof setStatus } {
+				throw new Error(STALE_MESSAGE);
+			},
+		};
+		expect(() => safeSetStatus(staleCtx, "fallback", "x")).not.toThrow();
+		expect(setStatus).not.toHaveBeenCalled();
+	});
+
+	it("rethrows non-stale errors", () => {
+		const boom = new Error("status exploded");
+		const ctx = {
+			ui: {
+				notify: vi.fn(),
+				setStatus: () => {
+					throw boom;
+				},
+			},
+		};
+		expect(() => safeSetStatus(ctx, "fallback", "x")).toThrow(boom);
+	});
+});


### PR DESCRIPTION
Follow-up to #393 (fixed for the toggle-opencode path by #394). On pi-free 2.7.0 + pi 0.85.1 the same stale-ctx guard still fires on two other paths.

## What was happening

Pi invalidates an extension runner's `ExtensionAPI` (`pi`) and every `ExtensionContext` (`ctx`) it handed out as soon as the session is replaced or reloaded. From that moment any `pi.*` call or lazy `ctx.*` getter access throws `This extension ctx is stale after session replacement or reload…`.

1. **Auto-fallback auto-continue surfaced `Extension error` to the user.** The `agent_settled` handler touches `ctx.ui` / `ctx.modelRegistry` and the notifier (fed by a possibly-stale `lastSeenCtx`) *after* awaits (candidate auth checks, `pi.setModel`). Any interleaved session change threw out of the handler, which Pi surfaces as an Extension error for the current turn — even though the switch itself succeeded.
2. **Detached built-in-toggle capture failed at session start.** `entry.task` awaits credential resolution/network; a mid-flight session change rejected it, and `trackDetachedSessionStart` logged `built-in-toggle-capture-opencode-free detached failed … stale`.

## Fix

New shared guard (`lib/stale-ctx.ts`): `isStaleContextError()`, `safeNotify()`, `safeSetStatus()`. Rule: snapshot what you need from `ctx` synchronously at handler entry; treat a stale-context throw after an `await` as “session moved on” — log at debug/info and stop work for the dead session instead of throwing. Non-stale errors still propagate unchanged.

- `lib/auto-fallback/notify.ts` — all notifies/status updates stale-safe.
- `lib/auto-fallback/index.ts` — post-await notifies via `safeNotify`; stale-aware `setModel`/`sendUserMessage` logging; `agent_settled` body extracted to `handleAgentSettled()` behind a stale guard.
- `lib/built-in-toggle.ts` — detached capture catches stale → info + resolves (a live session's `session_start` starts a fresh capture); restore/refresh downgrade stale to info; toggle command extracted to `runToggleCommand()` with the same guard.

## Verification

- New `tests/stale-ctx.test.ts` (12 unit tests), `tests/built-in-toggle-stale.test.ts` (3 tests incl. a session-start-metrics spy observing detached-task outcomes), +2 integration tests in `tests/auto-fallback.integration.test.ts`.
- 4 of the 5 new behavioral tests **fail on pre-fix code** with the exact stale error, pass post-fix.
- Full suite: 76 files, 823 tests pass; `tsc --noEmit` clean.

Fixes #509.