### PR TITLE
test(rpc): shared harness, toggle e2e, artifacts, hoisting canary; strict free views (#510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Execute pi-ai entries from production tree
         run: node scripts/smoke-pi-ai-entries.mjs .
 
+      - name: Verify pi-ai deps hoist canonically in production tree
+        run: node scripts/check-hoisting.mjs .
+
   test:
     name: Unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -228,3 +231,20 @@ jobs:
         run: |
           INSTALL_DIR=$(npm root -g)/pi-free
           node scripts/smoke-pi-ai-entries.mjs "$INSTALL_DIR"
+
+      - name: Verify pi-ai deps hoist canonically in installed tree
+        shell: bash
+        run: |
+          INSTALL_DIR=$(npm root -g)/pi-free
+          node scripts/check-hoisting.mjs "$INSTALL_DIR"
+
+      # Failure forensics: the smoke scripts preserve free.log/free.json
+      # into .smoke-artifacts/ on failure (the temp HOME is deleted).
+      # Upload them so a red install-test is debuggable from the run.
+      - name: Upload smoke failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: smoke-artifacts-${{ matrix.os }}
+          path: .smoke-artifacts/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .pisessionsummaries/
 .pi-lens/
 *.log
+.smoke-artifacts/
 .pi/greedysearch-sources/
 .DS_Store
 dist/

--- a/agents.md
+++ b/agents.md
@@ -194,6 +194,7 @@ One resolution rule behind every filter decision (`resolveModelView` in `lib/reg
 - `/toggle-free` flips the global flag **and clears all per-provider choices** so the new default applies uniformly — a stale explicit choice must never fight it on the next session.
 - Toggle commands flip the *effective* view and persist it (never the stored pref, which no-ops under an opposing global).
 - Captures and filters resolve live at call time; registration-time values must never be frozen (see defect shape 2).
+- Strict free views: zero free models resolves to an *empty* free view (provider hides from the picker), never to the paid catalog. The old empty-to-all fallback leaked paid models under an explicit free-only choice; flipping to all stays available through an explicit toggle.
 - `lib/toggle-state.ts` provides the generic `createToggleState<T>()` mode machine (`"free"` | `"all"`, `{free, all}` storage, empty-`all` → `free` fallback). Its internal persist targets legacy keys; production toggle paths persist through the overrides map instead.
 
 ### Quota Monitoring

--- a/lib/toggle-state.ts
+++ b/lib/toggle-state.ts
@@ -44,10 +44,13 @@ export function createToggleState<T>({
 			return { mode: "free", models: stored.free };
 		}
 
-		if (stored.free.length > 0) {
-			return { mode: "free", models: stored.free };
-		}
-		return { mode: "all", models: stored.all };
+		// Strict: a free view with no free models resolves to an EMPTY free
+		// view, never to the paid catalog. Falling back to "all" here
+		// silently violated an explicit free-only choice (global or
+		// per-provider): a provider with zero free models hides from the
+		// picker instead of leaking paid models. Flipping to "all" stays
+		// available through an explicit toggle.
+		return { mode: "free", models: stored.free };
 	}
 
 	function persist(mode: ToggleMode): void {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"banner.svg",
 		"scripts/check-extensions.mjs",
 		"scripts/pi-install-smoke.mjs",
-		"scripts/rpc-load-check.mjs"
+		"scripts/rpc-load-check.mjs",
+		"scripts/lib/rpc-driver.mjs"
 	],
 	"scripts": {
 		"audit:prod": "npm audit --omit=dev --omit=peer --audit-level=high",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"check:tarball": "node scripts/check-tarball.mjs",
 		"check:prod-install-shape": "node scripts/check-prod-install-shape.mjs",
 		"check:closure": "node scripts/check-installed-closure.mjs",
+		"check:hoisting": "node scripts/check-hoisting.mjs",
 		"lint": "tsc --noEmit",
 		"prepare": "npm run build",
 		"test": "vitest",

--- a/scripts/check-hoisting.mjs
+++ b/scripts/check-hoisting.mjs
@@ -64,7 +64,9 @@ if (!piAiRoot) {
 
 let piAiPkg;
 try {
-	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8"));
+	// NOSONAR (jssecurity:S8707) -- same justification as the CLI gate
+	// above: local read-only diagnostic over an operator-supplied tree.
+	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8")); // NOSONAR
 } catch (error) {
 	console.error(
 		`[hoisting] FAIL: cannot read pi-ai package.json: ${error.message}`,

--- a/scripts/check-hoisting.mjs
+++ b/scripts/check-hoisting.mjs
@@ -18,12 +18,27 @@
  *     (default: the current directory)
  */
 import { createRequire } from "node:module";
-import { existsSync } from "node:fs";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const packageDir = resolve(process.argv[2] ?? ".");
+
+// Validate the CLI-supplied directory before touching the filesystem
+// beneath it (same shape as check-installed-closure.mjs).
+// NOSONAR (jssecurity:S8707): local read-only diagnostic over an
+// operator-supplied tree — no writes, no exec, no network, no privilege
+// boundary; output goes to the operator's own terminal.
+let packageStat;
+try {
+	packageStat = statSync(packageDir); // NOSONAR -- see justification above
+} catch {
+	packageStat = undefined;
+}
+if (!packageStat?.isDirectory()) {
+	console.error(`[hoisting] FAIL: not a package directory: ${packageDir}`);
+	process.exit(1);
+}
 
 function findPackageUp(startDir, segments) {
 	let dir = startDir;

--- a/scripts/check-hoisting.mjs
+++ b/scripts/check-hoisting.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Hoisting canary: fail when pi-ai resolves a runtime dependency from a
+ * nested copy instead of the hoisted tree.
+ *
+ * npm sometimes nests duplicates (our own lockfile has nested `typebox`
+ * under pi-coding-agent) — harmless until the nested copy goes missing or
+ * stale, at which point pi-ai's internal imports break in ways the closure
+ * check can only catch after the fact. Asserting the *resolved* location
+ * is canonical fails at install time, with both paths named. Sibling
+ * subtrees that pi-ai's walk-up never crosses are ignored.
+ *
+ * Companion to check-installed-closure.mjs (which proves resolvability):
+ * this proves canonical placement. Both run in install-test on every OS.
+ *
+ * Usage:
+ *   node scripts/check-hoisting.mjs [pi-free-package-dir]
+ *     (default: the current directory)
+ */
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const packageDir = resolve(process.argv[2] ?? ".");
+
+function findPackageUp(startDir, segments) {
+	let dir = startDir;
+	for (;;) {
+		const candidate = join(dir, "node_modules", ...segments);
+		if (existsSync(join(candidate, "package.json"))) return candidate;
+		const parent = dirname(dir);
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+}
+
+const piAiRoot = findPackageUp(join(packageDir, "dist"), [
+	"@earendil-works",
+	"pi-ai",
+]);
+if (!piAiRoot) {
+	console.error(
+		"[hoisting] FAIL: @earendil-works/pi-ai is not resolvable from the installed tree.",
+	);
+	process.exit(1);
+}
+
+let piAiPkg;
+try {
+	piAiPkg = JSON.parse(readFileSync(join(piAiRoot, "package.json"), "utf8"));
+} catch (error) {
+	console.error(
+		`[hoisting] FAIL: cannot read pi-ai package.json: ${error.message}`,
+	);
+	process.exit(1);
+}
+
+// piAiRoot is <root>/node_modules/<scope>/pi-ai: three levels up is the
+// install root whose node_modules is the canonical hoisted location.
+const topLevel = dirname(dirname(dirname(piAiRoot)));
+const requireFromPiAi = createRequire(
+	pathToFileURL(join(piAiRoot, "package.json")).href,
+);
+const offenders = [];
+for (const name of Object.keys(piAiPkg.dependencies ?? {})) {
+	const segments = name.split("/");
+	const canonical = join(topLevel, "node_modules", ...segments);
+	let resolvedRoot;
+	try {
+		const resolvedFile = requireFromPiAi.resolve(name);
+		// Walk up from the resolved file to its package root.
+		let dir = dirname(resolvedFile);
+		for (;;) {
+			if (existsSync(join(dir, "package.json"))) {
+				const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+				if (pkg.name === name) {
+					resolvedRoot = dir;
+					break;
+				}
+			}
+			const parent = dirname(dir);
+			if (parent === dir) break;
+			dir = parent;
+		}
+	} catch {
+		// Unresolvable here is the closure check's jurisdiction, not this
+		// script's (import-only packages also fail require.resolve) — skip.
+		continue;
+	}
+	if (resolvedRoot && resolvedRoot !== canonical) {
+		offenders.push(`${name} resolves from nested ${resolvedRoot}`);
+	}
+}
+
+if (offenders.length > 0) {
+	console.error(
+		`[hoisting] FAIL: ${offenders.length} pi-ai runtime dep(s) resolve outside the hoisted tree:`,
+	);
+	for (const offender of offenders) console.error(`  - ${offender}`);
+	process.exit(1);
+}
+
+console.log(
+	`[hoisting] PASS: all pi-ai runtime deps resolve from ${join(topLevel, "node_modules")}`,
+);

--- a/scripts/check-tarball.mjs
+++ b/scripts/check-tarball.mjs
@@ -89,6 +89,7 @@ const required = [
 	"package/scripts/check-extensions.mjs",
 	"package/scripts/pi-install-smoke.mjs",
 	"package/scripts/rpc-load-check.mjs",
+	"package/scripts/lib/rpc-driver.mjs",
 ];
 
 for (const file of required) {
@@ -103,7 +104,7 @@ const forbiddenPatterns = [
 	/^package\/.+\.tgz$/,
 	/^package\/.+\.env(?:\..*)?$/,
 	/^package\/(?:\.env(?:\..*)?|npm-debug\.log|yarn-error\.log)$/,
-	/^package\/scripts\/(?!check-extensions\.mjs$|pi-install-smoke\.mjs$|rpc-load-check\.mjs$).+/,
+	/^package\/scripts\/(?!check-extensions\.mjs$|pi-install-smoke\.mjs$|rpc-load-check\.mjs$|lib\/rpc-driver\.mjs$).+/,
 ];
 
 const forbidden = entries.filter((entry) =>

--- a/scripts/lib/rpc-driver.mjs
+++ b/scripts/lib/rpc-driver.mjs
@@ -123,8 +123,7 @@ export function bootPi({ cwd, env, timeoutMs = 120_000, noSession = true }) {
 		send(command, stepTimeoutMs = 20_000) {
 			return new Promise((resolveSend, rejectSend) => {
 				const stepTimer = setTimeout(
-					() =>
-						rejectSend(new Error(`timed out waiting for ${command.type}`)),
+					() => rejectSend(new Error(`timed out waiting for ${command.type}`)),
 					stepTimeoutMs,
 				);
 				if (stepTimer.unref) stepTimer.unref();
@@ -151,6 +150,37 @@ export function bootPi({ cwd, env, timeoutMs = 120_000, noSession = true }) {
 		/** Prompt Pi (slash commands dispatch through preflight — no model runs). */
 		prompt(text) {
 			return this.send({ type: "prompt", message: text });
+		},
+		/**
+		 * Fetch until assert() passes twice in a row, then return the
+		 * last fetch. Pi rebuilds its model snapshot unfiltered on every
+		 * (re-)registration and re-applies the filtered view when the
+		 * availability refresh lands — so the first sight of a provider
+		 * can transiently show paid models for seconds on slow/fresh
+		 * boots. Asserting that transient as final is a flake factory;
+		 * a twice-consecutive pass is the settled-state contract.
+		 */
+		async waitSettled(fetch, assert, { timeoutMs, steadyMs = 3000, intervalMs = 2000, label }) {
+			const deadline = Date.now() + timeoutMs;
+			let lastError;
+			for (;;) {
+				try {
+					const value = await fetch();
+					assert(value);
+					await sleep(steadyMs);
+					const again = await fetch();
+					assert(again);
+					return again;
+				} catch (error) {
+					lastError = error;
+				}
+				if (Date.now() >= deadline) {
+					throw new Error(
+						`timed out waiting for settled ${label} after ${timeoutMs}ms${lastError ? `: ${lastError.message}` : ""}`,
+					);
+				}
+				await sleep(intervalMs);
+			}
 		},
 		/**
 		 * Poll an async condition until it returns non-null, or throw on

--- a/scripts/lib/rpc-driver.mjs
+++ b/scripts/lib/rpc-driver.mjs
@@ -152,6 +152,29 @@ export function bootPi({ cwd, env, timeoutMs = 120_000, noSession = true }) {
 		prompt(text) {
 			return this.send({ type: "prompt", message: text });
 		},
+		/**
+		 * Poll an async condition until it returns non-null, or throw on
+		 * deadline. Replaces fixed sleeps: slow runners need wall-clock
+		 * patience, fast ones should not wait out arbitrary delays.
+		 */
+		async waitFor(fn, { timeoutMs, intervalMs = 2000, label }) {
+			const deadline = Date.now() + timeoutMs;
+			let lastError;
+			for (;;) {
+				try {
+					const value = await fn();
+					if (value) return value;
+				} catch (error) {
+					lastError = error;
+				}
+				if (Date.now() >= deadline) {
+					throw new Error(
+						`timed out waiting for ${label} after ${timeoutMs}ms${lastError ? `: ${lastError.message}` : ""}`,
+					);
+				}
+				await sleep(intervalMs);
+			}
+		},
 		extensionErrors: state.extensionErrors,
 		/** Fail with message (plus any observed extension errors). */
 		fail(message) {

--- a/scripts/lib/rpc-driver.mjs
+++ b/scripts/lib/rpc-driver.mjs
@@ -1,0 +1,177 @@
+/**
+ * Shared harness for the RPC smoke drivers (rpc-load-check,
+ * rpc-session-check, rpc-toggle-check). One place owns the Pi RPC
+ * lifecycle: spawning, JSON-lines framing, request/response matching by
+ * command, extension_error collection, and timeouts — so protocol quirks
+ * are fixed once, not per driver.
+ *
+ * Drivers stay focused on their assertions; this module never asserts.
+ */
+
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const sleep = (ms) =>
+	new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+
+/**
+ * Boot Pi in RPC --no-session mode (or with a session when `withSession`).
+ * Returns a driver object; call `driver.close(code)` at the end (it kills
+ * Pi and exits the process).
+ *
+ * @param {object} options
+ * @param {string} options.cwd project directory for the Pi process
+ * @param {NodeJS.ProcessEnv} options.env environment (must carry isolated HOME)
+ * @param {number} [options.timeoutMs] overall deadline (default 120s)
+ * @param {boolean} [options.noSession] pass --no-session (default true)
+ */
+export function bootPi({ cwd, env, timeoutMs = 120_000, noSession = true }) {
+	const piModule = fileURLToPath(
+		import.meta.resolve("@earendil-works/pi-coding-agent"),
+	);
+	const args = [join(dirname(piModule), "cli.js"), "--mode", "rpc"];
+	if (noSession) args.push("--no-session");
+	const pi = spawn(process.execPath, args, {
+		cwd,
+		stdio: ["pipe", "pipe", "inherit"],
+		env,
+		shell: false,
+	});
+
+	const state = {
+		buffer: "",
+		extensionErrors: [],
+		pending: null,
+		finished: false,
+		timer: null,
+		onFailure: null,
+	};
+
+	function finish(code, message) {
+		if (state.finished) return;
+		state.finished = true;
+		if (state.timer) clearTimeout(state.timer);
+		if (message) console.log(message);
+		try {
+			pi.kill("SIGKILL");
+		} catch {
+			// The process may already have exited.
+		}
+		process.exit(code);
+	}
+
+	state.timer = setTimeout(() => {
+		if (state.onFailure) state.onFailure(new Error("TIMEOUT"));
+		else finish(2, "TIMEOUT waiting for RPC checks");
+	}, timeoutMs);
+	if (state.timer.unref) state.timer.unref();
+
+	function handleLine(line) {
+		let message;
+		try {
+			message = JSON.parse(line);
+		} catch {
+			return;
+		}
+		if (
+			(message.type === "event" && message.event === "extension_error") ||
+			message.type === "extension_error"
+		) {
+			state.extensionErrors.push(message);
+			console.log("extension_error:", JSON.stringify(message).slice(0, 500));
+			return;
+		}
+		if (message.type !== "response" || !state.pending) return;
+		if (message.command !== state.pending.command) return;
+		const current = state.pending;
+		state.pending = null;
+		if (message.error) {
+			current.reject(new Error(`${message.command}: ${message.error}`));
+		} else {
+			current.resolve(message.data);
+		}
+	}
+
+	pi.stdout.on("data", (data) => {
+		state.buffer += data.toString();
+		let newline;
+		while ((newline = state.buffer.indexOf("\n")) >= 0) {
+			const line = state.buffer.slice(0, newline).replace(/\r$/, "");
+			state.buffer = state.buffer.slice(newline + 1);
+			if (line.trim()) handleLine(line);
+		}
+	});
+
+	pi.on("error", (error) => {
+		if (state.onFailure) state.onFailure(error);
+		else finish(1, `FAIL: could not start Pi: ${error.message}`);
+	});
+	pi.on("exit", (code) => {
+		if (state.finished) return;
+		const error = new Error(`Pi exited early (code ${code ?? "unknown"})`);
+		if (state.onFailure) state.onFailure(error);
+		else
+			finish(
+				state.extensionErrors.length > 0 ? 1 : 2,
+				`Pi exited before checks completed (code ${code ?? "unknown"})`,
+			);
+	});
+
+	return {
+		/** Send a command; resolves with response data. */
+		send(command, stepTimeoutMs = 20_000) {
+			return new Promise((resolveSend, rejectSend) => {
+				const stepTimer = setTimeout(
+					() =>
+						rejectSend(new Error(`timed out waiting for ${command.type}`)),
+					stepTimeoutMs,
+				);
+				if (stepTimer.unref) stepTimer.unref();
+				state.pending = {
+					command: command.type,
+					resolve: (data) => {
+						clearTimeout(stepTimer);
+						resolveSend(data);
+					},
+					reject: (error) => {
+						clearTimeout(stepTimer);
+						rejectSend(error);
+					},
+				};
+				try {
+					pi.stdin.write(`${JSON.stringify(command)}\n`);
+				} catch (error) {
+					state.pending = null;
+					clearTimeout(stepTimer);
+					rejectSend(error);
+				}
+			});
+		},
+		/** Prompt Pi (slash commands dispatch through preflight — no model runs). */
+		prompt(text) {
+			return this.send({ type: "prompt", message: text });
+		},
+		extensionErrors: state.extensionErrors,
+		/** Fail with message (plus any observed extension errors). */
+		fail(message) {
+			if (state.extensionErrors.length > 0) {
+				console.log(
+					`extension_error events observed: ${JSON.stringify(state.extensionErrors).slice(0, 500)}`,
+				);
+			}
+			finish(1, `FAIL: ${message}`);
+		},
+		/** Pass with message. Fails instead if extension errors were observed. */
+		pass(message) {
+			if (state.extensionErrors.length > 0) {
+				this.fail(
+					`${state.extensionErrors.length} extension_error event(s) observed`,
+				);
+				return;
+			}
+			finish(0, `PASS: ${message}`);
+		},
+		close: finish,
+	};
+}

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -11,6 +11,7 @@
  */
 import { spawn } from "node:child_process";
 import {
+	copyFileSync,
 	existsSync,
 	mkdtempSync,
 	mkdirSync,
@@ -35,6 +36,10 @@ function scrubSecrets(environment) {
 	}
 	// Pi needs a provider to initialize RPC, but this value is deliberately fake.
 	environment.ANTHROPIC_API_KEY = "sk-ant-dummy-pi-free-install-smoke";
+	// Presence-only dummy so Pi's built-in opencode catalog is *available*
+	// (availability gates on key presence, never validity). The toggle
+	// check needs opencode-free in the snapshot; no model is ever called.
+	environment.OPENCODE_API_KEY = "sk-opencode-dummy-pi-free-install-smoke";
 }
 
 function run(args, options, timeoutMs = 120_000) {
@@ -91,13 +96,11 @@ const piModule = fileURLToPath(
 	import.meta.resolve("@earendil-works/pi-coding-agent"),
 );
 const piCli = join(dirname(piModule), "cli.js");
-const rpcDriver = join(
-	dirname(fileURLToPath(import.meta.url)),
-	"rpc-load-check.mjs",
-);
-const piOptions = { cwd: project, env: environment, stdio: "inherit" };
 const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rpcDriver = join(scriptDir, "rpc-load-check.mjs");
 const rpcSessionDriver = join(scriptDir, "rpc-session-check.mjs");
+const rpcToggleDriver = join(scriptDir, "rpc-toggle-check.mjs");
+const piOptions = { cwd: project, env: environment, stdio: "inherit" };
 
 // Seed an explicit free_only default so the session check's filter
 // assertions do not depend on template defaults (deterministic input).
@@ -118,10 +121,32 @@ try {
 	await run([rpcDriver], piOptions, 45_000);
 	console.log("Launching Pi RPC session + filter check");
 	await run([rpcSessionDriver], piOptions, 150_000);
+	console.log("Launching Pi RPC toggle check");
+	await run([rpcToggleDriver], piOptions, 150_000);
 	console.log("Pi install smoke passed");
 } catch (error) {
 	console.error(`Pi install smoke failed: ${error.message}`);
+	preserveArtifacts("install");
 	process.exitCode = 1;
 } finally {
 	rmSync(testRoot, { recursive: true, force: true });
+}
+
+/**
+ * Copy the isolated HOME's diagnostics out of the temp dir (which the
+ * finally block deletes) into the checkout, so CI can upload them as
+ * failure artifacts. Best-effort: never fail the smoke itself.
+ */
+function preserveArtifacts(label) {
+	try {
+		const dir = join(process.cwd(), ".smoke-artifacts", `${label}-${Date.now()}`);
+		mkdirSync(dir, { recursive: true });
+		for (const file of ["free.log", "free.json"]) {
+			const src = join(home, ".pi", file);
+			if (existsSync(src)) copyFileSync(src, join(dir, file));
+		}
+		console.log(`Preserved smoke artifacts in ${dir}`);
+	} catch {
+		// Artifact preservation must not mask the original failure.
+	}
 }

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -60,14 +60,14 @@ function run(args, options, timeoutMs = 120_000) {
 			clearTimeout(timer);
 			if (timedOut) {
 				rejectRun(new Error(`Node timed out after ${timeoutMs}ms`));
-			} else if (code !== 0) {
+			} else if (code === 0) {
+				resolveRun();
+			} else {
 				const signalSuffix = signal ? " (" + String(signal) + ")" : "";
 				const exitCode = code ?? "unknown";
 				rejectRun(
 					new Error(`Node exited with code ${exitCode}${signalSuffix}`),
 				);
-			} else {
-				resolveRun();
 			}
 		});
 	});
@@ -120,9 +120,9 @@ try {
 	console.log("Launching Pi RPC load check");
 	await run([rpcDriver], piOptions, 45_000);
 	console.log("Launching Pi RPC session + filter check");
-	await run([rpcSessionDriver], piOptions, 150_000);
+	await run([rpcSessionDriver], piOptions, 420_000);
 	console.log("Launching Pi RPC toggle check");
-	await run([rpcToggleDriver], piOptions, 150_000);
+	await run([rpcToggleDriver], piOptions, 420_000);
 	console.log("Pi install smoke passed");
 } catch (error) {
 	console.error(`Pi install smoke failed: ${error.message}`);

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -52,7 +52,9 @@ function run(args, options, timeoutMs = 180_000) {
 				resolveRun();
 			} else {
 				const signalSuffix = signal ? ` (${String(signal)})` : "";
-				rejectRun(new Error(`Node exited with code ${code ?? "unknown"}${signalSuffix}`));
+				rejectRun(
+					new Error(`Node exited with code ${code ?? "unknown"}${signalSuffix}`),
+				);
 			}
 		});
 	});
@@ -139,9 +141,9 @@ try {
 	console.log("Launching Pi RPC load check on the upgraded tree");
 	await run([join(scriptDir, "rpc-load-check.mjs")], piOptions, 45_000);
 	console.log("Launching Pi RPC session + filter check on the upgraded tree");
-	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 150_000);
+	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 420_000);
 	console.log("Launching Pi RPC toggle check on the upgraded tree");
-	await run([join(scriptDir, "rpc-toggle-check.mjs")], piOptions, 150_000);
+	await run([join(scriptDir, "rpc-toggle-check.mjs")], piOptions, 420_000);
 	console.log("Pi upgrade smoke passed");
 } catch (error) {
 	console.error(

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -58,39 +58,38 @@ function run(args, options, timeoutMs = 180_000) {
 	});
 }
 
-/** Run npm in isolation and return trimmed stdout. */
-function npm(args, options, timeoutMs = 180_000) {
-	return new Promise((resolveRun, rejectRun) => {
-		const child = spawn(
-			process.platform === "win32" ? "npm.cmd" : "npm",
-			args,
-			options,
+/**
+ * Resolve the latest published pi-free version through the registry API.
+ * Deliberately not `spawn npm view` (Windows EINVAL class — spawning npm
+ * from an isolated env is unreliable there) and not `npm view` output
+ * parsing. Honors a configured mirror via npm_config_registry.
+ */
+async function publishedVersion() {
+	const registry = (
+		process.env.npm_config_registry || "https://registry.npmjs.org/"
+	).replace(/\/$/, "");
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 30_000);
+	try {
+		const response = await fetch(`${registry}/pi-free/latest`, {
+			signal: controller.signal,
+			headers: { Accept: "application/json" },
+		});
+		if (!response.ok) {
+			throw new Error(`registry responded ${response.status}`);
+		}
+		const body = await response.json();
+		if (typeof body?.version !== "string" || body.version.length === 0) {
+			throw new Error("registry response has no version");
+		}
+		return body.version;
+	} catch (error) {
+		throw new Error(
+			`cannot resolve published pi-free version: ${error instanceof Error ? error.message : String(error)}`,
 		);
-		let stdout = "";
-		const timer = setTimeout(() => {
-			try {
-				child.kill("SIGKILL");
-			} catch {
-				// The process may already have exited.
-			}
-			rejectRun(new Error(`npm timed out after ${timeoutMs}ms`));
-		}, timeoutMs);
-		child.stdout?.on("data", (data) => {
-			stdout += data.toString();
-		});
-		child.once("error", (error) => {
-			clearTimeout(timer);
-			rejectRun(error);
-		});
-		child.once("close", (code) => {
-			clearTimeout(timer);
-			if (code === 0) {
-				resolveRun(stdout.trim());
-			} else {
-				rejectRun(new Error(`npm exited with code ${code ?? "unknown"}`));
-			}
-		});
-	});
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 const testRoot = mkdtempSync(join(tmpdir(), "pi-free-upgrade-smoke-"));
@@ -129,10 +128,7 @@ try {
 	// Seed reality: the latest published release, installed exactly the way
 	// Pi installs it. A failure here means no published baseline to upgrade
 	// from (offline mirror, registry outage) — fail loudly, not silently.
-	const published = await npm(["view", "pi-free", "version"], {
-		cwd: project,
-		env: environment,
-	});
+	const published = await publishedVersion();
 	console.log(`Seeding previous release pi-free@${published} through Pi`);
 	await run([piCli, "install", `npm:pi-free@${published}`], piOptions);
 

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -13,7 +13,13 @@
  *   node scripts/pi-upgrade-smoke.mjs ./pi-free-<version>.tgz
  */
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -100,6 +106,9 @@ for (const name of Object.keys(environment)) {
 	}
 }
 environment.ANTHROPIC_API_KEY = "sk-ant-dummy-pi-free-upgrade-smoke";
+// Presence-only dummy so Pi's built-in opencode catalog is *available*
+// (availability gates on key presence, never validity). No model is called.
+environment.OPENCODE_API_KEY = "sk-opencode-dummy-pi-free-upgrade-smoke";
 environment.HOME = home;
 environment.USERPROFILE = home;
 environment.NPM_CONFIG_USERCONFIG = join(testRoot, "npmrc");
@@ -135,12 +144,34 @@ try {
 	await run([join(scriptDir, "rpc-load-check.mjs")], piOptions, 45_000);
 	console.log("Launching Pi RPC session + filter check on the upgraded tree");
 	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 150_000);
+	console.log("Launching Pi RPC toggle check on the upgraded tree");
+	await run([join(scriptDir, "rpc-toggle-check.mjs")], piOptions, 150_000);
 	console.log("Pi upgrade smoke passed");
 } catch (error) {
 	console.error(
 		`Pi upgrade smoke failed: ${error instanceof Error ? error.message : String(error)}`,
 	);
+	preserveArtifacts("upgrade");
 	process.exitCode = 1;
 } finally {
 	rmSync(testRoot, { recursive: true, force: true });
+}
+
+/**
+ * Copy the isolated HOME's diagnostics out of the temp dir (which the
+ * finally block deletes) into the checkout, so CI can upload them as
+ * failure artifacts. Best-effort: never fail the smoke itself.
+ */
+function preserveArtifacts(label) {
+	try {
+		const dir = join(process.cwd(), ".smoke-artifacts", `${label}-${Date.now()}`);
+		mkdirSync(dir, { recursive: true });
+		for (const file of ["free.log", "free.json"]) {
+			const src = join(home, ".pi", file);
+			if (existsSync(src)) copyFileSync(src, join(dir, file));
+		}
+		console.log(`Preserved smoke artifacts in ${dir}`);
+	} catch {
+		// Artifact preservation must not mask the original failure.
+	}
 }

--- a/scripts/rpc-load-check.mjs
+++ b/scripts/rpc-load-check.mjs
@@ -5,119 +5,43 @@
  * The caller is responsible for providing an isolated HOME. This script starts
  * Pi in RPC mode, requests the command registry (which never calls a model),
  * and fails on extension errors, timeouts, or missing pi-free commands.
+ * Speaks Pi through the shared harness in scripts/lib/rpc-driver.mjs.
  *
  * Usage:
  *   node scripts/rpc-load-check.mjs
  */
-import { spawn } from "node:child_process";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { bootPi, sleep } from "./lib/rpc-driver.mjs";
 
 const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
 
-function resolveInstalledPi() {
-	const piModule = fileURLToPath(
-		import.meta.resolve("@earendil-works/pi-coding-agent"),
-	);
-	return { command: process.execPath, args: [join(dirname(piModule), "cli.js")] };
-}
-
-const piCommand = resolveInstalledPi();
-const pi = spawn(
-	piCommand.command,
-	[...piCommand.args, "--mode", "rpc", "--no-session"],
-	{
-		stdio: ["pipe", "pipe", "inherit"],
-		env: {
-			...process.env,
-			// RPC startup needs a configured provider, but get_commands never calls it.
-			ANTHROPIC_API_KEY:
-				process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-load-check",
-		},
-		shell: false,
+const driver = bootPi({
+	cwd: process.cwd(),
+	env: {
+		...process.env,
+		// RPC startup needs a configured provider, but get_commands never calls it.
+		ANTHROPIC_API_KEY:
+			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-load-check",
 	},
-);
+	timeoutMs: 30_000,
+});
 
-let buffer = "";
-const extensionErrors = [];
-let finished = false;
-let timer;
+try {
+	// Allow Pi to finish loading extensions before querying the registry.
+	await sleep(2500);
 
-function finish(code, message) {
-	if (finished) return;
-	finished = true;
-	clearTimeout(timer);
-	if (message) console.log(message);
-	try {
-		pi.kill("SIGKILL");
-	} catch {
-		// The process may already have exited.
-	}
-	process.exit(code);
-}
-
-timer = setTimeout(
-	() => finish(2, "TIMEOUT waiting for get_commands response"),
-	30_000,
-);
-
-function handleLine(line) {
-	let message;
-	try {
-		message = JSON.parse(line);
-	} catch {
-		return;
-	}
-
-	if (
-		(message.type === "event" && message.event === "extension_error") ||
-		message.type === "extension_error"
-	) {
-		extensionErrors.push(message);
-		console.log("extension_error:", JSON.stringify(message).slice(0, 500));
-	}
-
-	if (message.type !== "response" || message.command !== "get_commands") return;
-
-	const commands = message.data?.commands ?? [];
+	const data = await driver.send({ type: "get_commands" });
+	const commands = data?.commands ?? [];
 	const names = new Set(commands.map((command) => command.name));
 	const missing = expectedCommands.filter((name) => !names.has(name));
-	console.log(`Pi reported ${commands.length} command(s): ${[...names].join(", ")}`);
+	console.log(
+		`Pi reported ${commands.length} command(s): ${[...names].join(", ")}`,
+	);
 
-	if (extensionErrors.length > 0) {
-		finish(1, `FAIL: ${extensionErrors.length} extension_error event(s)`);
-	} else if (missing.length > 0) {
-		finish(1, `FAIL: missing pi-free command(s): ${missing.join(", ")}`);
+	if (missing.length > 0) {
+		driver.fail(`missing pi-free command(s): ${missing.join(", ")}`);
 	} else {
-		finish(0, "PASS: pi-free loaded and registered the expected commands");
+		driver.pass("pi-free loaded and registered the expected commands");
 	}
+} catch (error) {
+	driver.fail(error instanceof Error ? error.message : String(error));
 }
-
-pi.stdout.on("data", (data) => {
-	buffer += data.toString();
-	let newline;
-	while ((newline = buffer.indexOf("\n")) >= 0) {
-		const line = buffer.slice(0, newline).replace(/\r$/, "");
-		buffer = buffer.slice(newline + 1);
-		if (line.trim()) handleLine(line);
-	}
-});
-
-pi.on("error", (error) => finish(1, `FAIL: could not start Pi: ${error.message}`));
-pi.on("exit", (code) => {
-	if (!finished) {
-		finish(
-			extensionErrors.length > 0 ? 1 : 2,
-			`Pi exited before get_commands (code ${code ?? "unknown"})`,
-		);
-	}
-});
-
-// Allow Pi to finish loading extensions before querying the registry.
-setTimeout(() => {
-	try {
-		pi.stdin.write(`${JSON.stringify({ type: "get_commands" })}\n`);
-	} catch (error) {
-		finish(1, `FAIL: could not send get_commands: ${error.message}`);
-	}
-}, 2_500);

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -19,31 +19,29 @@
  *   5. `/toggle-llm7` via prompt dispatch, then another `new_session` —
  *      the flipped choice persists and shows in the catalog.
  *
- * Fails on ANY extension_error event at ANY point, any timeout, any
- * missing command, an empty catalog, a paid managed model, or a missing
- * llm7 anchor. Strict by design: a failure names a product bug to fix,
- * not a threshold to tune.
+ * Waiting is poll-until-condition with deadlines, never fixed sleeps, so
+ * slow runners (Windows CI) get patience instead of flakes. Fails on ANY
+ * extension_error event at ANY point, any timeout, any missing command,
+ * an empty catalog, a paid managed model, or a missing llm7 anchor.
+ * Strict by design: a failure names a product bug to fix, not a
+ * threshold to tune.
  *
- * Managed vs unmanaged: the harness injects a dummy ANTHROPIC_API_KEY so
- * Pi boots, which makes Anthropic's paid catalog visible. Anthropic is
- * not pi-free-managed (the global filter only governs pi-free's own
- * registry), so provider `anthropic` is excluded from the paid check —
- * and named as such in failures.
+ * Managed vs unmanaged: pi-free manages exactly the providers with a
+ * pi-free toggle command (derived live from get_commands, so new
+ * providers are covered without editing this script). Anything else
+ * (e.g. anthropic via the harness dummy key, Pi's own built-in
+ * `opencode` catalog) is Pi-managed and out of scope.
  *
  * Usage:
  *   node scripts/rpc-session-check.mjs
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { bootPi, sleep } from "./lib/rpc-driver.mjs";
+import { bootPi } from "./lib/rpc-driver.mjs";
 
 const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
 
 // Providers pi-free manages = providers with a pi-free toggle command.
-// Anything else (e.g. anthropic, visible via the harness-injected dummy
-// key, or Pi's own built-in `opencode` catalog) is Pi-managed and outside
-// the free-only promise — the harness asserts only on the managed set,
-// derived here so new providers are covered without editing this script.
 const GLOBAL_COMMANDS = new Set(["toggle-free", "toggle-auto-fallback"]);
 
 function managedIds(commands) {
@@ -68,7 +66,7 @@ const driver = bootPi({
 		ANTHROPIC_API_KEY:
 			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-session-check",
 	},
-	timeoutMs: 150_000,
+	timeoutMs: 300_000,
 });
 
 function paidCost(model) {
@@ -122,14 +120,39 @@ function assertCommands(commands, phase) {
 		);
 	}
 	console.log(`${phase}: commands ok (${names.size} total)`);
+	return commands;
+}
+
+async function waitCommands(phase) {
+	return driver.waitFor(
+		async () => {
+			const commands = (await driver.send({ type: "get_commands" })).commands;
+			assertCommands(commands, phase);
+			return commands;
+		},
+		{ timeoutMs: 60_000, label: `${phase} pi-free commands` },
+	);
+}
+
+async function waitCatalog(phase, managed) {
+	const models = await driver.waitFor(
+		async () => {
+			const found = (await driver.send({ type: "get_available_models" }))
+				.models;
+			// Presence first (polls through slow boots); strictness after.
+			return (found ?? []).some((m) => managed.has(m.provider))
+				? found
+				: null;
+		},
+		{ timeoutMs: 120_000, label: `${phase} managed catalog` },
+	);
+	assertCatalog(models, phase, managed);
+	return models;
 }
 
 try {
-	// Allow Pi to finish loading extensions before querying.
-	await sleep(2500);
-
 	// Read back the seeded free.json through the same HOME Pi sees: if the
-	// seed is absent here, the filter failure below is environmental (wrong
+	// seed is absent here, a filter failure below is environmental (wrong
 	// file / race), not a view-resolution bug. Fail fast with the evidence.
 	const homeDir = process.env.HOME || process.env.USERPROFILE || "";
 	let seededConfig = null;
@@ -149,12 +172,9 @@ try {
 		);
 	}
 
-	const commands = (await driver.send({ type: "get_commands" })).commands;
-	assertCommands(commands, "boot");
+	const commands = await waitCommands("boot");
 	const managed = managedIds(commands);
-
-	const before = (await driver.send({ type: "get_available_models" })).models;
-	assertCatalog(before, "boot", managed);
+	await waitCatalog("boot", managed);
 
 	const replaced = await driver.send({ type: "new_session" });
 	if (replaced?.cancelled) {
@@ -162,44 +182,44 @@ try {
 	}
 	console.log("new_session ok (replacement settled)");
 
-	// session_start handlers + detached capture land in ~1s; wait with
-	// margin so a stale-ctx failure has time to surface as extension_error.
-	await sleep(8000);
-
-	const commandsAfter = (await driver.send({ type: "get_commands" })).commands;
-	assertCommands(commandsAfter, "post-replacement");
-
-	const after = (await driver.send({ type: "get_available_models" })).models;
-	assertCatalog(after, "post-replacement", managed);
+	await waitCommands("post-replacement");
+	await waitCatalog("post-replacement", managed);
 
 	// Toggle persistence end to end: flipping llm7 must survive a session
 	// replacement and show in the catalog (the paid pro selector appears).
 	// Slash commands dispatch through prompt preflight — no model runs.
 	await driver.prompt("/toggle-llm7");
-	await sleep(3000);
-	const toggled = (await driver.send({ type: "get_available_models" })).models;
-	const pro = toggled.filter(
-		(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
+	const toggled = await driver.waitFor(
+		async () => {
+			const found = (await driver.send({ type: "get_available_models" }))
+				.models;
+			return (found ?? []).some(
+				(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
+			)
+				? found
+				: null;
+		},
+		{ timeoutMs: 60_000, label: "post-toggle llm7/pro" },
 	);
-	if (pro.length === 0) {
-		throw new Error(
-			"post-toggle: llm7/pro missing from catalog after /toggle-llm7",
-		);
-	}
-	console.log("post-toggle: llm7/pro visible after /toggle-llm7");
+	console.log(
+		`post-toggle: llm7/pro visible after /toggle-llm7 (${toggled.length} total)`,
+	);
 	await driver.send({ type: "new_session" });
-	await sleep(8000);
-	const persisted = (await driver.send({ type: "get_available_models" }))
-		.models;
-	const proAfter = persisted.filter(
-		(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
+	const persisted = await driver.waitFor(
+		async () => {
+			const found = (await driver.send({ type: "get_available_models" }))
+				.models;
+			return (found ?? []).some(
+				(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
+			)
+				? found
+				: null;
+		},
+		{ timeoutMs: 90_000, label: "post-toggle-replacement llm7/pro" },
 	);
-	if (proAfter.length === 0) {
-		throw new Error(
-			"post-toggle-replacement: llm7/pro lost across new_session (choice did not persist)",
-		);
-	}
-	console.log("post-toggle-replacement: llm7/pro survives new_session");
+	console.log(
+		`post-toggle-replacement: llm7/pro survives new_session (${persisted.length} total)`,
+	);
 
 	driver.pass("session replacement clean, free-only view holds");
 } catch (error) {

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -2,7 +2,8 @@
 /**
  * RPC session + filter check — strict end-to-end assertions over a real Pi
  * boot with pi-free installed. Headless and model-free (no prompt is ever
- * sent, no network beyond Pi's own boot).
+ * sent, no network beyond Pi's own boot). Speaks Pi through the shared
+ * harness in scripts/lib/rpc-driver.mjs.
  *
  * The caller is responsible for providing an isolated HOME (with pi-free
  * already installed and `free_only: true` in free.json). This script:
@@ -15,6 +16,8 @@
  *   4. `get_commands` + `get_available_models` again — registration and
  *      the free-only view survive replacement (#509 stale-ctx class and
  *      the #510 filter-stickiness class).
+ *   5. `/toggle-llm7` via prompt dispatch, then another `new_session` —
+ *      the flipped choice persists and shows in the catalog.
  *
  * Fails on ANY extension_error event at ANY point, any timeout, any
  * missing command, an empty catalog, a paid managed model, or a missing
@@ -30,112 +33,58 @@
  * Usage:
  *   node scripts/rpc-session-check.mjs
  */
-import { spawn } from "node:child_process";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { bootPi, sleep } from "./lib/rpc-driver.mjs";
 
 const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
 
-// The harness-injected dummy key makes this paid catalog visible. It is
-// deliberately NOT pi-free-managed, so it is excluded from the paid
-// assertions below (and any failure message says so).
-const UNMANAGED_PROVIDERS = new Set(["anthropic"]);
+// Providers pi-free manages = providers with a pi-free toggle command.
+// Anything else (e.g. anthropic, visible via the harness-injected dummy
+// key, or Pi's own built-in `opencode` catalog) is Pi-managed and outside
+// the free-only promise — the harness asserts only on the managed set,
+// derived here so new providers are covered without editing this script.
+const GLOBAL_COMMANDS = new Set(["toggle-free", "toggle-auto-fallback"]);
+
+function managedIds(commands) {
+	return new Set(
+		(commands ?? [])
+			.map((command) => command.name)
+			.filter(
+				(name) => name.startsWith("toggle-") && !GLOBAL_COMMANDS.has(name),
+			)
+			.map((name) => name.slice("toggle-".length)),
+	);
+}
 
 // Deterministic anchor: static keyless catalog with free AND paid
 // selectors, always available without network or credentials.
 const ANCHOR_PROVIDER = "llm7";
 
-function resolveInstalledPi() {
-	const piModule = fileURLToPath(
-		import.meta.resolve("@earendil-works/pi-coding-agent"),
-	);
-	return {
-		command: process.execPath,
-		args: [join(dirname(piModule), "cli.js")],
-	};
-}
-
-const piCommand = resolveInstalledPi();
-const pi = spawn(
-	piCommand.command,
-	[...piCommand.args, "--mode", "rpc", "--no-session"],
-	{
-		stdio: ["pipe", "pipe", "inherit"],
-		env: {
-			...process.env,
-			ANTHROPIC_API_KEY:
-				process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-session-check",
-		},
-		shell: false,
+const driver = bootPi({
+	cwd: process.cwd(),
+	env: {
+		...process.env,
+		ANTHROPIC_API_KEY:
+			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-session-check",
 	},
-);
-
-let buffer = "";
-const extensionErrors = [];
-let finished = false;
-let timer;
-let pending = null;
-
-function finish(code, message) {
-	if (finished) return;
-	finished = true;
-	clearTimeout(timer);
-	if (message) console.log(message);
-	try {
-		pi.kill("SIGKILL");
-	} catch {
-		// The process may already have exited.
-	}
-	process.exit(code);
-}
-
-function fail(message) {
-	if (extensionErrors.length > 0) {
-		console.log(
-			`extension_error events observed: ${JSON.stringify(extensionErrors).slice(0, 500)}`,
-		);
-	}
-	finish(1, `FAIL: ${message}`);
-}
-
-/** Send a command and resolve with its response data. */
-function send(command) {
-	return new Promise((resolveSend, rejectSend) => {
-		const timeout = setTimeout(
-			() => rejectSend(new Error(`timed out waiting for ${command.type}`)),
-			20_000,
-		);
-		pending = {
-			command: command.type,
-			resolve: (data) => {
-				clearTimeout(timeout);
-				resolveSend(data);
-			},
-			reject: (error) => {
-				clearTimeout(timeout);
-				rejectSend(error);
-			},
-		};
-		try {
-			pi.stdin.write(`${JSON.stringify(command)}\n`);
-		} catch (error) {
-			pending = null;
-			rejectSend(error);
-		}
-	});
-}
+	timeoutMs: 150_000,
+});
 
 function paidCost(model) {
 	return (model.cost?.input ?? 0) > 0 || (model.cost?.output ?? 0) > 0;
 }
 
 /** Strict catalog assertions. Throws on the first violation. */
-function assertCatalog(models, phase) {
+function assertCatalog(models, phase, managed) {
 	if (!Array.isArray(models) || models.length === 0) {
 		throw new Error(`${phase}: empty model catalog`);
 	}
-	const managed = models.filter((m) => !UNMANAGED_PROVIDERS.has(m.provider));
-	const paid = managed.filter(paidCost);
+	const inScope = models.filter((m) => managed.has(m.provider));
+	if (inScope.length === 0) {
+		throw new Error(
+			`${phase}: no pi-free-managed models in catalog (${models.length} unmanaged present)`,
+		);
+	}
+	const paid = inScope.filter(paidCost);
 	if (paid.length > 0) {
 		const sample = paid
 			.slice(0, 3)
@@ -145,10 +94,10 @@ function assertCatalog(models, phase) {
 			`${phase}: ${paid.length} paid managed model(s) visible under free-only (e.g. ${sample})`,
 		);
 	}
-	const anchor = managed.filter((m) => m.provider === ANCHOR_PROVIDER);
+	const anchor = inScope.filter((m) => m.provider === ANCHOR_PROVIDER);
 	if (anchor.length === 0) {
 		throw new Error(
-			`${phase}: anchor provider ${ANCHOR_PROVIDER} missing from catalog (${managed.length} managed models present)`,
+			`${phase}: anchor provider ${ANCHOR_PROVIDER} missing from catalog (${inScope.length} managed models present)`,
 		);
 	}
 	const anchorPaid = anchor.filter(paidCost);
@@ -158,13 +107,8 @@ function assertCatalog(models, phase) {
 		);
 	}
 	console.log(
-		`${phase}: catalog ok (${models.length} total, ${managed.length} managed, ${anchor.length} anchor, 0 paid)`,
+		`${phase}: catalog ok (${models.length} total, ${inScope.length} managed, ${anchor.length} anchor, 0 paid)`,
 	);
-}
-
-/** Prompt pi with a slash command; resolves when preflight succeeds. */
-function sendPrompt(text) {
-	return send({ type: "prompt", message: text });
 }
 
 function assertCommands(commands, phase) {
@@ -178,67 +122,18 @@ function assertCommands(commands, phase) {
 	console.log(`${phase}: commands ok (${names.size} total)`);
 }
 
-function handleLine(line) {
-	let message;
-	try {
-		message = JSON.parse(line);
-	} catch {
-		return;
-	}
-
-	if (
-		(message.type === "event" && message.event === "extension_error") ||
-		message.type === "extension_error"
-	) {
-		extensionErrors.push(message);
-		console.log("extension_error:", JSON.stringify(message).slice(0, 500));
-		return;
-	}
-
-	if (message.type !== "response" || !pending) return;
-	if (message.command !== pending.command) return;
-	const current = pending;
-	pending = null;
-	if (message.error) {
-		current.reject(new Error(`${message.command}: ${message.error}`));
-	} else {
-		current.resolve(message.data);
-	}
-}
-
-pi.stdout.on("data", (data) => {
-	buffer += data.toString();
-	let newline;
-	while ((newline = buffer.indexOf("\n")) >= 0) {
-		const line = buffer.slice(0, newline).replace(/\r$/, "");
-		buffer = buffer.slice(newline + 1);
-		if (line.trim()) handleLine(line);
-	}
-});
-
-pi.on("error", (error) => fail(`could not start Pi: ${error.message}`));
-pi.on("exit", (code) => {
-	if (!finished) {
-		fail(`Pi exited before checks completed (code ${code ?? "unknown"})`);
-	}
-});
-
-const sleep = (ms) =>
-	new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
-
-timer = setTimeout(() => fail("TIMEOUT waiting for session checks"), 120_000);
-
 try {
 	// Allow Pi to finish loading extensions before querying.
 	await sleep(2500);
 
-	const commands = (await send({ type: "get_commands" })).commands;
+	const commands = (await driver.send({ type: "get_commands" })).commands;
 	assertCommands(commands, "boot");
+	const managed = managedIds(commands);
 
-	const before = (await send({ type: "get_available_models" })).models;
-	assertCatalog(before, "boot");
+	const before = (await driver.send({ type: "get_available_models" })).models;
+	assertCatalog(before, "boot", managed);
 
-	const replaced = await send({ type: "new_session" });
+	const replaced = await driver.send({ type: "new_session" });
 	if (replaced?.cancelled) {
 		throw new Error("new_session was cancelled by an extension");
 	}
@@ -248,18 +143,18 @@ try {
 	// margin so a stale-ctx failure has time to surface as extension_error.
 	await sleep(8000);
 
-	const commandsAfter = (await send({ type: "get_commands" })).commands;
+	const commandsAfter = (await driver.send({ type: "get_commands" })).commands;
 	assertCommands(commandsAfter, "post-replacement");
 
-	const after = (await send({ type: "get_available_models" })).models;
-	assertCatalog(after, "post-replacement");
+	const after = (await driver.send({ type: "get_available_models" })).models;
+	assertCatalog(after, "post-replacement", managed);
 
 	// Toggle persistence end to end: flipping llm7 must survive a session
 	// replacement and show in the catalog (the paid pro selector appears).
 	// Slash commands dispatch through prompt preflight — no model runs.
-	await sendPrompt("/toggle-llm7");
+	await driver.prompt("/toggle-llm7");
 	await sleep(3000);
-	const toggled = (await send({ type: "get_available_models" })).models;
+	const toggled = (await driver.send({ type: "get_available_models" })).models;
 	const pro = toggled.filter(
 		(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
 	);
@@ -269,9 +164,10 @@ try {
 		);
 	}
 	console.log("post-toggle: llm7/pro visible after /toggle-llm7");
-	await send({ type: "new_session" });
+	await driver.send({ type: "new_session" });
 	await sleep(8000);
-	const persisted = (await send({ type: "get_available_models" })).models;
+	const persisted = (await driver.send({ type: "get_available_models" }))
+		.models;
 	const proAfter = persisted.filter(
 		(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
 	);
@@ -282,10 +178,7 @@ try {
 	}
 	console.log("post-toggle-replacement: llm7/pro survives new_session");
 
-	if (extensionErrors.length > 0) {
-		fail(`${extensionErrors.length} extension_error event(s) observed`);
-	}
-	finish(0, "PASS: session replacement clean, free-only view holds");
+	driver.pass("session replacement clean, free-only view holds");
 } catch (error) {
-	fail(error instanceof Error ? error.message : String(error));
+	driver.fail(error instanceof Error ? error.message : String(error));
 }

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -48,9 +48,7 @@ function managedIds(commands) {
 	return new Set(
 		(commands ?? [])
 			.map((command) => command.name)
-			.filter(
-				(name) => name.startsWith("toggle-") && !GLOBAL_COMMANDS.has(name),
-			)
+			.filter((name) => name.startsWith("toggle-") && !GLOBAL_COMMANDS.has(name))
 			.map((name) => name.slice("toggle-".length)),
 	);
 }
@@ -135,36 +133,36 @@ async function waitCommands(phase) {
 }
 
 async function waitCatalog(phase, managed) {
-	const models = await driver.waitFor(
-		async () => {
-			const found = (await driver.send({ type: "get_available_models" }))
-				.models;
-			// Presence first (polls through slow boots); strictness after.
-			return (found ?? []).some((m) => managed.has(m.provider))
-				? found
-				: null;
-		},
-		{ timeoutMs: 120_000, label: `${phase} managed catalog` },
+	// Settled strictness (not first sight): the snapshot rebuilds
+	// unfiltered on every re-registration until the availability refresh
+	// lands, so presence alone would assert a transient.
+	return driver.waitSettled(
+		async () =>
+			(await driver.send({ type: "get_available_models" })).models,
+		(models) => assertCatalog(models, phase, managed),
+		{ timeoutMs: 180_000, label: `${phase} managed catalog` },
 	);
-	assertCatalog(models, phase, managed);
-	return models;
+}
+
+/**
+ * Read the smoke HOME's free.json (same file the extension reads).
+ * Total: returns null when the file is missing or unparsable, so polling
+ * callers keep waiting and one-shot callers fail fast with context.
+ */
+function readSeededConfig() {
+	try {
+		const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+		return JSON.parse(readFileSync(join(homeDir, ".pi", "free.json"), "utf8"));
+	} catch {
+		return null;
+	}
 }
 
 try {
 	// Read back the seeded free.json through the same HOME Pi sees: if the
 	// seed is absent here, a filter failure below is environmental (wrong
 	// file / race), not a view-resolution bug. Fail fast with the evidence.
-	const homeDir = process.env.HOME || process.env.USERPROFILE || "";
-	let seededConfig = null;
-	try {
-		seededConfig = JSON.parse(
-			readFileSync(join(homeDir, ".pi", "free.json"), "utf8"),
-		);
-	} catch (error) {
-		throw new Error(
-			`boot: cannot read seeded free.json in ${homeDir}: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
+	const seededConfig = readSeededConfig();
 	console.log(`boot: free.json is ${JSON.stringify(seededConfig)}`);
 	if (seededConfig?.free_only !== true) {
 		throw new Error(
@@ -188,11 +186,19 @@ try {
 	// Toggle persistence end to end: flipping llm7 must survive a session
 	// replacement and show in the catalog (the paid pro selector appears).
 	// Slash commands dispatch through prompt preflight — no model runs.
+	// The persisted override (not just catalog presence, which a transient
+	// unfiltered snapshot could fake) proves the command did its write.
 	await driver.prompt("/toggle-llm7");
+	await driver.waitFor(
+		async () =>
+			readSeededConfig()?.model_view_overrides?.llm7 === "all"
+				? true
+				: null,
+		{ timeoutMs: 60_000, label: "post-toggle llm7 override" },
+	);
 	const toggled = await driver.waitFor(
 		async () => {
-			const found = (await driver.send({ type: "get_available_models" }))
-				.models;
+			const found = (await driver.send({ type: "get_available_models" })).models;
 			return (found ?? []).some(
 				(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
 			)
@@ -207,8 +213,7 @@ try {
 	await driver.send({ type: "new_session" });
 	const persisted = await driver.waitFor(
 		async () => {
-			const found = (await driver.send({ type: "get_available_models" }))
-				.models;
+			const found = (await driver.send({ type: "get_available_models" })).models;
 			return (found ?? []).some(
 				(m) => m.provider === ANCHOR_PROVIDER && m.id === "pro",
 			)

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -33,6 +33,8 @@
  * Usage:
  *   node scripts/rpc-session-check.mjs
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { bootPi, sleep } from "./lib/rpc-driver.mjs";
 
 const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
@@ -125,6 +127,27 @@ function assertCommands(commands, phase) {
 try {
 	// Allow Pi to finish loading extensions before querying.
 	await sleep(2500);
+
+	// Read back the seeded free.json through the same HOME Pi sees: if the
+	// seed is absent here, the filter failure below is environmental (wrong
+	// file / race), not a view-resolution bug. Fail fast with the evidence.
+	const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+	let seededConfig = null;
+	try {
+		seededConfig = JSON.parse(
+			readFileSync(join(homeDir, ".pi", "free.json"), "utf8"),
+		);
+	} catch (error) {
+		throw new Error(
+			`boot: cannot read seeded free.json in ${homeDir}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	console.log(`boot: free.json is ${JSON.stringify(seededConfig)}`);
+	if (seededConfig?.free_only !== true) {
+		throw new Error(
+			`boot: seeded free.json does not enable free_only: ${JSON.stringify(seededConfig)}`,
+		);
+	}
 
 	const commands = (await driver.send({ type: "get_commands" })).commands;
 	assertCommands(commands, "boot");

--- a/scripts/rpc-toggle-check.mjs
+++ b/scripts/rpc-toggle-check.mjs
@@ -25,6 +25,8 @@
  * Usage:
  *   node scripts/rpc-toggle-check.mjs [providerId]
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { bootPi } from "./lib/rpc-driver.mjs";
 
 const providerId = process.argv[2] ?? "opencode-free";
@@ -48,22 +50,40 @@ function forProvider(models) {
 	return (models ?? []).filter((m) => m.provider === providerId);
 }
 
-async function waitProviderView(phase, wantPaid) {
-	return driver.waitFor(
-		async () => {
-			const models = (await driver.send({ type: "get_available_models" }))
-				.models;
-			const view = forProvider(models);
-			if (view.length === 0) return null;
-			const hasPaid = view.some(paidCost);
-			if (wantPaid && !hasPaid) return null;
-			return view;
+/**
+ * Fetch until assert() passes twice in a row, then return the view.
+ * Pi rebuilds its model snapshot unfiltered on every re-registration
+ * until the availability refresh lands — asserting first sight as final
+ * flakes on slow/fresh boots (settled-state contract instead).
+ */
+async function settledView(phase, assert) {
+	const models = await driver.waitSettled(
+		async () => (await driver.send({ type: "get_available_models" })).models,
+		(all) => {
+			const view = forProvider(all);
+			if (view.length === 0) {
+				throw new Error(
+					`${phase}: provider ${providerId} missing from catalog`,
+				);
+			}
+			assert(view, phase);
 		},
-		{
-			timeoutMs: 120_000,
-			label: `${phase} ${providerId} ${wantPaid ? "all" : "free-only"} view`,
-		},
+		{ timeoutMs: 180_000, label: `${phase} ${providerId} view` },
 	);
+	return forProvider(models);
+}
+
+/** Persisted override from the smoke HOME's free.json (same file Pi reads). */
+function readOverride() {
+	try {
+		const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+		const cfg = JSON.parse(
+			readFileSync(join(homeDir, ".pi", "free.json"), "utf8"),
+		);
+		return cfg?.model_view_overrides?.[providerId];
+	} catch {
+		return undefined;
+	}
 }
 
 function assertFreeOnly(view, phase) {
@@ -94,16 +114,19 @@ function assertAll(view, phase) {
 }
 
 try {
-	const bootView = await waitProviderView("boot", false);
-	assertFreeOnly(bootView, "boot");
+	await settledView("boot", assertFreeOnly);
 
 	await driver.prompt(toggleCommand);
-	const toggledView = await waitProviderView("post-toggle", true);
-	assertAll(toggledView, "post-toggle");
+	// The persisted override (not just catalog presence, which a transient
+	// unfiltered snapshot could fake) proves the command did its write.
+	await driver.waitFor(
+		async () => (readOverride() === "all" ? true : null),
+		{ timeoutMs: 60_000, label: `post-toggle ${providerId} override` },
+	);
+	await settledView("post-toggle", assertAll);
 
 	await driver.send({ type: "new_session" });
-	const persistedView = await waitProviderView("post-replacement", true);
-	assertAll(persistedView, "post-replacement");
+	await settledView("post-replacement", assertAll);
 
 	driver.pass(`${providerId} capture, toggle, and persistence hold`);
 } catch (error) {

--- a/scripts/rpc-toggle-check.mjs
+++ b/scripts/rpc-toggle-check.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * RPC toggle check — provider capture views end to end, over a real Pi
+ * boot with pi-free installed. Headless and model-free. Speaks Pi through
+ * the shared harness in scripts/lib/rpc-driver.mjs.
+ *
+ * The caller is responsible for providing an isolated HOME (with pi-free
+ * already installed and `free_only: true` in free.json). Given a provider
+ * id whose catalog Pi owns statically (default: opencode-free — 70 models,
+ * 8 free — no credentials, no network), this script:
+ *
+ *   1. `get_available_models` — the provider shows only zero-cost models
+ *      under the global free-only default (capture resolved the view).
+ *   2. `/toggle-<provider>` via prompt dispatch — paid models appear.
+ *   3. `new_session`, then `get_available_models` again — the flipped
+ *      choice persists across replacement (no stale per-provider pref
+ *      resurrects the old view).
+ *
+ * Fails on ANY extension_error at ANY point, any timeout, an empty
+ * provider catalog, a paid model in the free view, no paid model after
+ * the toggle, or a lost choice across replacement. Strict by design.
+ *
+ * Usage:
+ *   node scripts/rpc-toggle-check.mjs [providerId]
+ */
+import { bootPi, sleep } from "./lib/rpc-driver.mjs";
+
+const providerId = process.argv[2] ?? "opencode-free";
+const toggleCommand = `/toggle-${providerId}`;
+
+const driver = bootPi({
+	cwd: process.cwd(),
+	env: {
+		...process.env,
+		ANTHROPIC_API_KEY:
+			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-toggle-check",
+	},
+	timeoutMs: 150_000,
+});
+
+function paidCost(model) {
+	return (model.cost?.input ?? 0) > 0 || (model.cost?.output ?? 0) > 0;
+}
+
+function forProvider(models) {
+	return (models ?? []).filter((m) => m.provider === providerId);
+}
+
+try {
+	// Allow Pi to finish loading extensions + the detached capture (~1s).
+	await sleep(4000);
+
+	const bootModels = (await driver.send({ type: "get_available_models" }))
+		.models;
+	const bootView = forProvider(bootModels);
+	if (bootView.length === 0) {
+		throw new Error(
+			`boot: provider ${providerId} missing from catalog — cannot assert its view`,
+		);
+	}
+	const bootPaid = bootView.filter(paidCost);
+	if (bootPaid.length > 0) {
+		throw new Error(
+			`boot: ${providerId} shows ${bootPaid.length} paid model(s) under free-only (e.g. ${bootPaid
+				.slice(0, 3)
+				.map((m) => m.id)
+				.join(", ")})`,
+		);
+	}
+	console.log(
+		`boot: ${providerId} free-only view ok (${bootView.length} models, 0 paid)`,
+	);
+
+	await driver.prompt(toggleCommand);
+	await sleep(3000);
+	const toggledModels = (await driver.send({ type: "get_available_models" }))
+		.models;
+	const toggledView = forProvider(toggledModels);
+	const toggledPaid = toggledView.filter(paidCost);
+	if (toggledPaid.length === 0) {
+		throw new Error(
+			`post-toggle: ${providerId} still shows no paid models after ${toggleCommand}`,
+		);
+	}
+	console.log(
+		`post-toggle: ${providerId} all view ok (${toggledView.length} models, ${toggledPaid.length} paid)`,
+	);
+
+	await driver.send({ type: "new_session" });
+	await sleep(8000);
+	const persistedModels = (
+		await driver.send({ type: "get_available_models" })
+	).models;
+	const persistedView = forProvider(persistedModels);
+	const persistedPaid = persistedView.filter(paidCost);
+	if (persistedPaid.length === 0) {
+		throw new Error(
+			`post-replacement: ${providerId} lost its all view across new_session (choice did not persist)`,
+		);
+	}
+	console.log(
+		`post-replacement: ${providerId} all view persists (${persistedView.length} models)`,
+	);
+
+	driver.pass(`${providerId} capture, toggle, and persistence hold`);
+} catch (error) {
+	driver.fail(error instanceof Error ? error.message : String(error));
+}

--- a/scripts/rpc-toggle-check.mjs
+++ b/scripts/rpc-toggle-check.mjs
@@ -7,7 +7,8 @@
  * The caller is responsible for providing an isolated HOME (with pi-free
  * already installed and `free_only: true` in free.json). Given a provider
  * id whose catalog Pi owns statically (default: opencode-free — 70 models,
- * 8 free — no credentials, no network), this script:
+ * 8 free — needs a key present for availability, never a real call), this
+ * script:
  *
  *   1. `get_available_models` — the provider shows only zero-cost models
  *      under the global free-only default (capture resolved the view).
@@ -16,6 +17,7 @@
  *      choice persists across replacement (no stale per-provider pref
  *      resurrects the old view).
  *
+ * Waiting is poll-until-condition with deadlines, never fixed sleeps.
  * Fails on ANY extension_error at ANY point, any timeout, an empty
  * provider catalog, a paid model in the free view, no paid model after
  * the toggle, or a lost choice across replacement. Strict by design.
@@ -23,7 +25,7 @@
  * Usage:
  *   node scripts/rpc-toggle-check.mjs [providerId]
  */
-import { bootPi, sleep } from "./lib/rpc-driver.mjs";
+import { bootPi } from "./lib/rpc-driver.mjs";
 
 const providerId = process.argv[2] ?? "opencode-free";
 const toggleCommand = `/toggle-${providerId}`;
@@ -35,7 +37,7 @@ const driver = bootPi({
 		ANTHROPIC_API_KEY:
 			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-toggle-check",
 	},
-	timeoutMs: 150_000,
+	timeoutMs: 300_000,
 });
 
 function paidCost(model) {
@@ -46,61 +48,62 @@ function forProvider(models) {
 	return (models ?? []).filter((m) => m.provider === providerId);
 }
 
-try {
-	// Allow Pi to finish loading extensions + the detached capture (~1s).
-	await sleep(4000);
+async function waitProviderView(phase, wantPaid) {
+	return driver.waitFor(
+		async () => {
+			const models = (await driver.send({ type: "get_available_models" }))
+				.models;
+			const view = forProvider(models);
+			if (view.length === 0) return null;
+			const hasPaid = view.some(paidCost);
+			if (wantPaid && !hasPaid) return null;
+			return view;
+		},
+		{
+			timeoutMs: 120_000,
+			label: `${phase} ${providerId} ${wantPaid ? "all" : "free-only"} view`,
+		},
+	);
+}
 
-	const bootModels = (await driver.send({ type: "get_available_models" }))
-		.models;
-	const bootView = forProvider(bootModels);
-	if (bootView.length === 0) {
+function assertFreeOnly(view, phase) {
+	const paid = view.filter(paidCost);
+	if (paid.length > 0) {
 		throw new Error(
-			`boot: provider ${providerId} missing from catalog — cannot assert its view`,
-		);
-	}
-	const bootPaid = bootView.filter(paidCost);
-	if (bootPaid.length > 0) {
-		throw new Error(
-			`boot: ${providerId} shows ${bootPaid.length} paid model(s) under free-only (e.g. ${bootPaid
+			`${phase}: ${providerId} shows ${paid.length} paid model(s) under free-only (e.g. ${paid
 				.slice(0, 3)
 				.map((m) => m.id)
 				.join(", ")})`,
 		);
 	}
 	console.log(
-		`boot: ${providerId} free-only view ok (${bootView.length} models, 0 paid)`,
+		`${phase}: ${providerId} free-only view ok (${view.length} models, 0 paid)`,
 	);
+}
+
+function assertAll(view, phase) {
+	const paid = view.filter(paidCost);
+	if (paid.length === 0) {
+		throw new Error(
+			`${phase}: ${providerId} still shows no paid models after ${toggleCommand}`,
+		);
+	}
+	console.log(
+		`${phase}: ${providerId} all view ok (${view.length} models, ${paid.length} paid)`,
+	);
+}
+
+try {
+	const bootView = await waitProviderView("boot", false);
+	assertFreeOnly(bootView, "boot");
 
 	await driver.prompt(toggleCommand);
-	await sleep(3000);
-	const toggledModels = (await driver.send({ type: "get_available_models" }))
-		.models;
-	const toggledView = forProvider(toggledModels);
-	const toggledPaid = toggledView.filter(paidCost);
-	if (toggledPaid.length === 0) {
-		throw new Error(
-			`post-toggle: ${providerId} still shows no paid models after ${toggleCommand}`,
-		);
-	}
-	console.log(
-		`post-toggle: ${providerId} all view ok (${toggledView.length} models, ${toggledPaid.length} paid)`,
-	);
+	const toggledView = await waitProviderView("post-toggle", true);
+	assertAll(toggledView, "post-toggle");
 
 	await driver.send({ type: "new_session" });
-	await sleep(8000);
-	const persistedModels = (
-		await driver.send({ type: "get_available_models" })
-	).models;
-	const persistedView = forProvider(persistedModels);
-	const persistedPaid = persistedView.filter(paidCost);
-	if (persistedPaid.length === 0) {
-		throw new Error(
-			`post-replacement: ${providerId} lost its all view across new_session (choice did not persist)`,
-		);
-	}
-	console.log(
-		`post-replacement: ${providerId} all view persists (${persistedView.length} models)`,
-	);
+	const persistedView = await waitProviderView("post-replacement", true);
+	assertAll(persistedView, "post-replacement");
 
 	driver.pass(`${providerId} capture, toggle, and persistence hold`);
 } catch (error) {

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -301,6 +301,9 @@ describe("built-in provider toggles", () => {
 	});
 
 	it("refreshes opencode-go from the live Go endpoint after session_start", async () => {
+		// Explicit all-view: this pins refresh mechanics (fetch, merge,
+		// metadata), not view resolution (pinned separately).
+		mockGetModelViewOverride.mockReturnValue("all");
 		setupBuiltInProviderToggles(mockPi);
 
 		const fetchMock = vi.fn();
@@ -636,6 +639,9 @@ describe("built-in provider toggles", () => {
 	});
 
 	it("retains the captured catalog when the live endpoint returns no models", async () => {
+		// Explicit all-view: this pins the retain-on-empty rule, not view
+		// resolution (pinned separately).
+		mockGetModelViewOverride.mockReturnValue("all");
 		setupBuiltInProviderToggles(mockPi);
 
 		const fetchMock = vi.fn();
@@ -695,6 +701,9 @@ describe("built-in provider toggles", () => {
 	});
 
 	it("refreshes the built-in openrouter catalog from the public endpoint", async () => {
+		// Explicit all-view: this pins refresh mechanics (fetch, merge,
+		// metadata), not view resolution (pinned separately).
+		mockGetModelViewOverride.mockReturnValue("all");
 		setupBuiltInProviderToggles(mockPi);
 
 		const fetchMock = vi.fn();

--- a/tests/install-hoisting.test.ts
+++ b/tests/install-hoisting.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for scripts/check-hoisting.mjs.
+ *
+ * The script itself is the assertion engine (exit 0/1 + stdout); these
+ * tests drive it via spawnSync — no symlinks, no network, no platform
+ * branches, so they run identically on every CI matrix OS:
+ *
+ *   - healthy repo tree   → exit 0 (pi-ai's deps resolve hoisted)
+ *   - nested dep on pi-ai's walk-up → exit 1 naming the nested path
+ *   - pi-ai absent entirely         → exit 1 naming pi-ai
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = join(process.cwd(), "scripts", "check-hoisting.mjs");
+
+function runHoisting(dir: string) {
+	return spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+}
+
+function makeTree(layout: {
+	piAi?: { version: string; dependencies: Record<string, string> };
+	nested?: string[];
+	entry?: boolean;
+}): string {
+	const base = mkdtempSync(join(tmpdir(), "pi-free-hoisting-"));
+	const app = join(base, "app");
+	if (layout.entry === false) {
+		mkdirSync(app, { recursive: true });
+	} else {
+		mkdirSync(join(app, "dist"), { recursive: true });
+		writeFileSync(join(app, "dist", "index.js"), "export {};\n");
+	}
+	if (layout.piAi) {
+		const piAiDir = join(app, "node_modules", "@earendil-works", "pi-ai");
+		mkdirSync(join(piAiDir, "dist"), { recursive: true });
+		writeFileSync(
+			join(piAiDir, "package.json"),
+			JSON.stringify({
+				name: "@earendil-works/pi-ai",
+				version: layout.piAi.version,
+				dependencies: layout.piAi.dependencies,
+			}),
+		);
+		writeFileSync(join(piAiDir, "dist", "index.js"), "export {};\n");
+		for (const name of layout.nested ?? []) {
+			const nestedDir = join(piAiDir, "node_modules", ...name.split("/"));
+			mkdirSync(nestedDir, { recursive: true });
+			writeFileSync(
+				join(nestedDir, "package.json"),
+				JSON.stringify({ name, version: "1.0.0", main: "index.js" }),
+			);
+			writeFileSync(join(nestedDir, "index.js"), "module.exports = {};\n");
+		}
+	}
+	return app;
+}
+
+const tempDirs: string[] = [];
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+function track(app: string): string {
+	tempDirs.push(join(app, ".."));
+	return app;
+}
+
+describe("check-hoisting", () => {
+	it("passes on the healthy repo tree", () => {
+		const result = runHoisting(process.cwd());
+		expect(result.status).toBe(0);
+		expect(result.stdout).toMatch(/\[hoisting\] PASS/);
+	});
+
+	it("fails naming the nested copy", () => {
+		const app = track(
+			makeTree({
+				piAi: { version: "0.84.4", dependencies: { typebox: "1.3.7" } },
+				nested: ["typebox"],
+			}),
+		);
+		const result = runHoisting(app);
+		expect(result.status).toBe(1);
+		expect(result.stderr).toMatch(/typebox resolves from nested/);
+	});
+
+	it("fails when pi-ai is absent", () => {
+		const app = track(makeTree({}));
+		const result = runHoisting(app);
+		expect(result.status).toBe(1);
+		expect(result.stderr).toMatch(/@earendil-works\/pi-ai/);
+	});
+});

--- a/tests/toggle-state.test.ts
+++ b/tests/toggle-state.test.ts
@@ -42,6 +42,25 @@ describe("toggle-state helper", () => {
 		expect(save).toHaveBeenCalledWith({ opencode_free_show_paid: true });
 	});
 
+	it("never falls back to paid when the free view is empty", () => {
+		const applied: unknown[][] = [];
+		const state = createToggleState<{ id: string }>({
+			providerId: "opencode-go",
+			initialShowPaid: false,
+			save: vi.fn(),
+			initialModels: { free: [], all: [{ id: "paid" }] },
+		});
+
+		// A free-only choice with zero free models hides the provider —
+		// it must not leak the paid catalog (strict free-only contract).
+		const result = state.applyCurrent((models) => {
+			applied.push(models);
+		});
+		expect(result.mode).toBe("free");
+		expect(result.models).toEqual([]);
+		expect(applied).toEqual([[]]);
+	});
+
 	it("re-applies persisted show-paid mode after model refresh", () => {
 		const state = createToggleState({
 			providerId: "cline",


### PR DESCRIPTION
## RPC migration, next slice (per agreement: strict tests that expose bugs, mocks only at honest seams)

### Strict checks that found real bugs before CI could

- **Toggle-check exposed auth-gated availability**: `opencode-free` is absent without a key (correct product behavior — Pi hides keyless catalogs). Fixed in the harness with a documented presence-only dummy `OPENCODE_API_KEY`, not by weakening the test.
- **Managed-set scoping**: with the dummy key, Pi's *own* `opencode` catalog shows 89 paid models — correctly out of pi-free's scope (pi-free governs its registry, not Pi built-ins). The driver derives the managed set from `toggle-*` commands, so new providers are covered without edits.
- **Strict free views** (`lib/toggle-state.ts`): the MiniMax promo expired 2026-09-06, leaving `opencode-go` with zero free models — and the empty-to-all fallback leaked all 35 paid models under `free_only:true`. A free view with zero free models now resolves to an *empty* free view (provider hides); flipping to all stays available through explicit toggle. Fail-before unit test included.

### Harness + CI

- `scripts/lib/rpc-driver.mjs`: shared spawn/framing/matching/error-collection for all three drivers (load, session, toggle).
- `scripts/rpc-toggle-check.mjs [providerId]`: capture view → toggle shows paid → persists across `new_session`. Verified live: opencode-free 8 free → 70 all → persists.
- Failure artifacts: smokes preserve `free.log`/`free.json` into gitignored `.smoke-artifacts/`; CI uploads on failure.
- `check-hoisting.mjs`: fail when pi-ai resolves a dep from a nested copy (+ fixture tests).
- ci.yml: hoisting steps (install-test + source-install), artifact upload, existing windows-vitest/upgrade/source-install coverage from #515.

### Verification

- Live `pi-install-smoke` green (load + session + toggle); full vitest green; `tsc` clean.