### PR TITLE
fix(restore): skip Pi fallback artifacts; prove deferred restore live (#519)

### DIFF
--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -424,15 +424,20 @@ function readModelChanges(
 /**
  * Resolve the model choice to restore for a built-in-toggle provider.
  *
- * Pi's startup fallback ("Could not restore model … Using …") APPENDS a
- * `model_change` entry for the fallback model, so by the time the captured
- * catalog registers, `buildSessionContext().model` reports the fallback —
- * not the session's persisted choice — and a naive read would silently skip
- * the restore. The raw entry trail disambiguates: a trailing model_change
- * naming ANOTHER provider only counts as the user's deliberate choice if it
- * predates this run. A trailing change stamped during this run can only be
- * Pi's own fallback (the TUI is not interactive yet), so the last pre-run
- * change for this provider is the choice to restore.
+ * Pi's startup/switch fallback ("Could not restore model … Using …")
+ * APPENDS a `model_change` entry for the fallback model, so by the time
+ * the captured catalog registers, `buildSessionContext().model` reports
+ * the fallback — not the session's persisted choice — and a naive read
+ * would silently skip the restore. The raw entry trail disambiguates, but
+ * only if every during-run entry is treated as Pi speaking: the fallback
+ * append lands AFTER the user's persisted trail, so "trailing change
+ * names another provider, look back" restores over a deliberate
+ * departure whenever Pi's append is newest (verified live: a pre-run
+ * trail ending in another provider still restored the older choice).
+ * Walk back past all during-run entries instead: the last PRE-RUN entry
+ * is the user's persisted choice — restore it iff it names this
+ * provider, and honor a departure to another provider by doing nothing.
+ * Undated entries cannot be proven pre-run and count as a departure.
  */
 function resolveSavedModelChoice(
 	providerId: string,
@@ -442,17 +447,15 @@ function resolveSavedModelChoice(
 	if (contextModel?.provider === providerId) return contextModel;
 	const changes = readModelChanges(session);
 	if (!changes || changes.length === 0) return undefined;
-	const last = changes.at(-1);
-	if (!last) return undefined;
-	if (last.provider === providerId) return last;
-	// Trailing change names another provider. If it was not written during
-	// this run, it is a deliberate choice from a previous run — honor it.
-	const lastAt = last.timestamp ? Date.parse(last.timestamp) : Number.NaN;
-	if (Number.isNaN(lastAt) || lastAt < RUN_STARTED_AT - CLOCK_SKEW_MS) {
-		return undefined;
-	}
-	for (let i = changes.length - 2; i >= 0; i--) {
-		if (changes[i].provider === providerId) return changes[i];
+	for (let i = changes.length - 1; i >= 0; i--) {
+		const change = changes[i];
+		const at = change.timestamp ? Date.parse(change.timestamp) : Number.NaN;
+		if (Number.isNaN(at) || at < RUN_STARTED_AT - CLOCK_SKEW_MS) {
+			// Last user choice (or undatable): restore iff ours, else
+			// honor the departure to another provider.
+			return change.provider === providerId ? change : undefined;
+		}
+		// During-run entry: Pi's fallback artifact — skip.
 	}
 	return undefined;
 }

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -265,14 +265,15 @@ function applyFilterToProvider(
 	}
 
 	if (view === "free") {
-		if (entry.stored.free.length > 0) {
-			entry.reRegister(entry.stored.free);
-			_logger.info(
-				`[pi-free] ${providerId}: filtered to ${entry.stored.free.length} free models`,
-			);
-		} else {
-			_logger.warn(`[pi-free] ${providerId}: no free models available`);
-		}
+		// Strict: register the free list even when it is empty (the provider
+		// then hides from the picker) — retaining the previous registration
+		// would leak the paid catalog it was meant to hide. An empty free
+		// list under free-only is routine for paid-only catalogs, not a
+		// warning.
+		entry.reRegister(entry.stored.free);
+		_logger.info(
+			`[pi-free] ${providerId}: filtered to ${entry.stored.free.length} free models`,
+		);
 	} else {
 		showAllForProvider(providerId, entry);
 	}

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -100,6 +100,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const rpcDriver = join(scriptDir, "rpc-load-check.mjs");
 const rpcSessionDriver = join(scriptDir, "rpc-session-check.mjs");
 const rpcToggleDriver = join(scriptDir, "rpc-toggle-check.mjs");
+const rpcRestoreDriver = join(scriptDir, "rpc-restore-check.mjs");
 const piOptions = { cwd: project, env: environment, stdio: "inherit" };
 
 // Seed an explicit free_only default so the session check's filter
@@ -123,6 +124,8 @@ try {
 	await run([rpcSessionDriver], piOptions, 420_000);
 	console.log("Launching Pi RPC toggle check");
 	await run([rpcToggleDriver], piOptions, 420_000);
+	console.log("Launching Pi RPC restore check");
+	await run([rpcRestoreDriver], piOptions, 420_000);
 	console.log("Pi install smoke passed");
 } catch (error) {
 	console.error(`Pi install smoke failed: ${error.message}`);

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -121,11 +121,11 @@ try {
 	console.log("Launching Pi RPC load check");
 	await run([rpcDriver], piOptions, 45_000);
 	console.log("Launching Pi RPC session + filter check");
-	await run([rpcSessionDriver], piOptions, 420_000);
+	await run([rpcSessionDriver], piOptions, 660_000);
 	console.log("Launching Pi RPC toggle check");
-	await run([rpcToggleDriver], piOptions, 420_000);
+	await run([rpcToggleDriver], piOptions, 660_000);
 	console.log("Launching Pi RPC restore check");
-	await run([rpcRestoreDriver], piOptions, 420_000);
+	await run([rpcRestoreDriver], piOptions, 660_000);
 	console.log("Pi install smoke passed");
 } catch (error) {
 	console.error(`Pi install smoke failed: ${error.message}`);

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -141,11 +141,11 @@ try {
 	console.log("Launching Pi RPC load check on the upgraded tree");
 	await run([join(scriptDir, "rpc-load-check.mjs")], piOptions, 45_000);
 	console.log("Launching Pi RPC session + filter check on the upgraded tree");
-	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 420_000);
+	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 660_000);
 	console.log("Launching Pi RPC toggle check on the upgraded tree");
-	await run([join(scriptDir, "rpc-toggle-check.mjs")], piOptions, 420_000);
+	await run([join(scriptDir, "rpc-toggle-check.mjs")], piOptions, 660_000);
 	console.log("Launching Pi RPC restore check on the upgraded tree");
-	await run([join(scriptDir, "rpc-restore-check.mjs")], piOptions, 420_000);
+	await run([join(scriptDir, "rpc-restore-check.mjs")], piOptions, 660_000);
 	console.log("Pi upgrade smoke passed");
 } catch (error) {
 	console.error(

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -144,6 +144,8 @@ try {
 	await run([join(scriptDir, "rpc-session-check.mjs")], piOptions, 420_000);
 	console.log("Launching Pi RPC toggle check on the upgraded tree");
 	await run([join(scriptDir, "rpc-toggle-check.mjs")], piOptions, 420_000);
+	console.log("Launching Pi RPC restore check on the upgraded tree");
+	await run([join(scriptDir, "rpc-restore-check.mjs")], piOptions, 420_000);
 	console.log("Pi upgrade smoke passed");
 } catch (error) {
 	console.error(

--- a/scripts/rpc-restore-check.mjs
+++ b/scripts/rpc-restore-check.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * RPC restore check — pi-free's deferred saved-model restore end to end,
+ * over a real Pi boot with pi-free installed. Headless and model-free
+ * (no prompt is ever sent). Speaks Pi through the shared harness in
+ * scripts/lib/rpc-driver.mjs.
+ *
+ * Background: Pi resolves a resumed session's model BEFORE extension
+ * provider registrations flush, so sessions saved with a built-in-toggle
+ * provider (opencode-free/…) hit Pi's fallback on every resume. After the
+ * capture applies its catalog view, pi-free re-reads the session's
+ * persisted choice and re-selects it. This driver proves that whole arc
+ * live by switching into crafted session files:
+ *
+ *   0. Read a free opencode-free model id from the live catalog (no
+ *      hardcoded catalog ids — the catalog rotates between Pi releases).
+ *   1. Deliberate previous-run switch wins: trailing model_change names
+ *      another provider with a pre-run timestamp → no restore (stays put).
+ *   2. Plain restore: trailing choice names opencode-free/<id> → the
+ *      session ends on exactly that model.
+ *   3. Poisoned context: trailing change during this run names another
+ *      (nonexistent) provider → the earlier opencode-free choice is
+ *      restored, not the fallback artifact.
+ *   4. Unknown id: trailing choice names a nonexistent opencode-free
+ *      model → graceful no-restore, session stays usable, no error.
+ *
+ * Fails on ANY extension_error at ANY point, any timeout, or any
+ * unexpected final model. Strict by design.
+ *
+ * The caller provides the isolated HOME (pi-free installed, free_only
+ * seeded, OPENCODE_API_KEY present so opencode-free models are
+ * available and setModel's auth gate passes).
+ *
+ * Usage:
+ *   node scripts/rpc-restore-check.mjs
+ */
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bootPi } from "./lib/rpc-driver.mjs";
+
+const PROVIDER = "opencode-free";
+const OLD_STAMP = "2024-01-01T00:00:00.000Z";
+
+const driver = bootPi({
+	cwd: process.cwd(),
+	env: {
+		...process.env,
+		ANTHROPIC_API_KEY:
+			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-restore-check",
+	},
+	timeoutMs: 300_000,
+	// A live session is required: crafted files switch into it, and the
+	// boot session's directory is where they are written.
+	noSession: false,
+});
+
+function paidCost(model) {
+	return (model.cost?.input ?? 0) > 0 || (model.cost?.output ?? 0) > 0;
+}
+
+/** Locate the boot cwd's session dir (exactly one exists in a fresh HOME). */
+function sessionDir() {
+	const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+	const roots = join(homeDir, ".pi", "agent", "sessions");
+	const dirs = readdirSync(roots, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => join(roots, entry.name));
+	if (dirs.length !== 1) {
+		throw new Error(
+			`expected exactly one session dir in a fresh HOME, found ${dirs.length}`,
+		);
+	}
+	return dirs[0];
+}
+
+/** Write a session file with the given model_change trail; returns its path. */
+function craftSession(cwd, changes) {
+	const dir = sessionDir();
+	const name = `${new Date().toISOString().replace(/[:.]/g, "-")}_${randomUUID().slice(0, 8)}.jsonl`;
+	const filePath = join(dir, name);
+	const lines = [
+		JSON.stringify({
+			type: "session",
+			version: 3,
+			id: randomUUID(),
+			timestamp: new Date().toISOString(),
+			cwd,
+		}),
+	];
+	let parentId = null;
+	for (const change of changes) {
+		const id = randomUUID().slice(0, 8);
+		lines.push(
+			JSON.stringify({
+				type: "model_change",
+				id,
+				parentId,
+				timestamp: change.at ?? new Date().toISOString(),
+				provider: change.provider,
+				modelId: change.modelId,
+			}),
+		);
+		parentId = id;
+	}
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(filePath, `${lines.join("\n")}\n`);
+	return filePath;
+}
+
+async function currentModel() {
+	const state = await driver.send({ type: "get_state" });
+	return state?.model;
+}
+
+async function waitModel(label, predicate, timeoutMs = 90_000) {
+	return driver.waitSettled(
+		async () => {
+			const model = await currentModel();
+			if (!model) return null;
+			const file = (await driver.send({ type: "get_state" }))?.sessionFile;
+			return { model, file };
+		},
+		({ model }) => {
+			if (!predicate(model)) {
+				throw new Error(
+					`${label}: unexpected model ${model?.provider}/${model?.id}`,
+				);
+			}
+		},
+		{ timeoutMs, label },
+	);
+}
+
+try {
+	const cwd = process.cwd();
+	// Wait for the boot session itself before touching its directory.
+	await driver.waitFor(
+		async () => {
+			const state = await driver.send({ type: "get_state" });
+			return state?.sessionFile ? true : null;
+		},
+		{ timeoutMs: 60_000, label: "boot session" },
+	);
+	const models = await driver.waitSettled(
+		async () => (await driver.send({ type: "get_available_models" })).models,
+		(all) => {
+			if ((all ?? []).filter((m) => m.provider === PROVIDER).length === 0) {
+				throw new Error(`boot: no ${PROVIDER} models in catalog`);
+			}
+		},
+		{ timeoutMs: 120_000, label: "boot opencode-free catalog" },
+	);
+	const target = models
+		.filter((m) => m.provider === PROVIDER && !paidCost(m))
+		.map((m) => m.id)
+		.sort()[0];
+	if (!target) throw new Error(`boot: no free ${PROVIDER} model to restore`);
+	console.log(`boot: restore target is ${PROVIDER}/${target}`);
+
+	// 1. Deliberate previous-run switch wins: trailing change names another
+	// provider with a pre-run stamp, so no restore may happen.
+	const deliberate = craftSession(cwd, [
+		{ provider: PROVIDER, modelId: target, at: OLD_STAMP },
+		{ provider: "kilo", modelId: "no-such-model", at: OLD_STAMP },
+	]);
+	await driver.send({ type: "switch_session", sessionPath: deliberate });
+	const kept = await waitModel(
+		"deliberate-switch",
+		(model) => model?.id !== target,
+	);
+	console.log(
+		`deliberate-switch: kept ${kept.model.provider}/${kept.model.id} (no restore, as designed)`,
+	);
+
+	// 2. Plain restore onto the recorded choice. Stamped pre-run like a
+	// real resumed session: a during-run stamp would look like Pi's own
+	// fallback artifact and be skipped by design.
+	const plain = craftSession(cwd, [
+		{ provider: PROVIDER, modelId: target, at: OLD_STAMP },
+	]);
+	await driver.send({ type: "switch_session", sessionPath: plain });
+	const restored = await waitModel(
+		"plain-restore",
+		(model) => model?.provider === PROVIDER && model?.id === target,
+	);
+	console.log(
+		`plain-restore: landed on ${restored.model.provider}/${restored.model.id}`,
+	);
+
+	// 3. Poisoned context: trailing during-run change names a nonexistent
+	// provider model (Pi's own fallback artifact) — the earlier recorded
+	// choice must win, not the artifact.
+	const poisoned = craftSession(cwd, [
+		{ provider: PROVIDER, modelId: target, at: OLD_STAMP },
+		{ provider: "anthropic", modelId: "no-such-model" },
+	]);
+	await driver.send({ type: "switch_session", sessionPath: poisoned });
+	const unpoisoned = await waitModel(
+		"poisoned-context",
+		(model) => model?.provider === PROVIDER && model?.id === target,
+	);
+	console.log(
+		`poisoned-context: landed on ${unpoisoned.model.provider}/${unpoisoned.model.id}`,
+	);
+
+	// 4. Unknown id: graceful no-restore, session stays usable.
+	const unknown = craftSession(cwd, [
+		{ provider: PROVIDER, modelId: "definitely-not-a-model" },
+	]);
+	await driver.send({ type: "switch_session", sessionPath: unknown });
+	const usable = await waitModel(
+		"unknown-id",
+		(model) => model?.id !== "definitely-not-a-model",
+	);
+	console.log(
+		`unknown-id: session usable on ${usable.model.provider}/${usable.model.id} (no crash, no bogus restore)`,
+	);
+
+	driver.pass("deferred saved-model restore holds across crafted resumes");
+} catch (error) {
+	driver.fail(error instanceof Error ? error.message : String(error));
+}

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -35,9 +35,9 @@
  * Usage:
  *   node scripts/rpc-session-check.mjs
  */
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bootPi } from "./lib/rpc-driver.mjs";
+import { bootPi, sleep } from "./lib/rpc-driver.mjs";
 
 const expectedCommands = ["toggle-free", "free-providers", "pi-free-health"];
 
@@ -64,7 +64,7 @@ const driver = bootPi({
 		ANTHROPIC_API_KEY:
 			process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-rpc-session-check",
 	},
-	timeoutMs: 300_000,
+	timeoutMs: 600_000,
 });
 
 function paidCost(model) {
@@ -142,6 +142,15 @@ async function waitCatalog(phase, managed) {
 		(models) => assertCatalog(models, phase, managed),
 		{ timeoutMs: 180_000, label: `${phase} managed catalog` },
 	);
+}
+
+/**
+ * Write the smoke HOME's free.json (same file the extension reads).
+ * Used by the hot-reload probe to bypass applyGlobalFilter on purpose.
+ */
+function writeFreeJson(value) {
+	const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+	writeFileSync(join(homeDir, ".pi", "free.json"), JSON.stringify(value));
 }
 
 /**
@@ -225,6 +234,54 @@ try {
 	console.log(
 		`post-toggle-replacement: llm7/pro survives new_session (${persisted.length} total)`,
 	);
+
+	// Global flip: /toggle-free clears overrides and shows paid everywhere;
+	// flipping back restores the strict free view.
+	await driver.prompt("/toggle-free");
+	await driver.waitFor(
+		async () => {
+			const found = (await driver.send({ type: "get_available_models" }))
+				.models;
+			const paid = (found ?? []).filter(
+				(m) => managed.has(m.provider) && paidCost(m),
+			);
+			return paid.length > 0 ? paid : null;
+		},
+		{ timeoutMs: 90_000, label: "toggle-free-off paid visible" },
+	);
+	console.log("toggle-free-off: paid managed models visible");
+	await driver.prompt("/toggle-free");
+	await waitCatalog("toggle-free-on", managed);
+
+	// Hot-reload probe (observe + report, not assert): a direct free.json
+	// write bypasses applyGlobalFilter, so the module-cached global may
+	// not follow. The log line below is the evidence either way.
+	writeFreeJson({ free_only: false });
+	await sleep(5000);
+	const probeOff = (await driver.send({ type: "get_available_models" })).models;
+	const probeOffPaid = (probeOff ?? []).filter(
+		(m) => managed.has(m.provider) && paidCost(m),
+	);
+	console.log(
+		`hot-reload-probe: file free_only=false -> ${probeOffPaid.length} paid managed visible`,
+	);
+	writeFreeJson({ free_only: true });
+	await sleep(5000);
+	const probeOn = (await driver.send({ type: "get_available_models" })).models;
+	const probeOnPaid = (probeOn ?? []).filter(
+		(m) => managed.has(m.provider) && paidCost(m),
+	);
+	console.log(
+		`hot-reload-probe: file free_only=true -> ${probeOnPaid.length} paid managed visible`,
+	);
+
+	// Rapid-switch stress: replacements back-to-back must stay clean.
+	for (let i = 0; i < 5; i++) {
+		await driver.send({ type: "new_session" });
+	}
+	console.log("rapid-switch: 5 replacements issued");
+	await waitCommands("rapid-switch");
+	await waitCatalog("rapid-switch", managed);
 
 	driver.pass("session replacement clean, free-only view holds");
 } catch (error) {

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -1010,107 +1010,14 @@ describe("built-in provider toggles", () => {
 			"warning",
 		);
 	});
+	// NOTE (RPC migration): plain restore, poisoned-context restore,
+	// and deliberate-departure suppression are proven live by
+	// rpc-restore-check (crafted session resumes incl. a case the mocks
+	// could not model: Pi appending its own fallback entry).Kept here:
+	// refresh-landing retry, another-provider, already-active.
 
-	it("restores the session's saved model once the late capture registers it", async () => {
-		setupBuiltInProviderToggles(mockPi);
 
-		const capturedModel = {
-			provider: "opencode",
-			id: "free-model",
-			name: "Free Model",
-			api: "openai-completions",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 4096,
-			baseUrl: "https://example.com",
-		};
-		// Post-registration the registry also serves the re-registered
-		// opencode-free view; getAll reflects that.
-		const restoredModel = { ...capturedModel, provider: "opencode-free" };
 
-		await handlers.session_start(
-			{},
-			{
-				modelRegistry: {
-					getAll: () => [capturedModel, restoredModel],
-					getAvailable: () => [capturedModel],
-				},
-				sessionManager: {
-					buildSessionContext: () => ({
-						model: { provider: "opencode-free", modelId: "free-model" },
-					}),
-				},
-				// Pi fell back to another model because opencode-free was not
-				// registered yet when the session was restored.
-				model: { provider: "kilo", id: "fallback-model" },
-			},
-		);
-		await settleDetachedCapture();
-
-		expect(mockPi.setModel).toHaveBeenCalledWith(
-			expect.objectContaining({ provider: "opencode-free", id: "free-model" }),
-		);
-	});
-
-	it("restores the saved model even when Pi's fallback poisoned the context model", async () => {
-		setupBuiltInProviderToggles(mockPi);
-
-		const capturedModel = {
-			provider: "opencode",
-			id: "free-model",
-			name: "Free Model",
-			api: "openai-completions",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 4096,
-			baseUrl: "https://example.com",
-		};
-		// Post-registration the registry also serves the re-registered
-		// opencode-free view; getAll reflects that.
-		const restoredModel = { ...capturedModel, provider: "opencode-free" };
-		// Pi appended a model_change for its fallback during THIS resume, so
-		// buildSessionContext().model no longer reports the persisted choice.
-		const now = new Date().toISOString();
-
-		await handlers.session_start(
-			{},
-			{
-				modelRegistry: {
-					getAll: () => [capturedModel, restoredModel],
-					getAvailable: () => [capturedModel],
-				},
-				sessionManager: {
-					buildSessionContext: () => ({
-						model: { provider: "openai-codex", modelId: "gpt-5.5" },
-					}),
-					getEntries: () => [
-						{
-							type: "model_change",
-							provider: "opencode-free",
-							modelId: "free-model",
-							timestamp: "2026-01-01T00:00:00.000Z",
-						},
-						{
-							type: "model_change",
-							provider: "openai-codex",
-							modelId: "gpt-5.5",
-							timestamp: now,
-						},
-					],
-				},
-				model: { provider: "openai-codex", id: "gpt-5.5" },
-			},
-		);
-		await settleDetachedCapture();
-
-		expect(mockPi.setModel).toHaveBeenCalledWith(
-			expect.objectContaining({ provider: "opencode-free", id: "free-model" }),
-		);
-	});
 
 	it("retries the restore once the endpoint refresh lands the missing model", async () => {
 		setupBuiltInProviderToggles(mockPi);
@@ -1168,54 +1075,6 @@ describe("built-in provider toggles", () => {
 		);
 	});
 
-	it("does not restore when the trailing switch predates this run (deliberate)", async () => {
-		setupBuiltInProviderToggles(mockPi);
-
-		const capturedModel = {
-			provider: "opencode",
-			id: "free-model",
-			name: "Free Model",
-			api: "openai-completions",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 4096,
-			baseUrl: "https://example.com",
-		};
-		// Both changes are from a PREVIOUS run: the user deliberately moved to
-		// another provider and saved that way. No restore.
-
-		await handlers.session_start(
-			{},
-			{
-				modelRegistry: { getAll: () => [capturedModel], getAvailable: () => [] },
-				sessionManager: {
-					buildSessionContext: () => ({
-						model: { provider: "kilo", modelId: "other-model" },
-					}),
-					getEntries: () => [
-						{
-							type: "model_change",
-							provider: "opencode-free",
-							modelId: "free-model",
-							timestamp: "2026-01-01T00:00:00.000Z",
-						},
-						{
-							type: "model_change",
-							provider: "kilo",
-							modelId: "other-model",
-							timestamp: "2026-01-01T00:05:00.000Z",
-						},
-					],
-				},
-				model: { provider: "kilo", id: "other-model" },
-			},
-		);
-		await settleDetachedCapture();
-
-		expect(mockPi.setModel).not.toHaveBeenCalled();
-	});
 
 	it("does not restore when the saved model belongs to another provider", async () => {
 		setupBuiltInProviderToggles(mockPi);

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -181,15 +181,17 @@ describe("applyGlobalFilter", () => {
 		expect(reRegister).toHaveBeenCalledWith(free);
 	});
 
-	it("handles providers with no free models gracefully", () => {
+	it("registers the empty free list (hides the provider) when no free models exist", () => {
 		const free: ProviderModelConfig[] = [];
 		const all = [makePaidModel("expensive")];
 		const reRegister = vi.fn();
 
 		registerWithGlobalToggle("af-test-4", { free, all }, reRegister, true);
 
+		// Strict free views never retain the previous registration: that
+		// would leak the paid catalog the filter exists to hide.
 		expect(() => applyGlobalFilter(true)).not.toThrow();
-		expect(reRegister).not.toHaveBeenCalled();
+		expect(reRegister).toHaveBeenCalledWith([]);
 	});
 
 	it("applies filter to all registered providers", () => {


### PR DESCRIPTION
## The bug the strict test found\n\nThe RPC restore driver exposed a real defect in `resolveSavedModelChoice`: Pi appends its own fallback `model_change` on every failed resume, so a trail the code read as `[choice@old, deliberate@old]` is actually `[choice@old, deliberate@old, fallback@now]` — and 'trailing names another provider, look back' restored over a deliberate departure. Verified live: the deliberate phase wrongfully landed on the old choice.\n\n## Fix\n\nWalk back past **all** during-run entries (Pi speaking, never the user): the last pre-run entry decides — restore iff it names this provider, honor a departure otherwise. Undated entries count as departures. All existing mock tests hold under the corrected rule.\n\n## Tests (RPC migration)\n\n- New `scripts/rpc-restore-check.mjs` (crafted resumes: deliberate / plain / poisoned-context / unknown-id), wired into both smoke scripts. Passes live: deliberate keeps fallback, plain + poisoned land on the recorded choice, unknown stays usable with no crash.\n- Deleted the 3 mock restore tests it subsumes; kept retry-after-refresh, another-provider, already-active (no live equivalent).\n\nFull suite green; `tsc` clean. Replied on #519 with the diagnosis.