### PR TITLE
fix(refresh): persist the effective view, not the complete fetch (#519)

### DIFF
--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -752,14 +752,35 @@ export async function refreshNativeProviderModels<T extends Model<Api>>(
 			recordNativeEmptyRetain(providerId);
 			return;
 		}
+		// Persist the EFFECTIVE view, not the complete fetch: under a free
+		// view the store keeps only free models, so Pi's per-refresh
+		// structuredClone + store write (the ~59% startup-CPU sink from
+		// #519) scale with visible models, not the full paid catalog.
+		// In-memory state still takes the complete list via onFetched, so
+		// toggling to all works offline until the next network refresh.
+		const persistModels =
+			resolveModelView(providerId) === "free"
+				? models.filter((model) =>
+						isFreeModel(
+							{ ...model, provider: providerId },
+							models as ProviderModelConfig[],
+						),
+					)
+				: models;
+		_logger.debug(
+				`[${providerId}] persisting ${persistModels.length}/${models.length} models (${resolveModelView(providerId)} view)`,
+			);
 		// Only count as "ok" if persistence actually published: a superseded
 		// generation (publish() returns false — update never ran) or a store
 		// write failure must not inflate the success counter.
 		if (
-			await persistNativeProviderModels(providerId, context, models, () =>
+			await persistNativeProviderModels(providerId, context, persistModels, () =>
 				onFetched(models),
 			)
 		) {
+			// Telemetry counts the fetched catalog (refresh productivity),
+			// not the persisted view — the view filter above only shrinks
+			// what hits the disk/network-clone path.
 			recordNativeRefreshOk(providerId, models.length);
 		}
 	} catch (err) {

--- a/tests/cline-provider.test.ts
+++ b/tests/cline-provider.test.ts
@@ -480,6 +480,10 @@ describe("normalizeStoredClineModels", () => {
 
 describe("refreshModels online", () => {
 	it("fetches the public catalog, persists to the store, and publishes models", async () => {
+	// All-view: pins persist mechanics, not view filtering (pinned in
+	// native-openai-provider persist-filtered-views tests).
+		mockGetModelViewOverride.mockReturnValue("all");
+
 		mockFetchClineCatalog.mockResolvedValue({
 			all: [freeCfg("a"), paidCfg("b")],
 			free: [freeCfg("a")],
@@ -509,7 +513,9 @@ describe("refreshModels online", () => {
 		// Catalogs populated for the toggle.
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
-		// getModels exposes the complete catalog; Pi applies filterModels.
+		// getModels exposes the complete catalog; Pi applies filterModels
+		// under the free view resolved live below.
+		mockGetModelViewOverride.mockReturnValue(undefined);
 		expect(
 			provider
 				.getModels()

--- a/tests/kilo-provider.test.ts
+++ b/tests/kilo-provider.test.ts
@@ -243,6 +243,9 @@ describe("refreshModels offline init", () => {
 
 describe("refreshModels online", () => {
 	it("fetches, persists to the store, and publishes models", async () => {
+	// All-view: pins persist mechanics, not view filtering.
+		mockGetModelViewOverride.mockReturnValue("all");
+
 		mockFetchKiloCatalog.mockResolvedValue({
 			all: [freeCfg("a"), paidCfg("b")],
 			free: [freeCfg("a")],
@@ -260,7 +263,9 @@ describe("refreshModels online", () => {
 		// Catalogs populated for the toggle.
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
-		// getModels exposes the complete catalog; Pi applies filterModels.
+		// getModels exposes the complete catalog; Pi applies filterModels
+		// under the free view resolved live below.
+		mockGetModelViewOverride.mockReturnValue(undefined);
 		expect(
 			provider
 				.getModels()

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -351,6 +351,9 @@ describe("refreshModels offline init", () => {
 
 describe("refreshModels online", () => {
 	it("publishes the static selector catalog and persists it, with zero network", async () => {
+	// All-view: pins persist mechanics, not view filtering.
+		mockGetModelViewOverride.mockReturnValue("all");
+
 		const { store, written } = makeStore();
 		const { provider, stored } = createLlm7Provider();
 
@@ -377,7 +380,9 @@ describe("refreshModels online", () => {
 		// Catalogs populated for the toggle.
 		expect(stored.all.map((m) => m.id)).toEqual(["default", "fast", "pro"]);
 		expect(stored.free.map((m) => m.id)).toEqual(["default", "fast"]);
-		// getModels exposes the complete catalog; Pi applies filterModels.
+		// getModels exposes the complete catalog; Pi applies filterModels
+		// under the free view resolved live below.
+		mockGetModelViewOverride.mockReturnValue(undefined);
 		expect(provider.getModels().map((m) => m.id)).toEqual([
 			"default",
 			"fast",

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -311,7 +311,68 @@ describe("createNativeOpenAIProvider", () => {
 		).toEqual(["free"]);
 	});
 
+	// NOTE (RPC migration): filter-view behavior is proven live by
+	// rpc-session-check (managed zero-paid + toggle phases incl.
+	// persistence). View resolution itself is pinned in
+	// registry-provider-overrides.test.ts against the real resolver.
+	describe("persist filtered views (#519)", () => {
+		const freeOnly = { id: "f", name: "free stuff" };
+		const paidOnly = { id: "p", name: "paid stuff" };
+
+		async function runPersist(view: "free" | "all") {
+			mockResolveModelView.mockReturnValue(view);
+			const persisted: Array<{
+				persist?: { models: readonly unknown[] };
+			}> = [];
+			const published: unknown[][] = [];
+			const publish = vi.fn(
+				async (publication: {
+					persist?: { models: readonly unknown[] };
+					update?: () => void;
+				}) => {
+					persisted.push(publication);
+					publication.update?.();
+					return true;
+				},
+			);
+			await refreshNativeProviderModels(
+				"test-native",
+				{
+					allowNetwork: true,
+					credential: { type: "api_key", key: "stored-key" },
+					publish,
+					signal: new AbortController().signal,
+				} as unknown as RefreshModelsContext,
+				() => {},
+				async () => [freeOnly, paidOnly] as never[],
+				(models: unknown[]) => {
+					published.push(models);
+				},
+			);
+			return { persisted, published };
+		}
+
+		it("persists only free models under a free view", async () => {
+			const { persisted, published } = await runPersist("free");
+			// Disk stays small (the #519 structuredClone sink scales with
+			// this list); memory still takes the complete catalog.
+			expect(persisted).toHaveLength(1);
+			expect(persisted[0].persist?.models).toEqual([freeOnly]);
+			expect(published).toEqual([[freeOnly, paidOnly]]);
+		});
+
+		it("persists the complete catalog under an all view", async () => {
+			const { persisted, published } = await runPersist("all");
+			expect(persisted).toHaveLength(1);
+			expect(persisted[0].persist?.models).toEqual([freeOnly, paidOnly]);
+			expect(published).toEqual([[freeOnly, paidOnly]]);
+		});
+	});
+
 	it("supports Pi 0.84 stored/publish model lifecycle", async () => {
+		// All-view: this pins publish mechanics, not view filtering (pinned
+		// in the persist-filtered-views block above).
+		mockResolveModelView.mockReturnValue("all");
 		const controller = new AbortController();
 		const publish = vi.fn(
 			async (publication: {

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -38,11 +38,7 @@ vi.mock("../lib/registry.ts", () => ({
 	// real rule is unit-tested in registry-provider-overrides.test.ts).
 	resolveModelView: (providerId: string) =>
 		mockGetModelViewOverride(providerId) ??
-		(mockGetZenmuxShowPaid()
-			? "all"
-			: mockGetGlobalFreeOnly()
-				? "free"
-				: "all"),
+		(mockGetZenmuxShowPaid() ? "all" : mockGetGlobalFreeOnly() ? "free" : "all"),
 	isFreeModel: (model: { cost?: { input?: number; output?: number } }) =>
 		(model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0,
 }));
@@ -192,6 +188,9 @@ describe("createZenmuxProvider", () => {
 	});
 
 	it("fetches with the effective stored key and persists the catalog", async () => {
+	// All-view: pins persist mechanics, not view filtering.
+		mockGetModelViewOverride.mockReturnValue("all");
+
 		mockGetZenmuxApiKey.mockReturnValue("sk-ambient");
 		mockFetchWithRetry.mockResolvedValue(
 			response([
@@ -248,6 +247,8 @@ describe("createZenmuxProvider", () => {
 			"free-model",
 			"paid-model",
 		]);
+		// Pi applies filterModels under the free view resolved live below.
+		mockGetModelViewOverride.mockReturnValue(undefined);
 		expect(
 			provider.filterModels!(provider.getModels(), undefined).map(
 				(model) => model.id,


### PR DESCRIPTION
## Diagnosis (confirmed)

Under `free_only`, every refresh persisted the **complete** fetched catalog — requesty's 705 stored vs 11 free — which Pi then `structuredClone`s twice per provider per boot (the reported ~59% startup CPU). Two compounding causes, both verified:

1. **Persist path never filtered**: `refreshNativeModels` handed the complete fetch to `persistNativeProviderModels`. Nothing between fetch and disk consults the view.
2. **Empty-to-all fallback leaked paid**: with zero free models (e.g. opencode-go post-MiniMax-promo-expiry), `toggle-state.resolveMode` fell back to the *all* view — displaying 35 paid models under an explicit free-only choice. Caught live by the strict RPC session check.

## Fix

- Persist resolves the effective view (`resolveModelView`) and stores only free models under free-only; memory still takes the complete list via `onFetched`, so toggle-off works offline until the next network refresh. Telemetry keeps counting fetched models (unchanged meaning).
- `resolveMode("free")` with zero free models now resolves to an *empty* free view (provider hides) instead of the paid catalog; flipping to all stays available through explicit toggle.
- Tests: fail-before persist-filter tests, strict-mode unit test, persist-mechanics suites scoped to all-view; full suite green, `tsc` clean.

Related to #519.