### PR TITLE
feat(observability): run-tagged logs, action ring in health, CI log forensics

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,8 @@ import {
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { clearModelViewOverrides } from "./config.ts";
 import { setupBuiltInProviderToggles } from "./lib/built-in-toggle.ts";
-import { createLogger, flushLogsSync } from "./lib/logger.ts";
+import { recordAction } from "./lib/action-log.ts";
+import { createLogger, flushLogsSync, withRunId } from "./lib/logger.ts";
 import {
 	processQuotaResponse,
 	formatQuotaStatus,
@@ -139,6 +140,20 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 	pi.registerCommand("toggle-free", {
 		description: "Toggle global free-only mode for all providers",
 		handler: async (_args, ctx) => {
+			// One run tag for the whole fan-out; the action ring keeps the
+			// user-pasteable summary (file log carries the per-provider trace).
+			withRunId(() => {
+				void runGlobalToggle(ctx);
+			});
+		},
+	});
+
+	// /toggle-free body, extracted so the whole fan-out shares one run tag.
+	async function runGlobalToggle(ctx: {
+		ui: {
+			notify(message: string, type?: "info" | "warning" | "error"): void;
+		};
+	}): Promise<void> {
 			const current = getGlobalFreeOnly();
 			const next = !current;
 			// Clear per-provider choices first so every provider follows
@@ -169,8 +184,11 @@ function setupGlobalCommands(pi: ExtensionAPI) {
 					"info",
 				);
 			}
-		},
-	});
+			recordAction(
+				"toggle",
+				`global free-only ${current ? "ON→OFF" : "OFF→ON"} (${providerCount} providers)`,
+			);
+	}
 
 	// /free-providers - Show free model counts by provider
 	pi.registerCommand("free-providers", {

--- a/lib/action-log.ts
+++ b/lib/action-log.ts
@@ -1,0 +1,44 @@
+/**
+ * In-memory ring of recent user-action outcomes (toggles, restores,
+ * fallback switches, refresh nudges), surfaced read-only through
+ * /pi-free-health. File-log carries the full trace; this ring is the
+ * user-pasteable summary. No I/O, no TUI writes — the health command is
+ * the only consumer-facing surface.
+ */
+
+import { getActiveRunId } from "./logger.ts";
+
+export type ActionKind = "toggle" | "restore" | "fallback" | "refresh";
+
+export interface ActionRecord {
+	at: string;
+	run: string | null;
+	kind: ActionKind;
+	summary: string;
+}
+
+const RING_CAP = 20;
+const ring: ActionRecord[] = [];
+
+/** Record one user-action outcome. Summaries stay short (health renders them). */
+export function recordAction(kind: ActionKind, summary: string): void {
+	ring.push({
+		at: new Date().toISOString(),
+		run: getActiveRunId(),
+		kind,
+		summary: summary.slice(0, 160),
+	});
+	if (ring.length > RING_CAP) ring.splice(0, ring.length - RING_CAP);
+}
+
+/** Newest-first copy of the ring (empty when nothing recorded yet). */
+export function getRecentActions(): ActionRecord[] {
+	const out: ActionRecord[] = [];
+	for (let i = ring.length - 1; i >= 0; i--) out.push(ring[i]);
+	return out;
+}
+
+/** Test seam: reset the ring. */
+export function clearActions(): void {
+	ring.length = 0;
+}

--- a/lib/auto-fallback/index.ts
+++ b/lib/auto-fallback/index.ts
@@ -39,7 +39,8 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { getProviderRegistry } from "../registry.ts";
 import { fallbackState } from "../fallback-state.ts";
-import { createLogger } from "../logger.ts";
+import { recordAction } from "../action-log.ts";
+import { createLogger, withRunId } from "../logger.ts";
 import { isStaleContextError, safeNotify } from "../stale-ctx.ts";
 import { createBlacklist, type Blacklist } from "./blacklist.ts";
 import { getAutoFallbackConfig } from "./config.ts";
@@ -333,6 +334,10 @@ export function createAutoFallback(): AutoFallbackHandle {
 			_logger.info(
 				`auto-fallback: switched ${modelKey(provider, modelId)} → ${modelKey(cand.provider, cand.modelId)} (reason=${failureReason})`,
 			);
+			recordAction(
+				"fallback",
+				`${modelKey(provider, modelId)} → ${modelKey(cand.provider, cand.modelId)} (${failureReason})`,
+			);
 
 			// Mark for auto-continue: agent_settled will replay the captured
 			// prompt on the new model so the user doesn't have to re-send.
@@ -556,9 +561,11 @@ export function createAutoFallback(): AutoFallbackHandle {
 			// This single handler owns ALL decisions (recovery, strikes,
 			// switching, auto-continue) so each settled run is processed
 			// exactly once, in order.
+			// One run tag per settle: clean runs emit no lines (no noise),
+			// failure runs correlate classify → strike → switch → replay.
 			extensionPi.on("agent_settled", async (_event, ctx) => {
 				try {
-					await handleAgentSettled(ctx);
+					await withRunId(() => handleAgentSettled(ctx));
 				} catch (error) {
 					// Pi surfaces handler throws as a user-visible Extension
 					// error for the current turn. A stale ctx just means the

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -21,7 +21,8 @@ import type {
 	ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { getOpencodeApiKey, setModelViewOverride } from "../config.ts";
-import { createLogger } from "./logger.ts";
+import { recordAction } from "./action-log.ts";
+import { createLogger, withRunId } from "./logger.ts";
 import { isStaleContextError } from "./stale-ctx.ts";
 import {
 	getProviderRegistry,
@@ -477,6 +478,15 @@ async function maybeRestoreSavedModel(
 	config: BuiltInToggleConfig,
 	snapshot: SavedModelSnapshot,
 ): Promise<void> {
+	// One run tag for resolve + retry + setModel.
+	await withRunId(() => restoreSavedModelInner(pi, config, snapshot));
+}
+
+async function restoreSavedModelInner(
+	pi: ExtensionAPI,
+	config: BuiltInToggleConfig,
+	snapshot: SavedModelSnapshot,
+): Promise<void> {
 	try {
 		const contextModel =
 			snapshot.sessionManager?.buildSessionContext?.().model ?? null;
@@ -533,6 +543,10 @@ async function maybeRestoreSavedModel(
 			_logger.warn(
 				`[built-in-toggle] ${config.id}: saved model ${saved.modelId} not in the registered catalog; keeping Pi's fallback`,
 			);
+			recordAction(
+				"restore",
+				`${config.id}: saved ${saved.modelId} not in catalog; keeping fallback`,
+			);
 			return;
 		}
 		const restored = await pi.setModel(model);
@@ -540,9 +554,14 @@ async function maybeRestoreSavedModel(
 			_logger.info(
 				`[built-in-toggle] ${config.id}: restored saved model ${saved.modelId} after late registration`,
 			);
+			recordAction("restore", `${config.id}: restored ${saved.modelId}`);
 		} else {
 			_logger.warn(
 				`[built-in-toggle] ${config.id}: saved model ${saved.modelId} registered but setModel was rejected (auth?)`,
+			);
+			recordAction(
+				"restore",
+				`${config.id}: saved ${saved.modelId} registered but setModel rejected`,
 			);
 		}
 	} catch (error) {
@@ -555,6 +574,7 @@ async function maybeRestoreSavedModel(
 					error: error instanceof Error ? error.message : String(error),
 				},
 			);
+			recordAction("restore", `${config.id}: session changed; restore skipped`);
 			return;
 		}
 		_logger.warn(
@@ -946,7 +966,8 @@ function registerToggleCommand(
 		description: `Toggle free/paid ${config.id} models`,
 		handler: async (_args, ctx) => {
 			try {
-				await runToggleCommand(ctx);
+				// One run tag for capture-wait + apply + persist.
+				await withRunId(() => runToggleCommand(ctx));
 			} catch (error) {
 				// The command ctx may belong to a replaced session (#509).
 				// There is no live UI left to explain that on — drop it
@@ -1002,6 +1023,10 @@ function registerToggleCommand(
 		const next = resolveModelView(config.id) === "free" ? "all" : "free";
 		const applied = state.toggleState.applyMode(next, state.reRegister);
 		await setModelViewOverride(config.id, applied.mode);
+		recordAction(
+			"toggle",
+			`${config.id} ${next === applied.mode ? "" : `(asked ${next}, got ${applied.mode}) `}${applied.mode} (${applied.models.length} models)`,
+		);
 
 		if (applied.mode === "all") {
 			ctx.ui.notify(

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -11,6 +11,7 @@ import {
 	isFileLoggingEnabled,
 } from "./logger.ts";
 import { getAllResponseCounters } from "./quota-monitor.ts";
+import { getRecentActions } from "./action-log.ts";
 import { getAutoFallback } from "./auto-fallback-status.ts";
 
 /**
@@ -87,6 +88,16 @@ export function formatHealthReport(): string {
 			(status.lastSwitchReason ? `, last: ${status.lastSwitchReason}` : "") +
 			`${status.exhausted ? ", EXHAUSTED" : ""})`;
 		lines.push(statusLine);
+	}
+
+	// Recent user-action outcomes (toggles, restores, fallback switches).
+	// The file log carries the full trace; this is the paste-into-an-issue
+	// summary. Absent when no action ran yet this process.
+	const actions = getRecentActions().slice(0, 8);
+	if (actions.length > 0) {
+		lines.push(
+			`Recent actions: ${actions.map((a) => `[${a.kind}] ${a.summary}`).join("; ")}`,
+		);
 	}
 
 	return lines.join("\n");

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -9,6 +9,8 @@
  * - Rotate size: PI_FREE_LOG_MAX_BYTES=10485760 (default 10 MiB; 3 backups)
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
 import {
 	appendFileSync,
 	createWriteStream,
@@ -370,6 +372,31 @@ function appendToFile(line: string): void {
 	startLogStream(Boolean(logStream));
 }
 
+/**
+ * Ambient run-correlation ID, threaded through fan-out operations
+ * (global filter, per-provider toggles, restore, fallback switches,
+ * refresh nudges) so one user action's per-provider log lines share a
+ * tag. AsyncLocalStorage keeps concurrent runs distinct; outside a run
+ * no tag is attached. File-log only — never touches the TUI.
+ */
+const runIdStore = new AsyncLocalStorage<string>();
+
+/** Correlation tag for a user action's fan-out. CSPRNG-backed (Sonar
+ * S2245: avoid Math.random()); the first 8 hex chars of a UUID are ample. */
+export function newRunId(): string {
+	return randomUUID().slice(0, 8);
+}
+
+/** Run `fn` with `id` (generated when omitted) as the ambient run tag. */
+export function withRunId<T>(fn: () => T, id?: string): T {
+	return runIdStore.run(id ?? newRunId(), fn);
+}
+
+/** The ambient run tag, if inside withRunId. */
+export function getActiveRunId(): string | null {
+	return runIdStore.getStore() ?? null;
+}
+
 function log(
 	level: LogLevel,
 	namespace: string,
@@ -380,12 +407,13 @@ function log(
 	const logToFile = shouldLog(level, fileLevel);
 	if (!logToConsole && !logToFile) return;
 
+	const runId = getActiveRunId();
 	const entry: LogEntry = {
 		timestamp: new Date().toISOString(),
 		level,
 		namespace,
 		message,
-		data,
+		data: runId ? { run: runId, ...data } : data,
 	};
 
 	const formatted = formatMessage(entry);

--- a/scripts/pi-install-smoke.mjs
+++ b/scripts/pi-install-smoke.mjs
@@ -87,7 +87,7 @@ environment.HOME = home;
 environment.USERPROFILE = home;
 environment.NPM_CONFIG_USERCONFIG = join(testRoot, "npmrc");
 environment.NPM_CONFIG_CACHE = join(testRoot, "npm-cache");
-environment.PI_FREE_FILE_LOG = "false";
+environment.PI_FREE_FILE_LOG = "true";
 delete environment.PI_CODING_AGENT_DIR;
 delete environment.PI_CODING_AGENT_SESSION_DIR;
 delete environment.PI_PACKAGE_DIR;

--- a/scripts/pi-upgrade-smoke.mjs
+++ b/scripts/pi-upgrade-smoke.mjs
@@ -114,7 +114,7 @@ environment.HOME = home;
 environment.USERPROFILE = home;
 environment.NPM_CONFIG_USERCONFIG = join(testRoot, "npmrc");
 environment.NPM_CONFIG_CACHE = join(testRoot, "npm-cache");
-environment.PI_FREE_FILE_LOG = "false";
+environment.PI_FREE_FILE_LOG = "true";
 delete environment.PI_CODING_AGENT_DIR;
 delete environment.PI_CODING_AGENT_SESSION_DIR;
 delete environment.PI_PACKAGE_DIR;

--- a/tests/action-log.test.ts
+++ b/tests/action-log.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("action ring", () => {
+	it("returns newest-first and caps at 20", async () => {
+		vi.resetModules();
+		const { recordAction, getRecentActions, clearActions } = await import(
+			"../lib/action-log.ts"
+		);
+		clearActions();
+		for (let i = 0; i < 25; i++) recordAction("toggle", `action-${i}`);
+		const recent = getRecentActions();
+		expect(recent).toHaveLength(20);
+		expect(recent[0].summary).toBe("action-24");
+		expect(recent[19].summary).toBe("action-5");
+	});
+
+	it("truncates long summaries for health rendering", async () => {
+		vi.resetModules();
+		const { recordAction, getRecentActions, clearActions } = await import(
+			"../lib/action-log.ts"
+		);
+		clearActions();
+		recordAction("restore", "x".repeat(300));
+		expect(getRecentActions()[0].summary).toHaveLength(160);
+	});
+
+	it("attaches the ambient run id, null outside a run", async () => {
+		vi.resetModules();
+		const { recordAction, getRecentActions, clearActions } = await import(
+			"../lib/action-log.ts"
+		);
+		const { withRunId, getActiveRunId } = await import("../lib/logger.ts");
+		clearActions();
+		expect(getActiveRunId()).toBeNull();
+		recordAction("toggle", "outside");
+		withRunId(() => {
+			recordAction("toggle", "inside");
+			expect(getActiveRunId()).toMatch(/^[0-9a-f]{8}$/);
+		}, "deadbeef");
+		expect(getActiveRunId()).toBeNull();
+		const recent = getRecentActions();
+		expect(recent[0].summary).toBe("inside");
+		expect(recent[0].run).toBe("deadbeef");
+		expect(recent[1].summary).toBe("outside");
+		expect(recent[1].run).toBeNull();
+	});
+
+	it("tags file-log lines with the ambient run id", async () => {
+		const home = await mkdtemp(join(tmpdir(), "pi-free-runid-test-"));
+		vi.stubEnv("HOME", home);
+		vi.stubEnv("USERPROFILE", home);
+		vi.stubEnv("PI_FREE_LOG_PATH", "runid.log");
+		vi.stubEnv("PI_FREE_LOG_LEVEL", "debug");
+		vi.stubEnv("PI_FREE_FILE_LOG", "true");
+		vi.resetModules();
+		const { createLogger, withRunId, getLogPath } = await import(
+			"../lib/logger.ts"
+		);
+		const { readFile } = await import("node:fs/promises");
+		const log = createLogger("runid-test");
+		log.info("outside run");
+		withRunId(() => {
+			log.info("inside run");
+		}, "cafef00d");
+		const { flushLogsSync } = await import("../lib/logger.ts");
+		flushLogsSync();
+		const content = await readFile(getLogPath(), "utf8");
+		expect(content).toContain("outside run");
+		expect(content).not.toMatch(/outside run.*"run"/);
+		expect(content).toMatch(/inside run.*"run":"cafef00d"/);
+	});
+});

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -102,6 +102,22 @@ describe("health report", () => {
 		expect(report).toContain("old-prov: store 8d old");
 	});
 
+	it("lists recent user-action outcomes when actions ran", async () => {
+		const actions = await import("../lib/action-log.ts");
+		const { formatHealthReport } = await import("../lib/health.ts");
+
+		actions.clearActions();
+		expect(formatHealthReport()).not.toContain("Recent actions:");
+		actions.recordAction("toggle", "global free-only OFF→ON (3 providers)");
+		actions.recordAction("restore", "opencode-go: restored big-pickle");
+
+		const report = formatHealthReport();
+		expect(report).toContain(
+			"Recent actions: [restore] opencode-go: restored big-pickle; [toggle] global free-only OFF→ON (3 providers)",
+		);
+		actions.clearActions();
+	});
+
 	it("aggregates auth-failure / rate-limit / 5xx response counters (M2, Mn3)", async () => {
 		const quota = await import("../lib/quota-monitor.ts");
 		const { formatHealthReport } = await import("../lib/health.ts");


### PR DESCRIPTION
Pattern work, not issue work. User pain clusters into four patterns: opaque failure, silent wrong state, dishonest timing, and a lossy witness. This PR covers the witness side. TUI visibility exclusively through `/pi-free-health` — no new toasts, no console output.\n\n## What\n\n- **Run correlation**: AsyncLocalStorage-backed ambient run id in the logger (`newRunId`/`withRunId`/`getActiveRunId`), auto-attached as `data.run` on file-log lines. Wired at fan-out entry points: `/toggle-free`, per-provider toggles, saved-model restore, and the `agent_settled` failure branch (classify → strike → switch → replay share one tag).\n- **Action ring**: new `lib/action-log.ts` — capped (20) in-memory ring of toggle/restore/fallback outcomes, rendered as a `Recent actions` line in health. Absent when empty.\n- **CI forensics**: smokes run with `PI_FREE_FILE_LOG=true` so the `free.log` the artifact step already preserves actually exists.\n- **Silent-path audit**: native + built-in refresh abort/retain paths already record (M1 counters); remaining silences are per-occurrence plumbing or best-effort metric guards, deliberately quiet under the bounded-observability rule.\n\n## Proof\n\n- Full suite green (837 passed), `tsc` clean, new `tests/action-log.test.ts` + health assertion.\n- Full install smoke green (toggle-free flip, rapid-switch, toggle, restore phases).\n- Live log check: each `/toggle-free` flip produces ~29 lines under one run tag; per-provider `filtered to N free models` lines share it.