### PR TITLE
feat(visibility): hide logged-out providers from /model (refs #530)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -13,6 +13,18 @@ Provider catalog, authentication, and setup for pi-free. Catalog contents and pr
 | **Paid/trial** | Credits, payment, or a trial balance is required. |
 | **Built-in/native** | Pi owns the catalog lifecycle, including native model-store refresh. |
 
+## Model visibility
+
+Providers you have not logged into do not appear in `/model`. Pi hides
+any provider whose auth does not resolve, and pi-free resolves undefined
+without a stored credential or ambient key — a visible-but-unchattable
+catalog is clutter, not discovery. Only genuinely keyless-usable
+providers stay visible logged out: Cline, FastRouter, and LLM7, whose
+public catalogs work without an account (chat still needs a key where
+the gateway requires one). Logging in (`/login <provider>` or the
+provider's API-key variable) makes its models appear after the next
+refresh.
+
 ## Native providers
 
 These providers use Pi's native provider surface and model store. Their toggles remain available even though Pi owns catalog refresh and credential persistence.
@@ -103,11 +115,11 @@ Agnes AI is a native OpenAI-compatible provider mixing free and paid chat models
 
 ### Venice AI
 
-Venice AI is a native OpenAI-compatible provider mixing free-classified and paid chat models. Pi uses the inference API at `https://api.venice.ai/api/v1/chat/completions` (100+ text models billed in USD or DIEM per million tokens); the same base also exposes `GET /models?type=text`. The model catalog is public, so models appear before login, but chat requires `VENICE_API_KEY` or `venice_api_key`; toggle with `/toggle-venice`. Free/paid classification follows the published pricing (zero-priced models count as free). **Balance gate:** Venice requires a positive account balance for all inference — including zero-priced models, which answer HTTP 402 on unfunded keys — so a model classified as free can still fail at request time until the account is funded.
+Venice AI is a native OpenAI-compatible provider mixing free-classified and paid chat models. Pi uses the inference API at `https://api.venice.ai/api/v1/chat/completions` (100+ text models billed in USD or DIEM per million tokens); the same base also exposes `GET /models?type=text`. The model catalog endpoint is public, but models appear only after login — chat requires `VENICE_API_KEY` or `venice_api_key`; toggle with `/toggle-venice`. Free/paid classification follows the published pricing (zero-priced models count as free). **Balance gate:** Venice requires a positive account balance for all inference — including zero-priced models, which answer HTTP 402 on unfunded keys — so a model classified as free can still fail at request time until the account is funded.
 
 ### Infron AI
 
-Infron AI (infron.ai) is a unified AI gateway with passthrough pricing and pooled upstream uptime; its OpenAI-compatible API runs on the OneRouter gateway at `https://llm.onerouter.pro/v1/chat/completions`. The catalog is public (anonymous `/models` returns 200), so models appear before login; chat requires `INFRON_API_KEY` or `infron_api_key`; toggle with `/toggle-infron`. The catalog mixes ~285 chat LLM entries with embeddings/image/video entries (filtered out); min prices are USD per million tokens, and the zero-priced entries (currently five, including three explicit `:free` ids) classify as free via Route A
+Infron AI (infron.ai) is a unified AI gateway with passthrough pricing and pooled upstream uptime; its OpenAI-compatible API runs on the OneRouter gateway at `https://llm.onerouter.pro/v1/chat/completions`. The catalog endpoint is public (anonymous `/models` returns 200), but models appear only after login; chat requires `INFRON_API_KEY` or `infron_api_key`; toggle with `/toggle-infron`. The catalog mixes ~285 chat LLM entries with embeddings/image/video entries (filtered out); min prices are USD per million tokens, and the zero-priced entries (currently five, including three explicit `:free` ids) classify as free via Route A
 
 ### Merge Gateway
 
@@ -115,7 +127,7 @@ Infron AI (infron.ai) is a unified AI gateway with passthrough pricing and poole
 
 ### CommandCode
 
-[CommandCode](https://commandcode.ai) is an AI subscription gateway routing to ~60 models (OpenAI GPT-5.6 family, Claude Opus/Sonnet, Gemini 3.x, Grok 4.6, Kimi K3, Qwen 3.7/3.8, GLM 5.x, DeepSeek V4) through one Provider API at `https://api.commandcode.ai/provider/v1/chat/completions`. The catalog is public (anonymous `/models` returns 200), so models appear before login; chat requires an account whose plan includes **Provider API access** (`COMMAND_CODE_API_KEY` or `commandcode_api_key`; Go plans answer `upgrade_required`) — toggle with `/toggle-commandcode`. Pricing comes from a curated USD-per-M table ported from the MIT-licensed patlux/pi-commandcode-provider extension (verified against CommandCode's official pricing page 2026-08-25); zero-priced entries (`poolside/laguna-s-2.1-free`, `stealth/ox-alpha`) classify as free. Wire note: `claude-*` models route over Anthropic Messages, everything else over OpenAI Chat Completions — the provider dispatches transports per model.
+[CommandCode](https://commandcode.ai) is an AI subscription gateway routing to ~60 models (OpenAI GPT-5.6 family, Claude Opus/Sonnet, Gemini 3.x, Grok 4.6, Kimi K3, Qwen 3.7/3.8, GLM 5.x, DeepSeek V4) through one Provider API at `https://api.commandcode.ai/provider/v1/chat/completions`. The catalog endpoint is public (anonymous `/models` returns 200), but models appear only after login; chat requires an account whose plan includes **Provider API access** (`COMMAND_CODE_API_KEY` or `commandcode_api_key`; Go plans answer `upgrade_required`) — toggle with `/toggle-commandcode`. Pricing comes from a curated USD-per-M table ported from the MIT-licensed patlux/pi-commandcode-provider extension (verified against CommandCode's official pricing page 2026-08-25); zero-priced entries (`poolside/laguna-s-2.1-free`, `stealth/ox-alpha`) classify as free. Wire note: `claude-*` models route over Anthropic Messages, everything else over OpenAI Chat Completions — the provider dispatches transports per model.
 
 ### FastRouter
 

--- a/lib/native-provider.ts
+++ b/lib/native-provider.ts
@@ -61,14 +61,6 @@ export interface NativeApiKeyAuthOptions {
 	prompt: string;
 	source: string;
 	getApiKey: () => string | undefined;
-	/**
-	 * Opt in to anonymous catalog resolution: when no stored credential or
-	 * ambient key exists, `resolve()` returns a truthy keyless result so Pi's
-	 * `MutableModels.refresh()` still runs `refreshModels()` and the provider's
-	 * public catalog can populate. Chat requests still require a real key —
-	 * the gateway rejects unauthenticated completions.
-	 */
-	anonymousCatalog?: boolean;
 }
 
 /** Build the standard persisted API-key auth used by keyed native providers. */
@@ -88,11 +80,14 @@ export function createNativeApiKeyAuth(
 			ctx: AuthContext;
 			credential?: ApiKeyCredential;
 		}): Promise<AuthResult | undefined> {
+			// No anonymous fallback: without a stored credential or ambient
+			// key, resolve() returns undefined and Pi hides the provider
+			// from /model (#530). A visible-but-unchattable catalog is
+			// clutter, not discovery — chat needs a key everywhere except
+			// the allowlisted keyless providers (cline, fastrouter, llm7),
+			// which carry their own resolvers.
 			const key = input.credential?.key ?? options.getApiKey();
 			if (!key) {
-				if (options.anonymousCatalog) {
-					return { auth: {}, source: "public catalog (no account)" };
-				}
 				return undefined;
 			}
 			return {

--- a/providers/commandcode/commandcode-auth.ts
+++ b/providers/commandcode/commandcode-auth.ts
@@ -17,5 +17,4 @@ export const commandCodeAuth = createNativeApiKeyAuth({
 	prompt: "CommandCode API key",
 	source: "COMMAND_CODE_API_KEY",
 	getApiKey: getCommandCodeApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/commandcode/commandcode.ts
+++ b/providers/commandcode/commandcode.ts
@@ -71,7 +71,6 @@ export default function commandCodeProvider(pi: ExtensionAPI): Promise<void> {
 		auth: commandCodeAuth,
 		getApiKey: getCommandCodeApiKey,
 		getShowPaid: getCommandCodeShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchCommandCodeModels(apiKey, signal),
 		apiForModel,
 		streams: dualTransportStreams,

--- a/providers/crofai/crofai-auth.ts
+++ b/providers/crofai/crofai-auth.ts
@@ -6,5 +6,4 @@ export const crofaiAuth = createNativeApiKeyAuth({
 	prompt: "CrofAI API key",
 	source: "CROFAI_API_KEY",
 	getApiKey: getCrofaiApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/crofai/crofai.ts
+++ b/providers/crofai/crofai.ts
@@ -148,7 +148,6 @@ export default function crofaiProvider(pi: ExtensionAPI): Promise<void> {
 		auth: crofaiAuth,
 		getApiKey: getCrofaiApiKey,
 		getShowPaid: getCrofaiShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchCrofaiModels(apiKey, signal),
 	});
 	return Promise.resolve();

--- a/providers/deepinfra/deepinfra-auth.ts
+++ b/providers/deepinfra/deepinfra-auth.ts
@@ -6,5 +6,4 @@ export const deepinfraAuth = createNativeApiKeyAuth({
 	prompt: "DeepInfra API key",
 	source: "DEEPINFRA_TOKEN",
 	getApiKey: getDeepinfraApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/deepinfra/deepinfra.ts
+++ b/providers/deepinfra/deepinfra.ts
@@ -182,7 +182,6 @@ export default function deepinfraProvider(pi: ExtensionAPI): Promise<void> {
 		auth: deepinfraAuth,
 		getApiKey: getDeepinfraApiKey,
 		getShowPaid: getDeepinfraShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchDeepinfraModels(apiKey, signal),
 		tosUrl: "https://deepinfra.com/pricing",
 	});

--- a/providers/infron/infron-auth.ts
+++ b/providers/infron/infron-auth.ts
@@ -17,5 +17,4 @@ export const infronAuth = createNativeApiKeyAuth({
 	prompt: "Infron API key",
 	source: "INFRON_API_KEY",
 	getApiKey: getInfronApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/infron/infron.ts
+++ b/providers/infron/infron.ts
@@ -42,7 +42,6 @@ export default function infronProvider(pi: ExtensionAPI): Promise<void> {
 		auth: infronAuth,
 		getApiKey: getInfronApiKey,
 		getShowPaid: getInfronShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchInfronModels(apiKey, signal),
 	});
 	return Promise.resolve();

--- a/providers/kilo/kilo-auth.ts
+++ b/providers/kilo/kilo-auth.ts
@@ -195,9 +195,9 @@ export async function refreshKiloCredential(
  * Resolve the effective Kilo API key: a natively-stored key (from
  * `interaction.prompt` login) wins, then the ambient `KILO_API_KEY` env var /
  * `~/.pi/free.json` value via the shared config getter. When neither exists,
- * resolve a truthy keyless result so Pi's model refresh still runs and Kilo's
- * public gateway catalog can populate. Chat requests still require a real key
- * or OAuth login — the gateway rejects unauthenticated completions.
+ * resolve() returns undefined and Pi hides the provider from /model (#530):
+ * chat requires a real key or OAuth login — the gateway rejects
+ * unauthenticated completions — so a logged-out listing is clutter.
  */
 async function resolveKiloApiKey(input: {
 	ctx: AuthContext;
@@ -206,7 +206,7 @@ async function resolveKiloApiKey(input: {
 }): Promise<AuthResult | undefined> {
 	const key = input.credential?.key ?? getKiloApiKey();
 	if (!key) {
-		return { auth: {}, source: "public catalog (no account)" };
+		return undefined;
 	}
 	return {
 		auth: { apiKey: key },

--- a/providers/merge/merge-auth.ts
+++ b/providers/merge/merge-auth.ts
@@ -2,11 +2,10 @@
  * Merge Gateway API-key authentication.
  *
  * The model catalog (api-gateway.merge.dev/v1/openai/models) is KEYED —
- * anonymous requests return HTTP 401 (verified live) — so unlike public-
- * catalog providers this auth does NOT opt into `anonymousCatalog`: without a
- * stored credential or ambient key, `resolve()` returns undefined and Pi's
- * model refresh skips the provider until login/key setup. Chat requests use
- * the same key. Merge keys are issued at merge.dev.
+ * anonymous requests return HTTP 401 (verified live) — so without a stored
+ * credential or ambient key, `resolve()` returns undefined and Pi hides
+ * the provider until login/key setup. Chat requests use the same key.
+ * Merge keys are issued at merge.dev.
  */
 
 import { getMergeApiKey } from "../../config.ts";

--- a/providers/novita/novita-auth.ts
+++ b/providers/novita/novita-auth.ts
@@ -6,5 +6,4 @@ export const novitaAuth = createNativeApiKeyAuth({
 	prompt: "Novita API key",
 	source: "NOVITA_API_KEY",
 	getApiKey: getNovitaApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/novita/novita.ts
+++ b/providers/novita/novita.ts
@@ -167,7 +167,6 @@ export default function novitaProvider(pi: ExtensionAPI): Promise<void> {
 		auth: novitaAuth,
 		getApiKey: getNovitaApiKey,
 		getShowPaid: getNovitaShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchNovitaModels(apiKey, signal),
 		tosUrl: "https://novita.ai/terms",
 	});

--- a/providers/requesty/requesty-auth.ts
+++ b/providers/requesty/requesty-auth.ts
@@ -1,9 +1,10 @@
 /**
  * Requesty native authentication.
  *
- * Requesty's model catalog (router.requesty.ai/v1/models) is public, so
- * native auth resolves even when no key is configured. Chat requests use the
- * configured key; the gateway rejects unauthenticated completions.
+ * Without a stored credential or ambient key, resolve() returns undefined
+ * and Pi hides the provider from /model (#530): the public catalog is
+ * visible but chat needs a key — the gateway rejects unauthenticated
+ * completions — so a logged-out listing is clutter, not discovery.
  */
 
 import type {
@@ -23,7 +24,7 @@ async function resolveRequestyApiKey(input: {
 }): Promise<AuthResult | undefined> {
 	const key = input.credential?.key ?? getRequestyApiKey();
 	if (!key) {
-		return { auth: {}, source: "public catalog (no account)" };
+		return undefined;
 	}
 	return {
 		auth: { apiKey: key },

--- a/providers/routeway/routeway-auth.ts
+++ b/providers/routeway/routeway-auth.ts
@@ -6,5 +6,4 @@ export const routewayAuth = createNativeApiKeyAuth({
 	prompt: "Routeway API key",
 	source: "ROUTEWAY_API_KEY",
 	getApiKey: getRoutewayApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/routeway/routeway.ts
+++ b/providers/routeway/routeway.ts
@@ -187,7 +187,6 @@ export default function routewayProvider(pi: ExtensionAPI): Promise<void> {
 		auth: routewayAuth,
 		getApiKey: getRoutewayApiKey,
 		getShowPaid: getRoutewayShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchRoutewayModels(apiKey, signal),
 		tosUrl: "https://routeway.ai/terms",
 	});

--- a/providers/sambanova/sambanova-auth.ts
+++ b/providers/sambanova/sambanova-auth.ts
@@ -6,5 +6,4 @@ export const sambanovaAuth = createNativeApiKeyAuth({
 	prompt: "SambaNova API key",
 	source: "SAMBANOVA_API_KEY",
 	getApiKey: getSambanovaApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/sambanova/sambanova.ts
+++ b/providers/sambanova/sambanova.ts
@@ -46,7 +46,6 @@ export default function sambanovaProvider(pi: ExtensionAPI): Promise<void> {
 		auth: sambanovaAuth,
 		getApiKey: getSambanovaApiKey,
 		getShowPaid: getSambanovaShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: async (apiKey, signal) => {
 			const models = await fetchOpenAICompatibleModels(
 				"sambanova",

--- a/providers/venice/venice-auth.ts
+++ b/providers/venice/venice-auth.ts
@@ -16,5 +16,4 @@ export const veniceAuth = createNativeApiKeyAuth({
 	prompt: "Venice API key",
 	source: "VENICE_API_KEY",
 	getApiKey: getVeniceApiKey,
-	anonymousCatalog: true,
 });

--- a/providers/venice/venice.ts
+++ b/providers/venice/venice.ts
@@ -44,7 +44,6 @@ export default function veniceProvider(pi: ExtensionAPI): Promise<void> {
 		auth: veniceAuth,
 		getApiKey: getVeniceApiKey,
 		getShowPaid: getVeniceShowPaid,
-		allowUnauthenticated: true,
 		fetchModels: (apiKey, signal) => fetchVeniceModels(apiKey, signal),
 	});
 	return Promise.resolve();

--- a/providers/zenmux/zenmux-auth.ts
+++ b/providers/zenmux/zenmux-auth.ts
@@ -11,10 +11,10 @@ import type {
 import { getZenmuxApiKey } from "../../config.ts";
 
 /**
- * Resolve the ZenMux API key, or a truthy keyless result when nothing is
- * configured: ZenMux's model catalog is public, so native auth must resolve
- * anonymously for Pi's model refresh to populate it. Chat requests still use
- * the configured key (the gateway rejects unauthenticated requests).
+ * Without a stored credential or ambient key, resolve() returns undefined
+ * and Pi hides the provider from /model (#530): a visible-but-unchattable
+ * catalog is clutter, not discovery — the gateway rejects unauthenticated
+ * requests, so nothing here works logged out.
  */
 async function resolveZenmuxApiKey(input: {
 	ctx: AuthContext;
@@ -23,7 +23,7 @@ async function resolveZenmuxApiKey(input: {
 }): Promise<AuthResult | undefined> {
 	const key = input.credential?.key ?? getZenmuxApiKey();
 	if (!key) {
-		return { auth: {}, source: "public catalog (no account)" };
+		return undefined;
 	}
 	return {
 		auth: { apiKey: key },

--- a/scripts/rpc-session-check.mjs
+++ b/scripts/rpc-session-check.mjs
@@ -146,6 +146,31 @@ async function waitCatalog(phase, managed) {
 }
 
 /**
+ * Logged-out visibility (#530): the smoke boots with no native provider
+ * keys, so a logged-out native (kilo) must contribute zero models while
+ * the keyless allowlist anchor (llm7, static seed) stays present.
+ * Settled: absence is polled, never asserted on first sight.
+ */
+async function waitLoggedOutHidden(phase) {
+	await driver.waitFor(
+		async () => {
+			const models =
+				(await driver.send({ type: "get_available_models" })).models ?? [];
+			const kilo = models.filter((m) => m.provider === "kilo");
+			const anchor = models.filter((m) => m.provider === ANCHOR_PROVIDER);
+			if (kilo.length > 0) {
+				throw new Error(
+					`${phase}: logged-out kilo still visible (${kilo.length} models)`,
+				);
+			}
+			return anchor.length > 0 ? models : null;
+		},
+		{ timeoutMs: 120_000, label: `${phase} logged-out hidden` },
+	);
+	console.log(`${phase}: logged-out hidden (kilo absent, llm7 present)`);
+}
+
+/**
  * Write the smoke HOME's free.json (same file the extension reads).
  * Used by the hot-reload probe to bypass applyGlobalFilter on purpose.
  */
@@ -183,6 +208,7 @@ try {
 	const commands = await waitCommands("boot");
 	const managed = managedIds(commands);
 	await waitCatalog("boot", managed);
+	await waitLoggedOutHidden("boot");
 
 	const replaced = await driver.send({ type: "new_session" });
 	if (replaced?.cancelled) {

--- a/tests/anonymous-catalog.test.ts
+++ b/tests/anonymous-catalog.test.ts
@@ -1,12 +1,12 @@
 /**
- * Anonymous catalog resolution (#421).
+ * Logged-out provider visibility (#530).
  *
- * Pi's MutableModels.refresh() gates every provider's refreshModels() behind
- * auth resolution: if apiKey.resolve() returns undefined the catalog never
- * fetches. Providers with a public model catalog therefore resolve a truthy
- * keyless result when no credential is configured, so their models populate
- * anonymously. Providers whose catalogs require auth (stepfun, anyapi, bai,
- * opengateway) must keep resolving undefined.
+ * Pi hides providers whose auth doesn't resolve: if apiKey.resolve()
+ * returns undefined the catalog never fetches and /model stays clean.
+ * Providers whose catalogs are unusable without a key must therefore
+ * resolve undefined when no credential is configured — a visible-but-
+ * unchattable catalog is clutter, not discovery. Only genuinely
+ * keyless-usable providers (cline, fastrouter, llm7) resolve keyless.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -17,10 +17,19 @@ vi.mock("../config.ts", () => ({
 	getNovitaApiKey: () => undefined,
 	getRoutewayApiKey: () => undefined,
 	getSambanovaApiKey: () => undefined,
+	getCommandCodeApiKey: () => undefined,
+	getInfronApiKey: () => undefined,
+	getVeniceApiKey: () => undefined,
 	getStepfunApiKey: () => undefined,
 	getAnyapiApiKey: () => undefined,
 	getBaiApiKey: () => undefined,
 	getOpengatewayApiKey: () => undefined,
+	getKiloApiKey: () => undefined,
+	getRequestyApiKey: () => undefined,
+	getZenmuxApiKey: () => undefined,
+	getClineApiKey: () => undefined,
+	getFastrouterApiKey: () => undefined,
+	getLlm7ApiKey: () => undefined,
 	// Non-key exports pulled in transitively by lib/registry / native-provider.
 	getFreeOnly: () => false,
 	getProviderShowPaid: () => false,
@@ -33,13 +42,20 @@ import { deepinfraAuth } from "../providers/deepinfra/deepinfra-auth.ts";
 import { novitaAuth } from "../providers/novita/novita-auth.ts";
 import { routewayAuth } from "../providers/routeway/routeway-auth.ts";
 import { sambanovaAuth } from "../providers/sambanova/sambanova-auth.ts";
+import { commandCodeAuth } from "../providers/commandcode/commandcode-auth.ts";
+import { infronAuth } from "../providers/infron/infron-auth.ts";
+import { veniceAuth } from "../providers/venice/venice-auth.ts";
 import { stepfunAuth } from "../providers/stepfun/stepfun-auth.ts";
 import { anyapiAuth } from "../providers/anyapi/anyapi-auth.ts";
 import { baiAuth } from "../providers/bai/bai-auth.ts";
 import { opengatewayAuth } from "../providers/opengateway/opengateway-auth.ts";
+import { kiloApiKeyAuth } from "../providers/kilo/kilo-auth.ts";
+import { requestyAuth } from "../providers/requesty/requesty-auth.ts";
+import { zenmuxAuth } from "../providers/zenmux/zenmux-auth.ts";
+import { clineApiKeyAuth } from "../providers/cline/cline-auth.ts";
+import { fastrouterAuth } from "../providers/fastrouter/fastrouter-auth.ts";
+import { llm7Auth } from "../providers/llm7/llm7-auth.ts";
 import { createNativeApiKeyAuth } from "../lib/native-provider.ts";
-
-const anonymous = { auth: {}, source: "public catalog (no account)" };
 
 function resolveInput() {
 	return {
@@ -49,37 +65,51 @@ function resolveInput() {
 	} as never;
 }
 
-describe("shared-factory providers with public catalogs", () => {
+describe("shared-factory providers hide without a key (#530)", () => {
 	it.each([
 		["crofai", crofaiAuth],
 		["deepinfra", deepinfraAuth],
 		["novita", novitaAuth],
 		["routeway", routewayAuth],
 		["sambanova", sambanovaAuth],
-	])(
-		"%s resolves keyless auth so the public catalog can refresh",
-		async (_name, auth) => {
-			const result = await auth.apiKey?.resolve(resolveInput());
-			expect(result).toEqual(anonymous);
-			// No apiKey.check: a check would hide the public catalog before login.
-			expect(auth.apiKey).not.toHaveProperty("check");
-		},
-	);
-});
-
-describe("shared-factory providers with auth-required catalogs", () => {
-	it.each([
+		["commandcode", commandCodeAuth],
+		["infron", infronAuth],
+		["venice", veniceAuth],
 		["stepfun", stepfunAuth],
 		["anyapi", anyapiAuth],
 		["bai", baiAuth],
 		["opengateway", opengatewayAuth],
-	])("%s still resolves undefined without a key", async (_name, auth) => {
+	])("%s resolves undefined without a key", async (_name, auth) => {
 		expect(await auth.apiKey?.resolve(resolveInput())).toBeUndefined();
 	});
 });
 
-describe("createNativeApiKeyAuth anonymousCatalog option", () => {
-	it("resolves undefined without the opt-in", async () => {
+describe("custom-resolver providers hide without a key (#530)", () => {
+	it.each([
+		["kilo", { apiKey: kiloApiKeyAuth }],
+		["requesty", requestyAuth],
+		["zenmux", zenmuxAuth],
+	])("%s resolves undefined without a key", async (_name, auth) => {
+		expect(await auth.apiKey?.resolve(resolveInput())).toBeUndefined();
+	});
+});
+
+describe("keyless allowlist still resolves (cline, fastrouter, llm7)", () => {
+	it.each([
+		["cline", { apiKey: clineApiKeyAuth }],
+		["fastrouter", fastrouterAuth],
+		["llm7", llm7Auth],
+	])("%s resolves keyless auth for the public catalog", async (_name, auth) => {
+		const result = await auth.apiKey?.resolve(resolveInput());
+		expect(result).toBeDefined();
+		expect(result?.auth).toBeDefined();
+		// No apiKey.check: a check would hide the public catalog before login.
+		expect(auth.apiKey).not.toHaveProperty("check");
+	});
+});
+
+describe("createNativeApiKeyAuth", () => {
+	it("resolves undefined without a key", async () => {
 		const auth = createNativeApiKeyAuth({
 			name: "Test key",
 			prompt: "Test key",
@@ -87,17 +117,6 @@ describe("createNativeApiKeyAuth anonymousCatalog option", () => {
 			getApiKey: () => undefined,
 		});
 		expect(await auth.apiKey?.resolve(resolveInput())).toBeUndefined();
-	});
-
-	it("resolves keyless auth with the opt-in", async () => {
-		const auth = createNativeApiKeyAuth({
-			name: "Test key",
-			prompt: "Test key",
-			source: "TEST_API_KEY",
-			getApiKey: () => undefined,
-			anonymousCatalog: true,
-		});
-		expect(await auth.apiKey?.resolve(resolveInput())).toEqual(anonymous);
 	});
 
 	it("still prefers stored and ambient keys when configured", async () => {
@@ -106,7 +125,6 @@ describe("createNativeApiKeyAuth anonymousCatalog option", () => {
 			prompt: "Test key",
 			source: "TEST_API_KEY",
 			getApiKey: () => "ambient-key",
-			anonymousCatalog: true,
 		});
 		expect(
 			await auth.apiKey?.resolve({

--- a/tests/kilo-auth.test.ts
+++ b/tests/kilo-auth.test.ts
@@ -90,17 +90,13 @@ describe("apiKey.resolve", () => {
 		});
 	});
 
-	it("resolves keyless auth for the public catalog when nothing is configured", async () => {
+	it("resolves undefined without a key so Pi hides the provider (#530)", async () => {
 		mockGetKiloApiKey.mockReturnValue(undefined);
 		const result = await kiloApiKeyAuth.resolve({
 			ctx: authCtx,
 			signal: new AbortController().signal,
 		} as never);
-		expect(result).toEqual({
-			auth: {},
-			source: "public catalog (no account)",
-		});
-		expect(kiloApiKeyAuth).not.toHaveProperty("check");
+		expect(result).toBeUndefined();
 	});
 });
 

--- a/tests/zenmux-auth.test.ts
+++ b/tests/zenmux-auth.test.ts
@@ -11,7 +11,7 @@ vi.mock("../config.ts", () => ({
 import { zenmuxAuth } from "../providers/zenmux/zenmux-auth.ts";
 
 describe("ZenMux native API-key auth", () => {
-	it("resolves keyless auth for the public catalog when nothing is configured", async () => {
+	it("resolves undefined without a key so Pi hides the provider (#530)", async () => {
 		mockGetZenmuxApiKey.mockReturnValue(undefined);
 		expect(
 			await zenmuxAuth.apiKey?.resolve({
@@ -19,10 +19,7 @@ describe("ZenMux native API-key auth", () => {
 				credential: undefined,
 				signal: new AbortController().signal,
 			} as never),
-		).toEqual({
-			auth: {},
-			source: "public catalog (no account)",
-		});
+		).toBeUndefined();
 		expect(zenmuxAuth.apiKey).not.toHaveProperty("check");
 	});
 

--- a/tests/zenmux-provider.test.ts
+++ b/tests/zenmux-provider.test.ts
@@ -165,14 +165,14 @@ describe("createZenmuxProvider", () => {
 		const models = createModels();
 		models.setProvider(provider);
 		expect(await models.getAvailable()).toEqual([]);
-		// ZenMux's catalog is public: auth resolves anonymously so Pi's model
-		// refresh populates the catalog without a configured key.
+		// Logged out: auth resolves undefined so Pi hides the provider
+		// from /model (#530) — the endpoint is public but chat needs a key.
 		expect(
 			await zenmuxAuth.apiKey?.resolve({
 				ctx: {} as never,
 				signal: new AbortController().signal,
 			} as never),
-		).toEqual({ auth: {}, source: "public catalog (no account)" });
+		).toBeUndefined();
 	});
 
 	it("restores the native store offline without network", async () => {


### PR DESCRIPTION
Pi hides providers whose auth doesn't resolve; the visible-without-login set was pi-free's own anonymous opt-ins. Chat needs a key everywhere except the keyless allowlist, so those listings were clutter.\n\n## What\n\n- **Removed** the shared `anonymousCatalog` option (zero consumers left) + `allowUnauthenticated` from commandcode, crofai, deepinfra, infron, novita, routeway, sambanova, venice.\n- **kilo/requesty/zenmux** custom resolvers return undefined keyless. merge/qoder already hid.\n- **Allowlist untouched**: cline, fastrouter, llm7.\n- **Tests**: suite rewritten as hide pins (11 hiding + 3 allowlist + factory contract); auth/provider assertions flipped.\n- **Docs**: new Model visibility section; corrected three stale 'appear before login' claims.\n- **RPC**: boot pins kilo-absent / llm7-present keyless.\n\nFull suite green (861); tsc/oxlint/knip/format clean.