### PR TITLE
ci: detect sick install trees that load but crash on first pi-ai use (#510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,11 @@ jobs:
       - name: Run tests
         run: npm run test:run
 
+      # Drives createAutoFallback() against a REAL pi-coding-agent
+      # ModelRuntime (auth gates, setModel semantics) instead of mocks.
+      - name: Smoke auto-fallback status surface
+        run: npm run smoke:auto-fallback
+
   install-test:
     name: Install test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -186,3 +191,20 @@ jobs:
           echo "Loading compiled entry: $INSTALL_DIR/$ENTRY"
           node scripts/smoke-compiled.mjs "$INSTALL_DIR/$ENTRY"
           node scripts/smoke-pi-loader.mjs "$INSTALL_DIR/$ENTRY"
+
+      # #510: pi-ai was present but its own transitive dep (typebox) was
+      # unresolvable in the installed tree — a layout every load-only smoke
+      # above passes, while first real pi-ai use crashes. These two steps
+      # close that hole: the closure check proves the deps resolve, the
+      # entries smoke proves they execute. Both run on every matrix OS.
+      - name: Verify pi-ai transitive closure in installed tree (#510)
+        shell: bash
+        run: |
+          INSTALL_DIR=$(npm root -g)/pi-free
+          node scripts/check-installed-closure.mjs "$INSTALL_DIR"
+
+      - name: Execute pi-ai entries from installed tree (#510)
+        shell: bash
+        run: |
+          INSTALL_DIR=$(npm root -g)/pi-free
+          node scripts/smoke-pi-ai-entries.mjs "$INSTALL_DIR"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"check:runtime-imports": "node scripts/check-runtime-imports.mjs",
 		"check:tarball": "node scripts/check-tarball.mjs",
 		"check:prod-install-shape": "node scripts/check-prod-install-shape.mjs",
+		"check:closure": "node scripts/check-installed-closure.mjs",
 		"lint": "tsc --noEmit",
 		"prepare": "npm run build",
 		"test": "vitest",
@@ -59,6 +60,7 @@
 		"bench:startup": "tsx scripts/bench-startup.ts",
 		"smoke:compiled": "node scripts/smoke-compiled.mjs",
 		"smoke:pi-loader": "node scripts/smoke-pi-loader.mjs",
+		"smoke:pi-ai-entries": "node scripts/smoke-pi-ai-entries.mjs",
 		"smoke:pi-install": "node scripts/pi-install-smoke.mjs"
 	},
 	"overrides": {

--- a/scripts/check-installed-closure.mjs
+++ b/scripts/check-installed-closure.mjs
@@ -189,7 +189,9 @@ function hasImportableEntry(depRoot) {
 }
 
 if (missing.length > 0) {
-	console.error(
+	// NOSONAR (jssecurity:S8689) -- false positive, see justification at the
+	// per-dependency log below: public package metadata for the operator only.
+	console.error( // NOSONAR
 		`[install-closure] FAIL: pi-ai@${piAiPkg.version ?? "?"} at ${redactHome(piAiRoot)} has ${missing.length} unresolvable runtime dependenc(ies):`,
 	);
 	for (const { name, want, error } of missing) {
@@ -209,6 +211,8 @@ if (missing.length > 0) {
 }
 
 const count = Object.keys(runtimeDeps).length;
-console.log(
+// NOSONAR (jssecurity:S8689) -- false positive: version string, dep count,
+// and home-redacted path, printed for the operator only (see above).
+console.log( // NOSONAR
 	`[install-closure] PASS: pi-ai@${piAiPkg.version ?? "?"} + ${count} runtime dep(s) resolve from ${redactHome(piAiRoot)}`,
 );

--- a/scripts/check-installed-closure.mjs
+++ b/scripts/check-installed-closure.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Verify pi-ai's runtime dependency closure resolves from an installed tree.
+ *
+ * Regression detector for #510: pi-ai was physically present in
+ * `~/.pi/agent/npm/node_modules`, but its own internal `typebox` import
+ * failed there — a sick install tree that every load-only smoke check
+ * (bare entry import, extension-loader load, RPC `get_commands`) passes,
+ * because the crash only fires when pi-ai's real entry executes.
+ *
+ * This check mirrors what Node sees when pi-ai's own files import their
+ * bare-specifier dependencies: for each of pi-ai's runtime `dependencies`
+ * it resolves the package from pi-ai's location (Node's walk-up), failing
+ * loudly on the first unresolvable one. OS-agnostic by construction —
+ * `createRequire` + `path.join`, no shell, no platform probes.
+ *
+ * Usage:
+ *   node scripts/check-installed-closure.mjs [pi-free-package-dir]
+ *     (default: the current directory — the repo root after `npm run build`)
+ *
+ * In CI's install-test job the argument is the global install dir, so the
+ * check runs against the exact tree `pi install` produced, on every matrix
+ * OS. It also doubles as a user-facing diagnostic: point it at any suspect
+ * pi-free install and it names the missing package.
+ */
+import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const packageDir = resolve(process.argv[2] ?? ".");
+
+const entry = join(packageDir, "dist", "index.js");
+if (!existsSync(entry)) {
+	console.error(
+		`[install-closure] FAIL: compiled entry not found: ${entry} — run npm run build first.`,
+	);
+	process.exit(1);
+}
+
+/**
+ * Mimics Node's package lookup: walks up from `startDir`, checking
+ * `<dir>/node_modules/<...segments>` at each level. path.join keeps this
+ * correct on POSIX and Windows without any platform branch.
+ */
+function findPackageUp(startDir, segments) {
+	let dir = startDir;
+	for (;;) {
+		const candidate = join(dir, "node_modules", ...segments);
+		if (existsSync(join(candidate, "package.json"))) return candidate;
+		const parent = dirname(dir);
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+}
+
+const piAiRoot = findPackageUp(join(packageDir, "dist"), [
+	"@earendil-works",
+	"pi-ai",
+]);
+if (!piAiRoot) {
+	console.error(
+		"[install-closure] FAIL: @earendil-works/pi-ai is not resolvable from the installed tree " +
+			`(${entry}). A missing pi-ai breaks every provider stream.`,
+	);
+	process.exit(1);
+}
+
+let piAiPkg;
+try {
+	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8"));
+} catch (error) {
+	console.error(
+		`[install-closure] FAIL: cannot read pi-ai package.json in ${piAiRoot}: ${error.message}`,
+	);
+	process.exit(1);
+}
+
+// Runtime dependencies only: peer/dev/optional deps are the host's business,
+// but `dependencies` must resolve from pi-ai's own location or its internal
+// bare imports (typebox, openai, …) crash at first use — the #510 shape.
+//
+// Resolved with createRequire bound to pi-ai's package.json: real Node
+// walk-up semantics from pi-ai's location (unlike import.meta.resolve,
+// whose parent argument is ignored on some Node builds, silently scoping
+// the check to the script's own tree instead). createRequire alone
+// false-positives on import-only packages such as
+// @earendil-works/pi-telemetry (exports map with an `import` condition but
+// no CJS main), so a require failure falls through to a physical
+// present-and-ESM-importable check before the dep is reported missing.
+const runtimeDeps = piAiPkg.dependencies ?? {};
+const requireFromPiAi = createRequire(
+	pathToFileURL(join(piAiRoot, "package.json")).href,
+);
+const missing = [];
+for (const name of Object.keys(runtimeDeps)) {
+	try {
+		requireFromPiAi.resolve(name);
+	} catch (requireError) {
+		// Possibly import-only (see above) — verify physically before crying
+		// wolf. Anything genuinely absent from the walk-up stays missing.
+		const depRoot = findPackageUp(piAiRoot, name.split("/"));
+		if (depRoot && hasImportableEntry(depRoot)) continue;
+		missing.push({
+			name,
+			want: runtimeDeps[name],
+			error: requireError.message,
+		});
+	}
+}
+
+/**
+ * True when the package at `depRoot` offers an ESM-importable `.` entry:
+ * a string export, an `import`/`default` condition (shallow-nested maps
+ * included), or — with no exports map at all — a legacy main/index.js.
+ * Covers import-only packages whose require() fails while import() works.
+ */
+function hasImportableEntry(depRoot) {
+	let pkg;
+	try {
+		pkg = JSON.parse(readFileSync(join(depRoot, "package.json"), "utf8"));
+	} catch {
+		return false;
+	}
+	const exportsField = pkg.exports;
+	if (exportsField === undefined) {
+		return typeof pkg.main === "string" || existsSync(join(depRoot, "index.js"));
+	}
+	const rootEntry =
+		typeof exportsField === "string" ? exportsField : exportsField["."];
+	if (typeof rootEntry === "string") return true;
+	if (rootEntry && typeof rootEntry === "object") {
+		if (
+			typeof rootEntry.import === "string" ||
+			typeof rootEntry.default === "string"
+		) {
+			return true;
+		}
+		for (const value of Object.values(rootEntry)) {
+			if (typeof value === "string") return true;
+			if (
+				value &&
+				typeof value === "object" &&
+				(typeof value.import === "string" || typeof value.default === "string")
+			) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+if (missing.length > 0) {
+	console.error(
+		`[install-closure] FAIL: pi-ai@${piAiPkg.version ?? "?"} at ${piAiRoot} has ${missing.length} unresolvable runtime dependenc(ies):`,
+	);
+	for (const { name, want, error } of missing) {
+		console.error(`  - ${name}@${want}: ${error.split("\n")[0]}`);
+	}
+	console.error(
+		"[install-closure] The extension loads but crashes on first pi-ai use (#510). " +
+			"Reinstall the host tree (fresh `pi install`) so npm repairs the subtree.",
+	);
+	process.exit(1);
+}
+
+const count = Object.keys(runtimeDeps).length;
+console.log(
+	`[install-closure] PASS: pi-ai@${piAiPkg.version ?? "?"} + ${count} runtime dep(s) resolve from ${piAiRoot}`,
+);

--- a/scripts/check-installed-closure.mjs
+++ b/scripts/check-installed-closure.mjs
@@ -24,11 +24,41 @@
  * pi-free install and it names the missing package.
  */
 import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const packageDir = resolve(process.argv[2] ?? ".");
+
+/**
+ * Strip the user's home directory from logged paths (they carry the login
+ * name, and this output is routinely pasted into public issue reports).
+ * Best-effort exact-prefix match — anything else passes through untouched.
+ */
+function redactHome(text) {
+	const home = homedir();
+	if (typeof text !== "string" || !home || !text.startsWith(home)) {
+		return text;
+	}
+	return `~${text.slice(home.length)}`;
+}
+
+// Validate the CLI-supplied directory before touching the filesystem
+// beneath it (jssecurity:S8707): resolve() alone canonicalizes but does
+// not establish that the caller gave us a package directory at all.
+let packageStat;
+try {
+	packageStat = statSync(packageDir);
+} catch {
+	packageStat = undefined;
+}
+if (!packageStat?.isDirectory()) {
+	console.error(
+		`[install-closure] FAIL: not a package directory: ${redactHome(packageDir)}`,
+	);
+	process.exit(1);
+}
 
 const entry = join(packageDir, "dist", "index.js");
 if (!existsSync(entry)) {
@@ -61,7 +91,7 @@ const piAiRoot = findPackageUp(join(packageDir, "dist"), [
 if (!piAiRoot) {
 	console.error(
 		"[install-closure] FAIL: @earendil-works/pi-ai is not resolvable from the installed tree " +
-			`(${entry}). A missing pi-ai breaks every provider stream.`,
+			`(${redactHome(entry)}). A missing pi-ai breaks every provider stream.`,
 	);
 	process.exit(1);
 }
@@ -71,7 +101,7 @@ try {
 	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8"));
 } catch (error) {
 	console.error(
-		`[install-closure] FAIL: cannot read pi-ai package.json in ${piAiRoot}: ${error.message}`,
+		`[install-closure] FAIL: cannot read pi-ai package.json in ${redactHome(piAiRoot)}: ${redactHome(error.message)}`,
 	);
 	process.exit(1);
 }
@@ -110,10 +140,24 @@ for (const name of Object.keys(runtimeDeps)) {
 }
 
 /**
- * True when the package at `depRoot` offers an ESM-importable `.` entry:
- * a string export, an `import`/`default` condition (shallow-nested maps
- * included), or — with no exports map at all — a legacy main/index.js.
- * Covers import-only packages whose require() fails while import() works.
+ * True for an exports target Node can ESM-import: a plain path string or
+ * a conditions object offering an `import`/`default` entry.
+ */
+function hasImportCondition(target) {
+	if (typeof target === "string") return true;
+	return (
+		!!target &&
+		typeof target === "object" &&
+		(typeof target.import === "string" ||
+			typeof target.default === "string")
+	);
+}
+
+/**
+ * True when the package at `depRoot` offers an ESM-importable `.` entry
+ * (shallow-nested condition maps included), or — with no exports map at
+ * all — a legacy main/index.js. Covers import-only packages whose
+ * require() fails while import() works.
  */
 function hasImportableEntry(depRoot) {
 	let pkg;
@@ -128,34 +172,21 @@ function hasImportableEntry(depRoot) {
 	}
 	const rootEntry =
 		typeof exportsField === "string" ? exportsField : exportsField["."];
-	if (typeof rootEntry === "string") return true;
+	if (hasImportCondition(rootEntry)) return true;
 	if (rootEntry && typeof rootEntry === "object") {
-		if (
-			typeof rootEntry.import === "string" ||
-			typeof rootEntry.default === "string"
-		) {
-			return true;
-		}
-		for (const value of Object.values(rootEntry)) {
-			if (typeof value === "string") return true;
-			if (
-				value &&
-				typeof value === "object" &&
-				(typeof value.import === "string" || typeof value.default === "string")
-			) {
-				return true;
-			}
-		}
+		return Object.values(rootEntry).some(hasImportCondition);
 	}
 	return false;
 }
 
 if (missing.length > 0) {
 	console.error(
-		`[install-closure] FAIL: pi-ai@${piAiPkg.version ?? "?"} at ${piAiRoot} has ${missing.length} unresolvable runtime dependenc(ies):`,
+		`[install-closure] FAIL: pi-ai@${piAiPkg.version ?? "?"} at ${redactHome(piAiRoot)} has ${missing.length} unresolvable runtime dependenc(ies):`,
 	);
 	for (const { name, want, error } of missing) {
-		console.error(`  - ${name}@${want}: ${error.split("\n")[0]}`);
+		console.error(
+			`  - ${name}@${redactHome(want)}: ${redactHome(error.split("\n")[0])}`,
+		);
 	}
 	console.error(
 		"[install-closure] The extension loads but crashes on first pi-ai use (#510). " +
@@ -166,5 +197,5 @@ if (missing.length > 0) {
 
 const count = Object.keys(runtimeDeps).length;
 console.log(
-	`[install-closure] PASS: pi-ai@${piAiPkg.version ?? "?"} + ${count} runtime dep(s) resolve from ${piAiRoot}`,
+	`[install-closure] PASS: pi-ai@${piAiPkg.version ?? "?"} + ${count} runtime dep(s) resolve from ${redactHome(piAiRoot)}`,
 );

--- a/scripts/check-installed-closure.mjs
+++ b/scripts/check-installed-closure.mjs
@@ -45,11 +45,18 @@ function redactHome(text) {
 }
 
 // Validate the CLI-supplied directory before touching the filesystem
-// beneath it (jssecurity:S8707): resolve() alone canonicalizes but does
-// not establish that the caller gave us a package directory at all.
+// beneath it: resolve() alone canonicalizes but does not establish that
+// the caller gave us a package directory at all.
+// NOSONAR justification (jssecurity:S8707 on the statSync below): this is
+// a local read-only diagnostic — the operator points it at a tree and it
+// reads that tree's package.json files, which the operator could `cat`
+// themselves. No writes, no exec, no network, no privilege boundary, and
+// output goes to the operator's own terminal, so path traversal here
+// cannot reach anything unauthorized. The isDirectory gate below is the
+// meaningful validation (typos fail fast with a clear message).
 let packageStat;
 try {
-	packageStat = statSync(packageDir);
+	packageStat = statSync(packageDir); // NOSONAR -- see justification above
 } catch {
 	packageStat = undefined;
 }
@@ -98,7 +105,9 @@ if (!piAiRoot) {
 
 let piAiPkg;
 try {
-	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8"));
+	// NOSONAR (jssecurity:S8707) -- same justification as above: read-only
+	// diagnostic over an operator-supplied tree, no privilege boundary.
+	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8")); // NOSONAR
 } catch (error) {
 	console.error(
 		`[install-closure] FAIL: cannot read pi-ai package.json in ${redactHome(piAiRoot)}: ${redactHome(error.message)}`,
@@ -184,7 +193,11 @@ if (missing.length > 0) {
 		`[install-closure] FAIL: pi-ai@${piAiPkg.version ?? "?"} at ${redactHome(piAiRoot)} has ${missing.length} unresolvable runtime dependenc(ies):`,
 	);
 	for (const { name, want, error } of missing) {
-		console.error(
+		// NOSONAR (jssecurity:S8689) -- false positive: the logged values are
+		// public npm metadata (dependency name + version range) plus a
+		// home-redacted resolution error, printed for the operator only.
+		// No credentials, tokens, or file contents ever reach the logs.
+		console.error( // NOSONAR
 			`  - ${name}@${redactHome(want)}: ${redactHome(error.split("\n")[0])}`,
 		);
 	}

--- a/scripts/smoke-pi-ai-entries.mjs
+++ b/scripts/smoke-pi-ai-entries.mjs
@@ -16,11 +16,24 @@
  *   node scripts/smoke-pi-ai-entries.mjs [pi-free-package-dir]
  *     (default: the current directory — the repo root after `npm run build`)
  */
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const packageDir = resolve(process.argv[2] ?? ".");
+
+// Validate the CLI-supplied directory before touching the filesystem
+// beneath it (same shape as check-installed-closure.mjs).
+let packageStat;
+try {
+	packageStat = statSync(packageDir);
+} catch {
+	packageStat = undefined;
+}
+if (!packageStat?.isDirectory()) {
+	console.error(`[pi-ai-entries] FAIL: not a package directory: ${packageDir}`);
+	process.exit(1);
+}
 const loaderFile = join(packageDir, "dist", "lib", "pi-ai-loader.js");
 if (!existsSync(loaderFile)) {
 	console.error(

--- a/scripts/smoke-pi-ai-entries.mjs
+++ b/scripts/smoke-pi-ai-entries.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Execute pi-ai's real entry points from an installed tree.
+ *
+ * Companion to check-installed-closure.mjs for #510: the closure check
+ * proves pi-ai's transitive imports *resolve*; this smoke proves the
+ * entries actually *execute* end to end (a corrupt file or an
+ * export-shape drift would pass resolution and fail here).
+ *
+ * It loads through the installed package's own `loadPiAiEntry` (the same
+ * code path production streams use), so on a healthy tree it exercises the
+ * fast path, and on a sick-but-resilient tree it exercises whatever
+ * fallback the loader selects. No network, no model calls, no user files.
+ *
+ * Usage:
+ *   node scripts/smoke-pi-ai-entries.mjs [pi-free-package-dir]
+ *     (default: the current directory — the repo root after `npm run build`)
+ */
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const packageDir = resolve(process.argv[2] ?? ".");
+const loaderFile = join(packageDir, "dist", "lib", "pi-ai-loader.js");
+if (!existsSync(loaderFile)) {
+	console.error(
+		`[pi-ai-entries] FAIL: loader not found: ${loaderFile} — run npm run build first.`,
+	);
+	process.exit(1);
+}
+
+const { loadPiAiEntry } = await import(pathToFileURL(loaderFile).href);
+if (typeof loadPiAiEntry !== "function") {
+	console.error(
+		"[pi-ai-entries] FAIL: installed loader does not export loadPiAiEntry.",
+	);
+	process.exit(1);
+}
+
+function assertExports(entry, module, names) {
+	const missing = names.filter((name) => module?.[name] === undefined);
+	if (missing.length > 0) {
+		console.error(
+			`[pi-ai-entries] FAIL: "${entry}" loaded but missing export(s): ${missing.join(", ")}`,
+		);
+		process.exit(1);
+	}
+	console.log(`[pi-ai-entries] ok: "${entry}" (${names.join(", ")})`);
+}
+
+// The compat surface production streams consume (see lib/lazy-compat.ts and
+// the vendored bundle's export list in scripts/build.mjs).
+const compat = await loadPiAiEntry("compat");
+assertExports("compat", compat, [
+	"openAICompletionsApi",
+	"anthropicMessagesApi",
+	"openAIResponsesApi",
+	"googleGenerativeAIApi",
+]);
+
+// The catalog surface model-metadata consumes.
+const providersAll = await loadPiAiEntry("providers/all");
+assertExports("providers/all", providersAll, ["getBuiltinProviders"]);
+
+console.log(
+	"[pi-ai-entries] PASS: pi-ai entries execute from the installed tree",
+);

--- a/scripts/smoke-pi-ai-entries.mjs
+++ b/scripts/smoke-pi-ai-entries.mjs
@@ -24,9 +24,12 @@ const packageDir = resolve(process.argv[2] ?? ".");
 
 // Validate the CLI-supplied directory before touching the filesystem
 // beneath it (same shape as check-installed-closure.mjs).
+// NOSONAR (jssecurity:S8707): local read-only smoke test over an
+// operator-supplied tree — no writes, no exec, no network, no privilege
+// boundary; output goes to the operator's own terminal.
 let packageStat;
 try {
-	packageStat = statSync(packageDir);
+	packageStat = statSync(packageDir); // NOSONAR -- see justification above
 } catch {
 	packageStat = undefined;
 }

--- a/tests/install-closure.test.ts
+++ b/tests/install-closure.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression tests for scripts/check-installed-closure.mjs (#510).
+ *
+ * The script itself is the assertion engine (exit 0/1 + stderr); these tests
+ * drive it against fixture trees via spawnSync — no symlinks, no network, no
+ * platform branches, so they run identically on every CI matrix OS:
+ *
+ *   - healthy repo tree      → exit 0 (real pi-ai + real transitive deps)
+ *   - #510 shape             → exit 1 naming `typebox` (pi-ai present, dep
+ *                              missing — the layout every load-only smoke
+ *                              check passes while first real use crashes)
+ *   - pi-ai absent entirely  → exit 1 naming pi-ai
+ *   - no compiled entry      → exit 1 (misuse, e.g. unbuilt source checkout)
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = join(process.cwd(), "scripts", "check-installed-closure.mjs");
+
+function runClosure(dir: string) {
+	return spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+}
+
+function makeTree(layout: {
+	piAi?: { version: string; dependencies: Record<string, string> };
+	entry?: boolean;
+}): string {
+	const base = mkdtempSync(join(tmpdir(), "pi-free-closure-"));
+	const app = join(base, "app");
+	if (layout.entry === false) {
+		mkdirSync(app, { recursive: true });
+	} else {
+		mkdirSync(join(app, "dist"), { recursive: true });
+		writeFileSync(join(app, "dist", "index.js"), "export {};\n");
+	}
+	if (layout.piAi) {
+		const piAiDir = join(app, "node_modules", "@earendil-works", "pi-ai");
+		mkdirSync(join(piAiDir, "dist"), { recursive: true });
+		writeFileSync(
+			join(piAiDir, "package.json"),
+			JSON.stringify({
+				name: "@earendil-works/pi-ai",
+				version: layout.piAi.version,
+				dependencies: layout.piAi.dependencies,
+			}),
+		);
+		writeFileSync(join(piAiDir, "dist", "index.js"), "export {};\n");
+	}
+	return app;
+}
+
+const tempDirs: string[] = [];
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+function track(app: string): string {
+	// Fixture root is <tmp>/pi-free-closure-*/app — remove the whole sandbox.
+	tempDirs.push(join(app, ".."));
+	return app;
+}
+
+describe("check-installed-closure (#510)", () => {
+	it("passes on the healthy repo tree", () => {
+		const result = runClosure(process.cwd());
+		expect(result.status).toBe(0);
+		expect(result.stdout).toMatch(/\[install-closure\] PASS/);
+	});
+
+	it("fails naming typebox for the #510 shape (pi-ai without its dep)", () => {
+		const app = track(
+			makeTree({
+				piAi: { version: "0.84.4", dependencies: { typebox: "1.3.7" } },
+			}),
+		);
+		const result = runClosure(app);
+		expect(result.status).toBe(1);
+		expect(result.stderr).toMatch(/typebox/);
+	});
+
+	it("fails naming pi-ai when pi-ai is absent", () => {
+		const app = track(makeTree({}));
+		const result = runClosure(app);
+		expect(result.status).toBe(1);
+		expect(result.stderr).toMatch(/@earendil-works\/pi-ai/);
+	});
+
+	it("fails without a compiled entry", () => {
+		const app = track(
+			makeTree({
+				entry: false,
+				piAi: { version: "0.84.4", dependencies: {} },
+			}),
+		);
+		const result = runClosure(app);
+		expect(result.status).toBe(1);
+		expect(result.stderr).toMatch(/compiled entry not found/);
+	});
+});


### PR DESCRIPTION
## Why CI missed #510

The `typebox` crash escaped every existing gate for two structural reasons:

1. **The crash is lazy; all smoke checks are load-only.** The failing import (`pi-ai/dist` → `typebox`) executes only when `loadPiAiEntry("compat")` runs — a dynamic import fired on first provider-stream setup. But `smoke-compiled` is a bare entry import, `smoke-pi-loader` loads with no session/events, and `rpc-load-check` boots RPC `--no-session` and calls `get_commands` ("never calls a model"). None executes the compat path.
2. **CI tests a healthy tree; the reporter had a sick one.** `pi install` in a pristine isolated HOME always lays out a perfect tree. No job asserts the transitive closure resolves *from pi-ai's location*, and none covers upgrades over a long-lived agent dir.

(Also noted while investigating: there is no publint anywhere in the repo — and even if there were, it lints our own `exports`/`files`, not transitive resolution inside a foreign tree. `check-tarball` only asserts file presence.)

## What this adds (all OS-agnostic — no platform branches)

- `scripts/check-installed-closure.mjs` (`npm run check:closure`) — resolves each of pi-ai's runtime deps from pi-ai's location via `createRequire` scoping, plus a physical present-and-ESM-importable fallback so import-only packages (e.g. `@earendil-works/pi-telemetry`, exports `import` but no CJS main) don't false-positive. FAILs naming the missing package on the #510 shape. Doubles as a user-facing diagnostic.
- `scripts/smoke-pi-ai-entries.mjs` (`npm run smoke:pi-ai-entries`) — executes `compat` + `providers/all` through the installed loader, asserting key exports (resolution passing but execution failing is a distinct failure mode).
- `tests/install-closure.test.ts` — fixture trees (healthy / #510-shape / pi-ai-absent / unbuilt), spawnSync-driven, no symlinks/network, identical on every matrix OS.
- `ci.yml`: both scripts run in `install-test` against the real `pi install`ed tree on ubuntu+windows+macos; previously CI-invisible `smoke:auto-fallback` (real ModelRuntime) wired into the `test` job.

## Verification

- Closure: healthy tree PASS (10 deps); fabricated pi-ai-without-typebox FAIL naming `typebox` exit 1; no-pi-ai FAIL exit 1.
- End-to-end: `npm pack` → prefix-install → both scripts PASS (pulled pi-ai@0.85.1, same line as the reporter).
- Full suite: 77 files / 827 pass; `tsc` clean.

Related to #510 (detection + user diagnostic; the loader fallback for broken trees is separate product work).