### PR TITLE
test(rpc-migration): drop mock view-behavior tests covered live

### DIFF
--- a/tests/cline-provider.test.ts
+++ b/tests/cline-provider.test.ts
@@ -582,59 +582,10 @@ describe("refreshModels online", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Toggle interop (filterModels / decideView)
-// ---------------------------------------------------------------------------
-
-describe("toggle interop", () => {
-	async function seededProvider() {
-		mockFetchClineCatalog.mockResolvedValue({
-			all: [freeCfg("a"), paidCfg("b")],
-			free: [freeCfg("a")],
-		});
-		const { store } = makeStore();
-		const handle = createClineProvider();
-		await handle.provider.refreshModels?.(ctx({ store, allowNetwork: true }));
-		return handle;
-	}
-
-	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider } = await seededProvider();
-		expect(
-			provider
-				.getModels()
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["a"]);
-	});
-
-	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
-		mockGetClineShowPaid.mockReturnValue(true);
-		const { provider } = await seededProvider();
-		// show_paid true + global free-only true => filterModels returns all.
-		expect(
-			provider.filterModels!(provider.getModels(), undefined)
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-	});
-
-	it("decideView shows all when global free-only is off", async () => {
-		// No explicit override recorded: the view follows the global default.
-		mockGetModelViewOverride.mockReturnValue(undefined);
-		mockGetGlobalFreeOnly.mockReturnValue(false);
-		const { provider } = await seededProvider();
-		expect(
-			provider
-				.getModels()
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-	});
-});
+// NOTE (RPC migration): filter-view behavior is proven live by
+// rpc-toggle-check (opencode-free free/all/persist phases). View
+// resolution itself is pinned in registry-provider-overrides.test.ts
+// against the real resolver.
 
 // ---------------------------------------------------------------------------
 // Stream wiring (standard openai-completions via the lazy compat bridge)

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -6,10 +6,6 @@
  * refresh nudge.
  */
 
-import type {
-	ModelsStoreEntry,
-	ProviderModelsStore,
-} from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -104,19 +100,6 @@ function cfg(over: Record<string, unknown> = {}) {
 	};
 }
 
-function makeStore(): ProviderModelsStore {
-	let entry: ModelsStoreEntry | undefined;
-	return {
-		read: async () => entry,
-		write: async (e: ModelsStoreEntry) => {
-			entry = e;
-		},
-		delete: async () => {
-			entry = undefined;
-		},
-	};
-}
-
 describe("Cline factory wiring", () => {
 	let mockPi: ExtensionAPI;
 	let mockRegisterProvider: ReturnType<typeof vi.fn>;
@@ -208,43 +191,20 @@ describe("Cline factory wiring", () => {
 		).toBe(true);
 	});
 
-	it("refreshModels populates; global /toggle-free reRegister republishes the same provider", async () => {
+	// Population + views are proven live by rpc-toggle-check (capture views
+	// for a real catalog); this pins the re-registration wiring (same
+	// object, auth preserved) that RPC cannot see per provider.
+	it("global /toggle-free reRegister republishes the same provider object", async () => {
 		await clineProvider(mockPi);
 		const provider = mockRegisterProvider.mock.calls[0][0];
 
 		expect(capturedToggleArgs).toHaveLength(1);
-		const [, stored, reRegister] = capturedToggleArgs[0] as [
-			string,
-			{ free: unknown[]; all: unknown[] },
-			() => void,
-		];
+		const reRegister = capturedToggleArgs[0][2] as () => void;
 
-		// Pi refreshes (online) -> public catalogs populate.
-		await provider.refreshModels({ store: makeStore(), allowNetwork: true });
-		expect(stored.all).toHaveLength(2);
-		expect(stored.free).toHaveLength(1);
-
-		// Global /toggle-free showing all -> re-register the same provider.
 		mockRegisterProvider.mockClear();
 		reRegister();
-		expect(
-			provider
-				.getModels()
-				.map((m: { id: string }) => m.id)
-				.sort(),
-		).toEqual(["free-1", "paid-1"]);
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
-
-		// Global /toggle-free showing free invalidates the same provider object;
-		// Pi's filterModels applies the free view to the complete catalog.
-		reRegister();
-		expect(
-			provider
-				.getModels()
-				.map((m: { id: string }) => m.id)
-				.sort(),
-		).toEqual(["free-1", "paid-1"]);
 	});
 
 	// Flip/persist/view behavior is proven live by rpc-toggle-check

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -242,21 +242,14 @@ describe("Cline factory wiring", () => {
 		expect(buildClineHeaders()["X-Task-ID"]).toBe(after);
 	});
 
-	it("session_start nudges the model registry refresh and is safe without one", async () => {
+	// Nudge scoping/retry is pinned in native-refresh-nudge.test.ts; the
+	// live RPC suite proves refresh populates. This pins the wiring.
+	it("session_start registers a refresh-nudge handler safe without a registry", async () => {
 		await clineProvider(mockPi);
 		const handler = mockOn.mock.calls.find(
 			(call) => call[0] === "session_start",
 		)?.[1];
 		expect(handler).toBeDefined();
-
-		const refresh = vi.fn().mockResolvedValue(undefined);
-		await handler({}, { modelRegistry: { refresh } });
-		// Scoped to opted-in providers (never the whole registry), so
-		// foreign credential failures cannot fail our refresh.
-		expect(refresh).toHaveBeenCalledWith({
-			allowNetwork: true,
-			providers: expect.arrayContaining(["cline"]),
-		});
 
 		// No modelRegistry on the context -> safe no-op.
 		await expect(handler({}, {})).resolves.toBeUndefined();

--- a/tests/kilo-provider.test.ts
+++ b/tests/kilo-provider.test.ts
@@ -395,51 +395,10 @@ describe("toggle interop", () => {
 		return handle;
 	}
 
-	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider } = await seededProvider();
-		expect(
-			provider
-				.getModels()
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["a"]);
-
-		expect(
-			provider
-				.getModels()
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["a"]);
-	});
-
-	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
-		mockGetKiloShowPaid.mockReturnValue(true);
-		const { provider } = await seededProvider();
-		// show_paid true + global free-only true => filterModels returns all.
-		expect(
-			provider.filterModels!(provider.getModels(), undefined)
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-	});
-
-	it("filterModels shows all when global free-only is off", async () => {
-		// No explicit override recorded: the view follows the global default.
-		mockGetModelViewOverride.mockReturnValue(undefined);
-		mockGetGlobalFreeOnly.mockReturnValue(false);
-		const { provider } = await seededProvider();
-		expect(
-			provider.filterModels!(provider.getModels(), undefined)
-				.map((m) => m.id)
-				.sort(),
-		).toEqual(["a", "b"]);
-	});
+	// NOTE (RPC migration): filter-view behavior is proven live by
+	// rpc-session-check (managed zero-paid + toggle phases incl.
+	// persistence). The kilo_free_only escape hatch below has no live
+	// equivalent and stays.
 
 	it("filterModels forces free when kilo_free_only is set", async () => {
 		mockGetKiloFreeOnly.mockReturnValue(true);

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -4,10 +4,6 @@
  * hook both drive the native provider's visible catalog without dropping auth.
  */
 
-import type {
-	ModelsStoreEntry,
-	ProviderModelsStore,
-} from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -104,19 +100,6 @@ function cfg(over: Record<string, unknown> = {}) {
 	};
 }
 
-function makeStore(): ProviderModelsStore {
-	let entry: ModelsStoreEntry | undefined;
-	return {
-		read: async () => entry,
-		write: async (e: ModelsStoreEntry) => {
-			entry = e;
-		},
-		delete: async () => {
-			entry = undefined;
-		},
-	};
-}
-
 describe("Kilo toggle interop", () => {
 	let mockPi: ExtensionAPI;
 	let mockRegisterProvider: ReturnType<typeof vi.fn>;
@@ -150,51 +133,21 @@ describe("Kilo toggle interop", () => {
 		} as unknown as ExtensionAPI;
 	});
 
-	it("factory registers empty; refreshModels populates; toggle republishes", async () => {
+	// Population + views are proven live by rpc-session-check (managed
+	// catalog with free-only, all-view, and persistence phases); this pins
+	// the re-registration wiring (same object, auth preserved) that RPC
+	// cannot see per provider.
+	it("global /toggle-free reRegister republishes the same provider object", async () => {
 		await kiloProvider(mockPi);
-
-		// Native provider object registered (single arg).
 		const provider = mockRegisterProvider.mock.calls[0][0];
-		expect(provider.id).toBe("kilo");
-		expect(provider.getModels()).toEqual([]);
 
-		// Global toggle hook captured with mutable stored catalogs.
 		expect(capturedToggleArgs).toHaveLength(1);
-		const [providerId, stored, reRegister, hasKey] = capturedToggleArgs[0] as [
-			string,
-			{ free: unknown[]; all: unknown[] },
-			() => void,
-			boolean,
-		];
-		expect(providerId).toBe("kilo");
-		expect(hasKey).toBe(false);
+		const reRegister = capturedToggleArgs[0][2] as () => void;
 
-		// Pi refreshes (online) -> catalogs populate.
-		await provider.refreshModels({ store: makeStore(), allowNetwork: true });
-		expect(stored.all).toHaveLength(2);
-		expect(stored.free).toHaveLength(1);
-
-		// Global /toggle-free showing all -> re-register the same provider.
 		mockRegisterProvider.mockClear();
 		reRegister();
-		expect(
-			provider
-				.getModels()
-				.map((m: { id: string }) => m.id)
-				.sort(),
-		).toEqual(["free-1", "paid-1"]);
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
-
-		// Global /toggle-free showing free invalidates the same provider object;
-		// Pi's filterModels applies the free view to the complete catalog.
-		reRegister();
-		expect(
-			provider
-				.getModels()
-				.map((m: { id: string }) => m.id)
-				.sort(),
-		).toEqual(["free-1", "paid-1"]);
 	});
 
 	// Flip/persist/view behavior is proven live by rpc-toggle-check

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -443,56 +443,7 @@ describe("refreshModels online", () => {
 		]);
 	});
 });
-
-// ---------------------------------------------------------------------------
-// Toggle interop (filterModels)
-// ---------------------------------------------------------------------------
-
-describe("toggle interop", () => {
-	async function seededProvider() {
-		const { store } = makeStore();
-		const handle = createLlm7Provider();
-		await handle.provider.refreshModels?.(ctx({ store, allowNetwork: true }));
-		return handle;
-	}
-
-	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider } = await seededProvider();
-		expect(provider.getModels().map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-			"pro",
-		]);
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["default", "fast"]);
-
-		expect(provider.getModels().map((m) => m.id)).toEqual([
-			"default",
-			"fast",
-			"pro",
-		]);
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["default", "fast"]);
-	});
-
-	it("decideView shows all when per-provider show_paid is set under global free-only", async () => {
-		mockGetLlm7ShowPaid.mockReturnValue(true);
-		const { provider } = await seededProvider();
-		// show_paid true + global free-only true => filterModels returns all.
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["default", "fast", "pro"]);
-	});
-
-	it("decideView shows all when global free-only is off", async () => {
-		// No explicit override recorded: the view follows the global default.
-		mockGetModelViewOverride.mockReturnValue(undefined);
-		mockGetGlobalFreeOnly.mockReturnValue(false);
-		const { provider } = await seededProvider();
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map((m) => m.id),
-		).toEqual(["default", "fast", "pro"]);
-	});
-});
+// NOTE (RPC migration): filter-view behavior is proven live by
+// rpc-session-check (/toggle-llm7 phases incl. persistence across
+// replacement). View resolution itself is pinned in
+// registry-provider-overrides.test.ts against the real resolver.

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -6,10 +6,6 @@
  * notice, and the session_start refresh nudge.
  */
 
-import type {
-	ModelsStoreEntry,
-	ProviderModelsStore,
-} from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -79,19 +75,6 @@ vi.mock("../lib/logger.ts", () => ({
 }));
 
 import llm7Provider from "../providers/llm7/llm7.ts";
-
-function makeStore(): ProviderModelsStore {
-	let entry: ModelsStoreEntry | undefined;
-	return {
-		read: async () => entry,
-		write: async (e: ModelsStoreEntry) => {
-			entry = e;
-		},
-		delete: async () => {
-			entry = undefined;
-		},
-	};
-}
 
 describe("LLM7 factory wiring", () => {
 	let mockPi: ExtensionAPI;
@@ -164,42 +147,23 @@ describe("LLM7 factory wiring", () => {
 		).toBe(true);
 	});
 
-	it("refreshModels populates; global /toggle-free reRegister republishes the same provider", async () => {
+	// Population + views are proven live by rpc-session-check (llm7 anchor
+	// with free-only, all-view, and persistence phases); this pins the
+	// re-registration wiring (same object, auth preserved) that RPC
+	// cannot see per provider.
+	it("global /toggle-free reRegister republishes the same provider object", async () => {
 		await llm7Provider(mockPi);
 		const provider = mockRegisterProvider.mock.calls[0][0];
 
 		expect(capturedToggleArgs).toHaveLength(1);
-		const [, stored, reRegister] = capturedToggleArgs[0] as [
-			string,
-			{ free: unknown[]; all: unknown[] },
-			() => void,
-		];
+		const reRegister = capturedToggleArgs[0][2] as () => void;
 
-		// Pi refreshes (online) -> static catalogs populate.
-		await provider.refreshModels({ store: makeStore(), allowNetwork: true });
-		expect(stored.all).toHaveLength(3);
-		expect(stored.free).toHaveLength(2);
-
-		// Global /toggle-free showing all -> re-register the same provider.
 		mockRegisterProvider.mockClear();
 		reRegister();
-		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
-			"default",
-			"fast",
-			"pro",
-		]);
 		// Re-registration reused the SAME native provider object (auth preserved).
 		expect(mockRegisterProvider).toHaveBeenCalledWith(provider);
-
-		// Global /toggle-free showing free invalidates the same provider object;
-		// Pi's filterModels applies the free view to the complete catalog.
-		reRegister();
-		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
-			"default",
-			"fast",
-			"pro",
-		]);
 	});
+
 
 	// Flip/persist/view behavior is proven live by rpc-session-check
 	// (/toggle-llm7 through prompt dispatch, incl. persistence across

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -215,21 +215,14 @@ describe("LLM7 factory wiring", () => {
 		expect(notify).not.toHaveBeenCalled();
 	});
 
-	it("session_start nudges the model registry refresh and is safe without one", async () => {
+	// Nudge scoping/retry is pinned in native-refresh-nudge.test.ts; the
+	// live RPC suite proves refresh populates. This pins the wiring.
+	it("session_start registers a refresh-nudge handler safe without a registry", async () => {
 		await llm7Provider(mockPi);
 		const handler = mockOn.mock.calls.find(
 			(call) => call[0] === "session_start",
 		)?.[1];
 		expect(handler).toBeDefined();
-
-		const refresh = vi.fn().mockResolvedValue(undefined);
-		await handler({}, { modelRegistry: { refresh } });
-		// Scoped to opted-in providers (never the whole registry), so
-		// foreign credential failures cannot fail our refresh.
-		expect(refresh).toHaveBeenCalledWith({
-			allowNetwork: true,
-			providers: expect.arrayContaining(["llm7"]),
-		});
 
 		// No modelRegistry on the context -> safe no-op.
 		await expect(handler({}, {})).resolves.toBeUndefined();

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -225,91 +225,10 @@ describe("createNativeOpenAIProvider", () => {
 		expect(handle.provider.getModels()).toEqual([]);
 	});
 
-	it("keeps the complete catalog and filters it without replacing the provider", () => {
-		const handle = createNativeOpenAIProvider(options);
-		expect(handle.provider.getModels().map((item) => item.id)).toEqual([
-			"free",
-			"paid",
-		]);
-		expect(
-			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
-				(item) => item.id,
-			),
-		).toEqual(["free"]);
-
-		mockGetGlobalFreeOnly.mockReturnValue(false);
-		expect(
-			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
-				(item) => item.id,
-			),
-		).toEqual(["free", "paid"]);
-
-		mockGetGlobalFreeOnly.mockReturnValue(true);
-		mockResolveModelView.mockReturnValue("free");
-		expect(
-			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
-				(item) => item.id,
-			),
-		).toEqual(["free"]);
-	});
-
-	it("filters by the resolved view, not registration-time values", () => {
-		const handle = createNativeOpenAIProvider(options);
-		const ids = () =>
-			handle.provider
-				.filterModels!(handle.provider.getModels(), undefined)
-				.map((item) => item.id);
-
-		// Registration happened under the free view; a later explicit-all
-		// choice applies without re-registering (no stale pref, #510).
-		mockResolveModelView.mockReturnValue("all");
-		expect(ids()).toEqual(["free", "paid"]);
-		mockResolveModelView.mockReturnValue("free");
-		expect(ids()).toEqual(["free"]);
-	});
-
-	it("honors the resolved view on startup and lets toggling override in-session", async () => {
-		// The resolved view stands in for the effective choice (explicit
-		// per-provider override, else the global default): it is authoritative
-		// when the provider first boots, so a persisted free/all choice is not
-		// clobbered (DeepInfra regression: the old initialShowPaid override
-		// forced `showPaid=true` on every boot, so a persisted free toggle was
-		// lost on restart).
-		const persistedShowPaid = vi.fn(() => true);
-		const handle = createNativeOpenAIProvider({
-			...options,
-			getShowPaid: persistedShowPaid,
-		});
-
-		// Boot state follows the resolved view (explicit all → all models).
-		mockResolveModelView.mockReturnValue("all");
-		expect(handle.getShowPaid()).toBe(true);
-		expect(
-			handle.provider.filterModels!(handle.provider.getModels(), undefined).map(
-				(item) => item.id,
-			),
-		).toEqual(["free", "paid"]);
-
-		// Toggling to free updates the in-session override.
-		handle.setShowPaid(false);
-		expect(handle.getShowPaid()).toBe(false);
-
-		// A fresh provider (simulating a restart) obeys the resolved view
-		// again; the in-session override does not leak across instances.
-		persistedShowPaid.mockReturnValue(false);
-		mockResolveModelView.mockReturnValue("free");
-		const restarted = createNativeOpenAIProvider({
-			...options,
-			getShowPaid: persistedShowPaid,
-		});
-		expect(restarted.getShowPaid()).toBe(false);
-		expect(
-			restarted.provider.filterModels!(
-				restarted.provider.getModels(),
-				undefined,
-			).map((item) => item.id),
-		).toEqual(["free"]);
-	});
+	// NOTE (RPC migration): filter-view behavior (free/all/persisted
+	// views, in-session override isolation) is proven live by
+	// rpc-session-check; view resolution itself is pinned in
+	// registry-provider-overrides.test.ts against the real resolver.
 
 	it("supports Pi 0.84 stored/publish model lifecycle", async () => {
 		const controller = new AbortController();

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -226,9 +226,9 @@ describe("createNativeOpenAIProvider", () => {
 	});
 
 	// NOTE (RPC migration): filter-view behavior (free/all/persisted
-	// views, in-session override isolation) is proven live by
-	// rpc-session-check; view resolution itself is pinned in
-	// registry-provider-overrides.test.ts against the real resolver.
+	// views is proven live by rpc-session-check; restart isolation needs
+	// no test (per-instance closure variable). View resolution itself is
+	// pinned in registry-provider-overrides.test.ts.
 
 	it("supports Pi 0.84 stored/publish model lifecycle", async () => {
 		const controller = new AbortController();

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -304,22 +304,10 @@ describe("createZenmuxProvider", () => {
 		expect(written).toHaveLength(0);
 	});
 
-	it("keeps the full catalog while filterModels selects the free view", async () => {
-		const { provider, stored } = createZenmuxProvider();
-		const free = nativeModel("free");
-		const paid = nativeModel("paid", true);
-		stored.free = [free];
-		stored.all = [free, paid];
-		expect(provider.getModels().map((model) => model.id)).toEqual([
-			"free",
-			"paid",
-		]);
-		expect(
-			provider.filterModels!(provider.getModels(), undefined).map(
-				(model) => model.id,
-			),
-		).toEqual(["free"]);
-	});
+	// NOTE (RPC migration): filter-view behavior is proven live by
+	// rpc-toggle-check (opencode-free free/all/persist phases). View
+	// resolution itself is pinned in registry-provider-overrides.test.ts
+	// against the real resolver.
 });
 
 describe("fetchZenmuxCatalog", () => {

--- a/tests/zenmux.test.ts
+++ b/tests/zenmux.test.ts
@@ -149,6 +149,9 @@ describe("ZenMux native factory", () => {
 	// (opencode-free) + rpc-session-check (/toggle-llm7); this pins the
 	// per-provider wiring plus the nudge scoping, neither of which RPC
 	// asserts per provider.
+	// Toggle flip/persist behavior is proven live by rpc-toggle-check
+	// (opencode-free); nudge scoping/retry is pinned in
+	// native-refresh-nudge.test.ts. This pins the per-provider wiring.
 	it("wires the toggle and session refresh handlers", async () => {
 		await zenmuxProvider(mockPi);
 		const toggle = registerCommand.mock.calls.find(
@@ -159,14 +162,7 @@ describe("ZenMux native factory", () => {
 		const sessionStart = on.mock.calls.find(
 			(call) => call[0] === "session_start",
 		)?.[1];
-		const refresh = vi.fn().mockResolvedValue(undefined);
-		await sessionStart({}, { modelRegistry: { refresh } });
-		// Scoped to opted-in providers (never the whole registry), so
-		// foreign credential failures cannot fail our refresh.
-		expect(refresh).toHaveBeenCalledWith({
-			allowNetwork: true,
-			providers: expect.arrayContaining(["zenmux"]),
-		});
+		expect(sessionStart).toBeDefined();
 		await expect(sessionStart({}, {})).resolves.toBeUndefined();
 	});
 


### PR DESCRIPTION
Follow-up to #518 (which took built-in-toggle capture/toggle tests): the same migration for provider suites — delete behavior the live RPC suite proves, keep what it cannot see per provider.\n\n## Deleted (live-covered)\n\n- Refresh population + catalog assertions (llm7, cline, kilo-toggle factory tests) — rpc-session-check proves population (9 managed) live.\n- Filter-view assertions: keeps-catalog, decideView, global-off variants (kilo/llm7/cline/zenmux providers, native handle) — rpc-session-check (managed zero-paid + toggle phases) and rpc-toggle-check (free/all/persist) prove them live.\n- Nudge scoping assertions in llm7/cline/zenmux suites — pinned in native-refresh-nudge.test.ts against the refresh seam.\n- Toggle flip/persist/view bodies (kilo, llm7, cline, zenmux, ollama) — replaced by wiring-only registration assertions in an earlier round.\n\n## Kept (no live equivalent)\n\nRegistration shapes, auth resolution, store refresh mechanics, poisoning guards, abort handling, fetch boundaries, ToS notices, task-id rotation, reRegister same-object wiring, nudge wiring + safe-noop, kilo_free_only escape hatch.\n\n## Verification\n\nFull suite green (833 pass); tsc clean. Per-file commits throughout so each deletion is independently reviewable/revertable.