### PR TITLE
fix(deps): force qs ^6.16.0; OSV scans every PR (refs #31)

### DIFF
--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -4,12 +4,17 @@ name: OSV scan
 # than a job in ci.yml) so a problem specific to this one check — e.g. the
 # third-party scanner binary it downloads — can't take down the unrelated
 # lint/test/install gates, which have no such external dependency.
+#
+# Runs on EVERY pull request (not only lockfile-touching ones): a newly
+# published advisory can affect the existing tree while a PR touches no
+# deps — gating on lockfile changes created exactly that blind spot
+# (qs GHSA-q8mj-m7cp-5q26 published mid-PR, gate skipped, Dependabot
+# caught it instead). The scan itself takes seconds.
 
 on:
   schedule:
     # Weekly sweep for advisories against dependencies already in the
-    # lockfile, not just ones a PR happens to touch (`npm audit` on PRs
-    # only sees the PR's own tree at PR time).
+    # lockfile, not just ones a PR happens to touch.
     - cron: "0 6 * * 1"
   pull_request:
     branches: [master]
@@ -18,47 +23,9 @@ on:
 permissions: {}
 
 jobs:
-  # Gates the PR-triggered scan to PRs that actually touch the lockfile.
-  # Always runs (no job-level `if`) so schedule/workflow_dispatch triggers
-  # — which have no PR to diff — aren't skipped as an unmet `needs`
-  # dependency downstream.
-  detect-lockfile-change:
-    name: Detect lockfile change
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed: ${{ steps.diff.outputs.changed }}
-    steps:
-      # Pin to the PR's own head commit, NOT the default checkout ref. For
-      # pull_request events, actions/checkout defaults to GitHub's synthetic
-      # merge commit; diffing that against a stale base.sha picks up every
-      # change master accumulated in between as if the PR had made it.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Diff lockfile against base
-        id: diff
-        run: |
-          set -eu
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD" | grep -qx "package-lock.json"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
   osv-scan:
     name: OSV scan (advisory)
     runs-on: ubuntu-latest
-    needs: [detect-lockfile-change]
-    # Scheduled and manual runs always scan; PR runs only scan when the
-    # lockfile changed (dependency surface actually moved).
-    if: needs.detect-lockfile-change.outputs.changed == 'true'
     permissions:
       contents: read
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8794,12 +8794,13 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
 			"dev": true,
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
 			}
 		},
 		"brace-expansion": "^5.0.9",
-		"protobufjs": "^7.6.5"
+		"protobufjs": "^7.6.5",
+		"qs": "^6.16.0"
 	},
 	"engines": {
 		"node": ">=20.0.0"


### PR DESCRIPTION
Closes the qs advisories (GHSA-q8mj-m7cp-5q26, GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g) and the detection gap that let them sit in-tree.\n\n## Vuln\n\nqs@6.15.1 via `@stryker-mutator/core → typed-rest-client` (dev-only; prod tree never contained it). `npm audit fix` is a no-op (parent range pins it), so forced via `overrides` to ^6.16.0 — same-major security patch. Full `npm audit` clean after; platform natives verified intact post-install.\n\n## Detection gap\n\nThe OSV lane should have caught this: local run flags qs (3 mediums, fixes listed). It didn't because PR runs gated on lockfile changes and no PR touched deps after publication — every run skipped green while the vuln sat in the tree. Dependabot caught it instead (defense in depth worked). Gate dropped: the scan takes seconds, and a newly published advisory can hit an untouched tree. Weekly schedule kept.\n\nDependabot should auto-close #31 on merge.