### PR TITLE
ci(tsconfig): exactOptionalPropertyTypes + noUncheckedIndexedAccess (refs #526)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -91,6 +91,17 @@ function safeJsonReviver(
 
 const _logger = createLogger("config");
 
+/**
+ * Write-patch for free.json. Unlike Partial, members explicitly accept
+ * undefined: assigning undefined ERASES the key (saveConfig's
+ * JSON.stringify drop removes it). This is clearModelViewOverrides'
+ * mechanism — never widen a presence-sensitive READ type to match;
+ * omit the key instead.
+ */
+export type ConfigPatch = {
+	[K in keyof PiFreeConfig]?: PiFreeConfig[K] | undefined;
+};
+
 interface PiFreeConfig {
 	nvidia_api_key?: string;
 	ollama_api_key?: string;
@@ -590,13 +601,19 @@ export async function setModelViewOverride(
 	view: ModelViewChoice,
 ): Promise<void> {
 	const meta = PROVIDER_META_BY_ID.get(providerId);
-	await updateConfig((current) => ({
-		model_view_overrides: {
-			...current.model_view_overrides,
-			[providerId]: view,
-		},
-		...(meta ? { [meta.showPaidKey]: undefined } : {}),
-	}));
+	await updateConfig((current) => {
+		const patch: ConfigPatch = {
+			model_view_overrides: {
+				...current.model_view_overrides,
+				[providerId]: view,
+			},
+		};
+		// Erase the legacy snake_case key alongside the sparse-map write
+		// so the two representations can never disagree (explicit branch
+		// instead of a conditional spread).
+		if (meta) patch[meta.showPaidKey] = undefined;
+		return patch;
+	});
 }
 
 /**
@@ -608,7 +625,7 @@ export async function setModelViewOverride(
  * keys from free.json; the mtime bump invalidates the memoized parse.
  */
 export async function clearModelViewOverrides(): Promise<void> {
-	const cleared: Partial<PiFreeConfig> = { model_view_overrides: undefined };
+	const cleared: ConfigPatch = { model_view_overrides: undefined };
 	for (const meta of PROVIDER_META_BY_ID.values()) {
 		cleared[meta.showPaidKey] = undefined;
 	}
@@ -958,9 +975,7 @@ export function applyHidden<T extends { id: string }>(
 // Persistence
 // =============================================================================
 
-export async function saveConfig(
-	updates: Partial<PiFreeConfig>,
-): Promise<void> {
+export async function saveConfig(updates: ConfigPatch): Promise<void> {
 	const release = await _configLock.acquire();
 	try {
 		// Read the raw file content — never use loadConfigFile() here because
@@ -1050,7 +1065,7 @@ const _configLock = new ConfigLock();
  * recovery).
  */
 export async function updateConfig(
-	updater: (current: PiFreeConfig) => Partial<PiFreeConfig>,
+	updater: (current: PiFreeConfig) => ConfigPatch,
 ): Promise<void> {
 	const release = await _configLock.acquire();
 	try {

--- a/lib/action-log.ts
+++ b/lib/action-log.ts
@@ -34,7 +34,9 @@ export function recordAction(kind: ActionKind, summary: string): void {
 /** Newest-first copy of the ring (empty when nothing recorded yet). */
 export function getRecentActions(): ActionRecord[] {
 	const out: ActionRecord[] = [];
-	for (let i = ring.length - 1; i >= 0; i--) out.push(ring[i]);
+	// Loop bounds prove defined; the assertion documents it (no guard
+	// that could never fire).
+	for (let i = ring.length - 1; i >= 0; i--) out.push(ring[i]!);
 	return out;
 }
 

--- a/lib/auto-fallback/index.ts
+++ b/lib/auto-fallback/index.ts
@@ -523,7 +523,10 @@ export function createAutoFallback(): AutoFallbackHandle {
 				pendingAutoContinue = null;
 				const e = event as { prompt?: string; images?: unknown[] };
 				if (e && typeof e.prompt === "string") {
-					lastUserPrompt = { text: e.prompt, images: e.images };
+					// CapturedPrompt stays Pi-compatible (no undefined
+					// members): omit images instead of assigning undefined.
+					lastUserPrompt = { text: e.prompt };
+					if (e.images !== undefined) lastUserPrompt.images = e.images;
 				}
 			});
 

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -172,13 +172,15 @@ const providerStates = new Map<string, BuiltInProviderState>();
  */
 interface SavedModelSnapshot {
 	modelRegistry: CurrentModelRegistry;
-	sessionManager?: {
-		buildSessionContext?: () => {
-			model: { provider: string; modelId: string } | null;
-		};
-		getEntries?: () => unknown[];
-	};
-	model?: { provider: string; id: string };
+	sessionManager?:
+		| {
+				buildSessionContext?: () => {
+					model: { provider: string; modelId: string } | null;
+				};
+				getEntries?: () => unknown[];
+		  }
+		| undefined;
+	model?: { provider: string; id: string } | undefined;
 }
 
 interface PendingCapture {
@@ -390,7 +392,7 @@ const CLOCK_SKEW_MS = 5_000;
 interface ModelChangeEntry {
 	provider: string;
 	modelId: string;
-	timestamp?: string;
+	timestamp?: string | undefined;
 }
 
 function readModelChanges(
@@ -451,7 +453,8 @@ function resolveSavedModelChoice(
 	const changes = readModelChanges(session);
 	if (!changes || changes.length === 0) return undefined;
 	for (let i = changes.length - 1; i >= 0; i--) {
-		const change = changes[i];
+		// Loop bounds prove defined.
+		const change = changes[i]!;
 		const at = change.timestamp ? Date.parse(change.timestamp) : Number.NaN;
 		if (Number.isNaN(at) || at < RUN_STARTED_AT - CLOCK_SKEW_MS) {
 			// Last user choice (or undatable): restore iff ours, else
@@ -608,11 +611,15 @@ async function tryCaptureProvider(
 	const allModels = providerModels.map((m: Model<Api>) =>
 		modelToProviderConfig(m),
 	);
+	// Real guard (not an assertion): the length check above doesn't
+	// narrow [0] for the compiler.
+	const [first] = providerModels;
+	if (!first) return undefined;
 
 	return createProviderState(pi, config, {
 		allModels,
-		baseUrl: providerModels[0].baseUrl,
-		api: providerModels[0].api,
+		baseUrl: first.baseUrl,
+		api: first.api,
 		apiKey: await resolveApiKey(config.id, ctx.modelRegistry),
 		source: "captured",
 		modelRegistry: ctx.modelRegistry,
@@ -626,7 +633,7 @@ function createProviderState(
 		allModels: ProviderModelConfig[];
 		baseUrl: string;
 		api: Api;
-		apiKey?: string;
+		apiKey?: string | undefined;
 		source: "captured";
 		modelRegistry: CurrentModelRegistry;
 	},
@@ -1081,9 +1088,12 @@ function modelToProviderConfig(m: Model<Api>): ProviderModelConfig {
 		cost: m.cost,
 		contextWindow: m.contextWindow,
 		maxTokens: m.maxTokens,
-		headers: openCodeHeaders ?? m.headers,
 		compat: (m as any).compat,
 	};
+	// ProviderModelConfig is Pi-owned (no undefined members): omit headers
+	// when neither source produced any, instead of assigning undefined.
+	const resolvedHeaders = openCodeHeaders ?? m.headers;
+	if (resolvedHeaders) base.headers = resolvedHeaders;
 
 	// The provider-level OpenCode wrapper still regenerates headers, while the
 	// model-level API is preserved so Anthropic/Responses/Google routes remain

--- a/lib/built-in-toggle.ts
+++ b/lib/built-in-toggle.ts
@@ -645,8 +645,11 @@ function createProviderState(
 		isFreeModel({ ...m, provider: config.id }, allModels),
 	);
 
+	// No return-type annotation: Babel 8 (Stryker's instrumenter parser)
+	// rejects typed arrows in ternary position (UnexpectedTypeAnnotation).
+	// tsc still checks the inferred return at the assignment below.
 	const refreshModels = config.refreshEndpoint
-		? async (context: RefreshModelsContext): Promise<ProviderModelConfig[]> => {
+		? async (context: RefreshModelsContext) => {
 				const currentModels = () =>
 					stateForRefresh?.toggleState.getCurrentModels() ?? allModels;
 				if (!context.allowNetwork) {

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -22,6 +22,20 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Attach an optional abort signal to a RequestInit. RequestInit is
+ * lib.dom (no undefined members), so call sites must omit a missing
+ * signal instead of assigning undefined — this one seam owns that
+ * pattern so ~20 fetch sites don't repeat it.
+ */
+export function withSignal(
+	init: RequestInit,
+	signal?: AbortSignal | undefined,
+): RequestInit {
+	if (signal) init.signal = signal;
+	return init;
+}
+
+/**
  * Log a warning message for provider operations
  */
 export function logWarning(

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -30,7 +30,7 @@ interface LogEntry {
 	level: LogLevel;
 	namespace: string;
 	message: string;
-	data?: Record<string, unknown>;
+	data?: Record<string, unknown> | undefined;
 }
 
 const LOG_LEVELS: Record<LogLevel, number> = {
@@ -272,7 +272,8 @@ function attachLogStream(stream: WriteStream, existingBytes: number): void {
 	logBytes = existingBytes;
 	const pending = queuedLines.splice(0);
 	for (let index = 0; index < pending.length; index++) {
-		const line = pending[index];
+		// Loop bounds prove defined.
+		const line = pending[index]!;
 		const bytes = Buffer.byteLength(line, "utf8");
 		if (logBytes > 0 && logBytes + bytes > MAX_LOG_BYTES) {
 			queuedLines.push(...pending.slice(index));

--- a/lib/model-map.ts
+++ b/lib/model-map.ts
@@ -138,7 +138,9 @@ function parseMoeSize(lower: string): MoeSize | null {
 	while (true) {
 		const xIdx = lower.indexOf("x", searchPos);
 		if (xIdx <= 0) break;
-		const beforeChar = lower[xIdx - 1];
+		// charAt (not []) — out-of-range yields "" which fails the digit
+		// checks below, matching the guards' intent under indexed access.
+		const beforeChar = lower.charAt(xIdx - 1);
 		if (!(beforeChar >= "0" && beforeChar <= "9")) {
 			searchPos = xIdx + 1;
 			continue;
@@ -151,8 +153,8 @@ function parseMoeSize(lower: string): MoeSize | null {
 		let countStart = xIdx - 1;
 		while (
 			countStart > 0 &&
-			lower[countStart - 1] >= "0" &&
-			lower[countStart - 1] <= "9"
+			lower.charAt(countStart - 1) >= "0" &&
+			lower.charAt(countStart - 1) <= "9"
 		) {
 			countStart--;
 		}
@@ -167,7 +169,8 @@ function parseMoeSize(lower: string): MoeSize | null {
 			const afterB = lower.slice(bIdx + 1);
 			if (
 				afterB.length === 0 ||
-				((afterB[0] < "0" || afterB[0] > "9") && afterB[0] !== ".")
+				((afterB.charAt(0) < "0" || afterB.charAt(0) > "9") &&
+					afterB.charAt(0) !== ".")
 			) {
 				return { type: "moe", experts, sizePerExpert: size };
 			}
@@ -182,19 +185,20 @@ function parseMoeSize(lower: string): MoeSize | null {
  */
 function parseStandardSize(lower: string): StandardSize | null {
 	for (let i = 0; i < lower.length; i++) {
-		if (lower[i] !== "b") continue;
+		if (lower.charAt(i) !== "b") continue;
 		const afterB = lower.slice(i + 1);
 		if (
 			afterB.length > 0 &&
-			((afterB[0] >= "0" && afterB[0] <= "9") || afterB[0] === ".")
+			((afterB.charAt(0) >= "0" && afterB.charAt(0) <= "9") ||
+				afterB.charAt(0) === ".")
 		) {
 			continue; // b followed by digit or dot — not our match
 		}
 		let start = i;
 		while (
 			start > 0 &&
-			((lower[start - 1] >= "0" && lower[start - 1] <= "9") ||
-				lower[start - 1] === ".")
+			((lower.charAt(start - 1) >= "0" && lower.charAt(start - 1) <= "9") ||
+				lower.charAt(start - 1) === ".")
 		) {
 			start--;
 		}
@@ -263,12 +267,14 @@ export function mapOpenRouterModel(m: {
 		context_length?: number | null;
 		max_completion_tokens?: number | null;
 	};
-	pricing?: {
-		prompt?: string | null;
-		completion?: string | null;
-		input_cache_read?: string | null;
-		input_cache_write?: string | null;
-	};
+	pricing?:
+		| {
+				prompt?: string | null;
+				completion?: string | null;
+				input_cache_read?: string | null;
+				input_cache_write?: string | null;
+		  }
+		| undefined;
 	architecture?: {
 		input_modalities?: string[] | null;
 		output_modalities?: string[] | null;
@@ -495,18 +501,21 @@ export async function fetchOpenAICompatibleModels(
 	logger.info(`[${providerId}] Fetching models...`);
 
 	try {
+		// RequestInit is lib.dom (no undefined members): omit signal
+		// instead of assigning undefined.
+		const modelsInit: RequestInit = {
+			headers: {
+				// Public catalogs accept anonymous requests; an empty `Bearer `
+				// header can be rejected by gateways that would otherwise
+				// serve the endpoint anonymously.
+				...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+				"Content-Type": "application/json",
+			},
+		};
+		if (signal) modelsInit.signal = signal;
 		const response = await fetchWithRetry(
 			`${baseUrl}/models`,
-			{
-				headers: {
-					// Public catalogs accept anonymous requests; an empty `Bearer `
-					// header can be rejected by gateways that would otherwise
-					// serve the endpoint anonymously.
-					...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-					"Content-Type": "application/json",
-				},
-				signal,
-			},
+			modelsInit,
 			3,
 			1000,
 			30000,

--- a/lib/model-metadata.ts
+++ b/lib/model-metadata.ts
@@ -264,7 +264,7 @@ function mergeCompat(
 
 export interface ModelsDevEnrichmentOptions {
 	/** Provider id to scope models.dev lookup. Omit to search all providers. */
-	providerId?: string;
+	providerId?: string | undefined;
 	/** Values treated as provider defaults and safe to replace from models.dev. */
 	fallbackContextWindows?: number[];
 	fallbackMaxTokens?: number[];

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -111,7 +111,7 @@ export interface NativeOpenAIProviderOptions {
 	auth: ProviderAuth;
 	getApiKey: () => string | undefined;
 	getShowPaid: () => boolean;
-	initialModels?: ProviderModelConfig[];
+	initialModels?: ProviderModelConfig[] | undefined;
 	fetchModels: (
 		apiKey: string,
 		signal?: AbortSignal,
@@ -661,7 +661,7 @@ type NativeRefreshContext = {
 	/** Pi 0.84+ generation-checked publication API. */
 	publish?: (publication: {
 		persist?: NativeModelsStoreEntry | null;
-		update?: () => void;
+		update?: (() => void) | undefined;
 	}) => Promise<boolean>;
 	/** Pi <=0.83 legacy provider store. */
 	store?: {

--- a/lib/open-browser.ts
+++ b/lib/open-browser.ts
@@ -63,9 +63,10 @@ function resolveExe(name: string, absolutePath: string): string {
 	try {
 		const which = process.platform === "win32" ? "where" : "which";
 		// Use execFileSync with separate args — no shell injection vector
-		return execFileSync(which, [name], { encoding: "utf8" })
-			.trim()
-			.split("\n")[0];
+		return (
+			execFileSync(which, [name], { encoding: "utf8" }).trim().split("\n")[0] ??
+			name
+		);
 	} catch {
 		return name; // Last-resort fallback
 	}

--- a/lib/pi-ai-loader.ts
+++ b/lib/pi-ai-loader.ts
@@ -158,10 +158,19 @@ function isUsablePiAiRoot(root: string): boolean {
 		const version = typeof pkg.version === "string" ? pkg.version : "";
 		const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
 		if (!match) return false;
-		const candidate = [Number(match[1]), Number(match[2]), Number(match[3])];
+		// Destructure with safe defaults: match success proves all three
+		// groups participated, but the default keeps garbage fail-safe
+		// (NaN compares false below, rejecting the root).
+		const [, major = "", minor = "", patch = ""] = match;
+		const candidate = [Number(major), Number(minor), Number(patch)];
 		for (let i = 0; i < MIN_PI_AI_VERSION.length; i++) {
-			if (candidate[i] !== MIN_PI_AI_VERSION[i]) {
-				return candidate[i] > MIN_PI_AI_VERSION[i];
+			// NaN (unparseable) compares false below, rejecting the root —
+			// the safe direction. Want-default only satisfies the compiler
+			// (MIN_PI_AI_VERSION is a complete triple in practice).
+			const have = candidate[i] ?? Number.NaN;
+			const want = MIN_PI_AI_VERSION[i] ?? 0;
+			if (have !== want) {
+				return have > want;
 			}
 		}
 		return true;

--- a/lib/provider-probe.ts
+++ b/lib/provider-probe.ts
@@ -71,7 +71,7 @@ export interface ProviderProbe {
 		models: ProviderModelConfig[],
 		options?: {
 			useCache?: boolean;
-			onBroken?: (brokenIds: string[]) => void;
+			onBroken?: ((brokenIds: string[]) => void) | undefined;
 		},
 	) => Promise<string[]>;
 

--- a/lib/quota-monitor.ts
+++ b/lib/quota-monitor.ts
@@ -90,8 +90,11 @@ function extractQuota(
 	}
 
 	for (const [remainingKey, limitKey] of HEADER_PAIRS) {
-		const remaining = Number.parseFloat(normalized[remainingKey]);
-		const limit = Number.parseFloat(normalized[limitKey]);
+		const remainingRaw = normalized[remainingKey];
+		const limitRaw = normalized[limitKey];
+		if (remainingRaw === undefined || limitRaw === undefined) continue;
+		const remaining = Number.parseFloat(remainingRaw);
+		const limit = Number.parseFloat(limitRaw);
 		if (Number.isFinite(remaining) && Number.isFinite(limit) && limit > 0) {
 			return { remaining, limit, source: remainingKey };
 		}

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -21,9 +21,9 @@ interface ProviderEntry {
 	reRegister: (models: ProviderModelConfig[]) => void;
 	hasKey: boolean;
 	/** Native providers keep the complete catalog and filter it in Pi. */
-	native?: boolean;
+	native?: boolean | undefined;
 	/** Re-register the native provider without rebuilding a model array. */
-	invalidate?: () => void;
+	invalidate?: (() => void) | undefined;
 }
 
 // =============================================================================
@@ -100,10 +100,12 @@ function isPricingExposedCached(allModels: ProviderModelConfig[]): boolean {
  */
 export function isFreeModel(
 	model: ProviderModelConfig & {
-		provider?: string;
-		_pricingKnown?: boolean;
-		_freeKnown?: boolean;
-		_isFree?: boolean;
+		// Explicit undefined is tolerated (and pinned by tests): absent
+		// and undefined behave identically in the Route A/B checks below.
+		provider?: string | undefined;
+		_pricingKnown?: boolean | undefined;
+		_freeKnown?: boolean | undefined;
+		_isFree?: boolean | undefined;
 	},
 	allModels?: ProviderModelConfig[],
 ): boolean {
@@ -113,10 +115,10 @@ export function isFreeModel(
 // Internal implementation to work around TypeScript filter callback issues
 function isFreeModelInternal(
 	model: ProviderModelConfig & {
-		provider?: string;
-		_pricingKnown?: boolean;
-		_freeKnown?: boolean;
-		_isFree?: boolean;
+		provider?: string | undefined;
+		_pricingKnown?: boolean | undefined;
+		_freeKnown?: boolean | undefined;
+		_isFree?: boolean | undefined;
 	},
 	allModels: ProviderModelConfig[] | undefined,
 ): boolean {

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -31,7 +31,7 @@ interface TelemetryEntry {
 	totalTokens: number;
 	tokensPerSecond: number;
 	cost: number;
-	stopReason?: string;
+	stopReason?: string | undefined;
 	error?: string;
 	/** HTTP status code when the failure came from a provider response. */
 	statusCode?: number;
@@ -261,8 +261,8 @@ export function startModelCall(provider: string, model: string): string {
 /** Options for {@link recordModelCall} */
 export interface RecordModelCallOptions {
 	success: boolean;
-	stopReason?: string;
-	errorMessage?: string;
+	stopReason?: string | undefined;
+	errorMessage?: string | undefined;
 	/** HTTP status code observed on the provider response. */
 	statusCode?: number;
 	/** Structured failure class; derived from the message when omitted. */

--- a/lib/toggle-state.ts
+++ b/lib/toggle-state.ts
@@ -16,7 +16,7 @@ interface CreateToggleStateOptions<T> {
 	 * `opencode-free` → `opencode_free_show_paid`) must pass it so the
 	 * toggle survives a restart.
 	 */
-	configKey?: string;
+	configKey?: string | undefined;
 	save?: typeof saveConfig;
 	initialModels?: ToggleModelStore<T>;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,9 +16,9 @@ export interface CostConfig {
 
 export interface ModelIdentity {
 	id: string;
-	name?: string;
-	family?: string;
-	provider?: string;
+	name?: string | undefined;
+	family?: string | undefined;
+	provider?: string | undefined;
 }
 
 export type ModelMatchHints = Partial<ModelIdentity>;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -15,6 +15,7 @@ export {
 	MAX_RETRY_BACKOFF_MS,
 	parseModelResponse,
 	withFetchDeadline,
+	withSignal,
 } from "./fetch.ts";
 export {
 	cleanModelName,

--- a/provider-failover/benchmark-lookup.ts
+++ b/provider-failover/benchmark-lookup.ts
@@ -81,14 +81,14 @@ let debugEnabled = process.env.PI_FREE_BENCHMARK_DEBUG === "1";
  * "benchmark-lookup" namespace, using the buffered stream (no sync I/O).
  */
 function logDebug(entry: {
-	provider?: string;
+	provider?: string | undefined;
 	modelId: string;
 	modelName: string;
 	action: "attempt" | "match" | "miss" | "normalized";
 	strategy?: string;
 	normalizedId?: string;
 	matchKey?: string;
-	codingIndex?: number;
+	codingIndex?: number | undefined;
 	details?: string;
 }): void {
 	if (!debugEnabled) return;
@@ -355,12 +355,17 @@ function normalizeSizeTokenOrder(id: string): string {
 	const suffixes = new Set(["instruct", "chat"]);
 	const parts = id.split("-");
 	for (let i = 0; i < parts.length - 1; i++) {
-		const lower = parts[i].toLowerCase();
-		if (lower.endsWith("b") && suffixes.has(parts[i + 1].toLowerCase())) {
+		// Loop bounds prove both defined; the guard keeps it honest
+		// instead of asserting.
+		const current = parts[i];
+		const next = parts[i + 1];
+		if (current === undefined || next === undefined) continue;
+		const lower = current.toLowerCase();
+		if (lower.endsWith("b") && suffixes.has(next.toLowerCase())) {
 			// Validate the part before 'b' is a number
 			const num = lower.slice(0, -1);
 			if (num.length > 0 && !Number.isNaN(Number.parseFloat(num))) {
-				[parts[i], parts[i + 1]] = [parts[i + 1], parts[i]];
+				[parts[i], parts[i + 1]] = [next, current];
 				break;
 			}
 		}

--- a/providers/anyapi/anyapi.ts
+++ b/providers/anyapi/anyapi.ts
@@ -26,7 +26,11 @@ import {
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
-import { fetchWithRetry, mapOpenRouterModel } from "../../lib/util.ts";
+import {
+	fetchWithRetry,
+	mapOpenRouterModel,
+	withSignal,
+} from "../../lib/util.ts";
 import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
 import { anyapiAuth } from "./anyapi-auth.ts";
 
@@ -160,14 +164,16 @@ async function fetchAnyApiModels(
 ): Promise<AnyApiProviderModel[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_ANYAPI}/models`,
-		{
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				Accept: "application/json",
-				"Content-Type": "application/json",
+		withSignal(
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+					"Content-Type": "application/json",
+				},
 			},
 			signal,
-		},
+		),
 		3,
 		1000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/bai/bai.ts
+++ b/providers/bai/bai.ts
@@ -39,7 +39,7 @@ import {
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
 import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
-import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
+import { cleanModelName, fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { baiAuth } from "./bai-auth.ts";
 
 const _logger = createLogger("bai");
@@ -153,14 +153,16 @@ async function fetchBaiModels(
 	try {
 		const response = await fetchWithRetry(
 			`${BASE_URL_BAI}/models`,
-			{
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-					Accept: "application/json",
-					"Content-Type": "application/json",
+			withSignal(
+				{
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						Accept: "application/json",
+						"Content-Type": "application/json",
+					},
 				},
 				signal,
-			},
+			),
 			3,
 			1000,
 			DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/cline/cline-auth.ts
+++ b/providers/cline/cline-auth.ts
@@ -370,12 +370,15 @@ async function exchangeCodeForTokens(
 		};
 		if (candidate) payload.provider = candidate;
 
-		const res = await fetch(`${BASE_URL_CLINE}/auth/token`, {
+		// RequestInit is lib.dom (no undefined members): omit signal
+		// instead of assigning undefined.
+		const tokenInit: RequestInit = {
 			method: "POST",
 			headers: buildClineHeaders(),
 			body: JSON.stringify(payload),
-			signal,
-		});
+		};
+		if (signal) tokenInit.signal = signal;
+		const res = await fetch(`${BASE_URL_CLINE}/auth/token`, tokenInit);
 
 		if (!res.ok) {
 			lastError = `${res.status}: ${(await res.text().catch(() => "")).slice(0, 120)}`;
@@ -553,12 +556,16 @@ export function toApiKey(credentials: OAuthCredentials): string {
 export async function loginClineNative(
 	interaction: AuthInteraction,
 ): Promise<OAuthCredential> {
-	const credential = await loginCline({
+	// OAuthLoginCallbacks is Pi-owned (no undefined members): omit
+	// signal/instructions/placeholder instead of assigning undefined.
+	const callbacks: OAuthLoginCallbacks = {
 		onAuth: (info) =>
 			interaction.notify({
 				type: "auth_url",
 				url: info.url,
-				instructions: info.instructions,
+				...(info.instructions !== undefined
+					? { instructions: info.instructions }
+					: {}),
 			}),
 		onDeviceCode: (info) =>
 			interaction.notify({ type: "device_code", ...info }),
@@ -566,7 +573,9 @@ export async function loginClineNative(
 			interaction.prompt({
 				type: "text",
 				message: prompt.message,
-				placeholder: prompt.placeholder,
+				...(prompt.placeholder !== undefined
+					? { placeholder: prompt.placeholder }
+					: {}),
 			}),
 		onProgress: (message) => interaction.notify({ type: "progress", message }),
 		onManualCodeInput: () =>
@@ -580,8 +589,9 @@ export async function loginClineNative(
 				message: prompt.message,
 				options: prompt.options,
 			}),
-		signal: interaction.signal,
-	});
+	};
+	if (interaction.signal) callbacks.signal = interaction.signal;
+	const credential = await loginCline(callbacks);
 	return { ...credential, type: "oauth" };
 }
 

--- a/providers/cline/cline-headers.ts
+++ b/providers/cline/cline-headers.ts
@@ -26,7 +26,9 @@ function generateUlid(): string {
 	const rand = new Uint8Array(16);
 	crypto.getRandomValues(rand);
 	let r = "";
-	for (let i = 0; i < 16; i++) r += CHARS[rand[i] % 32];
+	// CHARS is a 32-symbol alphabet, so `% 32` never indexes out of range.
+	// Iterating bytes directly leaves only the alphabet index asserted.
+	for (const byte of rand) r += CHARS[byte % 32]!;
 	return ts + r;
 }
 

--- a/providers/commandcode/commandcode-models.ts
+++ b/providers/commandcode/commandcode-models.ts
@@ -28,7 +28,7 @@ import {
 	PROVIDER_COMMANDCODE,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 import {
 	MODEL_COSTS,
 	MODEL_INPUT_MODALITIES,
@@ -125,10 +125,12 @@ export async function fetchCommandCodeModels(
 	}
 	const response = await fetchWithRetry(
 		`${BASE_URL_COMMANDCODE}/models`,
-		{
-			headers,
+		withSignal(
+			{
+				headers,
+			},
 			signal,
-		},
+		),
 		1,
 		1_000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -34,7 +34,7 @@ import {
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
 import { registerNativeOpenAIProvider } from "../../lib/native-provider.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { crofaiAuth } from "./crofai-auth.ts";
 
 const _logger = createLogger("crofai");
@@ -75,13 +75,15 @@ async function fetchCrofaiModels(
 ): Promise<ProviderModelConfig[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_CROFAI}/models`,
-		{
-			headers: {
-				...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-				"Content-Type": "application/json",
+		withSignal(
+			{
+				headers: {
+					...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+					"Content-Type": "application/json",
+				},
 			},
 			signal,
-		},
+		),
 		3,
 		1000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -50,7 +50,7 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { deepinfraAuth } from "./deepinfra-auth.ts";
 
 const _logger = createLogger("deepinfra");
@@ -96,13 +96,15 @@ export async function fetchDeepinfraModels(
 ): Promise<ProviderModelConfig[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_DEEPINFRA}/models`,
-		{
-			headers: {
-				...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-				"Content-Type": "application/json",
+		withSignal(
+			{
+				headers: {
+					...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+					"Content-Type": "application/json",
+				},
 			},
 			signal,
-		},
+		),
 		3,
 		1000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/infron/infron-models.ts
+++ b/providers/infron/infron-models.ts
@@ -26,7 +26,7 @@ import {
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { isLikelyReasoningModel } from "../../lib/provider-compat.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 
 const _logger = createLogger("infron-models");
 
@@ -142,10 +142,12 @@ export async function fetchInfronModels(
 	}
 	const response = await fetchWithRetry(
 		`${BASE_URL_INFRON}/models`,
-		{
-			headers,
+		withSignal(
+			{
+				headers,
+			},
 			signal,
-		},
+		),
 		1,
 		1_000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/kilo/kilo-models.ts
+++ b/providers/kilo/kilo-models.ts
@@ -59,7 +59,7 @@ export function applyKiloCompat<
 // =============================================================================
 
 async function fetchKiloModels(options?: {
-	token?: string;
+	token?: string | undefined;
 	freeOnly?: boolean;
 }): Promise<ProviderModelConfig[]> {
 	const models = await fetchOpenRouterCompatibleModels({
@@ -81,7 +81,7 @@ async function fetchKiloModels(options?: {
  * an empty (dynamic) provider and recover on a later refresh.
  */
 export async function fetchKiloCatalog(options?: {
-	token?: string;
+	token?: string | undefined;
 	signal?: AbortSignal;
 }): Promise<{ all: ProviderModelConfig[]; free: ProviderModelConfig[] }> {
 	let all: ProviderModelConfig[];

--- a/providers/merge/merge-models.ts
+++ b/providers/merge/merge-models.ts
@@ -35,7 +35,7 @@ import {
 	PROVIDER_MERGE,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 
 const _logger = createLogger("merge-models");
 
@@ -249,7 +249,7 @@ export async function fetchMergeModels(
 
 		const response = await fetchWithRetry(
 			url,
-			{ headers, signal },
+			withSignal({ headers }, signal),
 			1,
 			1_000,
 			DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/model-fetcher.ts
+++ b/providers/model-fetcher.ts
@@ -33,13 +33,13 @@ interface OpenRouterCompatibleModel {
 
 interface FetchModelsOptions {
 	/** Provider id for scoped models.dev enrichment (e.g., openrouter, kilo). */
-	providerId?: string;
+	providerId?: string | undefined;
 	/** Base URL for the API (e.g., https://api.openrouter.ai/api/v1) */
 	baseUrl: string;
 	/** API key for authentication (optional) */
-	apiKey?: string;
+	apiKey?: string | undefined;
 	/** Only return free models (pricing === 0) */
-	freeOnly?: boolean;
+	freeOnly?: boolean | undefined;
 	/**
 	 * Drop models whose `architecture.output_modalities` include ANY of these
 	 * modalities, even when "text" is also present (e.g. image-generation
@@ -50,7 +50,7 @@ interface FetchModelsOptions {
 	/** Additional headers to include */
 	extraHeaders?: Record<string, string>;
 	/** Abort signal owned by the native provider refresh lifecycle. */
-	signal?: AbortSignal;
+	signal?: AbortSignal | undefined;
 	/** Number of retries for failed requests */
 	retries?: number;
 	/** Delay between retries in ms */

--- a/providers/novita/novita.ts
+++ b/providers/novita/novita.ts
@@ -42,7 +42,7 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { novitaAuth } from "./novita-auth.ts";
 
 const _logger = createLogger("novita");
@@ -87,13 +87,15 @@ export async function fetchNovitaModels(
 	try {
 		const response = await fetchWithRetry(
 			`${BASE_URL_NOVITA}/models`,
-			{
-				headers: {
-					...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-					"Content-Type": "application/json",
+			withSignal(
+				{
+					headers: {
+						...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+						"Content-Type": "application/json",
+					},
 				},
 				signal,
-			},
+			),
 			3,
 			1000,
 			DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/ollama/ollama-usage.ts
+++ b/providers/ollama/ollama-usage.ts
@@ -9,7 +9,7 @@
 
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { BASE_URL_OLLAMA, DEFAULT_FETCH_TIMEOUT_MS } from "../../constants.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,10 +91,12 @@ export async function fetchUsage(
 ): Promise<UsageData> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_OLLAMA}/api/usage`,
-		{
-			headers: { Authorization: `Bearer ${apiKey}` },
+		withSignal(
+			{
+				headers: { Authorization: `Bearer ${apiKey}` },
+			},
 			signal,
-		},
+		),
 		1,
 		1_000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/ollama/ollama.ts
+++ b/providers/ollama/ollama.ts
@@ -36,7 +36,11 @@ import {
 	getModelsDueForProbe,
 	recordModelProbeResults,
 } from "../../lib/probe-cache.ts";
-import { fetchWithRetry, fetchWithTimeout } from "../../lib/util.ts";
+import {
+	fetchWithRetry,
+	fetchWithTimeout,
+	withSignal,
+} from "../../lib/util.ts";
 import { resolveThinkingMap } from "./thinking-levels.ts";
 import {
 	createOllamaProvider as createNativeOllamaProvider,
@@ -356,7 +360,8 @@ async function concurrentMap<T, R>(
 				try {
 					results[index] = {
 						status: "fulfilled",
-						value: await fn(items[index]),
+						// Pool guard (`next < items.length`) proves defined.
+						value: await fn(items[index]!),
 					};
 				} catch (reason) {
 					results[index] = { status: "rejected", reason };
@@ -378,13 +383,15 @@ async function fetchModelIds(
 ): Promise<string[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_OLLAMA}/models`,
-		{
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"Content-Type": "application/json",
+		withSignal(
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
 			},
 			signal,
-		},
+		),
 		3,
 		1000,
 		DEFAULT_FETCH_TIMEOUT_MS,
@@ -413,15 +420,17 @@ async function fetchModelDetails(
 ): Promise<OllamaShowResponse> {
 	const response = await fetchWithTimeout(
 		`${OLLAMA_API_BASE}/api/show`,
-		{
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"Content-Type": "application/json",
+		withSignal(
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ model: modelId }),
 			},
-			body: JSON.stringify({ model: modelId }),
 			signal,
-		},
+		),
 		DETAIL_FETCH_TIMEOUT_MS,
 	);
 

--- a/providers/opengateway/opengateway.ts
+++ b/providers/opengateway/opengateway.ts
@@ -30,7 +30,7 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { opengatewayAuth } from "./opengateway-auth.ts";
 
 const _logger = createLogger("opengateway");
@@ -254,15 +254,17 @@ export async function fetchOpenGatewayModels(
 ): Promise<ProviderModelConfig[]> {
 	const response = await fetchWithRetry(
 		`${BASE_URL_OPENGATEWAY}/models`,
-		{
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				Accept: "application/json",
-				"Content-Type": "application/json",
-				"User-Agent": "pi-free-providers",
+		withSignal(
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+					"Content-Type": "application/json",
+					"User-Agent": "pi-free-providers",
+				},
 			},
 			signal,
-		},
+		),
 		3,
 		1000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/qoder/auth.ts
+++ b/providers/qoder/auth.ts
@@ -321,14 +321,18 @@ async function runDeviceFlow(
 		await abortableDelay(pollInterval, getSignal());
 
 		try {
-			const response = await fetch(pollURL, {
+			// RequestInit is lib.dom (no undefined members): getSignal()
+			// may return undefined — omit instead of assigning it.
+			const pollInit: RequestInit = {
 				method: "GET",
 				headers: {
 					Accept: "application/json",
 					"User-Agent": UA,
 				},
-				signal: getSignal(),
-			});
+			};
+			const pollSignal = getSignal();
+			if (pollSignal) pollInit.signal = pollSignal;
+			const response = await fetch(pollURL, pollInit);
 
 			if (response.status === 202 || response.status === 404) {
 				continue;
@@ -517,12 +521,16 @@ export async function refreshQoderToken(
 export async function loginQoderNative(
 	interaction: AuthInteraction,
 ): Promise<OAuthCredential> {
-	const credentials = await loginQoder({
+	// OAuthLoginCallbacks is Pi-owned (no undefined members): omit
+	// signal/instructions/placeholder instead of assigning undefined.
+	const callbacks: OAuthLoginCallbacks = {
 		onAuth: (info: { url: string; instructions?: string }) =>
 			interaction.notify({
 				type: "auth_url",
 				url: info.url,
-				instructions: info.instructions,
+				...(info.instructions !== undefined
+					? { instructions: info.instructions }
+					: {}),
 			}),
 		onProgress: (message: string) =>
 			interaction.notify({ type: "progress", message }),
@@ -530,9 +538,10 @@ export async function loginQoderNative(
 			interaction.prompt({
 				type: "text",
 				message: prompt.message,
-				placeholder: prompt.placeholder,
+				...(prompt.placeholder !== undefined
+					? { placeholder: prompt.placeholder }
+					: {}),
 			}),
-		signal: interaction.signal,
 		// The device/PAT flow exercised by this adapter only invokes
 		// onAuth/onProgress/onPrompt/signal. The interface's remaining required
 		// hooks are implemented explicitly (not cast away) so the object is a
@@ -546,7 +555,9 @@ export async function loginQoderNative(
 				verificationUri: info.verificationUri,
 			}),
 		onSelect: () => Promise.resolve(undefined),
-	});
+	};
+	if (interaction.signal) callbacks.signal = interaction.signal;
+	const credentials = await loginQoder(callbacks);
 	return { ...credentials, type: "oauth" };
 }
 

--- a/providers/qoder/cosy.ts
+++ b/providers/qoder/cosy.ts
@@ -33,7 +33,8 @@ export function getMachineId(): string {
 	}
 	const newId = crypto.randomUUID();
 	try {
-		const savePath = paths[1];
+		// Literal has exactly two entries (proven three lines up).
+		const savePath = paths[1]!;
 		mkdirSync(dirname(savePath), { recursive: true });
 		writeFileSync(savePath, newId, "utf8");
 	} catch {

--- a/providers/qoder/stream.ts
+++ b/providers/qoder/stream.ts
@@ -25,6 +25,7 @@ import type {
 import { AssistantMessageEventStream as LocalAssistantMessageEventStream } from "../../lib/assistant-message-event-stream.ts";
 import { BASE_URL_QODER } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { withSignal } from "../../lib/util.ts";
 import { getCachedModelConfig, staticModels } from "./models.ts";
 import { ThinkingTagParser } from "./thinking-parser.ts";
 import { transformMessagesForQoder, transformTools } from "./transform.ts";
@@ -410,12 +411,17 @@ async function fetchQoderStream(
 		"User-Agent": "pi-free-providers",
 	};
 
-	const response = await fetch(QODER_CHAT_URL, {
-		method: "POST",
-		headers,
-		body: Buffer.from(JSON.stringify(reqBody)),
-		signal,
-	});
+	const response = await fetch(
+		QODER_CHAT_URL,
+		withSignal(
+			{
+				method: "POST",
+				headers,
+				body: Buffer.from(JSON.stringify(reqBody)),
+			},
+			signal,
+		),
+	);
 
 	if (!response.ok) {
 		const errText = await response.text();

--- a/providers/requesty/requesty-models.ts
+++ b/providers/requesty/requesty-models.ts
@@ -16,7 +16,7 @@ import {
 	PROVIDER_REQUESTY,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 
 const _logger = createLogger("requesty-models");
 
@@ -94,10 +94,12 @@ export async function fetchRequestyModels(
 	}
 	const response = await fetchWithRetry(
 		`${BASE_URL_REQUESTY}/models`,
-		{
-			headers,
+		withSignal(
+			{
+				headers,
+			},
 			signal,
-		},
+		),
 		1,
 		1_000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -39,7 +39,7 @@ import {
 	registerNativeAvailabilityProbe,
 	registerNativeOpenAIProvider,
 } from "../../lib/native-provider.ts";
-import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
+import { cleanModelName, fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { routewayAuth } from "./routeway-auth.ts";
 
 const _logger = createLogger("routeway");
@@ -135,14 +135,16 @@ async function fetchRoutewayModels(
 	try {
 		const response = await fetchWithRetry(
 			`${BASE_URL_ROUTEWAY}/models`,
-			{
-				headers: {
-					...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-					Accept: "application/json",
-					"Content-Type": "application/json",
+			withSignal(
+				{
+					headers: {
+						...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+						Accept: "application/json",
+						"Content-Type": "application/json",
+					},
 				},
 				signal,
-			},
+			),
 			3,
 			1000,
 			DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/tokenrouter/tokenrouter.ts
+++ b/providers/tokenrouter/tokenrouter.ts
@@ -67,7 +67,7 @@ import {
 	getProxyModelCompat,
 	isLikelyReasoningModel,
 } from "../../lib/provider-compat.ts";
-import { cleanModelName, fetchWithRetry } from "../../lib/util.ts";
+import { cleanModelName, fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { tokenRouterAuth } from "./tokenrouter-auth.ts";
 
 const _logger = createLogger("tokenrouter");
@@ -427,14 +427,16 @@ async function fetchTokenRouterModels(
 	try {
 		const response = await fetchWithRetry(
 			`${BASE_URL_TOKENROUTER}/models`,
-			{
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-					Accept: "application/json",
-					"Content-Type": "application/json",
+			withSignal(
+				{
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						Accept: "application/json",
+						"Content-Type": "application/json",
+					},
 				},
 				signal,
-			},
+			),
 			3,
 			1000,
 			DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/venice/venice-models.ts
+++ b/providers/venice/venice-models.ts
@@ -28,7 +28,7 @@ import {
 	PROVIDER_VENICE,
 } from "../../constants.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 
 const _logger = createLogger("venice-models");
 
@@ -143,10 +143,12 @@ export async function fetchVeniceModels(
 	}
 	const response = await fetchWithRetry(
 		`${BASE_URL_VENICE}/models?type=text`,
-		{
-			headers,
+		withSignal(
+			{
+				headers,
+			},
 			signal,
-		},
+		),
 		1,
 		1_000,
 		DEFAULT_FETCH_TIMEOUT_MS,

--- a/providers/zenmux/zenmux-models.ts
+++ b/providers/zenmux/zenmux-models.ts
@@ -10,7 +10,7 @@ import { safeEnrichModelsWithModelsDev } from "../../lib/model-metadata.ts";
 import { withGatewayCompat } from "../../lib/native-provider.ts";
 import { getProxyModelCompat } from "../../lib/provider-compat.ts";
 import { isFreeModel } from "../../lib/registry.ts";
-import { fetchWithRetry } from "../../lib/util.ts";
+import { fetchWithRetry, withSignal } from "../../lib/util.ts";
 import { createLogger } from "../../lib/logger.ts";
 
 const _logger = createLogger("zenmux-models");
@@ -38,7 +38,8 @@ function extractZenmuxPrice(
 ): number {
 	const entries = pricings?.[key];
 	if (!entries || entries.length === 0) return 0;
-	return (entries[0].value ?? 0) / 1_000_000;
+	// Length check above proves defined.
+	return (entries[0]!.value ?? 0) / 1_000_000;
 }
 
 /**
@@ -47,7 +48,7 @@ function extractZenmuxPrice(
  * token is sent when present.
  */
 export async function fetchZenmuxCatalog(options: {
-	token?: string;
+	token?: string | undefined;
 	signal?: AbortSignal;
 }): Promise<{ all: ProviderModelConfig[]; free: ProviderModelConfig[] }> {
 	if (options.signal?.aborted) {
@@ -57,15 +58,17 @@ export async function fetchZenmuxCatalog(options: {
 	try {
 		const response = await fetchWithRetry(
 			`${BASE_URL_ZENMUX}/models`,
-			{
-				headers: {
-					...(options.token && {
-						Authorization: `Bearer ${options.token}`,
-					}),
-					"Content-Type": "application/json",
+			withSignal(
+				{
+					headers: {
+						...(options.token && {
+							Authorization: `Bearer ${options.token}`,
+						}),
+						"Content-Type": "application/json",
+					},
 				},
-				signal: options.signal,
-			},
+				options.signal,
+			),
 			3,
 			1000,
 			DEFAULT_FETCH_TIMEOUT_MS,

--- a/scripts/drive-pi-ai.ts
+++ b/scripts/drive-pi-ai.ts
@@ -72,7 +72,8 @@ function homeFile(...segments: string[]): string {
 function parseArgs(argv: string[]): Record<string, string | boolean> {
 	const args: Record<string, string | boolean> = {};
 	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
+		// Loop bounds prove defined.
+		const arg = argv[i]!;
 		if (!arg.startsWith("--")) continue;
 		const key = arg.slice(2);
 		if (key === "list" || key === "simple" || key === "anonymous") {

--- a/scripts/lib/stryker-diff.ts
+++ b/scripts/lib/stryker-diff.ts
@@ -33,7 +33,9 @@ function extractRelativeSpecifiers(content: string): string[] {
 	IMPORT_SPECIFIER_RE.lastIndex = 0;
 	let match = IMPORT_SPECIFIER_RE.exec(content);
 	while (match) {
-		if (match[1].startsWith(".")) specifiers.push(match[1]);
+		// Group 1 is mandatory when the overall pattern matches.
+		const specifier = match[1]!;
+		if (specifier.startsWith(".")) specifiers.push(specifier);
 		match = IMPORT_SPECIFIER_RE.exec(content);
 	}
 	return specifiers;

--- a/scripts/stryker-diff.ts
+++ b/scripts/stryker-diff.ts
@@ -11,7 +11,10 @@ import {
 function argumentValue(name: string, fallback: string): string {
 	let value = fallback;
 	for (let index = 0; index < process.argv.length - 1; index += 1) {
-		if (process.argv[index] === name) value = process.argv[index + 1];
+		// A flag without a following value keeps the default instead of
+		// assigning undefined (the loop bound only proves index defined).
+		if (process.argv[index] === name)
+			value = process.argv[index + 1] ?? fallback;
 	}
 	return value;
 }

--- a/tests/action-log.test.ts
+++ b/tests/action-log.test.ts
@@ -16,8 +16,8 @@ describe("action ring", () => {
 		for (let i = 0; i < 25; i++) recordAction("toggle", `action-${i}`);
 		const recent = getRecentActions();
 		expect(recent).toHaveLength(20);
-		expect(recent[0].summary).toBe("action-24");
-		expect(recent[19].summary).toBe("action-5");
+		expect(recent[0]!.summary).toBe("action-24");
+		expect(recent[19]!.summary).toBe("action-5");
 	});
 
 	it("truncates long summaries for health rendering", async () => {
@@ -26,7 +26,7 @@ describe("action ring", () => {
 			await import("../lib/action-log.ts");
 		clearActions();
 		recordAction("restore", "x".repeat(300));
-		expect(getRecentActions()[0].summary).toHaveLength(160);
+		expect(getRecentActions()[0]!.summary).toHaveLength(160);
 	});
 
 	it("attaches the ambient run id, null outside a run", async () => {
@@ -43,10 +43,10 @@ describe("action ring", () => {
 		}, "deadbeef");
 		expect(getActiveRunId()).toBeNull();
 		const recent = getRecentActions();
-		expect(recent[0].summary).toBe("inside");
-		expect(recent[0].run).toBe("deadbeef");
-		expect(recent[1].summary).toBe("outside");
-		expect(recent[1].run).toBeNull();
+		expect(recent[0]!.summary).toBe("inside");
+		expect(recent[0]!.run).toBe("deadbeef");
+		expect(recent[1]!.summary).toBe("outside");
+		expect(recent[1]!.run).toBeNull();
 	});
 
 	it("tags file-log lines with the ambient run id", async () => {

--- a/tests/auto-fallback.integration.test.ts
+++ b/tests/auto-fallback.integration.test.ts
@@ -334,7 +334,7 @@ describe("auto-fallback integration", () => {
 		);
 
 		const ctx = buildMockCtx({ provider: "kilo", id: "gpt-4o" });
-		await pi.commands["toggle-auto-fallback"].handler([], ctx);
+		await pi.commands["toggle-auto-fallback"]!.handler([], ctx);
 		expect(mockSaveConfig).toHaveBeenCalledWith({ auto_fallback: false });
 	});
 
@@ -377,7 +377,7 @@ describe("auto-fallback integration", () => {
 		expect(statusBefore.blacklistSize).toBeGreaterThanOrEqual(1);
 
 		const ctx = buildMockCtx({ provider: "kilo", id: "gpt-4o" });
-		await pi.commands["reset-fallback-blacklist"].handler([], ctx);
+		await pi.commands["reset-fallback-blacklist"]!.handler([], ctx);
 
 		const statusAfter = handle.getStatus();
 		expect(statusAfter.blacklistSize).toBe(0);
@@ -440,7 +440,7 @@ describe("auto-fallback integration", () => {
 		);
 
 		expect(pi.setModel).toHaveBeenCalledTimes(1);
-		const switchedTo = pi.setModel.mock.calls[0][0] as {
+		const switchedTo = pi.setModel.mock.calls[0]![0] as {
 			provider: string;
 			id: string;
 		};
@@ -511,7 +511,7 @@ describe("auto-fallback integration", () => {
 		);
 
 		expect(pi.setModel).toHaveBeenCalledTimes(1);
-		const switchedTo = pi.setModel.mock.calls[0][0] as {
+		const switchedTo = pi.setModel.mock.calls[0]![0] as {
 			provider: string;
 			id: string;
 		};

--- a/tests/built-in-toggle-stale.test.ts
+++ b/tests/built-in-toggle-stale.test.ts
@@ -176,7 +176,7 @@ describe("built-in-toggle stale context (#509)", () => {
 
 		// The session is replaced while the detached capture awaits: every
 		// lazy ctx.modelRegistry access now throws Pi's stale guard.
-		await handlers.session_start({}, { modelRegistry: staleRegistry() });
+		await handlers.session_start!({}, { modelRegistry: staleRegistry() });
 		await settleDetachedCapture();
 
 		const captures = detachedOutcomes.filter((o) =>
@@ -196,13 +196,13 @@ describe("built-in-toggle stale context (#509)", () => {
 	it("captures cleanly on the next session_start after a stale capture", async () => {
 		setupBuiltInProviderToggles(mockPi);
 
-		await handlers.session_start({}, { modelRegistry: staleRegistry() });
+		await handlers.session_start!({}, { modelRegistry: staleRegistry() });
 		await settleDetachedCapture();
 
 		// The live session retries: pending state was cleared, so a fresh
 		// capture registers into the current session's registry.
 		const registerProvider = vi.fn();
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -227,7 +227,7 @@ describe("built-in-toggle stale context (#509)", () => {
 
 		// No capture has run, so the command goes straight to tryCaptureProvider
 		// with the dead session's registry — must resolve, not reject.
-		await commands["toggle-opencode-free"](
+		await commands["toggle-opencode-free"]!(
 			{},
 			{ modelRegistry: staleRegistry() },
 		);

--- a/tests/built-in-toggle.test.ts
+++ b/tests/built-in-toggle.test.ts
@@ -151,7 +151,7 @@ describe("built-in provider toggles", () => {
 			resolveKey = resolve;
 		});
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -213,7 +213,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -283,7 +283,7 @@ describe("built-in provider toggles", () => {
 			return Promise.reject(new Error(`unexpected fetch: ${url}`));
 		});
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -310,11 +310,11 @@ describe("built-in provider toggles", () => {
 			"mimo-v2-pro",
 		]);
 		// Known ID keeps Pi's curated metadata and wire protocol.
-		expect(lastModels[0].name).toBe("MiniMax M2.7");
-		expect(lastModels[0].api).toBe("anthropic-messages");
+		expect(lastModels[0]!.name).toBe("MiniMax M2.7");
+		expect(lastModels[0]!.api).toBe("anthropic-messages");
 		// Discovered ID gets the Go protocol defaults.
-		expect(lastModels[1].api).toBe("openai-completions");
-		expect(lastModels[1].baseUrl).toBe("https://opencode.ai/zen/go/v1");
+		expect(lastModels[1]!.api).toBe("openai-completions");
+		expect(lastModels[1]!.baseUrl).toBe("https://opencode.ai/zen/go/v1");
 	});
 
 	it("retains the cached catalog when Pi's refresh fetch fails", async () => {
@@ -340,7 +340,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -388,7 +388,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -435,7 +435,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -484,7 +484,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -535,7 +535,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -619,7 +619,7 @@ describe("built-in provider toggles", () => {
 			return Promise.reject(new Error(`unexpected fetch: ${url}`));
 		});
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -696,7 +696,7 @@ describe("built-in provider toggles", () => {
 			return Promise.reject(new Error(`unexpected fetch: ${url}`));
 		});
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
@@ -719,11 +719,11 @@ describe("built-in provider toggles", () => {
 			"vendor/new-model",
 		]);
 		// Known ID keeps Pi's curated metadata (name + cost untouched).
-		expect(lastModels[0].name).toBe("Known Model");
-		expect(lastModels[0].cost?.input).toBe(3);
+		expect(lastModels[0]!.name).toBe("Known Model");
+		expect(lastModels[0]!.cost?.input).toBe(3);
 		// New ID is synthesized from live endpoint data.
-		expect(lastModels[1].name).toBe("Vendor New Model");
-		expect(lastModels[1].contextWindow).toBe(200000);
+		expect(lastModels[1]!.name).toBe("Vendor New Model");
+		expect(lastModels[1]!.contextWindow).toBe(200000);
 	});
 
 	it("registers into the latest registry when session_start fires again mid-capture", async () => {
@@ -758,10 +758,10 @@ describe("built-in provider toggles", () => {
 			registerProvider: vi.fn(),
 		};
 
-		await handlers.session_start({}, { modelRegistry: firstRegistry });
+		await handlers.session_start!({}, { modelRegistry: firstRegistry });
 		// Pi fires session_start again while the capture is still resolving
 		// credentials; the fresh registry must win.
-		await handlers.session_start({}, { modelRegistry: secondRegistry });
+		await handlers.session_start!({}, { modelRegistry: secondRegistry });
 
 		resolveKey?.(undefined);
 		await settleDetachedCapture();
@@ -807,7 +807,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -821,7 +821,10 @@ describe("built-in provider toggles", () => {
 		// Toggle while the capture is still pending: it must await the
 		// in-flight capture, not start its own.
 		const notify = vi.fn();
-		const toggleDone = commands["toggle-opencode-free"]({}, { ui: { notify } });
+		const toggleDone = commands["toggle-opencode-free"]!(
+			{},
+			{ ui: { notify } },
+		);
 		resolveKey?.(undefined);
 		await toggleDone;
 
@@ -864,7 +867,7 @@ describe("built-in provider toggles", () => {
 				baseUrl: "https://example.com",
 			},
 		];
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -892,7 +895,7 @@ describe("built-in provider toggles", () => {
 			getAvailable: () => models,
 			registerProvider: vi.fn(),
 		};
-		await handlers.session_start({}, { modelRegistry: freshRegistry });
+		await handlers.session_start!({}, { modelRegistry: freshRegistry });
 		await settleDetachedCapture();
 
 		expect(freshRegistry.registerProvider).toHaveBeenCalledWith(
@@ -918,7 +921,7 @@ describe("built-in provider toggles", () => {
 		};
 		const registerProvider = vi.fn();
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -971,12 +974,12 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => models } },
 		);
 		await settleDetachedCapture();
-		await commands["toggle-openrouter"]({}, { ui: { notify: vi.fn() } });
+		await commands["toggle-openrouter"]!({}, { ui: { notify: vi.fn() } });
 
 		expect(mockRegisterProvider).toHaveBeenLastCalledWith(
 			"openrouter",
@@ -999,7 +1002,7 @@ describe("built-in provider toggles", () => {
 		setupBuiltInProviderToggles(mockPi);
 
 		const notify = vi.fn();
-		await commands["toggle-opencode-free"](
+		await commands["toggle-opencode-free"]!(
 			{},
 			{
 				ui: { notify },
@@ -1052,7 +1055,7 @@ describe("built-in provider toggles", () => {
 			}),
 		);
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -1090,7 +1093,7 @@ describe("built-in provider toggles", () => {
 			baseUrl: "https://example.com",
 		};
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: { getAvailable: () => [capturedModel] },
@@ -1123,7 +1126,7 @@ describe("built-in provider toggles", () => {
 			baseUrl: "https://example.com",
 		};
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: { getAvailable: () => [capturedModel] },
@@ -1159,7 +1162,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -1201,7 +1204,7 @@ describe("built-in provider toggles", () => {
 			},
 		];
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{
 				modelRegistry: {
@@ -1253,13 +1256,13 @@ describe("built-in provider toggles", () => {
 		mockGetGlobalFreeOnly.mockReturnValue(false);
 		setupBuiltInProviderToggles(mockPi);
 
-		await handlers.session_start(
+		await handlers.session_start!(
 			{},
 			{ modelRegistry: { getAvailable: () => openCodeCatalog() } },
 		);
 		await settleDetachedCapture();
 
-		const registered = mockRegisterProvider.mock.calls[0][1].models as Array<{
+		const registered = mockRegisterProvider.mock.calls[0]![1].models as Array<{
 			id: string;
 		}>;
 		expect(registered.map((m) => m.id).sort()).toEqual([

--- a/tests/cline-provider.test.ts
+++ b/tests/cline-provider.test.ts
@@ -293,8 +293,8 @@ describe("refreshModels offline init", () => {
 
 		const models = provider.getModels();
 		expect(models).toHaveLength(1);
-		expect(models[0].api).toBe("openai-completions");
-		expect(models[0].baseUrl).toBe(BASE_URL_CLINE);
+		expect(models[0]!.api).toBe("openai-completions");
+		expect(models[0]!.baseUrl).toBe(BASE_URL_CLINE);
 	});
 
 	it("normalizes legacy XML-api models restored from the Pi 0.84+ stored snapshot", async () => {
@@ -496,14 +496,14 @@ describe("refreshModels online", () => {
 		);
 		// Store persisted exactly once with the full catalog.
 		expect(written).toHaveLength(1);
-		expect(written[0].models.map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(typeof written[0].checkedAt).toBe("number");
+		expect(written[0]!.models.map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(typeof written[0]!.checkedAt).toBe("number");
 		// Persisted models carry the standard OpenAI wire api + provider + baseUrl.
-		expect(written[0].models.every((m) => m.api === "openai-completions")).toBe(
-			true,
-		);
-		expect(written[0].models.every((m) => m.provider === "cline")).toBe(true);
-		expect(written[0].models.every((m) => m.baseUrl === BASE_URL_CLINE)).toBe(
+		expect(
+			written[0]!.models.every((m) => m.api === "openai-completions"),
+		).toBe(true);
+		expect(written[0]!.models.every((m) => m.provider === "cline")).toBe(true);
+		expect(written[0]!.models.every((m) => m.baseUrl === BASE_URL_CLINE)).toBe(
 			true,
 		);
 		// Catalogs populated for the toggle.
@@ -725,8 +725,8 @@ describe("stream wiring", () => {
 			}
 
 			expect(captured).toHaveLength(1);
-			expect(captured[0].url).toBe(`${BASE_URL_CLINE}/chat/completions`);
-			const sent = captured[0].headers;
+			expect(captured[0]!.url).toBe(`${BASE_URL_CLINE}/chat/completions`);
+			const sent = captured[0]!.headers;
 			expect(sent["authorization"]).toBe("Bearer workos:test-token");
 			expect(sent["user-agent"]).toBe("Cline/4.1.10");
 			expect(sent["x-client-version"]).toBe("4.1.10");

--- a/tests/cline.test.ts
+++ b/tests/cline.test.ts
@@ -138,7 +138,7 @@ describe("Cline factory wiring", () => {
 
 		// Native provider object registered (single arg).
 		expect(mockRegisterProvider).toHaveBeenCalledTimes(1);
-		const provider = mockRegisterProvider.mock.calls[0][0];
+		const provider = mockRegisterProvider.mock.calls[0]![0];
 		expect(provider.id).toBe("cline");
 		expect(provider.getModels()).toEqual([]);
 		expect(provider.auth.apiKey).toBeDefined();
@@ -192,10 +192,10 @@ describe("Cline factory wiring", () => {
 	// object, auth preserved) that RPC cannot see per provider.
 	it("global /toggle-free reRegister republishes the same provider object", async () => {
 		await clineProvider(mockPi);
-		const provider = mockRegisterProvider.mock.calls[0][0];
+		const provider = mockRegisterProvider.mock.calls[0]![0];
 
 		expect(capturedToggleArgs).toHaveLength(1);
-		const reRegister = capturedToggleArgs[0][2] as () => void;
+		const reRegister = capturedToggleArgs[0]![2] as () => void;
 
 		mockRegisterProvider.mockClear();
 		reRegister();

--- a/tests/fetch-openai-compatible.test.ts
+++ b/tests/fetch-openai-compatible.test.ts
@@ -35,11 +35,11 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 		);
 
 		expect(models).toHaveLength(1);
-		expect(models[0].id).toBe("meta/llama-3-70b");
-		expect(models[0].contextWindow).toBe(64_000); // from defaults
-		expect(models[0].maxTokens).toBe(8_192); // from defaults
-		expect(models[0].cost.input).toBe(0); // default when no pricing
-		expect(models[0].input).toEqual(["text"]);
+		expect(models[0]!.id).toBe("meta/llama-3-70b");
+		expect(models[0]!.contextWindow).toBe(64_000); // from defaults
+		expect(models[0]!.maxTokens).toBe(8_192); // from defaults
+		expect(models[0]!.cost.input).toBe(0); // default when no pricing
+		expect(models[0]!.input).toEqual(["text"]);
 	});
 
 	// ── Per-model context_length ───────────────────────────────
@@ -60,7 +60,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].contextWindow).toBe(1_000_000);
+		expect(models[0]!.contextWindow).toBe(1_000_000);
 	});
 
 	// ── Alternate field name: max_context_length ───────────────
@@ -80,7 +80,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].contextWindow).toBe(200_000);
+		expect(models[0]!.contextWindow).toBe(200_000);
 	});
 
 	// ── Alternate field name: context_window (snake_case) ──────
@@ -100,7 +100,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].contextWindow).toBe(131_072);
+		expect(models[0]!.contextWindow).toBe(131_072);
 	});
 
 	// ── Priority: context_length > max_context_length > context_window > default
@@ -123,7 +123,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			{ contextWindow: 99_999 },
 		);
 
-		expect(models[0].contextWindow).toBe(100_000);
+		expect(models[0]!.contextWindow).toBe(100_000);
 	});
 
 	// ── Per-model max_completion_tokens ────────────────────────
@@ -143,7 +143,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].maxTokens).toBe(131_072);
+		expect(models[0]!.maxTokens).toBe(131_072);
 	});
 
 	// ── Alternate field name: max_tokens ───────────────────────
@@ -163,7 +163,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].maxTokens).toBe(65_536);
+		expect(models[0]!.maxTokens).toBe(65_536);
 	});
 
 	// ── Per-model pricing ──────────────────────────────────────
@@ -183,8 +183,8 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].cost.input).toBe(0.000003);
-		expect(models[0].cost.output).toBe(0.000015);
+		expect(models[0]!.cost.input).toBe(0.000003);
+		expect(models[0]!.cost.output).toBe(0.000015);
 	});
 
 	it("reads per-model pricing from API (string)", async () => {
@@ -203,8 +203,8 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].cost.input).toBe(0.0000045);
-		expect(models[0].cost.output).toBe(0.000009);
+		expect(models[0]!.cost.input).toBe(0.0000045);
+		expect(models[0]!.cost.output).toBe(0.000009);
 	});
 
 	it("per-model pricing overrides defaults", async () => {
@@ -224,8 +224,8 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			{ cost: { input: 0.1, output: 0.2 } },
 		);
 
-		expect(models[0].cost.input).toBe(1.5); // API wins over defaults
-		expect(models[0].cost.output).toBe(4);
+		expect(models[0]!.cost.input).toBe(1.5); // API wins over defaults
+		expect(models[0]!.cost.output).toBe(4);
 	});
 
 	// ── Per-model reasoning ────────────────────────────────────
@@ -245,7 +245,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].reasoning).toBe(true);
+		expect(models[0]!.reasoning).toBe(true);
 	});
 
 	it("falls back to name heuristic when reasoning not in API", async () => {
@@ -259,7 +259,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].reasoning).toBe(true); // "r1" in name
+		expect(models[0]!.reasoning).toBe(true); // "r1" in name
 	});
 
 	// ── Per-model input_modalities ─────────────────────────────
@@ -279,7 +279,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].input).toEqual(["text", "image"]);
+		expect(models[0]!.input).toEqual(["text", "image"]);
 	});
 
 	it("defaults to text-only when no input_modalities", async () => {
@@ -293,7 +293,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 			"sk-test",
 		);
 
-		expect(models[0].input).toEqual(["text"]);
+		expect(models[0]!.input).toEqual(["text"]);
 	});
 
 	it("respects explicit defaults.input even without vision", async () => {
@@ -309,7 +309,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 		);
 
 		// Explicit default.input takes priority over no-vision fallback
-		expect(models[0].input).toEqual(["text", "image"]);
+		expect(models[0]!.input).toEqual(["text", "image"]);
 	});
 
 	// ── Plain array response (Together AI format) ──────────────
@@ -323,7 +323,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 		);
 
 		expect(models).toHaveLength(2);
-		expect(models[0].id).toBe("together/model-1");
+		expect(models[0]!.id).toBe("together/model-1");
 	});
 
 	// ── Empty responses ────────────────────────────────────────
@@ -351,7 +351,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 
 		expect(models).toHaveLength(1);
 		const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
-			.calls[0][1] as { headers: Record<string, string> };
+			.calls[0]![1] as { headers: Record<string, string> };
 		expect(init.headers).not.toHaveProperty("Authorization");
 	});
 
@@ -365,7 +365,7 @@ describe("fetchOpenAICompatibleModels — extended fields", () => {
 		);
 
 		const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
-			.calls[0][1] as { headers: Record<string, string> };
+			.calls[0]![1] as { headers: Record<string, string> };
 		expect(init.headers.Authorization).toBe("Bearer sk-test");
 	});
 

--- a/tests/isFreeModel.test.ts
+++ b/tests/isFreeModel.test.ts
@@ -220,7 +220,7 @@ describe("isFreeModel - freemium providers behavior", () => {
 			isFreeModel({ ...m, provider: "nvidia" }, models),
 		);
 		expect(freeModels).toHaveLength(1);
-		expect(freeModels[0].name).toBe("llama3.2-free");
+		expect(freeModels[0]!.name).toBe("llama3.2-free");
 	});
 });
 
@@ -408,10 +408,10 @@ describe("isFreeModel - pricing-exposure memo", () => {
 		];
 
 		// Priced catalog: zero-cost model is free (Route A).
-		expect(isFreeModel(priced[1], priced)).toBe(true);
+		expect(isFreeModel(priced[1]!, priced)).toBe(true);
 		// Unpriced catalog: name without "free" is not free (Route B).
-		expect(isFreeModel(unpriced[0], unpriced)).toBe(false);
+		expect(isFreeModel(unpriced[0]!, unpriced)).toBe(false);
 		// Revisit the first catalog: the cached verdict must still apply.
-		expect(isFreeModel(priced[1], priced)).toBe(true);
+		expect(isFreeModel(priced[1]!, priced)).toBe(true);
 	});
 });

--- a/tests/json-persistence.test.ts
+++ b/tests/json-persistence.test.ts
@@ -141,8 +141,8 @@ describe("JSON Persistence", () => {
 
 			const data = store.load();
 			expect(data).toHaveLength(2);
-			expect(data[0].event).toBe("first");
-			expect(data[1].event).toBe("second");
+			expect(data[0]!.event).toBe("first");
+			expect(data[1]!.event).toBe("second");
 		});
 
 		it("should clear entries", () => {
@@ -164,8 +164,8 @@ describe("JSON Persistence", () => {
 
 			const data = store.load();
 			expect(data).toHaveLength(2);
-			expect(data[0].event).toBe("first");
-			expect(data[1].event).toBe("third");
+			expect(data[0]!.event).toBe("first");
+			expect(data[1]!.event).toBe("third");
 		});
 	});
 });

--- a/tests/kilo-provider.test.ts
+++ b/tests/kilo-provider.test.ts
@@ -254,8 +254,8 @@ describe("refreshModels online", () => {
 		expect(mockFetchKiloCatalog).toHaveBeenCalledTimes(1);
 		// Store persisted exactly once with the full catalog.
 		expect(written).toHaveLength(1);
-		expect(written[0].models.map((m) => m.id).sort()).toEqual(["a", "b"]);
-		expect(typeof written[0].checkedAt).toBe("number");
+		expect(written[0]!.models.map((m) => m.id).sort()).toEqual(["a", "b"]);
+		expect(typeof written[0]!.checkedAt).toBe("number");
 		// Catalogs populated for the toggle.
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);

--- a/tests/kilo-toggle.test.ts
+++ b/tests/kilo-toggle.test.ts
@@ -135,10 +135,10 @@ describe("Kilo toggle interop", () => {
 	// cannot see per provider.
 	it("global /toggle-free reRegister republishes the same provider object", async () => {
 		await kiloProvider(mockPi);
-		const provider = mockRegisterProvider.mock.calls[0][0];
+		const provider = mockRegisterProvider.mock.calls[0]![0];
 
 		expect(capturedToggleArgs).toHaveLength(1);
-		const reRegister = capturedToggleArgs[0][2] as () => void;
+		const reRegister = capturedToggleArgs[0]![2] as () => void;
 
 		mockRegisterProvider.mockClear();
 		reRegister();

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -146,7 +146,7 @@ describe("Kilo extension wiring", () => {
 	it("global-toggle reRegister republishes the same provider object", async () => {
 		await kiloProvider(mockPi);
 		const reRegister = mockRegisterWithGlobalToggle.mock
-			.calls[0][2] as () => void;
+			.calls[0]![2] as () => void;
 		mockRegisterProvider.mockClear();
 
 		reRegister();

--- a/tests/llm7-provider.test.ts
+++ b/tests/llm7-provider.test.ts
@@ -359,19 +359,19 @@ describe("refreshModels online", () => {
 		expect(mockFetch).not.toHaveBeenCalled();
 		// Store persisted exactly once with the full catalog.
 		expect(written).toHaveLength(1);
-		expect(written[0].models.map((m) => m.id)).toEqual([
+		expect(written[0]!.models.map((m) => m.id)).toEqual([
 			"default",
 			"fast",
 			"pro",
 		]);
-		expect(typeof written[0].checkedAt).toBe("number");
+		expect(typeof written[0]!.checkedAt).toBe("number");
 		// Persisted models carry the native wire api + provider + baseUrl.
-		expect(written[0].models.every((m) => m.api === "openai-completions")).toBe(
-			true,
-		);
-		expect(written[0].models.every((m) => m.provider === "llm7")).toBe(true);
 		expect(
-			written[0].models.every((m) => m.baseUrl === "https://api.llm7.io/v1"),
+			written[0]!.models.every((m) => m.api === "openai-completions"),
+		).toBe(true);
+		expect(written[0]!.models.every((m) => m.provider === "llm7")).toBe(true);
+		expect(
+			written[0]!.models.every((m) => m.baseUrl === "https://api.llm7.io/v1"),
 		).toBe(true);
 		// Catalogs populated for the toggle.
 		expect(stored.all.map((m) => m.id)).toEqual(["default", "fast", "pro"]);

--- a/tests/llm7.test.ts
+++ b/tests/llm7.test.ts
@@ -106,7 +106,7 @@ describe("LLM7 factory wiring", () => {
 		// the provider.
 		expect(mockFetch).not.toHaveBeenCalled();
 		expect(mockRegisterProvider).toHaveBeenCalledTimes(1);
-		const provider = mockRegisterProvider.mock.calls[0][0];
+		const provider = mockRegisterProvider.mock.calls[0]![0];
 		expect(provider.id).toBe("llm7");
 		expect(provider.getModels().map((m: { id: string }) => m.id)).toEqual([
 			"default",
@@ -149,10 +149,10 @@ describe("LLM7 factory wiring", () => {
 	// cannot see per provider.
 	it("global /toggle-free reRegister republishes the same provider object", async () => {
 		await llm7Provider(mockPi);
-		const provider = mockRegisterProvider.mock.calls[0][0];
+		const provider = mockRegisterProvider.mock.calls[0]![0];
 
 		expect(capturedToggleArgs).toHaveLength(1);
-		const reRegister = capturedToggleArgs[0][2] as () => void;
+		const reRegister = capturedToggleArgs[0]![2] as () => void;
 
 		mockRegisterProvider.mockClear();
 		reRegister();

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -172,7 +172,7 @@ describe("logger file rotation", () => {
 					expect(size).toBeLessThanOrEqual(MAX_BYTES);
 				}
 			}
-			expect(await readFile(join(logDir, files[0]), "utf8")).toContain(
+			expect(await readFile(join(logDir, files[0]!), "utf8")).toContain(
 				"rotation-test",
 			);
 		} finally {

--- a/tests/model-fetcher.test.ts
+++ b/tests/model-fetcher.test.ts
@@ -135,7 +135,7 @@ describe("fetchOpenRouterCompatibleModels", () => {
 		});
 
 		const headers = (
-			fetchMock.mock.calls[0][1] as unknown as {
+			fetchMock.mock.calls[0]![1] as unknown as {
 				headers: Record<string, string>;
 			}
 		).headers;

--- a/tests/model-metadata.test.ts
+++ b/tests/model-metadata.test.ts
@@ -53,9 +53,10 @@ describe("models.dev metadata enrichment", () => {
 			},
 		});
 
-		const [model] = await enrichModelsWithModelsDev([baseModel], {
+		const enriched0 = await enrichModelsWithModelsDev([baseModel], {
 			providerId: "deepinfra",
 		});
+		const model = enriched0[0]!;
 
 		expect(model.contextWindow).toBe(262_144);
 		expect(model.maxTokens).toBe(32_768);
@@ -109,9 +110,10 @@ describe("models.dev metadata enrichment", () => {
 			compat: { supportsDeveloperRole: true },
 		};
 
-		const [model] = await enrichModelsWithModelsDev([explicit], {
+		const enriched1 = await enrichModelsWithModelsDev([explicit], {
 			providerId: "openrouter",
 		});
+		const model = enriched1[0]!;
 
 		expect(model.contextWindow).toBe(131_072);
 		expect(model.maxTokens).toBe(8_192);
@@ -141,10 +143,11 @@ describe("models.dev metadata enrichment", () => {
 			},
 		});
 
-		const [model] = await enrichModelsWithModelsDev([baseModel], {
+		const enriched2 = await enrichModelsWithModelsDev([baseModel], {
 			providerId: "openrouter",
 			enrichCost: "fallback-only",
 		});
+		const model = enriched2[0]!;
 
 		expect(model.cost).toEqual({
 			input: 0.000002,
@@ -172,10 +175,11 @@ describe("models.dev metadata enrichment", () => {
 		expect(
 			(await fetchModelsDevMeta("together"))["Qwen/Qwen3.6-Plus"],
 		).toBeDefined();
-		const [model] = await enrichModelsWithModelsDev(
+		const enriched3 = await enrichModelsWithModelsDev(
 			[{ ...baseModel, id: "Qwen/Qwen3.6-Plus" }],
 			{ providerId: "gateway-not-in-catalog" },
 		);
+		const model = enriched3[0]!;
 		expect(model.contextWindow).toBe(131_072);
 	});
 
@@ -215,7 +219,7 @@ describe("models.dev metadata enrichment", () => {
 	});
 
 	it("preserves native OpenCode protocol metadata during discovery", async () => {
-		const [model] = await applyNativeProtocolMetadata(
+		const enriched4 = await applyNativeProtocolMetadata(
 			[
 				{
 					...baseModel,
@@ -225,6 +229,7 @@ describe("models.dev metadata enrichment", () => {
 			],
 			"opencode",
 		);
+		const model = enriched4[0]!;
 
 		expect(model.api).toBe("openai-responses");
 		expect(model.baseUrl).toBe("https://opencode.ai/zen/v1");

--- a/tests/native-openai-provider.test.ts
+++ b/tests/native-openai-provider.test.ts
@@ -130,7 +130,7 @@ describe("gateway compat (developer role)", () => {
 		const handle = createNativeOpenAIProvider(options);
 		handle.ingest([model("m1", "M1")], [model("m1", "M1")]);
 
-		expect(compatOf(handle.stored.all[0]).supportsDeveloperRole).toBe(false);
+		expect(compatOf(handle.stored.all[0]!).supportsDeveloperRole).toBe(false);
 	});
 
 	it("preserves existing compat while forcing the role flag off", () => {
@@ -141,8 +141,8 @@ describe("gateway compat (developer role)", () => {
 		} as ProviderModelConfig;
 		handle.ingest([withCompat], [withCompat]);
 
-		expect(compatOf(handle.stored.all[0]).supportsStore).toBe(false);
-		expect(compatOf(handle.stored.all[0]).supportsDeveloperRole).toBe(false);
+		expect(compatOf(handle.stored.all[0]!).supportsStore).toBe(false);
+		expect(compatOf(handle.stored.all[0]!).supportsDeveloperRole).toBe(false);
 	});
 
 	it("re-stamps models restored from a pre-fix store entry", async () => {
@@ -161,9 +161,9 @@ describe("gateway compat (developer role)", () => {
 
 		await handle.provider.refreshModels?.(context(store));
 
-		expect(compatOf(handle.provider.getModels()[0]).supportsDeveloperRole).toBe(
-			false,
-		);
+		expect(
+			compatOf(handle.provider.getModels()[0]!).supportsDeveloperRole,
+		).toBe(false);
 	});
 });
 
@@ -213,7 +213,7 @@ describe("createNativeOpenAIProvider", () => {
 		expect(handle.provider.getModels().map((item) => item.id)).toEqual([
 			"stored-free",
 		]);
-		expect(handle.provider.getModels()[0].provider).toBe("test-native");
+		expect(handle.provider.getModels()[0]!.provider).toBe("test-native");
 	});
 
 	it("supports native-store-only initialization without a legacy cache", () => {
@@ -276,14 +276,14 @@ describe("createNativeOpenAIProvider", () => {
 			// Disk stays small (the #519 structuredClone sink scales with
 			// this list); memory still takes the complete catalog.
 			expect(persisted).toHaveLength(1);
-			expect(persisted[0].persist?.models).toEqual([freeOnly]);
+			expect(persisted[0]!.persist?.models).toEqual([freeOnly]);
 			expect(published).toEqual([[freeOnly, paidOnly]]);
 		});
 
 		it("persists the complete catalog under an all view", async () => {
 			const { persisted, published } = await runPersist("all");
 			expect(persisted).toHaveLength(1);
-			expect(persisted[0].persist?.models).toEqual([freeOnly, paidOnly]);
+			expect(persisted[0]!.persist?.models).toEqual([freeOnly, paidOnly]);
 			expect(published).toEqual([[freeOnly, paidOnly]]);
 		});
 	});
@@ -316,10 +316,10 @@ describe("createNativeOpenAIProvider", () => {
 		} as unknown as RefreshModelsContext);
 
 		expect(publish).toHaveBeenCalledOnce();
-		expect(publish.mock.calls[0][0].persist?.models[0]).toMatchObject({
+		expect(publish.mock.calls[0]![0].persist?.models[0]).toMatchObject({
 			id: "modern",
 		});
-		expect(handle.provider.getModels()[0].id).toBe("modern");
+		expect(handle.provider.getModels()[0]!.id).toBe("modern");
 	});
 
 	it("does not apply a stale Pi 0.84 publication", async () => {
@@ -367,7 +367,7 @@ describe("createNativeOpenAIProvider", () => {
 
 		expect(fetchModels).toHaveBeenCalledOnce();
 		expect(written).toHaveLength(1);
-		expect(written[0].models[0]).toMatchObject({
+		expect(written[0]!.models[0]!).toMatchObject({
 			id: "fresh-free",
 			provider: "test-native",
 			api: "openai-completions",
@@ -392,7 +392,7 @@ describe("createNativeOpenAIProvider", () => {
 		);
 
 		expect(fetchModels).toHaveBeenCalledOnce();
-		expect(written[0].models[0]).toMatchObject({ id: "public" });
+		expect(written[0]!.models[0]!).toMatchObject({ id: "public" });
 	});
 
 	it("registers one stable provider object and shared lifecycle hooks", async () => {
@@ -409,7 +409,7 @@ describe("createNativeOpenAIProvider", () => {
 		registerNativeOpenAIProvider(pi, options);
 
 		expect(registerProvider).toHaveBeenCalledTimes(2);
-		expect(registerProvider.mock.calls[0][0].id).toBe("test-native");
+		expect(registerProvider.mock.calls[0]![0].id).toBe("test-native");
 		expect(registerCommand).toHaveBeenCalledWith(
 			"toggle-test-native",
 			expect.any(Object),
@@ -418,7 +418,7 @@ describe("createNativeOpenAIProvider", () => {
 		expect(on).toHaveBeenCalledWith("session_start", expect.any(Function));
 
 		const refresh = vi.fn(async () => ({ errors: new Map() }));
-		const sessionHandler = on.mock.calls[0][1] as (
+		const sessionHandler = on.mock.calls[0]![1] as (
 			event: unknown,
 			context: { modelRegistry: { refresh: typeof refresh } },
 		) => Promise<void>;

--- a/tests/native-refresh-nudge.test.ts
+++ b/tests/native-refresh-nudge.test.ts
@@ -46,7 +46,7 @@ afterEach(() => {
 });
 
 async function fireSessionStart(pi: ReturnType<typeof mockPi>, ctx: unknown) {
-	await pi.handlers["session_start"]({}, ctx);
+	await pi.handlers["session_start"]!({}, ctx);
 	// Flush the detached chain (refresh await + result handling).
 	await vi.advanceTimersByTimeAsync(0);
 }

--- a/tests/ollama-provider.test.ts
+++ b/tests/ollama-provider.test.ts
@@ -69,6 +69,11 @@ vi.mock("../lib/session-start-metrics.ts", () => ({
 vi.mock("../lib/util.ts", () => ({
 	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
 	fetchWithTimeout: (...args: unknown[]) => mockFetchWithTimeout(...args),
+	// Mirror semantics: omit an undefined signal (RequestInit is lib.dom).
+	withSignal: (init: RequestInit, signal?: AbortSignal) => {
+		if (signal) init.signal = signal;
+		return init;
+	},
 }));
 
 vi.mock("../provider-helper.ts", () => ({
@@ -254,7 +259,7 @@ describe("Ollama native factory", () => {
 		await ollamaEntry(pi);
 
 		expect(registerProvider).toHaveBeenCalledTimes(1);
-		expect(registerProvider.mock.calls[0][0].id).toBe("ollama-cloud");
+		expect(registerProvider.mock.calls[0]![0].id).toBe("ollama-cloud");
 		expect(registerCommand).toHaveBeenCalledWith(
 			"toggle-ollama-cloud",
 			expect.any(Object),

--- a/tests/open-browser.test.ts
+++ b/tests/open-browser.test.ts
@@ -21,7 +21,7 @@ describe("openBrowser", () => {
 		try {
 			openBrowser("https://example.com/$(calc)");
 			expect(spawn).toHaveBeenCalledOnce();
-			const [cmd, args, opts] = vi.mocked(spawn).mock.calls[0];
+			const [cmd, args, opts] = vi.mocked(spawn).mock.calls[0]!;
 			// rundll32 is the launcher — bypasses cmd's command parser
 			expect(cmd).toMatch(/rundll32/i);
 			// URL is a single, separate argument — never interpolated
@@ -41,7 +41,7 @@ describe("openBrowser", () => {
 		Object.defineProperty(process, "platform", { value: "win32" });
 		try {
 			openBrowser("https://example.com/");
-			const [cmd, args] = vi.mocked(spawn).mock.calls[0];
+			const [cmd, args] = vi.mocked(spawn).mock.calls[0]!;
 			// The launcher must be rundll32, NOT cmd.exe
 			expect(cmd).not.toMatch(/cmd/i);
 			// And there must be no /c start "" in the args
@@ -58,8 +58,8 @@ describe("openBrowser", () => {
 		try {
 			openBrowser("https://example.com/it'cool&echo pwned");
 			expect(spawn).toHaveBeenCalledOnce();
-			const args = vi.mocked(spawn).mock.calls[0][1] as string[];
-			expect(args[args.length - 1]).toBe(
+			const args = vi.mocked(spawn).mock.calls[0]![1] as string[];
+			expect(args[args.length - 1]!).toBe(
 				"https://example.com/it'cool&echo pwned",
 			);
 		} finally {

--- a/tests/qoder-stream.test.ts
+++ b/tests/qoder-stream.test.ts
@@ -326,7 +326,7 @@ describe("Qoder stream parsing", () => {
 
 		await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
 
-		const bodyRaw = fetchMock.mock.calls[0][1].body;
+		const bodyRaw = fetchMock.mock.calls[0]![1].body;
 		let body: Record<string, unknown>;
 		try {
 			body = JSON.parse(bodyRaw.toString());

--- a/tests/qoder.test.ts
+++ b/tests/qoder.test.ts
@@ -180,10 +180,10 @@ describe("Qoder native provider", () => {
 		// The toggle flips the effective view (no getShowPaid travels with
 		// the registration, so there is nothing to go stale, #510).
 		const toggleOptions = mocks.registerNativeProviderToggle.mock
-			.calls[0][1] as Record<string, unknown>;
+			.calls[0]![1] as Record<string, unknown>;
 		expect(toggleOptions).not.toHaveProperty("getShowPaid");
 		const provider = getRegisteredProvider();
-		const reRegister = mocks.registerNativeProviderToggle.mock.calls[0][1]
+		const reRegister = mocks.registerNativeProviderToggle.mock.calls[0]![1]
 			.reRegister as () => void;
 		mocks.registerNativeProvider.mockClear();
 		reRegister();

--- a/tests/requesty-provider.test.ts
+++ b/tests/requesty-provider.test.ts
@@ -104,7 +104,7 @@ describe("fetchRequestyModels", () => {
 
 		const models = await fetchRequestyModels("");
 		expect(models).toHaveLength(1);
-		expect(models[0].id).toBe("nvidia/nemotron-3-super-120b-a12b");
+		expect(models[0]!.id).toBe("nvidia/nemotron-3-super-120b-a12b");
 		const [url, init] = fetchMock.mock.calls[0] as unknown as [
 			string,
 			RequestInit,

--- a/tests/startup-timing.test.ts
+++ b/tests/startup-timing.test.ts
@@ -97,8 +97,8 @@ describe("startup-timing", () => {
 		expect(order[0]).toBe("slow");
 		// Durations are monotonically non-increasing (slowest-first invariant).
 		for (let i = 1; i < summary.providers.length; i++) {
-			expect(summary.providers[i - 1].durationMs).toBeGreaterThanOrEqual(
-				summary.providers[i].durationMs,
+			expect(summary.providers[i - 1]!.durationMs).toBeGreaterThanOrEqual(
+				summary.providers[i]!.durationMs,
 			);
 		}
 	});

--- a/tests/stryker-diff.test.ts
+++ b/tests/stryker-diff.test.ts
@@ -42,7 +42,8 @@ describe("mapRelatedTests", () => {
 		(files: Record<string, string>) =>
 		(file: string): string => {
 			if (!(file in files)) throw new Error(`no fixture: ${file}`);
-			return files[file];
+			// Throw-guard above proves defined.
+			return files[file]!;
 		};
 
 	it("maps siblings and one-hop importers", () => {

--- a/tests/tokenrouter-free.test.ts
+++ b/tests/tokenrouter-free.test.ts
@@ -136,7 +136,7 @@ describe("TokenRouter compat", () => {
 				},
 			},
 		]);
-		expect(enriched[0].compat).toEqual({
+		expect(enriched[0]!.compat).toEqual({
 			supportsReasoningEffort: false,
 			requiresReasoningContentOnAssistantMessages: true,
 		});
@@ -234,8 +234,8 @@ describe("TokenRouter MiniMax handling", () => {
 			],
 		}) as { messages: Array<{ role: string }> };
 
-		expect(result.messages[0].role).toBe("system");
-		expect(result.messages[1].role).toBe("user");
+		expect(result.messages[0]!.role).toBe("system");
+		expect(result.messages[1]!.role).toBe("user");
 	});
 
 	it("leaves messages untouched when no developer role is present", () => {

--- a/tests/tokenrouter-provider.test.ts
+++ b/tests/tokenrouter-provider.test.ts
@@ -45,6 +45,11 @@ vi.mock("../lib/registry.ts", () => ({
 vi.mock("../lib/util.ts", () => ({
 	cleanModelName: (id: string) => id,
 	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+	// Mirror semantics: omit an undefined signal (RequestInit is lib.dom).
+	withSignal: (init: RequestInit, signal?: AbortSignal) => {
+		if (signal) init.signal = signal;
+		return init;
+	},
 }));
 
 vi.mock("../lib/model-metadata.ts", () => ({
@@ -285,7 +290,7 @@ describe("TokenRouter native factory", () => {
 		await tokenRouterEntry(pi);
 
 		expect(registerProvider).toHaveBeenCalledTimes(1);
-		expect(registerProvider.mock.calls[0][0].id).toBe("tokenrouter");
+		expect(registerProvider.mock.calls[0]![0].id).toBe("tokenrouter");
 		expect(registerCommand).toHaveBeenCalledWith(
 			"toggle-tokenrouter",
 			expect.any(Object),
@@ -312,7 +317,7 @@ describe("TokenRouter native factory", () => {
 			.map(([event, handler]) => [event, handler] as const)
 			.filter(([event]) => event === "before_provider_request");
 		expect(requestHandlers).toHaveLength(1);
-		const [, handler] = requestHandlers[0];
+		const [, handler] = requestHandlers[0]!;
 
 		const patched = await handler(
 			{ payload: { model: "MiniMax-M3", thinking: { type: "enabled" } } },

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -10,6 +10,7 @@ import {
 	MAX_RETRY_BACKOFF_MS,
 	parseModelResponse,
 	withFetchDeadline,
+	withSignal,
 } from "../lib/util.ts";
 
 describe("Utility Functions", () => {
@@ -270,7 +271,7 @@ describe("Utility Functions", () => {
 			);
 
 			expect(result.data).toHaveLength(2);
-			expect(result.data[0].id).toBe("model-1");
+			expect(result.data[0]!.id).toBe("model-1");
 		});
 
 		it("should throw on non-ok response", async () => {
@@ -526,6 +527,22 @@ describe("Utility Functions", () => {
 			await expect(withFetchDeadline(p, -1, "test")).resolves.toBe(
 				"passthrough",
 			);
+		});
+	});
+
+	describe("withSignal", () => {
+		// Pins the exactOptional contract: RequestInit is lib.dom (no
+		// undefined members), so a missing signal is omitted, not assigned.
+		it("omits the signal key when undefined", () => {
+			const init = withSignal({ method: "GET" }, undefined);
+			expect("signal" in init).toBe(false);
+		});
+
+		it("attaches a defined signal and returns the same object", () => {
+			const controller = new AbortController();
+			const init: RequestInit = { method: "GET" };
+			expect(withSignal(init, controller.signal)).toBe(init);
+			expect(init.signal).toBe(controller.signal);
 		});
 	});
 });

--- a/tests/wire-signature.test.ts
+++ b/tests/wire-signature.test.ts
@@ -31,7 +31,7 @@ describe("wire-signature logging (M3, #437)", () => {
 		});
 
 		expect(mockDebug).toHaveBeenCalledTimes(1);
-		const [message, data] = mockDebug.mock.calls[0];
+		const [message, data] = mockDebug.mock.calls[0]!;
 		expect(message).toContain("agent request contract");
 		expect(data.provider).toBe("cline");
 		expect(data.model).toBe("nvidia/nemotron-3.5-lightning:free");
@@ -61,7 +61,7 @@ describe("wire-signature logging (M3, #437)", () => {
 			() => ({ headers: { "User-Agent": "pi-free-providers" } }),
 		);
 
-		const data = mockDebug.mock.calls[0][1];
+		const data = mockDebug.mock.calls[0]![1];
 		expect(data.headerNames).toEqual(
 			expect.arrayContaining(["User-Agent", "X-Task-ID"]),
 		);
@@ -79,6 +79,6 @@ describe("wire-signature logging (M3, #437)", () => {
 			}),
 		).not.toThrow();
 		expect(mockDebug).toHaveBeenCalledTimes(1);
-		expect(mockDebug.mock.calls[0][1].headerNames).toEqual([]);
+		expect(mockDebug.mock.calls[0]![1].headerNames).toEqual([]);
 	});
 });

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -49,6 +49,11 @@ vi.mock("../lib/registry.ts", () => ({
 
 vi.mock("../lib/util.ts", () => ({
 	fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
+	// Mirror semantics: omit an undefined signal (RequestInit is lib.dom).
+	withSignal: (init: RequestInit, signal?: AbortSignal) => {
+		if (signal) init.signal = signal;
+		return init;
+	},
 }));
 
 vi.mock("../lib/model-metadata.ts", () => ({
@@ -243,7 +248,7 @@ describe("createZenmuxProvider", () => {
 		expect(stored.all).toHaveLength(2);
 		expect(stored.free).toHaveLength(1);
 		expect(written).toHaveLength(1);
-		expect(written[0].models.map((model) => model.id)).toEqual([
+		expect(written[0]!.models.map((model) => model.id)).toEqual([
 			"free-model",
 			"paid-model",
 		]);

--- a/tests/zenmux.test.ts
+++ b/tests/zenmux.test.ts
@@ -115,7 +115,7 @@ describe("ZenMux native factory", () => {
 		await zenmuxProvider(mockPi);
 
 		expect(registerProvider).toHaveBeenCalledTimes(1);
-		const provider = registerProvider.mock.calls[0][0];
+		const provider = registerProvider.mock.calls[0]![0];
 		expect(provider.id).toBe("zenmux");
 		expect(provider.auth.apiKey).toBeDefined();
 		expect(provider.getModels()).toEqual([]);
@@ -129,15 +129,15 @@ describe("ZenMux native factory", () => {
 	it("passes keyed-provider state to the global toggle registry", async () => {
 		mockGetZenmuxApiKey.mockReturnValue("sk-zenmux");
 		await zenmuxProvider(mockPi);
-		const args = mockRegisterWithGlobalToggle.mock.calls[0];
+		const args = mockRegisterWithGlobalToggle.mock.calls[0]!;
 		expect(args[0]).toBe("zenmux");
 		expect(args[3]).toBe(true);
 	});
 
 	it("re-registers the same native provider object on the global toggle", async () => {
 		await zenmuxProvider(mockPi);
-		const provider = registerProvider.mock.calls[0][0];
-		const reRegister = mockRegisterWithGlobalToggle.mock.calls[0][2] as (
+		const provider = registerProvider.mock.calls[0]![0];
+		const reRegister = mockRegisterWithGlobalToggle.mock.calls[0]![2] as (
 			models: unknown[],
 		) => void;
 
@@ -168,7 +168,7 @@ describe("ZenMux native factory", () => {
 
 	it("does not perform model refresh work during factory registration", async () => {
 		await zenmuxProvider(mockPi);
-		const provider = registerProvider.mock.calls[0][0];
+		const provider = registerProvider.mock.calls[0]![0];
 		await provider.refreshModels?.({
 			store: makeStore(),
 			allowNetwork: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
 		"moduleResolution": "NodeNext",
 		"lib": ["ES2022"],
 		"strict": true,
+		"exactOptionalPropertyTypes": true,
+		"noUncheckedIndexedAccess": true,
 		"noImplicitOverride": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Measured first (67 + 206 errors), migrated second, enabled third. The existing tsc lint gate is the regression guard — deliberately no second config to drift. (Also: withSignal caught a real test-double gap — 3 suites failed until their util mocks mirrored the seam.)\n\n## exactOptionalPropertyTypes — presence-aware\n\n- **ConfigPatch**: undefined-accepting write-patch so the erase-via-stringify mechanism typechecks; presence-sensitive READ types never widened.\n- **Plumbing widened** (zero runtime change): option bags, snapshot/metadata/telemetry/log types, isFreeModel extras (explicit-undefined tolerance stays test-pinned).\n- **External targets omit**: RequestInit, OAuthLoginCallbacks, AuthEvent/AuthPrompt, ProviderModelConfig, Pi's CapturedPromptLike.\n- **withSignal()** in lib/fetch.ts owns the 20-site omit pattern + unit pins.\n\n## noUncheckedIndexedAccess\n\nGuards where undefined is possible; `!` only where bounds/alphabet/regex prove it (each documented at site): charAt scanners, destructured argv/groups with fail-safe defaults, real guards in quota/benchmark/loader. Tests use `!` where fixtures guarantee.\n\n## Deferred per the earlier assessment\n\nnoPropertyAccessFromIndexSignature (low value-per-fix); noUnusedLocals/Parameters (oxlint owns it).\n\nFull suite green (853); tsc/oxlint/knip/format clean. Note: overlaps open #527 (zero-cost flags + parser fix included here in full); whichever merges second rebases.