### PR TITLE
fix(refresh): scoped nudge with retry + static llm7 seed; rpc session/filter e2e (#510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,21 @@ jobs:
       - name: Smoke-load compiled entry through Pi's real loader
         run: node scripts/smoke-pi-loader.mjs ./dist/index.js
 
+      # Same sick-tree detectors as install-test, run here against the
+      # --omit=dev tree so shape regressions surface one job earlier.
+      - name: Verify pi-ai transitive closure in production tree
+        run: node scripts/check-installed-closure.mjs .
+
+      - name: Execute pi-ai entries from production tree
+        run: node scripts/smoke-pi-ai-entries.mjs .
+
   test:
-    name: Unit tests
-    runs-on: ubuntu-latest
+    name: Unit tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -169,6 +181,14 @@ jobs:
         run: |
           TARBALL=$(ls pi-free-*.tgz)
           npm run smoke:pi-install -- "$PWD/$TARBALL"
+
+      # Upgrade over the latest published release (seeds a realistic
+      # long-lived tree), then re-verify load + session + filter checks.
+      - name: Upgrade published release through Pi and re-verify
+        shell: bash
+        run: |
+          TARBALL=$(ls pi-free-*.tgz)
+          npm run smoke:pi-upgrade -- "$PWD/$TARBALL"
 
       - name: Verify published relative imports resolve
         shell: bash

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -14,10 +14,12 @@ import type {
 } from "@earendil-works/pi-ai/compat";
 import type {
 	ExtensionAPI,
+	ExtensionContext,
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { applyHidden, setModelViewOverride } from "../config.ts";
 import { createLogger } from "./logger.ts";
+import { isStaleContextError } from "./stale-ctx.ts";
 import {
 	isFreeModel,
 	registerWithGlobalToggle,
@@ -500,13 +502,41 @@ export function registerNativeProviderToggle(
 	});
 }
 
+/** Delay before retrying a superseded refresh; captures (~1s) and endpoint
+ * refresh re-registrations (~2s) have settled by then. */
+const NUDGE_RETRY_DELAY_MS = 5000;
+
 /**
- * Nudge Pi's native model refresh once per extension session.
+ * Provider ids that asked for the session-start refresh nudge. The nudge
+ * refreshes exactly these (never the whole registry): tiers Pi owns
+ * outright (opencode-free/go, openrouter) never register here, so their
+ * credential failures (e.g. a missing OPENCODE_API_KEY) cannot fail a
+ * refresh that is none of their business. A Set (not the global
+ * registry) keeps the scope on providers that opted in, with no coupling
+ * to registration order.
+ */
+const nudgeProviderIds = new Set<string>();
+
+/**
+ * Nudge Pi's model refresh once per extension session, scoped to the
+ * opted-in providers.
  *
- * Pi 0.84 supersedes an in-flight refresh for each provider when a newer
- * refresh starts. Registering this handler once per provider while calling a
- * global refresh caused every handler to abort the previous providers' fetches
- * in a tight loop on session resume.
+ * Two hard-won constraints shape this:
+ *
+ * - Pi supersedes an in-flight refresh per provider when a newer refresh
+ *   begins — and every registerProvider/unregister fires a global offline
+ *   refresh. pi-free's own session-start captures re-register providers
+ *   ~40ms after this nudge fires, so an unscoped, unretried network
+ *   refresh is deterministically aborted before slow fetches land (empty
+ *   catalog on fresh installs). The nudge therefore retries once when
+ *   aborted, after the re-registration storm has settled.
+ * - Pi reports per-provider errors for the WHOLE registry, including
+ *   tiers pi-free does not refresh (missing OPENCODE_API_KEY). Only
+ *   errors for the scoped ids fail this nudge; anything else is noise.
+ *
+ * Registering this handler once per provider while calling a global
+ * refresh caused every handler to abort the previous providers' fetches
+ * in a tight loop on session resume (kept: the WeakSet guard below).
  */
 const nativeRefreshRegistrations = new WeakSet<object>();
 
@@ -516,46 +546,93 @@ export function registerNativeProviderRefresh(
 ): void {
 	if (nativeRefreshRegistrations.has(pi as object)) return;
 	nativeRefreshRegistrations.add(pi as object);
+	nudgeProviderIds.add(providerId);
 
 	pi.on(
 		"session_start",
-		// Stable label: this is a single global nudge registered once per runner
-		// (WeakSet guard above), not a per-provider handler — labeling it with
-		// whichever provider happened to register first was misleading in logs.
 		wrapSessionStartHandler("native-model-refresh", (_event, ctx) => {
-			try {
-				const registry = (
-					ctx as {
-						modelRegistry?: { refresh?: (opts?: unknown) => unknown };
-					}
-				).modelRegistry;
-				const result = registry?.refresh?.({ allowNetwork: true });
-				if (result && typeof (result as PromiseLike<unknown>).then === "function") {
-					const refreshTask = Promise.resolve(result).then((value) => {
-						const errors = (value as { errors?: { size?: number } } | undefined)
-							?.errors;
-						if (errors?.size && errors.size > 0) {
-							throw new Error(
-								`Pi model refresh reported ${errors.size} provider error(s)`,
-							);
-						}
-					});
-					trackDetachedSessionStart(
-						`${providerId}-model-refresh`,
-						refreshTask,
-						(err) => logRefreshFailure(providerId, err),
-					);
-				}
-			} catch (err) {
-				logRefreshFailure(providerId, err);
-			}
+			void runRefreshNudge(ctx, false);
 			return Promise.resolve();
 		}),
 	);
 }
 
-function logRefreshFailure(providerId: string, error: unknown): void {
-	_logger.warn(`Model refresh nudge failed for ${providerId}`, {
+async function runRefreshNudge(
+	ctx: ExtensionContext,
+	isRetry: boolean,
+): Promise<void> {
+	// No casts: ctx.modelRegistry is pi's typed ModelRegistry, whose
+	// refresh() takes ModelsRefreshOptions and returns ModelsRefreshResult
+	// ({aborted, errors: ReadonlyMap<string, Error>}).
+	try {
+		if (nudgeProviderIds.size === 0) {
+			_logger.debug(
+				"[native-model-refresh] no providers opted in; skipping nudge",
+			);
+			return;
+		}
+		const scopedIds = [...nudgeProviderIds];
+		const result = await ctx.modelRegistry?.refresh?.({
+			allowNetwork: true,
+			providers: scopedIds,
+		});
+		if (!result) {
+			_logger.debug(
+				"[native-model-refresh] registry refresh unavailable; skipping nudge",
+			);
+			return;
+		}
+		const ownErrors = [...result.errors].filter(([id]) =>
+			nudgeProviderIds.has(id),
+		);
+		if (ownErrors.length > 0) {
+			throw new Error(
+				`Pi model refresh reported ${ownErrors.length} pi-free provider error(s): ` +
+					ownErrors.map(([id, error]) => `${id} :: ${error.message}`).join(" | "),
+			);
+		}
+		if (result.aborted && !isRetry) {
+			_logger.info(
+				"[native-model-refresh] refresh superseded; retrying once after settle",
+			);
+			setTimeout(() => {
+				trackDetachedSessionStart(
+					"native-model-refresh-retry",
+					runRefreshNudge(ctx, true),
+					(err) => logRefreshFailure(err),
+				);
+			}, NUDGE_RETRY_DELAY_MS);
+			return;
+		}
+		if (result.aborted) {
+			_logger.warn(
+				"[native-model-refresh] retry superseded; catalogs stay as-is until the next refresh",
+			);
+			return;
+		}
+		trackDetachedSessionStart(
+			"native-model-refresh",
+			Promise.resolve(),
+			undefined,
+		);
+		_logger.debug(
+			`[native-model-refresh] refreshed ${scopedIds.length} provider(s) clean`,
+		);
+	} catch (err) {
+		// A replaced session invalidates the captured ctx mid-nudge (#509) —
+		// routine, not a warning.
+		if (isStaleContextError(err)) {
+			_logger.info("[native-model-refresh] session changed mid-nudge; dropping", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return;
+		}
+		logRefreshFailure(err);
+	}
+}
+
+function logRefreshFailure(error: unknown): void {
+	_logger.warn("Model refresh nudge failed", {
 		error: error instanceof Error ? error.message : String(error),
 	});
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 		"smoke:compiled": "node scripts/smoke-compiled.mjs",
 		"smoke:pi-loader": "node scripts/smoke-pi-loader.mjs",
 		"smoke:pi-ai-entries": "node scripts/smoke-pi-ai-entries.mjs",
-		"smoke:pi-install": "node scripts/pi-install-smoke.mjs"
+		"smoke:pi-install": "node scripts/pi-install-smoke.mjs",
+		"smoke:pi-upgrade": "node scripts/pi-upgrade-smoke.mjs"
 	},
 	"overrides": {
 		"brace-expansion": "^5.0.9",

--- a/providers/llm7/llm7-provider.ts
+++ b/providers/llm7/llm7-provider.ts
@@ -93,6 +93,18 @@ export function createLlm7Provider(): Llm7NativeProvider {
 		stored.free = next.free;
 	}
 
+	// Seed the static selector catalog at assembly so models are visible
+	// before the first refresh completes. Fresh installs have an empty
+	// store, and refresh publication can be superseded by a concurrent
+	// refresh (Pi aborts the older generation) — without this seed the
+	// catalog stays empty until an uncontested refresh lands. Refresh
+	// overwrites these on success and retains them on failure, exactly
+	// like the opengateway/qoder static seeds.
+	{
+		const seed = fetchLlm7Catalog();
+		ingest(seed.all, seed.free);
+	}
+
 	async function refreshModels(context: RefreshModelsContext): Promise<void> {
 		// Free split of the most recent build, kept beside the flat list the
 		// shared helper passes through (see the fetch callback below).

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -10,7 +10,13 @@
  *   node scripts/pi-install-smoke.mjs ./pi-free-<version>.tgz
  */
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -85,8 +91,21 @@ const piModule = fileURLToPath(
 	import.meta.resolve("@earendil-works/pi-coding-agent"),
 );
 const piCli = join(dirname(piModule), "cli.js");
-const rpcDriver = join(dirname(fileURLToPath(import.meta.url)), "rpc-load-check.mjs");
+const rpcDriver = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"rpc-load-check.mjs",
+);
 const piOptions = { cwd: project, env: environment, stdio: "inherit" };
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rpcSessionDriver = join(scriptDir, "rpc-session-check.mjs");
+
+// Seed an explicit free_only default so the session check's filter
+// assertions do not depend on template defaults (deterministic input).
+mkdirSync(join(home, ".pi"), { recursive: true });
+writeFileSync(
+	join(home, ".pi", "free.json"),
+	JSON.stringify({ free_only: true }, null, 2),
+);
 
 try {
 	// Pi treats a bare local path as a source extension, not an npm package.
@@ -97,6 +116,8 @@ try {
 	await run([piCli, "install", installSpec], piOptions);
 	console.log("Launching Pi RPC load check");
 	await run([rpcDriver], piOptions, 45_000);
+	console.log("Launching Pi RPC session + filter check");
+	await run([rpcSessionDriver], piOptions, 150_000);
 	console.log("Pi install smoke passed");
 } catch (error) {
 	console.error(`Pi install smoke failed: ${error.message}`);

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Upgrade-path smoke test: install the latest PUBLISHED pi-free, then
+ * upgrade it with the local tarball through Pi, and verify the upgraded
+ * tree the same way install-test does.
+ *
+ * Long-lived agent dirs (stale peers, nested duplicates, half-pruned
+ * trees) are where sick install shapes come from — a pristine install
+ * never exercises them. This seeds reality first: a real previous release
+ * installed the same way Pi installs it.
+ *
+ * Usage:
+ *   node scripts/pi-upgrade-smoke.mjs ./pi-free-<version>.tgz
+ */
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const tarball = process.argv[2] && resolve(process.argv[2]);
+if (!tarball || !existsSync(tarball)) {
+	console.error("Usage: node scripts/pi-upgrade-smoke.mjs <pi-free-tarball>");
+	process.exit(1);
+}
+
+function run(args, options, timeoutMs = 180_000) {
+	return new Promise((resolveRun, rejectRun) => {
+		const child = spawn(process.execPath, args, options);
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				// The process may already have exited.
+			}
+		}, timeoutMs);
+
+		child.once("error", rejectRun);
+		child.once("close", (code, signal) => {
+			clearTimeout(timer);
+			if (timedOut) {
+				rejectRun(new Error(`Node timed out after ${timeoutMs}ms`));
+			} else if (code === 0) {
+				resolveRun();
+			} else {
+				const signalSuffix = signal ? ` (${String(signal)})` : "";
+				rejectRun(new Error(`Node exited with code ${code ?? "unknown"}${signalSuffix}`));
+			}
+		});
+	});
+}
+
+/** Run npm in isolation and return trimmed stdout. */
+function npm(args, options, timeoutMs = 180_000) {
+	return new Promise((resolveRun, rejectRun) => {
+		const child = spawn(
+			process.platform === "win32" ? "npm.cmd" : "npm",
+			args,
+			options,
+		);
+		let stdout = "";
+		const timer = setTimeout(() => {
+			try {
+				child.kill("SIGKILL");
+			} catch {
+				// The process may already have exited.
+			}
+			rejectRun(new Error(`npm timed out after ${timeoutMs}ms`));
+		}, timeoutMs);
+		child.stdout?.on("data", (data) => {
+			stdout += data.toString();
+		});
+		child.once("error", (error) => {
+			clearTimeout(timer);
+			rejectRun(error);
+		});
+		child.once("close", (code) => {
+			clearTimeout(timer);
+			if (code === 0) {
+				resolveRun(stdout.trim());
+			} else {
+				rejectRun(new Error(`npm exited with code ${code ?? "unknown"}`));
+			}
+		});
+	});
+}
+
+const testRoot = mkdtempSync(join(tmpdir(), "pi-free-upgrade-smoke-"));
+const home = join(testRoot, "home");
+const project = join(testRoot, "project");
+mkdirSync(home);
+mkdirSync(project);
+
+const environment = { ...process.env };
+for (const name of Object.keys(environment)) {
+	if (/(?:API_KEY|APIKEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET)$/i.test(name)) {
+		delete environment[name];
+	}
+}
+environment.ANTHROPIC_API_KEY = "sk-ant-dummy-pi-free-upgrade-smoke";
+environment.HOME = home;
+environment.USERPROFILE = home;
+environment.NPM_CONFIG_USERCONFIG = join(testRoot, "npmrc");
+environment.NPM_CONFIG_CACHE = join(testRoot, "npm-cache");
+environment.PI_FREE_FILE_LOG = "false";
+delete environment.PI_CODING_AGENT_DIR;
+delete environment.PI_CODING_AGENT_SESSION_DIR;
+delete environment.PI_PACKAGE_DIR;
+
+const piModule = fileURLToPath(
+	import.meta.resolve("@earendil-works/pi-coding-agent"),
+);
+const piCli = join(dirname(piModule), "cli.js");
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const piOptions = { cwd: project, env: environment, stdio: "inherit" };
+
+try {
+	// Seed reality: the latest published release, installed exactly the way
+	// Pi installs it. A failure here means no published baseline to upgrade
+	// from (offline mirror, registry outage) — fail loudly, not silently.
+	const published = await npm(["view", "pi-free", "version"], {
+		cwd: project,
+		env: environment,
+	});
+	console.log(`Seeding previous release pi-free@${published} through Pi`);
+	await run([piCli, "install", `npm:pi-free@${published}`], piOptions);
+
+	console.log(`Upgrading through Pi with ${tarball}`);
+	const installSpec = `npm:pi-free@${pathToFileURL(tarball).href}`;
+	await run([piCli, "install", installSpec], piOptions);
+
+	console.log("Launching Pi RPC load check on the upgraded tree");
+	await run([join(scriptDir, "rpc-load-check.mjs")], piOptions, 45_000);
+	console.log("Launching Pi RPC session + filter check on the upgraded tree");
+	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 150_000);
+	console.log("Pi upgrade smoke passed");
+} catch (error) {
+	console.error(
+		`Pi upgrade smoke failed: ${error instanceof Error ? error.message : String(error)}`,
+	);
+	process.exitCode = 1;
+} finally {
+	rmSync(testRoot, { recursive: true, force: true });
+}

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * RPC session + filter check — strict end-to-end assertions over a real Pi
+ * boot with pi-free installed. Headless and model-free (no prompt is ever
+ * sent, no network beyond Pi's own boot).
+ *
+ * The caller is responsible for providing an isolated HOME (with pi-free
+ * already installed and `free_only: true` in free.json). This script:
+ *
+ *   1. `get_commands` — pi-free commands are registered.
+ *   2. `get_available_models` — the free-only view holds: every managed
+ *      model is zero-cost, anchored deterministically on llm7 (static
+ *      keyless catalog with both free and paid selectors).
+ *   3. `new_session` — session replacement settles with no cancellation.
+ *   4. `get_commands` + `get_available_models` again — registration and
+ *      the free-only view survive replacement (#509 stale-ctx class and
+ *      the #510 filter-stickiness class).
+ *
+ * Fails on ANY extension_error event at ANY point, any timeout, any
+ * missing command, an empty catalog, a paid managed model, or a missing
+ * llm7 anchor. Strict by design: a failure names a product bug to fix,
+ * not a threshold to tune.
+ *
+ * Managed vs unmanaged: the harness injects a dummy ANTHROPIC_API_KEY so
+ * Pi boots, which makes Anthropic's paid catalog visible. Anthropic is
+ * not pi-free-managed (the global filter only governs pi-free's own
+ * registry), so provider `anthropic` is excluded from the paid check —
+ * and named as such in failures.
+ *
+ * Usage:
+ *   node scripts/rpc-session-check.mjs
+ */
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
+
+// The harness-injected dummy key makes this paid catalog visible. It is
+// deliberately NOT pi-free-managed, so it is excluded from the paid
+// assertions below (and any failure message says so).
+const UNMANAGED_PROVIDERS = new Set(["anthropic"]);
+
+// Deterministic anchor: static keyless catalog with free AND paid
+// selectors, always available without network or credentials.
+const ANCHOR_PROVIDER = "llm7";
+
+function resolveInstalledPi() {
+	const piModule = fileURLToPath(
+		import.meta.resolve("@earendil-works/pi-coding-agent"),
+	);
+	return {
+		command: process.execPath,
+		args: [join(dirname(piModule), "cli.js")],
+	};
+}
+
+const piCommand = resolveInstalledPi();
+const pi = spawn(
+	piCommand.command,
+	[...piCommand.args, "--mode", "rpc", "--no-session"],
+	{
+		stdio: ["pipe", "pipe", "inherit"],
+		env: {
+			...process.env,
+			ANTHROPIC_API_KEY:
+				process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-session-check",
+		},
+		shell: false,
+	},
+);
+
+let buffer = "";
+const extensionErrors = [];
+let finished = false;
+let timer;
+let pending = null;
+
+function finish(code, message) {
+	if (finished) return;
+	finished = true;
+	clearTimeout(timer);
+	if (message) console.log(message);
+	try {
+		pi.kill("SIGKILL");
+	} catch {
+		// The process may already have exited.
+	}
+	process.exit(code);
+}
+
+function fail(message) {
+	if (extensionErrors.length > 0) {
+		console.log(
+			`extension_error events observed: ${JSON.stringify(extensionErrors).slice(0, 500)}`,
+		);
+	}
+	finish(1, `FAIL: ${message}`);
+}
+
+/** Send a command and resolve with its response data. */
+function send(command) {
+	return new Promise((resolveSend, rejectSend) => {
+		const timeout = setTimeout(
+			() => rejectSend(new Error(`timed out waiting for ${command.type}`)),
+			20_000,
+		);
+		pending = {
+			command: command.type,
+			resolve: (data) => {
+				clearTimeout(timeout);
+				resolveSend(data);
+			},
+			reject: (error) => {
+				clearTimeout(timeout);
+				rejectSend(error);
+			},
+		};
+		try {
+			pi.stdin.write(`${JSON.stringify(command)}\n`);
+		} catch (error) {
+			pending = null;
+			rejectSend(error);
+		}
+	});
+}
+
+function paidCost(model) {
+	return (model.cost?.input ?? 0) > 0 || (model.cost?.output ?? 0) > 0;
+}
+
+/** Strict catalog assertions. Throws on the first violation. */
+function assertCatalog(models, phase) {
+	if (!Array.isArray(models) || models.length === 0) {
+		throw new Error(`${phase}: empty model catalog`);
+	}
+	const managed = models.filter((m) => !UNMANAGED_PROVIDERS.has(m.provider));
+	const paid = managed.filter(paidCost);
+	if (paid.length > 0) {
+		const sample = paid
+			.slice(0, 3)
+			.map((m) => `${m.provider}/${m.id}`)
+			.join(", ");
+		throw new Error(
+			`${phase}: ${paid.length} paid managed model(s) visible under free-only (e.g. ${sample})`,
+		);
+	}
+	const anchor = managed.filter((m) => m.provider === ANCHOR_PROVIDER);
+	if (anchor.length === 0) {
+		throw new Error(
+			`${phase}: anchor provider ${ANCHOR_PROVIDER} missing from catalog (${managed.length} managed models present)`,
+		);
+	}
+	const anchorPaid = anchor.filter(paidCost);
+	if (anchorPaid.length > 0) {
+		throw new Error(
+			`${phase}: anchor provider shows paid models: ${anchorPaid.map((m) => m.id).join(", ")}`,
+		);
+	}
+	console.log(
+		`${phase}: catalog ok (${models.length} total, ${managed.length} managed, ${anchor.length} anchor, 0 paid)`,
+	);
+}
+
+/** Prompt pi with a slash command; resolves when preflight succeeds. */
+function sendPrompt(text) {
+	return send({ type: "prompt", message: text });
+}
+
+function assertCommands(commands, phase) {
+	const names = new Set((commands ?? []).map((command) => command.name));
+	const missing = expectedCommands.filter((name) => !names.has(name));
+	if (missing.length > 0) {
+		throw new Error(
+			`${phase}: missing pi-free command(s): ${missing.join(", ")}`,
+		);
+	}
+	console.log(`${phase}: commands ok (${names.size} total)`);
+}
+
+function handleLine(line) {
+	let message;
+	try {
+		message = JSON.parse(line);
+	} catch {
+		return;
+	}
+
+	if (
+		(message.type === "event" && message.event === "extension_error") ||
+		message.type === "extension_error"
+	) {
+		extensionErrors.push(message);
+		console.log("extension_error:", JSON.stringify(message).slice(0, 500));
+		return;
+	}
+
+	if (message.type !== "response" || !pending) return;
+	if (message.command !== pending.command) return;
+	const current = pending;
+	pending = null;
+	if (message.error) {
+		current.reject(new Error(`${message.command}: ${message.error}`));
+	} else {
+		current.resolve(message.data);
+	}
+}
+
+pi.stdout.on("data", (data) => {
+	buffer += data.toString();
+	let newline;
+	while ((newline = buffer.indexOf("\n")) >= 0) {
+		const line = buffer.slice(0, newline).replace(/\r$/, "");
+		buffer = buffer.slice(newline + 1);
+		if (line.trim()) handleLine(line);
+	}
+});
+
+pi.on("error", (error) => fail(`could not start Pi: ${error.message}`));
+pi.on("exit", (code) => {
+	if (!finished) {
+		fail(`Pi exited before checks completed (code ${code ?? "unknown"})`);
+	}
+});
+
+const sleep = (ms) =>
+	new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+
+timer = setTimeout(() => fail("TIMEOUT waiting for session checks"), 120_000);
+
+try {
+	// Allow Pi to finish loading extensions before querying.
+	await sleep(2500);
+
+	const commands = (await send({ type: "get_commands" })).commands;
+	assertCommands(commands, "boot");
+
+	const before = (await send({ type: "get_available_models" })).models;
+	assertCatalog(before, "boot");
+
+	const replaced = await send({ type: "new_session" });
+	if (replaced?.cancelled) {
+		throw new Error("new_session was cancelled by an extension");
+	}
+	console.log("new_session ok (replacement settled)");
+
+	// session_start handlers + detached capture land in ~1s; wait with
+	// margin so a stale-ctx failure has time to surface as extension_error.
+	await sleep(8000);
+
+	const commandsAfter = (await send({ type: "get_commands" })).commands;
+	assertCommands(commandsAfter, "post-replacement");
+
+	const after = (await send({ type: "get_available_models" })).models;
+	assertCatalog(after, "post-replacement");
+
+	// Toggle persistence end to end: flipping llm7 must survive a session
+	// replacement and show in the catalog (the paid pro selector appears).
+	// Slash commands dispatch through prompt preflight — no model runs.
+	await sendPrompt("/toggle-llm7");
+	await sleep(3000);
+	const toggled = (await send({ type: "get_available_models" })).models;
+	const pro = toggled.filter(
+		(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
+	);
+	if (pro.length === 0) {
+		throw new Error(
+			"post-toggle: llm7/pro missing from catalog after /toggle-llm7",
+		);
+	}
+	console.log("post-toggle: llm7/pro visible after /toggle-llm7");
+	await send({ type: "new_session" });
+	await sleep(8000);
+	const persisted = (await send({ type: "get_available_models" })).models;
+	const proAfter = persisted.filter(
+		(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
+	);
+	if (proAfter.length === 0) {
+		throw new Error(
+			"post-toggle-replacement: llm7/pro lost across new_session (choice did not persist)",
+		);
+	}
+	console.log("post-toggle-replacement: llm7/pro survives new_session");
+
+	if (extensionErrors.length > 0) {
+		fail(`${extensionErrors.length} extension_error event(s) observed`);
+	}
+	finish(0, "PASS: session replacement clean, free-only view holds");
+} catch (error) {
+	fail(error instanceof Error ? error.message : String(error));
+}

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -322,7 +322,12 @@ describe("Cline factory wiring", () => {
 
 		const refresh = vi.fn().mockResolvedValue(undefined);
 		await handler({}, { modelRegistry: { refresh } });
-		expect(refresh).toHaveBeenCalledWith({ allowNetwork: true });
+		// Scoped to opted-in providers (never the whole registry), so
+		// foreign credential failures cannot fail our refresh.
+		expect(refresh).toHaveBeenCalledWith({
+			allowNetwork: true,
+			providers: expect.arrayContaining(["cline"]),
+		});
 
 		// No modelRegistry on the context -> safe no-op.
 		await expect(handler({}, {})).resolves.toBeUndefined();

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -176,8 +176,14 @@ describe("createLlm7Provider shape", () => {
 		// Native auth: apiKey only — LLM7 has no OAuth flow.
 		expect(provider.auth.apiKey).toBeDefined();
 		expect(provider.auth.oauth).toBeUndefined();
-		// Empty before the first refresh (dynamic provider contract).
-		expect(provider.getModels()).toEqual([]);
+		// Seeded with the static selector catalog at assembly, so models are
+		// visible before the first refresh completes (fresh installs have an
+		// empty store and refresh publication can be superseded).
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
 	});
 });
 
@@ -290,11 +296,17 @@ describe("refreshModels offline init", () => {
 		).toEqual(["default", "fast"]);
 	});
 
-	it("stays empty when the store is empty and network is disallowed", async () => {
+	it("retains the seeded static catalog when the store is empty and network is disallowed", async () => {
 		const { provider } = createLlm7Provider();
 		await provider.refreshModels?.(ctx({ allowNetwork: false }));
 		expect(mockFetch).not.toHaveBeenCalled();
-		expect(provider.getModels()).toEqual([]);
+		// An empty restore must not wipe the assembly seed (restore only
+		// applies non-empty restores).
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
 	});
 
 	it("ignores stored models from other providers", async () => {
@@ -304,7 +316,12 @@ describe("refreshModels offline init", () => {
 		const { store } = makeStore(seeded);
 		const { provider } = createLlm7Provider();
 		await provider.refreshModels?.(ctx({ store, allowNetwork: false }));
-		expect(provider.getModels()).toEqual([]);
+		// Foreign models are filtered on restore; the assembly seed stands.
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
 	});
 
 	it("survives a failing store read without throwing", async () => {
@@ -319,7 +336,12 @@ describe("refreshModels offline init", () => {
 		await expect(
 			provider.refreshModels?.(ctx({ store, allowNetwork: false })),
 		).resolves.toBeUndefined();
-		expect(provider.getModels()).toEqual([]);
+		// A failed read must not wipe the assembly seed either.
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
 	});
 });
 
@@ -392,7 +414,12 @@ describe("refreshModels online", () => {
 			ctx({ store, allowNetwork: true, signal: controller.signal }),
 		);
 
-		expect(provider.getModels()).toEqual([]);
+		// Aborted before any phase ran: the seed stands, nothing persisted.
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
 		expect(written).toHaveLength(0);
 	});
 

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -118,16 +118,22 @@ describe("LLM7 factory wiring", () => {
 		} as unknown as ExtensionAPI;
 	});
 
-	it("factory is network-free and registers the native provider empty — even with no API key", async () => {
+	it("factory is network-free and registers the native provider seeded — even with no API key", async () => {
 		await llm7Provider(mockPi);
 
-		// The factory never fetches: models load via refreshModels. Unlike the
-		// legacy registration, a missing LLM7_API_KEY does NOT skip the provider.
+		// The factory never fetches: the static selector catalog is seeded
+		// at assembly (models load via refreshModels after that). Unlike
+		// the legacy registration, a missing LLM7_API_KEY does NOT skip
+		// the provider.
 		expect(mockFetch).not.toHaveBeenCalled();
 		expect(mockRegisterProvider).toHaveBeenCalledTimes(1);
 		const provider = mockRegisterProvider.mock.calls[0][0];
 		expect(provider.id).toBe("llm7");
-		expect(provider.getModels()).toEqual([]);
+		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
+			"default",
+			"fast",
+			"pro",
+		]);
 		expect(provider.auth.apiKey).toBeDefined();
 
 		// Lifecycle handlers + toggle command registered.
@@ -283,7 +289,12 @@ describe("LLM7 factory wiring", () => {
 
 		const refresh = vi.fn().mockResolvedValue(undefined);
 		await handler({}, { modelRegistry: { refresh } });
-		expect(refresh).toHaveBeenCalledWith({ allowNetwork: true });
+		// Scoped to opted-in providers (never the whole registry), so
+		// foreign credential failures cannot fail our refresh.
+		expect(refresh).toHaveBeenCalledWith({
+			allowNetwork: true,
+			providers: expect.arrayContaining(["llm7"]),
+		});
 
 		// No modelRegistry on the context -> safe no-op.
 		await expect(handler({}, {})).resolves.toBeUndefined();

--- a/tests/native-refresh-nudge.test.ts
+++ b/tests/native-refresh-nudge.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the session-start native refresh nudge
+ * (registerNativeProviderRefresh in lib/native-provider.ts).
+ *
+ * The nudge refreshes exactly the opted-in provider ids (never the whole
+ * registry), ignores other providers' errors, and retries once when
+ * superseded — the race that left fresh installs with an empty catalog.
+ * Mocks stop at honest seams (ExtensionAPI surface, modelRegistry.refresh);
+ * Pi's refresh orchestration itself is covered by the RPC session check.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRefresh = vi.fn();
+
+function mockCtx() {
+	return {
+		modelRegistry: {
+			refresh: (...args: unknown[]) => mockRefresh(...args),
+		},
+	};
+}
+
+function mockPi() {
+	const handlers: Record<string, Function> = {};
+	return {
+		handlers,
+		on: vi.fn((event: string, handler: Function) => {
+			handlers[event] = handler;
+		}),
+	};
+}
+
+let registerNativeProviderRefresh: typeof import("../lib/native-provider.ts")["registerNativeProviderRefresh"];
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	vi.resetModules();
+	vi.useFakeTimers();
+	({ registerNativeProviderRefresh } = await import(
+		"../lib/native-provider.ts"
+	));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+async function fireSessionStart(pi: ReturnType<typeof mockPi>, ctx: unknown) {
+	await pi.handlers["session_start"]({}, ctx);
+	// Flush the detached chain (refresh await + result handling).
+	await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("native refresh nudge", () => {
+	it("refreshes only the opted-in provider ids", async () => {
+		const pi = mockPi();
+		registerNativeProviderRefresh(pi as never, "kilo");
+		registerNativeProviderRefresh(pi as never, "kilo");
+		mockRefresh.mockResolvedValue({ aborted: false, errors: new Map() });
+
+		await fireSessionStart(pi, mockCtx());
+
+		expect(mockRefresh).toHaveBeenCalledTimes(1);
+		expect(mockRefresh).toHaveBeenCalledWith({
+			allowNetwork: true,
+			providers: ["kilo"],
+		});
+	});
+
+	it("ignores other providers' errors (e.g. missing OPENCODE_API_KEY)", async () => {
+		const pi = mockPi();
+		registerNativeProviderRefresh(pi as never, "kilo");
+		mockRefresh.mockResolvedValue({
+			aborted: false,
+			errors: new Map([
+				["opencode-free", new Error("Failed to resolve API key")],
+				["opencode-go", new Error("Failed to resolve API key")],
+			]),
+		});
+
+		await fireSessionStart(pi, mockCtx());
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		// No failure, no retry: foreign errors are noise.
+		expect(mockRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails loudly on its own providers' errors", async () => {
+		const pi = mockPi();
+		registerNativeProviderRefresh(pi as never, "kilo");
+		mockRefresh.mockResolvedValue({
+			aborted: false,
+			errors: new Map([["kilo", new Error("boom")]]),
+		});
+
+		await fireSessionStart(pi, mockCtx());
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		// Rejected task, and no retry for real errors (only aborts retry).
+		expect(mockRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries once when superseded, then stops", async () => {
+		const pi = mockPi();
+		registerNativeProviderRefresh(pi as never, "kilo");
+		mockRefresh.mockResolvedValueOnce({ aborted: true, errors: new Map() });
+		mockRefresh.mockResolvedValueOnce({ aborted: true, errors: new Map() });
+
+		await fireSessionStart(pi, mockCtx());
+		expect(mockRefresh).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(mockRefresh).toHaveBeenCalledTimes(2);
+
+		// Retry exhausted: no third attempt even with more time.
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(mockRefresh).toHaveBeenCalledTimes(2);
+	});
+
+	it("drops a stale retry ctx quietly instead of warning", async () => {
+		const pi = mockPi();
+		registerNativeProviderRefresh(pi as never, "kilo");
+		mockRefresh.mockResolvedValue({ aborted: true, errors: new Map() });
+
+		let accesses = 0;
+		const staleCtx = {
+			get modelRegistry(): unknown {
+				accesses++;
+				if (accesses > 1) {
+					throw new Error(
+						"This extension ctx is stale after session replacement or reload.",
+					);
+				}
+				return { refresh: (...args: unknown[]) => mockRefresh(...args) };
+			},
+		};
+		await fireSessionStart(pi, staleCtx);
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(mockRefresh).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/zenmux.test.ts
+++ b/tests/zenmux.test.ts
@@ -159,7 +159,12 @@ describe("ZenMux native factory", () => {
 		)?.[1];
 		const refresh = vi.fn().mockResolvedValue(undefined);
 		await sessionStart({}, { modelRegistry: { refresh } });
-		expect(refresh).toHaveBeenCalledWith({ allowNetwork: true });
+		// Scoped to opted-in providers (never the whole registry), so
+		// foreign credential failures cannot fail our refresh.
+		expect(refresh).toHaveBeenCalledWith({
+			allowNetwork: true,
+			providers: expect.arrayContaining(["zenmux"]),
+		});
 		await expect(sessionStart({}, {})).resolves.toBeUndefined();
 	});
 


### PR DESCRIPTION
The strict RPC session check (new here) exposed a fresh-boot empty catalog on the first run: Pi supersedes an in-flight refresh per provider when a newer refresh begins, and every registerProvider fires a global offline refresh — pi-free's own session-start captures re-register ~40ms after the network nudge fires, deterministically aborting slow fetches before they land. Verified live: llm7 persist aborted twice, store empty forever, catalog anthropic-only (details in the commit body).

## Product fixes

- **Scoped nudge with retry** (`lib/native-provider.ts`): refreshes exactly the opted-in provider ids (never the whole registry), ignores foreign provider errors (missing OPENCODE_API_KEY no longer fails our refresh), retries once when superseded, drops stale retry ctx quietly. Uses pi's real ExtensionContext/ModelRegistry/ModelsRefreshResult types — no casts.
- **llm7 static seeding** (`providers/llm7/llm7-provider.ts`): seeds the static selector catalog at assembly (mirrors opengateway/qoder), so models are visible before the first refresh completes.
- **Tests**: `tests/native-refresh-nudge.test.ts` (scoping, foreign-error ignore, own-error failure, retry-once, stale-drop); llm7 suites updated to the seeded contract; nudge-behavior assertions updated in cline/llm7/zenmux suites.

## RPC migration (per agreement: strict tests that expose bugs, mocks only at honest seams)

- **`scripts/rpc-session-check.mjs`**: boot catalog (free-only, llm7-anchored, zero paid managed), `new_session` with zero `extension_error`, post-replacement view, `/toggle-llm7` via prompt dispatch, persistence across another replacement. Passes live against `pi install`.
- **`scripts/pi-upgrade-smoke.mjs`**: previous published release, then upgrade with the tarball, then both RPC drivers. Passes live.
- **ci.yml**: upgrade smoke in install-test, vitest on windows, closure + entries smokes in source-install-build; pi-install-smoke runs both RPC drivers and seeds `free_only` deterministically.

## Verification

- Strict RPC suite green live (locally + upgrade path); full vitest 847+ pass; `tsc` clean.